### PR TITLE
abstract common feature class

### DIFF
--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -1,0 +1,79 @@
+#include "Feature.h"
+
+#include "Features/Clustered.h"
+#include "Features/DistantTreeLighting.h"
+#include "Features/GrassCollision.h"
+#include "Features/GrassLighting.h"
+#include "Features/ScreenSpaceShadows.h"
+
+void Feature::Load(json&)
+{
+	// convert string to wstring
+	auto ini_filename = GetIniFilename();
+	std::wstring ini_filename_w;
+	std::ranges::copy(ini_filename, std::back_inserter(ini_filename_w));
+	auto ini_path = L"Data\\Shaders\\Features\\" + ini_filename_w;
+
+	CSimpleIniA ini;
+	ini.SetUnicode();
+	ini.LoadFile(ini_path.c_str());
+	if (auto value = ini.GetValue("Info", "Version")) {
+		loaded = true;
+		version = value;
+		logger::info("{} successfully loaded", ini_filename);
+	} else {
+		loaded = false;
+		logger::warn("{} not successfully loaded", ini_filename);
+	}
+}
+
+bool Feature::ValidateCache(CSimpleIniA& a_ini)
+{
+	auto name = GetName();
+	auto ini_name = GetIniName();
+
+	logger::info("Validating {}", name);
+
+	auto enabledInCache = a_ini.GetBoolValue(ini_name.c_str(), "Enabled", false);
+	if (enabledInCache && !loaded) {
+		logger::info("Feature was uninstalled");
+		return false;
+	}
+	if (!enabledInCache && loaded) {
+		logger::info("Feature was installed");
+		return false;
+	}
+
+	if (loaded) {
+		auto versionInCache = a_ini.GetValue(ini_name.c_str(), "Version");
+		if (strcmp(versionInCache, version.c_str()) != 0) {
+			logger::info("Change in version detected. Installed {} but {} in Disk Cache", version, versionInCache);
+			return false;
+		} else {
+			logger::info("Installed version and cached version match.");
+		}
+	}
+
+	logger::info("Cached feature is valid");
+	return true;
+}
+
+void Feature::WriteDiskCacheInfo(CSimpleIniA& a_ini)
+{
+	auto ini_name = GetIniName();
+
+	a_ini.SetBoolValue(ini_name.c_str(), "Enabled", loaded);
+	a_ini.SetValue(ini_name.c_str(), "Version", version.c_str());
+}
+
+const std::vector<Feature*>& Feature::GetFeatureList()
+{
+	// Cat: essentially load order i guess
+	static std::vector<Feature*> features = {
+		GrassLighting::GetSingleton(),
+		DistantTreeLighting::GetSingleton(),
+		GrassCollision::GetSingleton(),
+		ScreenSpaceShadows::GetSingleton()
+	};
+	return features;
+}

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -1,6 +1,5 @@
 #include "Feature.h"
 
-#include "Features/Clustered.h"
 #include "Features/DistantTreeLighting.h"
 #include "Features/GrassCollision.h"
 #include "Features/GrassLighting.h"

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -16,7 +16,7 @@ struct Feature
 	virtual void Draw(const RE::BSShader* shader, const uint32_t descriptor) = 0;
 
 	virtual void Load(json& o_json);
-	virtual void Save(json& o_json);
+	virtual void Save(json& o_json) = 0;
 
 	virtual bool ValidateCache(CSimpleIniA& a_ini);
 	virtual void WriteDiskCacheInfo(CSimpleIniA& a_ini);

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -1,0 +1,26 @@
+#pragma once
+
+struct Feature
+{
+	bool loaded = false;
+	std::string version;
+
+	virtual std::string GetName() = 0;
+	virtual std::string GetIniFilename() = 0;
+	virtual std::string GetIniName() = 0;
+
+	virtual void SetupResources() = 0;
+	virtual void Reset() = 0;
+
+	virtual void DrawSettings() = 0;
+	virtual void Draw(const RE::BSShader* shader, const uint32_t descriptor) = 0;
+
+	virtual void Load(json& o_json);
+	virtual void Save(json& o_json);
+
+	virtual bool ValidateCache(CSimpleIniA& a_ini);
+	virtual void WriteDiskCacheInfo(CSimpleIniA& a_ini);
+
+	// Cat: add all the features in here
+	static const std::vector<Feature*>& GetFeatureList();
+};

--- a/src/Features/Clustered.h
+++ b/src/Features/Clustered.h
@@ -2,10 +2,12 @@
 
 #include <shared_mutex>
 
-#include <d3d11.h>
 #include <DirectXMath.h>
+#include <d3d11.h>
 
 #include "Buffer.h"
+
+// Cat: since this is WIP I'm leaving it as is
 
 class Clustered
 {

--- a/src/Features/DistantTreeLighting.cpp
+++ b/src/Features/DistantTreeLighting.cpp
@@ -150,18 +150,8 @@ void DistantTreeLighting::Load(json& o_json)
 {
 	if (o_json["Distant Tree Lighting"].is_object())
 		settings = o_json["Distant Tree Lighting"];
-	
-	CSimpleIniA ini;
-	ini.SetUnicode();
-	ini.LoadFile(L"Data\\Shaders\\Features\\TreeLODLighting.ini");
-	if (auto value = ini.GetValue("Info", "Version")) {
-		enabled = true;
-		version = value;
-		logger::info("TreeLODLighting.ini successfully loaded");
-	} else {
-		enabled = false;
-		logger::warn("TreeLODLighting.ini not successfully loaded");
-	}
+
+	Feature::Load(o_json);
 }
 
 void DistantTreeLighting::Save(json& o_json)
@@ -172,38 +162,4 @@ void DistantTreeLighting::Save(json& o_json)
 void DistantTreeLighting::SetupResources()
 {
 	perPass = new ConstantBuffer(ConstantBufferDesc<PerPass>());
-}
-
-bool DistantTreeLighting::ValidateCache(CSimpleIniA& a_ini)
-{
-	logger::info("Validating Tree LOD Lighting");
-
-	auto enabledInCache = a_ini.GetBoolValue("Tree LOD Lighting", "Enabled", false);
-	if (enabledInCache && !enabled) {
-		logger::info("Feature was uninstalled");
-		return false;
-	}
-	if (!enabledInCache && enabled) {
-		logger::info("Feature was installed");
-		return false;
-	}
-
-	if (enabled) {
-		auto versionInCache = a_ini.GetValue("Tree LOD Lighting", "Version");
-		if (strcmp(versionInCache, version.c_str()) != 0) {
-			logger::info("Change in version detected. Installed {} but {} in Disk Cache", version, versionInCache);
-			return false;
-		} else {
-			logger::info("Installed version and cached version match.");
-		}
-	}
-
-	logger::info("Cached feature is valid");
-	return true;
-}
-
-void DistantTreeLighting::WriteDiskCacheInfo(CSimpleIniA& a_ini)
-{
-	a_ini.SetBoolValue("Tree LOD Lighting", "Enabled", enabled);
-	a_ini.SetValue("Tree LOD Lighting", "Version", version.c_str());
 }

--- a/src/Features/DistantTreeLighting.h
+++ b/src/Features/DistantTreeLighting.h
@@ -11,9 +11,9 @@ struct DistantTreeLighting : Feature
 		return &singleton;
 	}
 
