### PR TITLE
fix: reenable controls when mouse closes menu

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -214,9 +214,6 @@ RE::BSEventNotifyControl Menu::ProcessEvent(RE::InputEvent* const* a_event, RE::
 						settingToggleKey = false;
 					} else if (key == toggleKey) {
 						IsEnabled = !IsEnabled;
-						if (const auto controlMap = RE::ControlMap::GetSingleton()) {
-							controlMap->GetRuntimeData().ignoreKeyboardMouse = IsEnabled;
-						}
 					}
 				}
 
@@ -241,6 +238,9 @@ RE::BSEventNotifyControl Menu::ProcessEvent(RE::InputEvent* const* a_event, RE::
 				break;
 			default:
 				continue;
+			}
+			if (const auto controlMap = RE::ControlMap::GetSingleton()) {
+				controlMap->GetRuntimeData().ignoreKeyboardMouse = IsEnabled;
 			}
 		}
 	}


### PR DESCRIPTION
Imgui will disable the IsEnabled boolean automatically on window close. On detecting any control input, this will always sync the controller state to the window state.

closes #15