-	virtual inline std::string GetName() { return "Screen-Space Shadows"; }
-	virtual inline std::string GetIniFilename() { return "ScreenSpaceShadows.ini"; }
-	virtual inline std::string GetIniName() { return "Screen-Space Shadows"; }
+	virtual inline std::string GetName() { return "Tree LOD Lighting"; }
+	virtual inline std::string GetIniFilename() { return "TreeLODLighting.ini"; }
+	virtual inline std::string GetIniName() { return "Tree LOD Lighting"; }
 
 	struct Settings
 	{

--- a/src/Features/DistantTreeLighting.h
+++ b/src/Features/DistantTreeLighting.h
@@ -1,36 +1,37 @@
 #pragma once
 
 #include "Buffer.h"
+#include "Feature.h"
 
-class DistantTreeLighting
+struct DistantTreeLighting : Feature
 {
-public:
 	static DistantTreeLighting* GetSingleton()
 	{
 		static DistantTreeLighting singleton;
 		return &singleton;
 	}
 
-	bool enabled = false;
-	std::string version;
+	virtual inline std::string GetName() { return "Screen-Space Shadows"; }
+	virtual inline std::string GetIniFilename() { return "ScreenSpaceShadows.ini"; }
+	virtual inline std::string GetIniName() { return "Screen-Space Shadows"; }
 
 	struct Settings
 	{
-		std::uint32_t	EnableComplexTreeLOD = 1;
-		std::uint32_t	EnableDirLightFix = 1;
-		float			SubsurfaceScatteringAmount = 0.5;
-		float			FogDimmerAmount = 1.0;
+		std::uint32_t EnableComplexTreeLOD = 1;
+		std::uint32_t EnableDirLightFix = 1;
+		float SubsurfaceScatteringAmount = 0.5;
+		float FogDimmerAmount = 1.0;
 	};
 
 	struct alignas(16) PerPass
 	{
-		DirectX::XMFLOAT4	EyePosition;
-		DirectX::XMFLOAT3X4	DirectionalAmbient;
-		DirectX::XMFLOAT4	DirLightColor;
-		DirectX::XMFLOAT4	DirLightDirection;
-		float				DirLightScale;
-		std::uint32_t		ComplexAtlasTexture;
-		Settings			Settings;
+		DirectX::XMFLOAT4 EyePosition;
+		DirectX::XMFLOAT3X4 DirectionalAmbient;
+		DirectX::XMFLOAT4 DirLightColor;
+		DirectX::XMFLOAT4 DirLightDirection;
+		float DirLightScale;
+		std::uint32_t ComplexAtlasTexture;
+		Settings Settings;
 		float pad0;
 		float pad1;
 	};
@@ -41,16 +42,13 @@ public:
 	RE::TESWorldSpace* lastWorldSpace = nullptr;
 	bool complexAtlasTexture = false;
 
-	void SetupResources();
+	virtual void SetupResources();
+	virtual inline void Reset() {}
 
-	void DrawSettings();
+	virtual void DrawSettings();
 	void ModifyDistantTree(const RE::BSShader* shader, const uint32_t descriptor);
-	void Draw(const RE::BSShader* shader, const uint32_t descriptor);
+	virtual void Draw(const RE::BSShader* shader, const uint32_t descriptor);
 
-	void Load(json& o_json);
-	void Save(json& o_json);
-
-
-	bool ValidateCache(CSimpleIniA& a_ini);
-	void WriteDiskCacheInfo(CSimpleIniA& a_ini);
+	virtual void Load(json& o_json);
+	virtual void Save(json& o_json);
 };

--- a/src/Features/GrassCollision.cpp
+++ b/src/Features/GrassCollision.cpp
@@ -190,7 +190,7 @@ void GrassCollision::UpdateCollisions()
 
 void GrassCollision::ModifyGrass(const RE::BSShader*, const uint32_t)
 {
-	if (!enabledFeature)
+	if (!loaded)
 		return;
 
 	if (updatePerFrame) {
@@ -251,17 +251,7 @@ void GrassCollision::Load(json& o_json)
 	if (o_json["Grass Collision"].is_object())
 		settings = o_json["Grass Collision"];
 
-	CSimpleIniA ini;
-	ini.SetUnicode();
-	ini.LoadFile(L"Data\\Shaders\\Features\\GrassCollision.ini");
-	if (auto value = ini.GetValue("Info", "Version")) {
-		enabledFeature = true;
-		version = value;
-		logger::info("GrassCollision.ini successfully loaded");
-	} else {
-		enabledFeature = false;
-		logger::warn("GrassCollision.ini not successfully loaded");
-	}
+	Feature::Load(o_json);
 }
 
 void GrassCollision::Save(json& o_json)
@@ -277,38 +267,4 @@ void GrassCollision::SetupResources()
 void GrassCollision::Reset()
 {
 	updatePerFrame = true;
-}
-
-bool GrassCollision::ValidateCache(CSimpleIniA& a_ini)
-{
-	logger::info("Validating Grass Collision");
-
-	auto enabledInCache = a_ini.GetBoolValue("Grass Collision", "Enabled", false);
-	if (enabledInCache && !enabledFeature) {
-		logger::info("Feature was uninstalled");
-		return false;
-	}
-	if (!enabledInCache && enabledFeature) {
-		logger::info("Feature was installed");
-		return false;
-	}
-
-	if (enabledFeature) {
-		auto versionInCache = a_ini.GetValue("Grass Collision", "Version");
-		if (strcmp(versionInCache, version.c_str()) != 0) {
-			logger::info("Change in version detected. Installed {} but {} in Disk Cache", version, versionInCache);
-			return false;
-		} else {
-			logger::info("Installed version and cached version match.");
-		}
-	}
-
-	logger::info("Cached feature is valid");
-	return true;
-}
-
-void GrassCollision::WriteDiskCacheInfo(CSimpleIniA& a_ini)
-{
-	a_ini.SetBoolValue("Grass Collision", "Enabled", enabledFeature);
-	a_ini.SetValue("Grass Collision", "Version", version.c_str());
 }

--- a/src/Features/GrassCollision.h
+++ b/src/Features/GrassCollision.h
@@ -1,18 +1,19 @@
 #pragma once
 
 #include "Buffer.h"
+#include "Feature.h"
 
-class GrassCollision
+struct GrassCollision : Feature
 {
-public:
 	static GrassCollision* GetSingleton()
 	{
 		static GrassCollision singleton;
 		return &singleton;
 	}
 
-	bool enabledFeature = false;
-	std::string version;
+	virtual inline std::string GetName() { return "Grass Collision"; }
+	virtual inline std::string GetIniFilename() { return "GrassCollision.ini"; }
+	virtual inline std::string GetIniName() { return "Grass Collision"; }
 
 	struct Settings
 	{
@@ -35,8 +36,6 @@ public:
 		float radius;
 	};
 
-	bool enabled = false;
-
 	std::unique_ptr<Buffer> collisions = nullptr;
 
 	Settings settings;
@@ -44,17 +43,14 @@ public:
 	bool updatePerFrame = false;
 	ConstantBuffer* perFrame = nullptr;
 
-	void SetupResources();
-	void Reset();
+	virtual void SetupResources();
+	virtual void Reset();
 
-	void DrawSettings();
+	virtual void DrawSettings();
 	void UpdateCollisions();
 	void ModifyGrass(const RE::BSShader* shader, const uint32_t descriptor);
-	void Draw(const RE::BSShader* shader, const uint32_t descriptor);
+	virtual void Draw(const RE::BSShader* shader, const uint32_t descriptor);
 
-	void Load(json& o_json);
-	void Save(json& o_json);
-
-	bool ValidateCache(CSimpleIniA& a_ini);
-	void WriteDiskCacheInfo(CSimpleIniA& a_ini);
+	virtual void Load(json& o_json);
+	virtual void Save(json& o_json);
 };

--- a/src/Features/GrassLighting.cpp
+++ b/src/Features/GrassLighting.cpp
@@ -115,17 +115,7 @@ void GrassLighting::Load(json& o_json)
 	if (o_json["Grass Lighting"].is_object())
 		settings = o_json["Grass Lighting"];
 
-	CSimpleIniA ini;
-	ini.SetUnicode();
-	ini.LoadFile(L"Data\\Shaders\\Features\\GrassLighting.ini");
-	if (auto value = ini.GetValue("Info", "Version")) {
-		enabled = true;
-		version = value;
-		logger::info("GrassLighting.ini successfully loaded");
-	} else {
-		enabled = false;
-		logger::warn("GrassLighting.ini not successfully loaded");
-	}
+	Feature::Load(o_json);
 }
 
 void GrassLighting::Save(json& o_json)
@@ -141,38 +131,4 @@ void GrassLighting::SetupResources()
 void GrassLighting::Reset()
 {
 	updatePerFrame = true;
-}
-
-bool GrassLighting::ValidateCache(CSimpleIniA& a_ini)
-{
-	logger::info("Validating Grass Lighting");
-
-	auto enabledInCache = a_ini.GetBoolValue("Grass Lighting", "Enabled", false);
-	if (enabledInCache && !enabled) {
-		logger::info("Feature was uninstalled");
-		return false;
-	}
-	if (!enabledInCache && enabled) {
-		logger::info("Feature was installed");
-		return false;
-	}
-
-	if (enabled) {
-		auto versionInCache = a_ini.GetValue("Grass Lighting", "Version");
-		if (strcmp(versionInCache, version.c_str()) != 0) {
-			logger::info("Change in version detected. Installed {} but {} in Disk Cache", version, versionInCache);
-			return false;
-		} else {
-			logger::info("Installed version and cached version match.");
-		}
-	}
-
-	logger::info("Cached feature is valid");
-	return true;
-}
-
-void GrassLighting::WriteDiskCacheInfo(CSimpleIniA& a_ini)
-{
-	a_ini.SetBoolValue("Grass Lighting", "Enabled", enabled);
-	a_ini.SetValue("Grass Lighting", "Version", version.c_str());
 }

--- a/src/Features/GrassLighting.h
+++ b/src/Features/GrassLighting.h
@@ -1,18 +1,19 @@
 #pragma once
 
 #include "Buffer.h"
+#include "Feature.h"
 
-class GrassLighting
+struct GrassLighting : Feature
 {
-public:
 	static GrassLighting* GetSingleton()
 	{
 		static GrassLighting singleton;
 		return &singleton;
 	}
 
-	bool enabled = false;
-	std::string version;
+	virtual inline std::string GetName() { return "Grass Lighting"; }
+	virtual inline std::string GetIniFilename() { return "GrassLighting.ini"; }
+	virtual inline std::string GetIniName() { return "Grass Lighting"; }
 
 	struct Settings
 	{
@@ -37,16 +38,13 @@ public:
 
 	bool updatePerFrame = false;
 	ConstantBuffer* perFrame = nullptr;
-	void SetupResources();
-	void Reset();
+	virtual void SetupResources();
+	virtual void Reset();
 
-	void DrawSettings();
+	virtual void DrawSettings();
 	void ModifyGrass(const RE::BSShader* shader, const uint32_t descriptor);
-	void Draw(const RE::BSShader* shader, const uint32_t descriptor);
+	virtual void Draw(const RE::BSShader* shader, const uint32_t descriptor);
 
-	void Load(json& o_json);
-	void Save(json& o_json);
-
-	bool ValidateCache(CSimpleIniA& a_ini);
-	void WriteDiskCacheInfo(CSimpleIniA& a_ini);
+	virtual void Load(json& o_json);
+	virtual void Save(json& o_json);
 };

--- a/src/Features/ScreenSpaceShadows.h
+++ b/src/Features/ScreenSpaceShadows.h
@@ -12,7 +12,7 @@ struct ScreenSpaceShadows : Feature
 	}
 
 	virtual inline std::string GetName() { return "Screen-Space Shadows"; }
-	virtual inline std::string GetIniFilename() { return "GrassLighting.ini"; }
+	virtual inline std::string GetIniFilename() { return "ScreenSpaceShadows.ini"; }
 	virtual inline std::string GetIniName() { return "Screen-Space Shadows"; }
 
 	struct Settings

--- a/src/Features/ScreenSpaceShadows.h
+++ b/src/Features/ScreenSpaceShadows.h
@@ -1,18 +1,19 @@
 #pragma once
 
 #include "Buffer.h"
+#include "Feature.h"
 
-class ScreenSpaceShadows
+struct ScreenSpaceShadows : Feature
 {
-public:
 	static ScreenSpaceShadows* GetSingleton()
 	{
 		static ScreenSpaceShadows singleton;
 		return &singleton;
 	}
 
-	bool enabledFeature = false;
-	std::string version;
+	virtual inline std::string GetName() { return "Screen-Space Shadows"; }
+	virtual inline std::string GetIniFilename() { return "GrassLighting.ini"; }
+	virtual inline std::string GetIniName() { return "Screen-Space Shadows"; }
 
 	struct Settings
 	{
@@ -62,12 +63,13 @@ public:
 
 	ID3D11ComputeShader* horizontalBlurProgram = nullptr;
 	ID3D11ComputeShader* verticalBlurProgram = nullptr;
-	
+
 	bool renderedScreenCamera = false;
 
-	void SetupResources();
+	virtual void SetupResources();
+	virtual void Reset();
 
-	void DrawSettings();
+	virtual void DrawSettings();
 	void ModifyGrass(const RE::BSShader* shader, const uint32_t descriptor);
 	void ModifyDistantTree(const RE::BSShader*, const uint32_t descriptor);
 
@@ -77,12 +79,8 @@ public:
 	ID3D11ComputeShader* GetComputeShaderVerticalBlur();
 
 	void ModifyLighting(const RE::BSShader* shader, const uint32_t descriptor);
-	void Draw(const RE::BSShader* shader, const uint32_t descriptor);
+	virtual void Draw(const RE::BSShader* shader, const uint32_t descriptor);
 
-	void Load(json& o_json);
-	void Save(json& o_json);
-
-	bool ValidateCache(CSimpleIniA& a_ini);
-	void WriteDiskCacheInfo(CSimpleIniA& a_ini);
-	void Reset();
+	virtual void Load(json& o_json);
+	virtual void Save(json& o_json);
 };

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -6,9 +6,7 @@
 #include "ShaderCache.h"
 #include "State.h"
 
-#include "Features/DistantTreeLighting.h"
-#include "Features/GrassCollision.h"
-#include "Features/GrassLighting.h"
+#include "Feature.h"
 #include "Features/ScreenSpaceShadows.h"
 
 #define SETTING_MENU_TOGGLEKEY "Toggle Key"

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -6,9 +6,9 @@
 #include "ShaderCache.h"
 #include "State.h"
 
-#include "Features/GrassLighting.h"
 #include "Features/DistantTreeLighting.h"
 #include "Features/GrassCollision.h"
+#include "Features/GrassLighting.h"
 #include "Features/ScreenSpaceShadows.h"
 
 #define SETTING_MENU_TOGGLEKEY "Toggle Key"
@@ -44,7 +44,7 @@ void Menu::Save(json& o_json)
 
 RE::BSEventNotifyControl Menu::ProcessEvent(RE::InputEvent* const* a_event, RE::BSTEventSource<RE::InputEvent*>* a_eventSource)
 {
-	 if (!a_event || !a_eventSource)
+	if (!a_event || !a_eventSource)
 		return RE::BSEventNotifyControl::kContinue;
 
 	for (auto event = *a_event; event; event = event->next) {
@@ -141,26 +141,18 @@ RE::BSEventNotifyControl Menu::ProcessEvent(RE::InputEvent* const* a_event, RE::
 			}
 
 			auto& io = ImGui::GetIO();
-			switch (button->device.get()) 
-			{
+			switch (button->device.get()) {
 			case RE::INPUT_DEVICE::kKeyboard:
-				if (!button->IsPressed()) 
-				{
-					if (settingToggleKey) 
-					{
+				if (!button->IsPressed()) {
+					if (settingToggleKey) {
 						toggleKey = key;
 						settingToggleKey = false;
-					} 
-					else if (key == toggleKey) 
-					{
+					} else if (key == toggleKey) {
 						IsEnabled = !IsEnabled;
-						if (const auto controlMap = RE::ControlMap::GetSingleton()) 
-						{
+						if (const auto controlMap = RE::ControlMap::GetSingleton()) {
 							controlMap->GetRuntimeData().ignoreKeyboardMouse = IsEnabled;
 						}
-					} 
-					else 
-					{
+					} else {
 						io.AddKeyEvent(VirtualKeyToImGuiKey(key), button->IsPressed());
 					}
 				}
@@ -200,7 +192,6 @@ void Menu::Init(IDXGISwapChain* swapchain, ID3D11Device* device, ID3D11DeviceCon
 	// Setup Platform/Renderer backends
 	ImGui_ImplWin32_Init(desc.OutputWindow);
 	ImGui_ImplDX11_Init(device, context);
-
 }
 
 void Menu::DrawSettings()
@@ -258,13 +249,9 @@ void Menu::DrawSettings()
 	ImGui::Spacing();
 
 	if (ImGui::CollapsingHeader("Menu", ImGuiTreeNodeFlags_DefaultOpen)) {
-		
-		if (settingToggleKey) 
-		{
+		if (settingToggleKey) {
 			ImGui::Text("Press any key to set as toggle key...");
-		} 
-		else 
-		{			
+		} else {
 			ImGui::Text("Toggle Key:");
 			ImGui::SameLine();
 			ImGui::TextColored(ImVec4(1, 1, 0, 1), "%s", KeyIdToString(toggleKey));
@@ -365,10 +352,8 @@ void Menu::DrawSettings()
 	}
 
 	if (ImGui::BeginTabBar("Features", ImGuiTabBarFlags_None)) {
-		GrassLighting::GetSingleton()->DrawSettings();
-		DistantTreeLighting::GetSingleton()->DrawSettings();
-		GrassCollision::GetSingleton()->DrawSettings();
-		ScreenSpaceShadows::GetSingleton()->DrawSettings();
+		for (auto* feature : Feature::GetFeatureList())
+			feature->DrawSettings();
 		ImGui::EndTabBar();
 	}
 
@@ -382,7 +367,6 @@ void Menu::DrawSettings()
 
 void Menu::DrawOverlay()
 {
-
 	// Start the Dear ImGui frame
 	ImGui_ImplDX11_NewFrame();
 	ImGui_ImplWin32_NewFrame();
@@ -396,8 +380,7 @@ void Menu::DrawOverlay()
 	compiledShaders = shaderCache.GetCompletedTasks();
 	totalShaders = shaderCache.GetTotalTasks();
 
-	 if (compiledShaders != totalShaders) 
-	 {
+	if (compiledShaders != totalShaders) {
 		ImGui::SetNextWindowBgAlpha(1);
 		ImGui::SetNextWindowPos(ImVec2(10, 10));
 		if (!ImGui::Begin("ShaderCompilationInfo", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings)) {
@@ -410,9 +393,8 @@ void Menu::DrawOverlay()
 		ImGui::End();
 	}
 
-	if (IsEnabled)
-	{
-	    ImGui::GetIO().MouseDrawCursor = true;
+	if (IsEnabled) {
+		ImGui::GetIO().MouseDrawCursor = true;
 		DrawSettings();
 	} else {
 		ImGui::GetIO().MouseDrawCursor = false;
@@ -453,111 +435,215 @@ const char* Menu::KeyIdToString(uint32_t key)
 const ImGuiKey Menu::VirtualKeyToImGuiKey(WPARAM vkKey)
 {
 	switch (vkKey) {
-		case VK_TAB: return ImGuiKey_Tab;
-		case VK_LEFT: return ImGuiKey_LeftArrow;
-		case VK_RIGHT: return ImGuiKey_RightArrow;
-		case VK_UP: return ImGuiKey_UpArrow;
-		case VK_DOWN: return ImGuiKey_DownArrow;
-		case VK_PRIOR: return ImGuiKey_PageUp;
-		case VK_NEXT: return ImGuiKey_PageDown;
-		case VK_HOME: return ImGuiKey_Home;
-		case VK_END: return ImGuiKey_End;
-		case VK_INSERT: return ImGuiKey_Insert;
-		case VK_DELETE: return ImGuiKey_Delete;
-		case VK_BACK: return ImGuiKey_Backspace;
-		case VK_SPACE: return ImGuiKey_Space;
-		case VK_RETURN: return ImGuiKey_Enter;
-		case VK_ESCAPE: return ImGuiKey_Escape;
-		case VK_OEM_7: return ImGuiKey_Apostrophe;
-		case VK_OEM_COMMA: return ImGuiKey_Comma;
-		case VK_OEM_MINUS: return ImGuiKey_Minus;
-		case VK_OEM_PERIOD: return ImGuiKey_Period;
-		case VK_OEM_2: return ImGuiKey_Slash;
-		case VK_OEM_1: return ImGuiKey_Semicolon;
-		case VK_OEM_PLUS: return ImGuiKey_Equal;
-		case VK_OEM_4: return ImGuiKey_LeftBracket;
-		case VK_OEM_5: return ImGuiKey_Backslash;
-		case VK_OEM_6: return ImGuiKey_RightBracket;
-		case VK_OEM_3: return ImGuiKey_GraveAccent;
-		case VK_CAPITAL: return ImGuiKey_CapsLock;
-		case VK_SCROLL: return ImGuiKey_ScrollLock;
-		case VK_NUMLOCK: return ImGuiKey_NumLock;
-		case VK_SNAPSHOT: return ImGuiKey_PrintScreen;
-		case VK_PAUSE: return ImGuiKey_Pause;
-		case VK_NUMPAD0: return ImGuiKey_Keypad0;
-		case VK_NUMPAD1: return ImGuiKey_Keypad1;
-		case VK_NUMPAD2: return ImGuiKey_Keypad2;
-		case VK_NUMPAD3: return ImGuiKey_Keypad3;
-		case VK_NUMPAD4: return ImGuiKey_Keypad4;
-		case VK_NUMPAD5: return ImGuiKey_Keypad5;
-		case VK_NUMPAD6: return ImGuiKey_Keypad6;
-		case VK_NUMPAD7: return ImGuiKey_Keypad7;
-		case VK_NUMPAD8: return ImGuiKey_Keypad8;
-		case VK_NUMPAD9: return ImGuiKey_Keypad9;
-		case VK_DECIMAL: return ImGuiKey_KeypadDecimal;
-		case VK_DIVIDE: return ImGuiKey_KeypadDivide;
-		case VK_MULTIPLY: return ImGuiKey_KeypadMultiply;
-		case VK_SUBTRACT: return ImGuiKey_KeypadSubtract;
-		case VK_ADD: return ImGuiKey_KeypadAdd;
-		case IM_VK_KEYPAD_ENTER: return ImGuiKey_KeypadEnter;
-		case VK_LSHIFT: return ImGuiKey_LeftShift;
-		case VK_LCONTROL: return ImGuiKey_LeftCtrl;
-		case VK_LMENU: return ImGuiKey_LeftAlt;
-		case VK_LWIN: return ImGuiKey_LeftSuper;
-		case VK_RSHIFT: return ImGuiKey_RightShift;
-		case VK_RCONTROL: return ImGuiKey_RightCtrl;
-		case VK_RMENU: return ImGuiKey_RightAlt;
-		case VK_RWIN: return ImGuiKey_RightSuper;
-		case VK_APPS: return ImGuiKey_Menu;
-		case '0': return ImGuiKey_0;
-		case '1': return ImGuiKey_1;
-		case '2': return ImGuiKey_2;
-		case '3': return ImGuiKey_3;
-		case '4': return ImGuiKey_4;
-		case '5': return ImGuiKey_5;
-		case '6': return ImGuiKey_6;
-		case '7': return ImGuiKey_7;
-		case '8': return ImGuiKey_8;
-		case '9': return ImGuiKey_9;
-		case 'A': return ImGuiKey_A;
-		case 'B': return ImGuiKey_B;
-		case 'C': return ImGuiKey_C;
-		case 'D': return ImGuiKey_D;
-		case 'E': return ImGuiKey_E;
-		case 'F': return ImGuiKey_F;
-		case 'G': return ImGuiKey_G;
-		case 'H': return ImGuiKey_H;
-		case 'I': return ImGuiKey_I;
-		case 'J': return ImGuiKey_J;
-		case 'K': return ImGuiKey_K;
-		case 'L': return ImGuiKey_L;
-		case 'M': return ImGuiKey_M;
-		case 'N': return ImGuiKey_N;
-		case 'O': return ImGuiKey_O;
-		case 'P': return ImGuiKey_P;
-		case 'Q': return ImGuiKey_Q;
-		case 'R': return ImGuiKey_R;
-		case 'S': return ImGuiKey_S;
-		case 'T': return ImGuiKey_T;
-		case 'U': return ImGuiKey_U;
-		case 'V': return ImGuiKey_V;
-		case 'W': return ImGuiKey_W;
-		case 'X': return ImGuiKey_X;
-		case 'Y': return ImGuiKey_Y;
-		case 'Z': return ImGuiKey_Z;
-		case VK_F1: return ImGuiKey_F1;
-		case VK_F2: return ImGuiKey_F2;
-		case VK_F3: return ImGuiKey_F3;
-		case VK_F4: return ImGuiKey_F4;
-		case VK_F5: return ImGuiKey_F5;
-		case VK_F6: return ImGuiKey_F6;
-		case VK_F7: return ImGuiKey_F7;
-		case VK_F8: return ImGuiKey_F8;
-		case VK_F9: return ImGuiKey_F9;
-		case VK_F10: return ImGuiKey_F10;
-		case VK_F11: return ImGuiKey_F11;
-		case VK_F12: return ImGuiKey_F12;
-		default:
-			return ImGuiKey_None;
+	case VK_TAB:
+		return ImGuiKey_Tab;
+	case VK_LEFT:
+		return ImGuiKey_LeftArrow;
+	case VK_RIGHT:
+		return ImGuiKey_RightArrow;
+	case VK_UP:
+		return ImGuiKey_UpArrow;
+	case VK_DOWN:
+		return ImGuiKey_DownArrow;
+	case VK_PRIOR:
+		return ImGuiKey_PageUp;
+	case VK_NEXT:
+		return ImGuiKey_PageDown;
+	case VK_HOME:
+		return ImGuiKey_Home;
+	case VK_END:
+		return ImGuiKey_End;
+	case VK_INSERT:
+		return ImGuiKey_Insert;
+	case VK_DELETE:
+		return ImGuiKey_Delete;
+	case VK_BACK:
+		return ImGuiKey_Backspace;
+	case VK_SPACE:
+		return ImGuiKey_Space;
+	case VK_RETURN:
+		return ImGuiKey_Enter;
+	case VK_ESCAPE:
+		return ImGuiKey_Escape;
+	case VK_OEM_7:
+		return ImGuiKey_Apostrophe;
+	case VK_OEM_COMMA:
+		return ImGuiKey_Comma;
+	case VK_OEM_MINUS:
+		return ImGuiKey_Minus;
+	case VK_OEM_PERIOD:
+		return ImGuiKey_Period;
+	case VK_OEM_2:
+		return ImGuiKey_Slash;
+	case VK_OEM_1:
+		return ImGuiKey_Semicolon;
+	case VK_OEM_PLUS:
+		return ImGuiKey_Equal;
+	case VK_OEM_4:
+		return ImGuiKey_LeftBracket;
+	case VK_OEM_5:
+		return ImGuiKey_Backslash;
+	case VK_OEM_6:
+		return ImGuiKey_RightBracket;
+	case VK_OEM_3:
+		return ImGuiKey_GraveAccent;
+	case VK_CAPITAL:
+		return ImGuiKey_CapsLock;
+	case VK_SCROLL:
+		return ImGuiKey_ScrollLock;
+	case VK_NUMLOCK:
+		return ImGuiKey_NumLock;
+	case VK_SNAPSHOT:
+		return ImGuiKey_PrintScreen;
+	case VK_PAUSE:
+		return ImGuiKey_Pause;
+	case VK_NUMPAD0:
+		return ImGuiKey_Keypad0;
+	case VK_NUMPAD1:
+		return ImGuiKey_Keypad1;
+	case VK_NUMPAD2:
+		return ImGuiKey_Keypad2;
+	case VK_NUMPAD3:
+		return ImGuiKey_Keypad3;
+	case VK_NUMPAD4:
+		return ImGuiKey_Keypad4;
+	case VK_NUMPAD5:
+		return ImGuiKey_Keypad5;
+	case VK_NUMPAD6:
+		return ImGuiKey_Keypad6;
+	case VK_NUMPAD7:
+		return ImGuiKey_Keypad7;
+	case VK_NUMPAD8:
+		return ImGuiKey_Keypad8;
+	case VK_NUMPAD9:
+		return ImGuiKey_Keypad9;
+	case VK_DECIMAL:
+		return ImGuiKey_KeypadDecimal;
+	case VK_DIVIDE:
+		return ImGuiKey_KeypadDivide;
+	case VK_MULTIPLY:
+		return ImGuiKey_KeypadMultiply;
+	case VK_SUBTRACT:
+		return ImGuiKey_KeypadSubtract;
+	case VK_ADD:
+		return ImGuiKey_KeypadAdd;
+	case IM_VK_KEYPAD_ENTER:
+		return ImGuiKey_KeypadEnter;
+	case VK_LSHIFT:
+		return ImGuiKey_LeftShift;
+	case VK_LCONTROL:
+		return ImGuiKey_LeftCtrl;
+	case VK_LMENU:
+		return ImGuiKey_LeftAlt;
+	case VK_LWIN:
+		return ImGuiKey_LeftSuper;
+	case VK_RSHIFT:
+		return ImGuiKey_RightShift;
+	case VK_RCONTROL:
+		return ImGuiKey_RightCtrl;
+	case VK_RMENU:
+		return ImGuiKey_RightAlt;
+	case VK_RWIN:
+		return ImGuiKey_RightSuper;
+	case VK_APPS:
+		return ImGuiKey_Menu;
+	case '0':
+		return ImGuiKey_0;
+	case '1':
+		return ImGuiKey_1;
+	case '2':
+		return ImGuiKey_2;
+	case '3':
+		return ImGuiKey_3;
+	case '4':
+		return ImGuiKey_4;
+	case '5':
+		return ImGuiKey_5;
+	case '6':
+		return ImGuiKey_6;
+	case '7':
+		return ImGuiKey_7;
+	case '8':
+		return ImGuiKey_8;
+	case '9':
+		return ImGuiKey_9;
+	case 'A':
+		return ImGuiKey_A;
+	case 'B':
+		return ImGuiKey_B;
+	case 'C':
+		return ImGuiKey_C;
+	case 'D':
+		return ImGuiKey_D;
+	case 'E':
+		return ImGuiKey_E;
+	case 'F':
+		return ImGuiKey_F;
+	case 'G':
+		return ImGuiKey_G;
+	case 'H':
+		return ImGuiKey_H;
+	case 'I':
+		return ImGuiKey_I;
+	case 'J':
+		return ImGuiKey_J;
+	case 'K':
+		return ImGuiKey_K;
+	case 'L':
+		return ImGuiKey_L;
+	case 'M':
+		return ImGuiKey_M;
+	case 'N':
+		return ImGuiKey_N;
+	case 'O':
+		return ImGuiKey_O;
+	case 'P':
+		return ImGuiKey_P;
+	case 'Q':
+		return ImGuiKey_Q;
+	case 'R':
+		return ImGuiKey_R;
+	case 'S':
+		return ImGuiKey_S;
+	case 'T':
+		return ImGuiKey_T;
+	case 'U':
+		return ImGuiKey_U;
+	case 'V':
+		return ImGuiKey_V;
+	case 'W':
+		return ImGuiKey_W;
+	case 'X':
+		return ImGuiKey_X;
+	case 'Y':
+		return ImGuiKey_Y;
+	case 'Z':
+		return ImGuiKey_Z;
+	case VK_F1:
+		return ImGuiKey_F1;
+	case VK_F2:
+		return ImGuiKey_F2;
+	case VK_F3:
+		return ImGuiKey_F3;
+	case VK_F4:
+		return ImGuiKey_F4;
+	case VK_F5:
+		return ImGuiKey_F5;
+	case VK_F6:
+		return ImGuiKey_F6;
+	case VK_F7:
+		return ImGuiKey_F7;
+	case VK_F8:
+		return ImGuiKey_F8;
+	case VK_F9:
+		return ImGuiKey_F9;
+	case VK_F10:
+		return ImGuiKey_F10;
+	case VK_F11:
+		return ImGuiKey_F11;
+	case VK_F12:
+		return ImGuiKey_F12;
+	default:
+		return ImGuiKey_None;
 	};
 }

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -198,162 +198,163 @@ void Menu::DrawSettings()
 	SetupImGuiStyle();
 	static bool visible = false;
 
-	ImGui::SetNextWindowSize({ 1024, 1024 }, ImGuiCond_FirstUseEver);
-	if (ImGui::Begin(std::format("Skyrim Community Shaders {}", Plugin::VERSION.string(".")).c_str(), &IsEnabled)) {
-		auto& shaderCache = SIE::ShaderCache::Instance();
+	ImGui::SetNextWindowSize({ 1024, 1024 }, ImGuiCond_Once);
+	ImGui::Begin(std::format("Skyrim Community Shaders {}", Plugin::VERSION.string(".")).c_str(), &IsEnabled);
 
-		if (ImGui::Button("Save Settings")) {
-			State::GetSingleton()->Save();
-		}
+	auto& shaderCache = SIE::ShaderCache::Instance();
 
-		ImGui::SameLine();
+	if (ImGui::Button("Save Settings")) {
+		State::GetSingleton()->Save();
+	}
 
-		if (ImGui::Button("Load Settings")) {
-			State::GetSingleton()->Load();
-		}
-		ImGui::SameLine();
+	ImGui::SameLine();
 
-		if (ImGui::Button("Clear Shader Cache")) {
-			shaderCache.Clear();
-			ScreenSpaceShadows::GetSingleton()->ClearComputeShader();
-		}
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-			ImGui::Text("The Shader Cache is the collection of compiled shaders which replace the vanilla shaders at runtime.");
-			ImGui::Text("Clearing the shader cache will mean that shaders are recompiled only when the game re-encounters them.");
-			ImGui::Text("This is only needed for hot-loading shaders for development purposes.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
-		}
+	if (ImGui::Button("Load Settings")) {
+		State::GetSingleton()->Load();
+	}
+	ImGui::SameLine();
 
-		ImGui::SameLine();
+	if (ImGui::Button("Clear Shader Cache")) {
+		shaderCache.Clear();
+		ScreenSpaceShadows::GetSingleton()->ClearComputeShader();
+	}
+	if (ImGui::IsItemHovered()) {
+		ImGui::BeginTooltip();
+		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		ImGui::Text("The Shader Cache is the collection of compiled shaders which replace the vanilla shaders at runtime.");
+		ImGui::Text("Clearing the shader cache will mean that shaders are recompiled only when the game re-encounters them.");
+		ImGui::Text("This is only needed for hot-loading shaders for development purposes.");
+		ImGui::PopTextWrapPos();
+		ImGui::EndTooltip();
+	}
 
-		if (ImGui::Button("Clear Disk Cache")) {
-			shaderCache.DeleteDiskCache();
-		}
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-			ImGui::Text("The Disk Cache is a collection of compiled shaders on disk, which are automatically created when shaders are added to the Shader Cache.");
-			ImGui::Text("If you do not have a Disk Cache, or it is outdated or invalid, you will see \"Compiling Shaders\" in the upper-left corner.");
-			ImGui::Text("After this has completed you will no longer see this message apart from when loading from the Disk Cache.");
-			ImGui::Text("Only delete the Disk Cache manually if you are encountering issues.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
-		}
+	ImGui::SameLine();
 
-		ImGui::Spacing();
+	if (ImGui::Button("Clear Disk Cache")) {
+		shaderCache.DeleteDiskCache();
+	}
+	if (ImGui::IsItemHovered()) {
+		ImGui::BeginTooltip();
+		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		ImGui::Text("The Disk Cache is a collection of compiled shaders on disk, which are automatically created when shaders are added to the Shader Cache.");
+		ImGui::Text("If you do not have a Disk Cache, or it is outdated or invalid, you will see \"Compiling Shaders\" in the upper-left corner.");
+		ImGui::Text("After this has completed you will no longer see this message apart from when loading from the Disk Cache.");
+		ImGui::Text("Only delete the Disk Cache manually if you are encountering issues.");
+		ImGui::PopTextWrapPos();
+		ImGui::EndTooltip();
+	}
 
-		if (ImGui::CollapsingHeader("Menu", ImGuiTreeNodeFlags_DefaultOpen)) {
-			if (settingToggleKey) {
-				ImGui::Text("Press any key to set as toggle key...");
-			} else {
-				ImGui::Text("Toggle Key:");
-				ImGui::SameLine();
-				ImGui::TextColored(ImVec4(1, 1, 0, 1), "%s", KeyIdToString(toggleKey));
+	ImGui::Spacing();
 
-				ImGui::SameLine();
-				if (ImGui::Button("Change")) {
-					settingToggleKey = true;
-				}
+	if (ImGui::CollapsingHeader("Menu", ImGuiTreeNodeFlags_DefaultOpen)) {
+		if (settingToggleKey) {
+			ImGui::Text("Press any key to set as toggle key...");
+		} else {
+			ImGui::Text("Toggle Key:");
+			ImGui::SameLine();
+			ImGui::TextColored(ImVec4(1, 1, 0, 1), "%s", KeyIdToString(toggleKey));
+
+			ImGui::SameLine();
+			if (ImGui::Button("Change")) {
+				settingToggleKey = true;
 			}
-		}
-
-		if (ImGui::CollapsingHeader("Advanced", ImGuiTreeNodeFlags_DefaultOpen)) {
-			bool useDump = shaderCache.IsDump();
-			if (ImGui::Checkbox("Dump Shaders", &useDump)) {
-				shaderCache.SetDump(useDump);
-			}
-			if (ImGui::IsItemHovered()) {
-				ImGui::BeginTooltip();
-				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-				ImGui::Text("Dump shaders at startup. This should be used only when reversing shaders. Normal users don't need this.");
-				ImGui::PopTextWrapPos();
-				ImGui::EndTooltip();
-			}
-			spdlog::level::level_enum logLevel = State::GetSingleton()->GetLogLevel();
-			const char* items[] = {
-				"trace",
-				"debug",
-				"info",
-				"warn",
-				"err",
-				"critical",
-				"off"
-			};
-			static int item_current = static_cast<int>(logLevel);
-			if (ImGui::Combo("Log Level", &item_current, items, IM_ARRAYSIZE(items))) {
-				ImGui::SameLine();
-				State::GetSingleton()->SetLogLevel(static_cast<spdlog::level::level_enum>(item_current));
-			}
-			if (ImGui::IsItemHovered()) {
-				ImGui::BeginTooltip();
-				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-				ImGui::Text("Log level. Trace is most verbose. Default is info.");
-				ImGui::PopTextWrapPos();
-				ImGui::EndTooltip();
-			}
-		}
-		if (ImGui::CollapsingHeader("General", ImGuiTreeNodeFlags_DefaultOpen)) {
-			bool useCustomShaders = shaderCache.IsEnabled();
-			if (ImGui::Checkbox("Enable Shaders", &useCustomShaders)) {
-				shaderCache.SetEnabled(useCustomShaders);
-			}
-			if (ImGui::IsItemHovered()) {
-				ImGui::BeginTooltip();
-				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-				ImGui::Text("Disabling this effectively disables all features.");
-				ImGui::PopTextWrapPos();
-				ImGui::EndTooltip();
-			}
-
-			bool useDiskCache = shaderCache.IsDiskCache();
-			if (ImGui::Checkbox("Enable Disk Cache", &useDiskCache)) {
-				shaderCache.SetDiskCache(useDiskCache);
-			}
-			if (ImGui::IsItemHovered()) {
-				ImGui::BeginTooltip();
-				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-				ImGui::Text("Disabling this stops shaders from being loaded from disk, as well as stops shaders from being saved to it.");
-				ImGui::PopTextWrapPos();
-				ImGui::EndTooltip();
-			}
-
-			bool useAsync = shaderCache.IsAsync();
-			if (ImGui::Checkbox("Enable Async", &useAsync)) {
-				shaderCache.SetAsync(useAsync);
-			}
-			if (ImGui::IsItemHovered()) {
-				ImGui::BeginTooltip();
-				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-				ImGui::Text("Skips a shader being replaced if it hasn't been compiled yet. Also makes compilation blazingly fast!");
-				ImGui::PopTextWrapPos();
-				ImGui::EndTooltip();
-			}
-		}
-
-		if (ImGui::CollapsingHeader("Replace Original Shaders", ImGuiTreeNodeFlags_DefaultOpen)) {
-			auto state = State::GetSingleton();
-			for (int classIndex = 0; classIndex < RE::BSShader::Type::Total - 1; ++classIndex) {
-				auto type = (RE::BSShader::Type)(classIndex + 1);
-				if (!(SIE::ShaderCache::IsSupportedShader(type) ||
-						// allow all shaders if debug or trace logging
-						(state->GetLogLevel()) <= spdlog::level::debug)) {
-					ImGui::BeginDisabled();
-					ImGui::Checkbox(std::format("{}", magic_enum::enum_name(type)).c_str(), &state->enabledClasses[classIndex]);
-					ImGui::EndDisabled();
-				} else
-					ImGui::Checkbox(std::format("{}", magic_enum::enum_name(type)).c_str(), &state->enabledClasses[classIndex]);
-			}
-		}
-
-		if (ImGui::BeginTabBar("Features", ImGuiTabBarFlags_None)) {
-			for (auto* feature : Feature::GetFeatureList())
-				feature->DrawSettings();
-			ImGui::EndTabBar();
 		}
 	}
+
+	if (ImGui::CollapsingHeader("Advanced", ImGuiTreeNodeFlags_DefaultOpen)) {
+		bool useDump = shaderCache.IsDump();
+		if (ImGui::Checkbox("Dump Shaders", &useDump)) {
+			shaderCache.SetDump(useDump);
+		}
+		if (ImGui::IsItemHovered()) {
+			ImGui::BeginTooltip();
+			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			ImGui::Text("Dump shaders at startup. This should be used only when reversing shaders. Normal users don't need this.");
+			ImGui::PopTextWrapPos();
+			ImGui::EndTooltip();
+		}
+		spdlog::level::level_enum logLevel = State::GetSingleton()->GetLogLevel();
+		const char* items[] = {
+			"trace",
+			"debug",
+			"info",
+			"warn",
+			"err",
+			"critical",
+			"off"
+		};
+		static int item_current = static_cast<int>(logLevel);
+		if (ImGui::Combo("Log Level", &item_current, items, IM_ARRAYSIZE(items))) {
+			ImGui::SameLine();
+			State::GetSingleton()->SetLogLevel(static_cast<spdlog::level::level_enum>(item_current));
+		}
+		if (ImGui::IsItemHovered()) {
+			ImGui::BeginTooltip();
+			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			ImGui::Text("Log level. Trace is most verbose. Default is info.");
+			ImGui::PopTextWrapPos();
+			ImGui::EndTooltip();
+		}
+	}
+	if (ImGui::CollapsingHeader("General", ImGuiTreeNodeFlags_DefaultOpen)) {
+		bool useCustomShaders = shaderCache.IsEnabled();
+		if (ImGui::Checkbox("Enable Shaders", &useCustomShaders)) {
+			shaderCache.SetEnabled(useCustomShaders);
+		}
+		if (ImGui::IsItemHovered()) {
+			ImGui::BeginTooltip();
+			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			ImGui::Text("Disabling this effectively disables all features.");
+			ImGui::PopTextWrapPos();
+			ImGui::EndTooltip();
+		}
+
+		bool useDiskCache = shaderCache.IsDiskCache();
+		if (ImGui::Checkbox("Enable Disk Cache", &useDiskCache)) {
+			shaderCache.SetDiskCache(useDiskCache);
+		}
+		if (ImGui::IsItemHovered()) {
+			ImGui::BeginTooltip();
+			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			ImGui::Text("Disabling this stops shaders from being loaded from disk, as well as stops shaders from being saved to it.");
+			ImGui::PopTextWrapPos();
+			ImGui::EndTooltip();
+		}
+
+		bool useAsync = shaderCache.IsAsync();
+		if (ImGui::Checkbox("Enable Async", &useAsync)) {
+			shaderCache.SetAsync(useAsync);
+		}
+		if (ImGui::IsItemHovered()) {
+			ImGui::BeginTooltip();
+			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			ImGui::Text("Skips a shader being replaced if it hasn't been compiled yet. Also makes compilation blazingly fast!");
+			ImGui::PopTextWrapPos();
+			ImGui::EndTooltip();
+		}
+	}
+
+	if (ImGui::CollapsingHeader("Replace Original Shaders", ImGuiTreeNodeFlags_DefaultOpen)) {
+		auto state = State::GetSingleton();
+		for (int classIndex = 0; classIndex < RE::BSShader::Type::Total - 1; ++classIndex) {
+			auto type = (RE::BSShader::Type)(classIndex + 1);
+			if (!(SIE::ShaderCache::IsSupportedShader(type) ||
+					// allow all shaders if debug or trace logging
+					(state->GetLogLevel()) <= spdlog::level::debug)) {
+				ImGui::BeginDisabled();
+				ImGui::Checkbox(std::format("{}", magic_enum::enum_name(type)).c_str(), &state->enabledClasses[classIndex]);
+				ImGui::EndDisabled();
+			} else
+				ImGui::Checkbox(std::format("{}", magic_enum::enum_name(type)).c_str(), &state->enabledClasses[classIndex]);
+		}
+	}
+
+	if (ImGui::BeginTabBar("Features", ImGuiTabBarFlags_None)) {
+		for (auto* feature : Feature::GetFeatureList())
+			feature->DrawSettings();
+		ImGui::EndTabBar();
+	}
+
 	ImGui::End();
 	ImGuiStyle& style = ImGui::GetStyle();
 	style = oldStyle;

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -198,163 +198,162 @@ void Menu::DrawSettings()
 	SetupImGuiStyle();
 	static bool visible = false;
 
-	ImGui::SetNextWindowSize({ 1024, 1024 }, ImGuiCond_Once);
-	ImGui::Begin(std::format("Skyrim Community Shaders {}", Plugin::VERSION.string(".")).c_str(), &IsEnabled);
+	ImGui::SetNextWindowSize({ 1024, 1024 }, ImGuiCond_FirstUseEver);
+	if (ImGui::Begin(std::format("Skyrim Community Shaders {}", Plugin::VERSION.string(".")).c_str(), &IsEnabled)) {
+		auto& shaderCache = SIE::ShaderCache::Instance();
 
-	auto& shaderCache = SIE::ShaderCache::Instance();
+		if (ImGui::Button("Save Settings")) {
+			State::GetSingleton()->Save();
+		}
 
-	if (ImGui::Button("Save Settings")) {
-		State::GetSingleton()->Save();
-	}
+		ImGui::SameLine();
 
-	ImGui::SameLine();
+		if (ImGui::Button("Load Settings")) {
+			State::GetSingleton()->Load();
+		}
+		ImGui::SameLine();
 
-	if (ImGui::Button("Load Settings")) {
-		State::GetSingleton()->Load();
-	}
-	ImGui::SameLine();
+		if (ImGui::Button("Clear Shader Cache")) {
+			shaderCache.Clear();
+			ScreenSpaceShadows::GetSingleton()->ClearComputeShader();
+		}
+		if (ImGui::IsItemHovered()) {
+			ImGui::BeginTooltip();
+			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			ImGui::Text("The Shader Cache is the collection of compiled shaders which replace the vanilla shaders at runtime.");
+			ImGui::Text("Clearing the shader cache will mean that shaders are recompiled only when the game re-encounters them.");
+			ImGui::Text("This is only needed for hot-loading shaders for development purposes.");
+			ImGui::PopTextWrapPos();
+			ImGui::EndTooltip();
+		}
 
-	if (ImGui::Button("Clear Shader Cache")) {
-		shaderCache.Clear();
-		ScreenSpaceShadows::GetSingleton()->ClearComputeShader();
-	}
-	if (ImGui::IsItemHovered()) {
-		ImGui::BeginTooltip();
-		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-		ImGui::Text("The Shader Cache is the collection of compiled shaders which replace the vanilla shaders at runtime.");
-		ImGui::Text("Clearing the shader cache will mean that shaders are recompiled only when the game re-encounters them.");
-		ImGui::Text("This is only needed for hot-loading shaders for development purposes.");
-		ImGui::PopTextWrapPos();
-		ImGui::EndTooltip();
-	}
+		ImGui::SameLine();
 
-	ImGui::SameLine();
+		if (ImGui::Button("Clear Disk Cache")) {
+			shaderCache.DeleteDiskCache();
+		}
+		if (ImGui::IsItemHovered()) {
+			ImGui::BeginTooltip();
+			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			ImGui::Text("The Disk Cache is a collection of compiled shaders on disk, which are automatically created when shaders are added to the Shader Cache.");
+			ImGui::Text("If you do not have a Disk Cache, or it is outdated or invalid, you will see \"Compiling Shaders\" in the upper-left corner.");
+			ImGui::Text("After this has completed you will no longer see this message apart from when loading from the Disk Cache.");
+			ImGui::Text("Only delete the Disk Cache manually if you are encountering issues.");
+			ImGui::PopTextWrapPos();
+			ImGui::EndTooltip();
+		}
 
-	if (ImGui::Button("Clear Disk Cache")) {
-		shaderCache.DeleteDiskCache();
-	}
-	if (ImGui::IsItemHovered()) {
-		ImGui::BeginTooltip();
-		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-		ImGui::Text("The Disk Cache is a collection of compiled shaders on disk, which are automatically created when shaders are added to the Shader Cache.");
-		ImGui::Text("If you do not have a Disk Cache, or it is outdated or invalid, you will see \"Compiling Shaders\" in the upper-left corner.");
-		ImGui::Text("After this has completed you will no longer see this message apart from when loading from the Disk Cache.");
-		ImGui::Text("Only delete the Disk Cache manually if you are encountering issues.");
-		ImGui::PopTextWrapPos();
-		ImGui::EndTooltip();
-	}
+		ImGui::Spacing();
 
-	ImGui::Spacing();
+		if (ImGui::CollapsingHeader("Menu", ImGuiTreeNodeFlags_DefaultOpen)) {
+			if (settingToggleKey) {
+				ImGui::Text("Press any key to set as toggle key...");
+			} else {
+				ImGui::Text("Toggle Key:");
+				ImGui::SameLine();
+				ImGui::TextColored(ImVec4(1, 1, 0, 1), "%s", KeyIdToString(toggleKey));
 
-	if (ImGui::CollapsingHeader("Menu", ImGuiTreeNodeFlags_DefaultOpen)) {
-		if (settingToggleKey) {
-			ImGui::Text("Press any key to set as toggle key...");
-		} else {
-			ImGui::Text("Toggle Key:");
-			ImGui::SameLine();
-			ImGui::TextColored(ImVec4(1, 1, 0, 1), "%s", KeyIdToString(toggleKey));
-
-			ImGui::SameLine();
-			if (ImGui::Button("Change")) {
-				settingToggleKey = true;
+				ImGui::SameLine();
+				if (ImGui::Button("Change")) {
+					settingToggleKey = true;
+				}
 			}
 		}
+
+		if (ImGui::CollapsingHeader("Advanced", ImGuiTreeNodeFlags_DefaultOpen)) {
+			bool useDump = shaderCache.IsDump();
+			if (ImGui::Checkbox("Dump Shaders", &useDump)) {
+				shaderCache.SetDump(useDump);
+			}
+			if (ImGui::IsItemHovered()) {
+				ImGui::BeginTooltip();
+				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+				ImGui::Text("Dump shaders at startup. This should be used only when reversing shaders. Normal users don't need this.");
+				ImGui::PopTextWrapPos();
+				ImGui::EndTooltip();
+			}
+			spdlog::level::level_enum logLevel = State::GetSingleton()->GetLogLevel();
+			const char* items[] = {
+				"trace",
+				"debug",
+				"info",
+				"warn",
+				"err",
+				"critical",
+				"off"
+			};
+			static int item_current = static_cast<int>(logLevel);
+			if (ImGui::Combo("Log Level", &item_current, items, IM_ARRAYSIZE(items))) {
+				ImGui::SameLine();
+				State::GetSingleton()->SetLogLevel(static_cast<spdlog::level::level_enum>(item_current));
+			}
+			if (ImGui::IsItemHovered()) {
+				ImGui::BeginTooltip();
+				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+				ImGui::Text("Log level. Trace is most verbose. Default is info.");
+				ImGui::PopTextWrapPos();
+				ImGui::EndTooltip();
+			}
+		}
+		if (ImGui::CollapsingHeader("General", ImGuiTreeNodeFlags_DefaultOpen)) {
+			bool useCustomShaders = shaderCache.IsEnabled();
+			if (ImGui::Checkbox("Enable Shaders", &useCustomShaders)) {
+				shaderCache.SetEnabled(useCustomShaders);
+			}
+			if (ImGui::IsItemHovered()) {
+				ImGui::BeginTooltip();
+				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+				ImGui::Text("Disabling this effectively disables all features.");
+				ImGui::PopTextWrapPos();
+				ImGui::EndTooltip();
+			}
+
+			bool useDiskCache = shaderCache.IsDiskCache();
+			if (ImGui::Checkbox("Enable Disk Cache", &useDiskCache)) {
+				shaderCache.SetDiskCache(useDiskCache);
+			}
+			if (ImGui::IsItemHovered()) {
+				ImGui::BeginTooltip();
+				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+				ImGui::Text("Disabling this stops shaders from being loaded from disk, as well as stops shaders from being saved to it.");
+				ImGui::PopTextWrapPos();
+				ImGui::EndTooltip();
+			}
+
+			bool useAsync = shaderCache.IsAsync();
+			if (ImGui::Checkbox("Enable Async", &useAsync)) {
+				shaderCache.SetAsync(useAsync);
+			}
+			if (ImGui::IsItemHovered()) {
+				ImGui::BeginTooltip();
+				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+				ImGui::Text("Skips a shader being replaced if it hasn't been compiled yet. Also makes compilation blazingly fast!");
+				ImGui::PopTextWrapPos();
+				ImGui::EndTooltip();
+			}
+		}
+
+		if (ImGui::CollapsingHeader("Replace Original Shaders", ImGuiTreeNodeFlags_DefaultOpen)) {
+			auto state = State::GetSingleton();
+			for (int classIndex = 0; classIndex < RE::BSShader::Type::Total - 1; ++classIndex) {
+				auto type = (RE::BSShader::Type)(classIndex + 1);
+				if (!(SIE::ShaderCache::IsSupportedShader(type) ||
+						// allow all shaders if debug or trace logging
+						(state->GetLogLevel()) <= spdlog::level::debug)) {
+					ImGui::BeginDisabled();
+					ImGui::Checkbox(std::format("{}", magic_enum::enum_name(type)).c_str(), &state->enabledClasses[classIndex]);
+					ImGui::EndDisabled();
+				} else
+					ImGui::Checkbox(std::format("{}", magic_enum::enum_name(type)).c_str(), &state->enabledClasses[classIndex]);
+			}
+		}
+
+		if (ImGui::BeginTabBar("Features", ImGuiTabBarFlags_None)) {
+			for (auto* feature : Feature::GetFeatureList())
+				feature->DrawSettings();
+			ImGui::EndTabBar();
+		}
 	}
-
-	if (ImGui::CollapsingHeader("Advanced", ImGuiTreeNodeFlags_DefaultOpen)) {
-		bool useDump = shaderCache.IsDump();
-		if (ImGui::Checkbox("Dump Shaders", &useDump)) {
-			shaderCache.SetDump(useDump);
-		}
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-			ImGui::Text("Dump shaders at startup. This should be used only when reversing shaders. Normal users don't need this.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
-		}
-		spdlog::level::level_enum logLevel = State::GetSingleton()->GetLogLevel();
-		const char* items[] = {
-			"trace",
-			"debug",
-			"info",
-			"warn",
-			"err",
-			"critical",
-			"off"
-		};
-		static int item_current = static_cast<int>(logLevel);
-		if (ImGui::Combo("Log Level", &item_current, items, IM_ARRAYSIZE(items))) {
-			ImGui::SameLine();
-			State::GetSingleton()->SetLogLevel(static_cast<spdlog::level::level_enum>(item_current));
-		}
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-			ImGui::Text("Log level. Trace is most verbose. Default is info.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
-		}
-	}
-	if (ImGui::CollapsingHeader("General", ImGuiTreeNodeFlags_DefaultOpen)) {
-		bool useCustomShaders = shaderCache.IsEnabled();
-		if (ImGui::Checkbox("Enable Shaders", &useCustomShaders)) {
-			shaderCache.SetEnabled(useCustomShaders);
-		}
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-			ImGui::Text("Disabling this effectively disables all features.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
-		}
-
-		bool useDiskCache = shaderCache.IsDiskCache();
-		if (ImGui::Checkbox("Enable Disk Cache", &useDiskCache)) {
-			shaderCache.SetDiskCache(useDiskCache);
-		}
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-			ImGui::Text("Disabling this stops shaders from being loaded from disk, as well as stops shaders from being saved to it.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
-		}
-
-		bool useAsync = shaderCache.IsAsync();
-		if (ImGui::Checkbox("Enable Async", &useAsync)) {
-			shaderCache.SetAsync(useAsync);
-		}
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-			ImGui::Text("Skips a shader being replaced if it hasn't been compiled yet. Also makes compilation blazingly fast!");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
-		}
-	}
-
-	if (ImGui::CollapsingHeader("Replace Original Shaders", ImGuiTreeNodeFlags_DefaultOpen)) {
-		auto state = State::GetSingleton();
-		for (int classIndex = 0; classIndex < RE::BSShader::Type::Total - 1; ++classIndex) {
-			auto type = (RE::BSShader::Type)(classIndex + 1);
-			if (!(SIE::ShaderCache::IsSupportedShader(type) ||
-					// allow all shaders if debug or trace logging
-					(state->GetLogLevel()) <= spdlog::level::debug)) {
-				ImGui::BeginDisabled();
-				ImGui::Checkbox(std::format("{}", magic_enum::enum_name(type)).c_str(), &state->enabledClasses[classIndex]);
-				ImGui::EndDisabled();
-			} else
-				ImGui::Checkbox(std::format("{}", magic_enum::enum_name(type)).c_str(), &state->enabledClasses[classIndex]);
-		}
-	}
-
-	if (ImGui::BeginTabBar("Features", ImGuiTabBarFlags_None)) {
-		for (auto* feature : Feature::GetFeatureList())
-			feature->DrawSettings();
-		ImGui::EndTabBar();
-	}
-
 	ImGui::End();
 	ImGuiStyle& style = ImGui::GetStyle();
 	style = oldStyle;

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -6,9 +6,9 @@
 #include <d3dcompiler.h>
 #include <wrl/client.h>
 
-#include "State.h"
 #include "Features/GrassCollision.h"
 #include "Features/ScreenSpaceShadows.h"
+#include "State.h"
 
 namespace SIE
 {
@@ -103,7 +103,7 @@ namespace SIE
 				++defines;
 			}
 
-			if (ScreenSpaceShadows::GetSingleton()->enabledFeature) {
+			if (ScreenSpaceShadows::GetSingleton()->loaded) {
 				defines[0] = { "SCREEN_SPACE_SHADOWS", nullptr };
 				++defines;
 			}
@@ -152,7 +152,7 @@ namespace SIE
 				++defines;
 			}
 
-			if (ScreenSpaceShadows::GetSingleton()->enabledFeature) {
+			if (ScreenSpaceShadows::GetSingleton()->loaded) {
 				defines[0] = { "SCREEN_SPACE_SHADOWS", nullptr };
 				++defines;
 			}
@@ -265,13 +265,12 @@ namespace SIE
 				++defines;
 			}
 
-			if (GrassCollision::GetSingleton()->enabledFeature)
-			{
-				defines[0] = { "GRASS_COLLISION", nullptr };		
+			if (GrassCollision::GetSingleton()->loaded) {
+				defines[0] = { "GRASS_COLLISION", nullptr };
 				++defines;
 			}
 
-			if (ScreenSpaceShadows::GetSingleton()->enabledFeature) {
+			if (ScreenSpaceShadows::GetSingleton()->loaded) {
 				defines[0] = { "SCREEN_SPACE_SHADOWS", nullptr };
 				++defines;
 			}

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -7,10 +7,6 @@
 
 #include "Feature.h"
 #include "Features/Clustered.h"
-// #include "Features/GrassLighting.h"
-// #include "Features/DistantTreeLighting.h"
-// #include "Features/GrassCollision.h"
-// #include "Features/ScreenSpaceShadows.h"
 
 void State::Draw()
 {


### PR DESCRIPTION
Note:
- Compiled and tested this time;
- Duplicate version strings, `ValidateCache` and `WriteDiskCacheInfo` implementations are eliminated; `Load` is simplified;
- I refrained from using templates, otherwise singletons and settings I/O may be interfaced;
- `enabled` and `enabledFeature` are unified into `loaded`, as that is what the logger says. Except for `ScreenSpaceShadows`, It has both;
- Feature names. You may further combine `GetName` and `GetIniName` since they're the same in all cases. Even more agressive, deduce ini filenames from the name by eliminating space and hyphens.
- Totally public feature classes are structs now;
- All features are contained within a vector, obtained with `Feature::GetFeatureList()`. The list order implies function call orders.
- `Clustered` is untouched since it is unfinished;
- The formatting is all over the place. I did have clang-format this time though.