### PR TITLE
WIP: VR SSS work 

### DIFF
--- a/features/Grass Lighting/Shaders/RunGrass.hlsl
+++ b/features/Grass Lighting/Shaders/RunGrass.hlsl
@@ -487,7 +487,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	dirLightColor *= shadowColor.x;
 
 #		if defined(SCREEN_SPACE_SHADOWS)
-	float dirLightSShadow = PrepassScreenSpaceShadows(input.WorldPosition, eyeOffset);
+	float dirLightSShadow = PrepassScreenSpaceShadows(input.WorldPosition, eyeIndex);
 	dirLightColor *= dirLightSShadow;
 #		endif  // !SCREEN_SPACE_SHADOWS
 

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/Common.hlsl
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/Common.hlsl
@@ -1,0 +1,61 @@
+#include "../Common/VR.hlsl"
+cbuffer PerFrame : register(b0)
+{
+	float2 BufferDim;
+	float2 RcpBufferDim;
+	float4x4 ProjMatrix[2];
+	float4x4 InvProjMatrix[2];
+	float4 DynamicRes;
+	float4 InvDirLightDirectionVS[2];
+	float ShadowDistance;
+	uint MaxSamples;
+	float FarDistanceScale;
+	float FarThicknessScale;
+	float FarHardness;
+	float NearDistance;
+	float NearThickness;
+	float NearHardness;
+	float BlurRadius;
+	float BlurDropoff;
+};
+RWTexture2D<float> OcclusionRW : register(u0);
+
+SamplerState LinearSampler : register(s0);
+Texture2D<float> DepthTexture : register(t0);
+
+// Get a raw depth from the depth buffer.
+float GetDepth(float2 uv)
+{
+	// #ifdef VR
+	// 	uv = ConvertToVRUV(uv);
+	// #else
+	// 	uv = uv;
+	// #endif  // VR
+	// effects like screen space shadows, can get artefacts if a point sampler is used
+	return DepthTexture.SampleLevel(LinearSampler, uv * DynamicRes.xy, 0).r;
+}
+
+// Inverse project UV + raw depth into the view space.
+float3 InverseProjectUVZ(float2 uv, float z, uint a_eyeIndex = 0)
+{
+	uv.y = 1 - uv.y;
+	float4 cp = float4(float3(uv, z) * 2 - 1, 1);  // convert uv [0,1] to [-1, 1]
+	float4 vp = mul(InvProjMatrix[a_eyeIndex], cp);
+	return float3(vp.xy, vp.z) / vp.w;
+}
+
+float3 InverseProjectUV(float2 uv, uint a_eyeIndex = 0)
+{
+	return InverseProjectUVZ(uv, GetDepth(uv), a_eyeIndex);
+}
+
+float2 ViewToUV(float3 x, bool is_position = true, uint a_eyeIndex = 0)
+{
+	float4 uv = mul(ProjMatrix[a_eyeIndex], float4(x, (float)is_position));
+	uv.xy /= uv.w;                            // normalize
+	uv.xy = uv * float2(0.5f, -0.5f) + 0.5f;  // convert from [-1,1] to [0,1]
+	return uv.xy;
+}
+
+bool IsSaturated(float value) { return value == saturate(value); }
+bool IsSaturated(float2 value) { return IsSaturated(value.x) && IsSaturated(value.y); }

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/FilterCS.hlsl
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/FilterCS.hlsl
@@ -1,4 +1,4 @@
-
+#include "Common.hlsl"
 // Copyright (C) 2019-2022 Alessio Tamburini (aletamburini78@gmail.com) AKA Alenet
 // All rights reserved.
 
@@ -27,51 +27,7 @@
 
 // HAVE FUN!
 
-RWTexture2D<float> OcclusionRW : register(u0);
-
-SamplerState LinearSampler : register(s0);
-
-Texture2D<float4> DepthTexture : register(t0);
 Texture2D<float> OcclusionTexture : register(t1);
-
-cbuffer PerFrame : register(b0)
-{
-	float2 BufferDim;
-	float2 RcpBufferDim;
-	float4x4 ProjMatrix;
-	float4x4 InvProjMatrix;
-	float4 DynamicRes;
-	float4 InvDirLightDirectionVS;
-	float ShadowDistance;
-	uint MaxSamples;
-	float FarDistanceScale;
-	float FarThicknessScale;
-	float FarHardness;
-	float NearDistance;
-	float NearThickness;
-	float NearHardness;
-	float BlurRadius;
-	float BlurDropoff;
-};
-
-float GetDepth(float2 uv)
-{
-	return DepthTexture.SampleLevel(LinearSampler, uv, 0).r;
-}
-
-// Inverse project UV + raw depth into the view space.
-float3 InverseProjectUVZ(float2 uv, float z)
-{
-	uv.y = 1 - uv.y;
-	float4 cp = float4(float3(uv, z) * 2 - 1, 1);
-	float4 vp = mul(InvProjMatrix, cp);
-	return float3(vp.xy, vp.z) / vp.w;
-}
-
-float3 InverseProjectUV(float2 uv)
-{
-	return InverseProjectUVZ(uv, GetDepth(uv));
-}
 
 #define cKernelSize 12
 
@@ -105,9 +61,8 @@ static const float2 BlurOffsets[cKernelSize] = {
 	float2(6.0f, 6.0f)
 };
 
-[numthreads(32, 32, 1)] void main(uint3 DTid
-								  : SV_DispatchThreadID) {
-
+float FilterCS(uint3 DTid, float2 TexCoord, float startDepth, uint a_eyeIndex = 0)
+{
 #if defined(HORIZONTAL)
 	float2 OffsetMask = float2(1.0f, 0.0f);
 #elif defined(VERTICAL)
@@ -116,16 +71,10 @@ static const float2 BlurOffsets[cKernelSize] = {
 #	error "Must define an axis!"
 #endif
 
-	float2 TexCoord = (DTid.xy + 0.5) * RcpBufferDim;
-
-	float startDepth = GetDepth(TexCoord * 2);
-	if (startDepth >= 1)
-		return;
-
 	float WeightSum = 0.114725602f;
 	float color1 = OcclusionTexture.SampleLevel(LinearSampler, TexCoord * 2, 0).r * WeightSum;
 
-	float depth1 = InverseProjectUVZ(TexCoord * 2, startDepth).z;
+	float depth1 = InverseProjectUVZ(TexCoord, startDepth, a_eyeIndex).z;
 
 	float depthDrop = depth1 * BlurDropoff;
 
@@ -137,7 +86,7 @@ static const float2 BlurOffsets[cKernelSize] = {
 		float2 uv = TexCoord + (BlurOffsets[i] * OffsetMask * RcpBufferDim / 2) * BlurRadius;
 #endif
 		float4 color2 = OcclusionTexture.SampleLevel(LinearSampler, uv * 2, 0).r;
-		float depth2 = InverseProjectUV(uv * 2).z;
+		float depth2 = InverseProjectUV(uv * 2, a_eyeIndex).z;
 
 		// Depth-awareness
 		float awareness = saturate(depthDrop - abs(depth1 - depth2));
@@ -146,5 +95,22 @@ static const float2 BlurOffsets[cKernelSize] = {
 		WeightSum += BlurWeights[i] * awareness;
 	}
 	color1 /= WeightSum;
-	OcclusionRW[DTid.xy] = color1;
+	return color1;
+}
+
+[numthreads(32, 32, 1)] void main(uint3 DTid           // [pixels]
+								  : SV_DispatchThreadID) {
+	float2 TexCoord = (DTid.xy + 0.5) * RcpBufferDim;  // convert to [0,1]
+
+#ifdef VR
+	uint eyeIndex = (DTid.x * RcpBufferDim.x >= 0.5) ? 1 : 0;
+#else
+	uint eyeIndex = 0;
+#endif  // VR
+
+	float startDepth = GetDepth(TexCoord * 2);
+	if (startDepth >= 1)
+		return;
+
+	OcclusionRW[DTid.xy] = FilterCS(DTid, TexCoord, startDepth, eyeIndex);
 }

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/FilterCS.hlsl
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/FilterCS.hlsl
@@ -98,7 +98,7 @@ float FilterCS(uint3 DTid, float2 TexCoord, float startDepth, uint a_eyeIndex = 
 	return color1;
 }
 
-[numthreads(32, 32, 1)] void main(uint3 DTid           // [pixels]
+[numthreads(32, 32, 1)] void main(uint3 DTid  // [pixels]
 								  : SV_DispatchThreadID) {
 	float2 TexCoord = (DTid.xy + 0.5) * RcpBufferDim;  // convert to [0,1]
 

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/RaymarchCS.hlsl
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/RaymarchCS.hlsl
@@ -1,59 +1,5 @@
-RWTexture2D<float> OcclusionRW : register(u0);
-
-SamplerState LinearSampler : register(s0);
-
-Texture2D<float> DepthTexture : register(t0);
+#include "Common.hlsl"
 Texture2D<float> ShadowTexture : register(t1);
-
-cbuffer PerFrame : register(b0)
-{
-	float2 BufferDim;
-	float2 RcpBufferDim;
-	float4x4 ProjMatrix;
-	float4x4 InvProjMatrix;
-	float4 DynamicRes;
-	float4 InvDirLightDirectionVS;
-	float ShadowDistance;
-	uint MaxSamples;
-	float FarDistanceScale;
-	float FarThicknessScale;
-	float FarHardness;
-	float NearDistance;
-	float NearThickness;
-	float NearHardness;
-	float BlurRadius;
-	float BlurDropoff;
-};
-
-bool IsSaturated(float value) { return value == saturate(value); }
-bool IsSaturated(float2 value) { return IsSaturated(value.x) && IsSaturated(value.y); }
-
-// Get a raw depth from the depth buffer.
-float GetDepth(float2 uv)
-{
-	// effects like screen space shadows, can get artefacts if a point sampler is used
-	return DepthTexture.SampleLevel(LinearSampler, uv * DynamicRes.xy, 0).r;
-}
-
-float2 ViewToUV(float3 x, bool is_position = true)
-{
-	float4 uv = mul(ProjMatrix, float4(x, (float)is_position));
-	return (uv.xy / uv.w) * float2(0.5f, -0.5f) + 0.5f;
-}
-
-// Inverse project UV + raw depth into the view space.
-float3 InverseProjectUVZ(float2 uv, float z)
-{
-	uv.y = 1 - uv.y;
-	float4 cp = float4(float3(uv, z) * 2 - 1, 1);
-	float4 vp = mul(InvProjMatrix, cp);
-	return float3(vp.xy, vp.z) / vp.w;
-}
-
-float3 InverseProjectUV(float2 uv)
-{
-	return InverseProjectUVZ(uv, GetDepth(uv));
-}
 
 // https://www.shadertoy.com/view/Xt23zV
 float smoothbumpstep(float edge0, float edge1, float x)
@@ -69,7 +15,7 @@ float InterleavedGradientNoise(float2 uv)
 	return frac(magic.z * frac(dot(uv, magic.xy)));
 }
 
-float ScreenSpaceShadowsUV(float2 texcoord, float3 lightDirectionVS)
+float ScreenSpaceShadowsUV(float2 texcoord, float3 lightDirectionVS, uint a_eyeIndex = 0)
 {
 	// Ignore the sky
 	float startDepth = GetDepth(texcoord);
@@ -77,7 +23,7 @@ float ScreenSpaceShadowsUV(float2 texcoord, float3 lightDirectionVS)
 		return 1;
 
 	// Compute ray position in view-space
-	float3 rayPos = InverseProjectUVZ(texcoord, startDepth);
+	float3 rayPos = InverseProjectUVZ(texcoord, startDepth, a_eyeIndex);
 
 	// Blends effect variables between near, mid and far field
 	float blendFactorFar = smoothstep(ShadowDistance / 3, ShadowDistance / 2, rayPos.z);
@@ -111,14 +57,14 @@ float ScreenSpaceShadowsUV(float2 texcoord, float3 lightDirectionVS)
 
 		// Step the ray
 		rayPos += rayStep;
-		rayUV = ViewToUV(rayPos);
+		rayUV = ViewToUV(rayPos, true, a_eyeIndex);
 
 		// Ensure the UV coordinates are inside the screen
 		if (!IsSaturated(rayUV))
 			break;
 
 		// Compute the difference between the ray's and the camera's depth
-		float rayDepth = InverseProjectUV(rayUV).z;
+		float rayDepth = InverseProjectUV(rayUV, a_eyeIndex).z;
 
 		// Difference between the current ray distance and the marched light
 		float depthDelta = rayPos.z - rayDepth;
@@ -144,5 +90,12 @@ float ScreenSpaceShadowsUV(float2 texcoord, float3 lightDirectionVS)
 [numthreads(32, 32, 1)] void main(uint3 DTid
 								  : SV_DispatchThreadID) {
 	float2 TexCoord = (DTid.xy + 0.5) * RcpBufferDim * DynamicRes.zw;
-	OcclusionRW[DTid.xy] = ScreenSpaceShadowsUV(TexCoord, InvDirLightDirectionVS);
+
+#ifdef VR
+	uint eyeIndex = (TexCoord.x >= 0.5) ? 1 : 0;
+#else
+	uint eyeIndex = 0;
+#endif  // VR
+
+	OcclusionRW[DTid.xy] = ScreenSpaceShadowsUV(TexCoord, InvDirLightDirectionVS[eyeIndex].xyz, eyeIndex);
 }

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/ShadowsPS.hlsli
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/ShadowsPS.hlsli
@@ -18,14 +18,19 @@ float2 SSGetDynamicResolutionAdjustedScreenPosition(float2 uv)
 	return uv * DynamicResolutionParams1.xy;
 }
 
-float PrepassScreenSpaceShadows(float3 positionWS, uint eyeIndex = 0)
+float PrepassScreenSpaceShadows(float3 positionWS, uint a_eyeIndex = 0)
 {
 #if defined(EYE)
 	return 1;
 #else
 	if (EnableSSS) {
-		float2 texCoord = ViewToUV(WorldToView(positionWS, true, eyeIndex), true, eyeIndex);
+		float2 texCoord = ViewToUV(WorldToView(positionWS, true, a_eyeIndex), true, a_eyeIndex);
 		float2 coords = SSGetDynamicResolutionAdjustedScreenPosition(texCoord) / 2;
+#	ifdef VR
+		// X coordinate is further shifted because VR uav is split between left and right eye.
+		// So X in [0, .5] is the left eye and [.5, 1] is the right eye
+		coords.x = (coords.x + (a_eyeIndex * .5)) / 2;
+#	endif
 		float shadow = TexOcclusionSampler.SampleLevel(LinearSampler, coords, 0);
 		return shadow;
 	}

--- a/package/Shaders/Common/VR.hlsl
+++ b/package/Shaders/Common/VR.hlsl
@@ -1,22 +1,22 @@
-/*
-* Multiply for matrixes that will use an a_eyeIndex.
-* This uses a standard mul if in flat
-*
-* @param a_matrix The matrix to multiple against
-* @param a_vector The vector to multiply
-* @param a_eyeIndex The a_eyeIndex, normally 0 for flat
-* @return The result of a mul that works in VR with eyeindex
+/**
+ Converts uv to the eye specific uv.
+
+In VR, texture buffers include the lef tand right eye in the same buffer. 
+This means the x value [0, .5] represents the left eye, and the y value (.5, 1] are the right eye.
+
+This returns the adjusted value
+
+@param uv - uv coords [0,1]
+@param a_eyeIndex The eyeIndex; 0 is left, 1 is right
+@returns adjused uv coords for the VR texture buffer
 */
-float4 NG_mul(float4x4 a_matrix, float4 a_vector, uint a_eyeIndex = 0)
+float2 ConvertToVRUV(float2 uv)
 {
-#if !defined(VR)
-	float4 result = mul(a_matrix, a_vector);
-#else
-	float4 result;
-	result.x = dot(a_matrix[a_eyeIndex + 0].xyzw, a_vector.xyzw);
-	result.y = dot(a_matrix[a_eyeIndex + 1].xyzw, a_vector.xyzw);
-	result.z = dot(a_matrix[a_eyeIndex + 2].xyzw, a_vector.xyzw);
-	result.w = dot(a_matrix[a_eyeIndex + 3].xyzw, a_vector.xyzw);
-#endif  // VR
-	return result;
+#ifdef VR
+	if (uv.x >= .5)
+		uv.x = (uv.x / 2 + .5);  // Right Eye: [0, 1] -> [.5,1];
+	else
+		uv.x = uv.x / 2;         //	Left Eye: [0, 1] -> [0,.5],
+#endif
+	return uv;
 }

--- a/package/Shaders/Common/VR.hlsl
+++ b/package/Shaders/Common/VR.hlsl
@@ -16,7 +16,7 @@ float2 ConvertToVRUV(float2 uv)
 	if (uv.x >= .5)
 		uv.x = (uv.x / 2 + .5);  // Right Eye: [0, 1] -> [.5,1];
 	else
-		uv.x = uv.x / 2;         //	Left Eye: [0, 1] -> [0,.5],
+		uv.x = uv.x / 2;  //	Left Eye: [0, 1] -> [0,.5],
 #endif
 	return uv;
 }

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1590,7 +1590,7 @@ PS_OUTPUT main(PS_INPUT input)
 #	endif  // defined (DEFSHADOW) && defined (SHADOW_DIR)
 
 #	if defined(SCREEN_SPACE_SHADOWS)
-	float dirLightSShadow = PrepassScreenSpaceShadows(input.WorldPosition.xyz);
+	float dirLightSShadow = PrepassScreenSpaceShadows(input.WorldPosition.xyz, eyeIndex);
 	dirLightColor *= dirLightSShadow;
 #	endif  // SCREEN_SPACE_SHADOWS
 

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -259,12 +259,12 @@ cbuffer PerMaterial : register(b1)
 	float4 ShallowColor : packoffset(c0);
 	float4 DeepColor : packoffset(c1);
 	float4 ReflectionColor : packoffset(c2);
-	float4 FresnelRI : packoffset(c3);      // Fresnel amount in x, specular power in z
-	float4 BlendRadius : packoffset(c4);    // flowmap scale in y, specular radius in z
-	float4 VarAmounts : packoffset(c5);     // Sun specular power in x, reflection amount in y, alpha in z, refraction magnitude in w
+	float4 FresnelRI : packoffset(c3);    // Fresnel amount in x, specular power in z
+	float4 BlendRadius : packoffset(c4);  // flowmap scale in y, specular radius in z
+	float4 VarAmounts : packoffset(c5);   // Sun specular power in x, reflection amount in y, alpha in z, refraction magnitude in w
 	float4 NormalsAmplitude : packoffset(c6);
-	float4 WaterParams : packoffset(c7);    // noise falloff in x, reflection magnitude in y, sun sparkle power in z, framebuffer range in w
-	float4 FogNearColor : packoffset(c8);   // above water fog amount in w
+	float4 WaterParams : packoffset(c7);   // noise falloff in x, reflection magnitude in y, sun sparkle power in z, framebuffer range in w
+	float4 FogNearColor : packoffset(c8);  // above water fog amount in w
 	float4 FogFarColor : packoffset(c9);
 	float4 FogParam : packoffset(c10);      // above water fog distance far in z, above water fog range in w
 	float4 DepthControl : packoffset(c11);  // depth reflections factor in x, depth refractions factor in y, depth normals factor in z, depth specular lighting factor in w
@@ -350,7 +350,7 @@ float3 GetWaterNormal(PS_INPUT input, float distanceFactor, float normalsDepthFa
 #		else
 	float3 finalNormal =
 		normalize(float3(0, 0, 1) + NormalsAmplitude.xxx * normals1);
-#		endif      // defined (FLOWMAP) && !defined(BLEND_NORMALS)
+#		endif  // defined (FLOWMAP) && !defined(BLEND_NORMALS)
 
 #		if defined(WADING)
 #			if defined(FLOWMAP)
@@ -502,7 +502,7 @@ float3 GetSunColor(float3 normal, float3 viewDirection)
 	return (reflectionMul * sunDirection) * DeepColor.w + WaterParams.z * (sunMul * sunDirection);
 #		endif  // defined(INTERIOR) || defined(UNDERWATER)
 }
-#	endif      // defined (FLOWMAP) && !defined(BLEND_NORMALS)
+#	endif  // defined (FLOWMAP) && !defined(BLEND_NORMALS)
 
 #	if defined(WATER_BLENDING)
 #		include "WaterBlending/WaterBlending.hlsli"
@@ -613,10 +613,10 @@ PS_OUTPUT main(PS_INPUT input)
 		}
 #				endif  // VERTEX_ALPHA_DEPTH
 	}
-#			endif      // DEPTH
-#		endif          // WATER_BLENDING
+#			endif  // DEPTH
+#		endif      // WATER_BLENDING
 
-#	endif              // defined(SPECULAR) && (NUM_SPECULAR_LIGHTS != 0)
+#	endif  // defined(SPECULAR) && (NUM_SPECULAR_LIGHTS != 0)
 
 #	if defined(STENCIL)
 	float3 viewDirection = normalize(input.WorldPosition.xyz);

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -3,7 +3,7 @@
 
 #if defined(VERTEX_ALPHA_DEPTH)
 #	define VC
-#endif
+#endif  // VERTEX_ALPHA_DEPTH
 
 struct VS_INPUT
 {
@@ -11,18 +11,18 @@ struct VS_INPUT
 	float4 Position : POSITION0;
 #	if defined(NORMAL_TEXCOORD)
 	float2 TexCoord0 : TEXCOORD0;
-#	endif
+#	endif  // NORMAL_TEXCOORD
 #	if defined(VC)
 	float4 Color : COLOR0;
-#	endif
-#endif
+#	endif  // VC
+#endif      // defined(SPECULAR) || defined(UNDERWATER) || defined(STENCIL) || defined(SIMPLE)
 
 #if defined(LOD)
 	float4 Position : POSITION0;
 #	if defined(VC)
 	float4 Color : COLOR0;
-#	endif
-#endif
+#	endif  // VC
+#endif      // LOD
 };
 
 struct VS_OUTPUT
@@ -35,14 +35,14 @@ struct VS_OUTPUT
 	float4 TexCoord2 : TEXCOORD2;
 #	if defined(WADING) || (defined(FLOWMAP) && (defined(REFRACTIONS) || defined(BLEND_NORMALS))) || (defined(VERTEX_ALPHA_DEPTH) && defined(VC)) || ((defined(SPECULAR) && NUM_SPECULAR_LIGHTS == 0) && defined(FLOWMAP) /*!defined(NORMAL_TEXCOORD) && !defined(BLEND_NORMALS) && !defined(VC)*/)
 	float4 TexCoord3 : TEXCOORD3;
-#	endif
+#	endif  // defined(WADING) || (defined(FLOWMAP) && (defined(REFRACTIONS) || defined(BLEND_NORMALS))) || (defined(VERTEX_ALPHA_DEPTH) && defined(VC)) || ((defined(SPECULAR) && NUM_SPECULAR_LIGHTS == 0) && defined(FLOWMAP)
 #	if defined(FLOWMAP)
 	nointerpolation float TexCoord4 : TEXCOORD4;
-#	endif
+#	endif  // FLOWMAP
 #	if NUM_SPECULAR_LIGHTS == 0
 	float4 MPosition : TEXCOORD5;
-#	endif
-#endif
+#	endif  // NUM_SPECULAR_LIGHTS == 0
+#endif      // defined(SPECULAR) || defined(UNDERWATER)
 
 #if defined(SIMPLE)
 	float4 HPosition : SV_POSITION0;
@@ -51,20 +51,20 @@ struct VS_OUTPUT
 	float4 TexCoord1 : TEXCOORD1;
 	float4 TexCoord2 : TEXCOORD2;
 	float4 MPosition : TEXCOORD5;
-#endif
+#endif  // SIMPLE
 
 #if defined(LOD)
 	float4 HPosition : SV_POSITION0;
 	float4 FogParam : COLOR0;
 	float4 WPosition : TEXCOORD0;
 	float4 TexCoord1 : TEXCOORD1;
-#endif
+#endif  // LOD
 
 #if defined(STENCIL)
 	float4 HPosition : SV_POSITION0;
 	float4 WorldPosition : POSITION1;
 	float4 PreviousWorldPosition : POSITION2;
-#endif
+#endif  // STENCIL
 };
 
 #ifdef VSHADER
@@ -98,8 +98,8 @@ VS_OUTPUT main(VS_INPUT input)
 	VS_OUTPUT vsout;
 
 	float4 inputPosition = float4(input.Position.xyz, 1.0);
-	float4 worldPos = mul(World, inputPosition);
-	float4 worldViewPos = mul(WorldViewProj, inputPosition);
+	float4 worldPos = mul(World[eyeIndex], inputPosition);
+	float4 worldViewPos = mul(WorldViewProj[eyeIndex], inputPosition);
 
 	float heightMult = min((1.0 / 10000.0) * max(worldViewPos.z - 70000, 0), 1);
 
@@ -109,7 +109,7 @@ VS_OUTPUT main(VS_INPUT input)
 
 #	if defined(STENCIL)
 	vsout.WorldPosition = worldPos;
-	vsout.PreviousWorldPosition = mul(PreviousWorld, inputPosition);
+	vsout.PreviousWorldPosition = mul(PreviousWorld[eyeIndex], inputPosition);
 #	else
 	float fogColorParam = min(VSFogFarColor.w,
 		pow(saturate(length(worldViewPos.xyz) * VSFogParam.y - VSFogParam.x), NormalsScale.w));
@@ -127,7 +127,7 @@ VS_OUTPUT main(VS_INPUT input)
 #		else
 #			if !defined(SPECULAR) || (NUM_SPECULAR_LIGHTS == 0)
 	vsout.MPosition.xyzw = inputPosition.xyzw;
-#			endif
+#			endif  // !defined(SPECULAR) || (NUM_SPECULAR_LIGHTS == 0)
 
 	float2 posAdjust = worldPos.xy + QPosAdjust.xy;
 
@@ -149,8 +149,8 @@ VS_OUTPUT main(VS_INPUT input)
 		scrollAdjust2 = 0.0;
 		scrollAdjust3 = 0.0;
 	}
-#				endif
-#			endif
+#				endif  // NORMAL_TEXCOORD
+#			endif      // !(defined(FLOWMAP) && (defined(REFRACTIONS) || defined(BLEND_NORMALS) || defined(DEPTH) || NUM_SPECULAR_LIGHTS == 0))
 
 	vsout.TexCoord1 = 0.0;
 	vsout.TexCoord2 = 0.0;
@@ -164,8 +164,8 @@ VS_OUTPUT main(VS_INPUT input)
 	vsout.TexCoord1.xy = NormalsScroll0.xy + scrollAdjust1;
 	vsout.TexCoord1.zw = 0.0;
 	vsout.TexCoord2.xy = 0.0;
-#					endif
-#				endif
+#					endif  // BLEND_NORMALS
+#				endif      // !(((defined(SPECULAR) || NUM_SPECULAR_LIGHTS == 0) || (defined(UNDERWATER) && defined(REFRACTIONS))) && !defined(NORMAL_TEXCOORD))
 #				if !defined(NORMAL_TEXCOORD)
 	vsout.TexCoord3 = 0.0;
 #				elif defined(WADING)
@@ -177,7 +177,7 @@ VS_OUTPUT main(VS_INPUT input)
 	vsout.TexCoord2.zw = (CellTexCoordOffset.xy + input.TexCoord0.xy) / ObjectUV.xx;
 	vsout.TexCoord3.xy = (CellTexCoordOffset.zw + input.TexCoord0.xy);
 	vsout.TexCoord3.zw = input.TexCoord0.xy;
-#				endif
+#				endif  // NORMAL_TEXCOORD
 	vsout.TexCoord4 = ObjectUV.x;
 #			else
 	vsout.TexCoord1.xy = NormalsScroll0.xy + scrollAdjust1;
@@ -189,19 +189,19 @@ VS_OUTPUT main(VS_INPUT input)
 	vsout.TexCoord3 = 0.0;
 #					if (defined(NORMAL_TEXCOORD) && ((!defined(BLEND_NORMALS) && !defined(VERTEX_ALPHA_DEPTH)) || defined(WADING)))
 	vsout.TexCoord3.xy = input.TexCoord0;
-#					endif
+#					endif  // (defined(NORMAL_TEXCOORD) && ((!defined(BLEND_NORMALS) && !defined(VERTEX_ALPHA_DEPTH)) || defined(WADING)))
 #					if defined(VERTEX_ALPHA_DEPTH) && defined(VC)
 	vsout.TexCoord3.z = input.Color.w;
-#					endif
-#				endif
-#			endif
-#		endif
-#	endif
+#					endif  // defined(VERTEX_ALPHA_DEPTH) && defined(VC)
+#				endif      // (defined(WADING) || (defined(VERTEX_ALPHA_DEPTH) && defined(VC)))
+#			endif          // !(((defined(SPECULAR) || NUM_SPECULAR_LIGHTS == 0) || (defined(UNDERWATER) && defined(REFRACTIONS))) && !defined(NORMAL_TEXCOORD))
+#		endif              // FLOWMAP
+#	endif                  // LOD
 
 	return vsout;
 }
 
-#endif
+#endif  // STENCIL
 
 typedef VS_OUTPUT PS_INPUT;
 
@@ -259,12 +259,12 @@ cbuffer PerMaterial : register(b1)
 	float4 ShallowColor : packoffset(c0);
 	float4 DeepColor : packoffset(c1);
 	float4 ReflectionColor : packoffset(c2);
-	float4 FresnelRI : packoffset(c3);    // Fresnel amount in x, specular power in z
-	float4 BlendRadius : packoffset(c4);  // flowmap scale in y, specular radius in z
-	float4 VarAmounts : packoffset(c5);   // Sun specular power in x, reflection amount in y, alpha in z, refraction magnitude in w
+	float4 FresnelRI : packoffset(c3);      // Fresnel amount in x, specular power in z
+	float4 BlendRadius : packoffset(c4);    // flowmap scale in y, specular radius in z
+	float4 VarAmounts : packoffset(c5);     // Sun specular power in x, reflection amount in y, alpha in z, refraction magnitude in w
 	float4 NormalsAmplitude : packoffset(c6);
-	float4 WaterParams : packoffset(c7);   // noise falloff in x, reflection magnitude in y, sun sparkle power in z, framebuffer range in w
-	float4 FogNearColor : packoffset(c8);  // above water fog amount in w
+	float4 WaterParams : packoffset(c7);    // noise falloff in x, reflection magnitude in y, sun sparkle power in z, framebuffer range in w
+	float4 FogNearColor : packoffset(c8);   // above water fog amount in w
 	float4 FogFarColor : packoffset(c9);
 	float4 FogParam : packoffset(c10);      // above water fog distance far in z, above water fog range in w
 	float4 DepthControl : packoffset(c11);  // depth reflections factor in x, depth refractions factor in y, depth normals factor in z, depth specular lighting factor in w
@@ -294,7 +294,7 @@ float3 GetFlowmapNormal(PS_INPUT input, float2 uvShift, float multiplier, float 
 							 rotatedFlowVector);
 	return float3(FlowMapNormalsTex.Sample(FlowMapNormalsSampler, uv).xy, flowmapColor.z);
 }
-#		endif
+#		endif  // FLOWMAP
 
 float3 GetWaterNormal(PS_INPUT input, float distanceFactor, float normalsDepthFactor)
 {
@@ -319,7 +319,7 @@ float3 GetWaterNormal(PS_INPUT input, float distanceFactor, float normalsDepthFa
 			0);
 	flowmapNormal.z =
 		sqrt(1 - flowmapNormal.x * flowmapNormal.x - flowmapNormal.y * flowmapNormal.y);
-#		endif
+#		endif  // FLOWMAP
 
 	float3 normals1 = Normals01Tex.Sample(Normals01Sampler, input.TexCoord1.xy).xyz * 2.0 +
 	                  float3(-1, -1, -2);
@@ -339,29 +339,29 @@ float3 GetWaterNormal(PS_INPUT input, float distanceFactor, float normalsDepthFa
 	float3 finalNormal = blendedNormal;
 #			else
 	float3 finalNormal = normalize(lerp(float3(0, 0, 1), blendedNormal, normalsDepthFactor));
-#			endif
+#			endif  // UNDERWATER
 
 #			if defined(FLOWMAP)
 	float normalBlendFactor =
 		normalMul.y * ((1 - normalMul.x) * flowmapNormal3.z + normalMul.x * flowmapNormal2.z) +
 		(1 - normalMul.y) * (normalMul.x * flowmapNormal1.z + (1 - normalMul.x) * flowmapNormal0.z);
 	finalNormal = normalize(lerp(normals1 + float3(0, 0, 1), normalize(lerp(finalNormal, flowmapNormal, normalBlendFactor)), distanceFactor));
-#			endif
+#			endif  // FLOWMAP
 #		else
 	float3 finalNormal =
 		normalize(float3(0, 0, 1) + NormalsAmplitude.xxx * normals1);
-#		endif
+#		endif      // defined (FLOWMAP) && !defined(BLEND_NORMALS)
 
 #		if defined(WADING)
 #			if defined(FLOWMAP)
 	float2 displacementUv = input.TexCoord3.zw;
 #			else
 	float2 displacementUv = input.TexCoord3.xy;
-#			endif
+#			endif  // FLOWMAP
 	float3 displacement = normalize(float3(NormalsAmplitude.w * (-0.5 + DisplacementTex.Sample(DisplacementSampler, displacementUv).zw),
 		0.04));
 	finalNormal = lerp(displacement, finalNormal, displacement.z);
-#		endif
+#		endif  // WADING
 
 	return finalNormal;
 }
@@ -385,12 +385,12 @@ float3 GetWaterSpecularColor(PS_INPUT input, float3 normal, float3 viewDirection
 			input.MPosition.z, 1);
 #				else
 	float4 reflectionNormalRaw = float4(VarAmounts.w * normal.xy, reflectionNormalZ, 1);
-#				endif
+#				endif  // NUM_SPECULAR_LIGHTS == 0
 
 	float4 reflectionNormal = mul(transpose(TextureProj), reflectionNormalRaw);
 	float3 reflectionColor =
 		ReflectionTex.Sample(ReflectionSampler, reflectionNormal.xy / reflectionNormal.ww).xyz;
-#			endif
+#			endif      // CUBEMAP
 
 #			if defined(CUBEMAP) && NUM_SPECULAR_LIGHTS == 0
 	float2 ssrReflectionUv = GetDynamicResolutionAdjustedScreenPosition(
@@ -402,7 +402,7 @@ float3 GetWaterSpecularColor(PS_INPUT input, float3 normal, float3 viewDirection
 
 	finalSsrReflectionColor = ssrReflectionColor.xyz;
 	ssrFraction = saturate(ssrReflectionColor.w * (SSRParams.x * distanceFactor));
-#			endif
+#			endif  // defined(CUBEMAP) && NUM_SPECULAR_LIGHTS == 0
 
 	float3 finalReflectionColor =
 		lerp(reflectionColor * WaterParams.w, finalSsrReflectionColor, ssrFraction);
@@ -410,7 +410,7 @@ float3 GetWaterSpecularColor(PS_INPUT input, float3 normal, float3 viewDirection
 #		else
 
 	return ReflectionColor.xyz * VarAmounts.y;
-#		endif
+#		endif  // REFLECTIONS
 }
 
 #		if defined(DEPTH)
@@ -419,7 +419,7 @@ float GetScreenDepth(float2 screenPosition)
 	float depth = DepthTex.Load(float3(screenPosition, 0)).x;
 	return (CameraData.w / (-depth * CameraData.z + CameraData.x));
 }
-#		endif
+#		endif  // DEPTH
 
 float3 GetLdotN(float3 normal)
 {
@@ -427,7 +427,7 @@ float3 GetLdotN(float3 normal)
 	return 1;
 #		else
 	return saturate(dot(SunDir.xyz, normal));
-#		endif
+#		endif  // defined(INTERIOR) || defined(UNDERWATER)
 }
 
 float GetFresnelValue(float3 normal, float3 viewDirection)
@@ -436,7 +436,7 @@ float GetFresnelValue(float3 normal, float3 viewDirection)
 	float3 actualNormal = -normal;
 #		else
 	float3 actualNormal = normal;
-#		endif
+#		endif  // UNDERWATER
 	float viewAngle = 1 - saturate(dot(-viewDirection, actualNormal));
 	return (1 - FresnelRI.x) * pow(viewAngle, 5) + FresnelRI.x;
 }
@@ -471,7 +471,7 @@ float3 GetWaterDiffuseColor(PS_INPUT input, float3 normal, float3 viewDirection,
 		refractionUvRaw =
 			DynamicResolutionParams2.xy * input.HPosition.xy * VPOSOffset.xy + VPOSOffset.zw;
 	}
-#			endif
+#			endif  // DEPTH
 
 	float2 refractionUV = GetDynamicResolutionAdjustedScreenPosition(refractionUvRaw);
 	float3 refractionColor = RefractionTex.Sample(RefractionSampler, refractionUV).xyz;
@@ -481,11 +481,11 @@ float3 GetWaterDiffuseColor(PS_INPUT input, float3 normal, float3 viewDirection,
 #			else
 	float refractionMul =
 		1 - pow(saturate((-distanceMul.x * FogParam.z + FogParam.z) / FogParam.w), FogNearColor.w);
-#			endif
+#			endif  // UNDERWATER
 	return lerp(refractionColor * WaterParams.w, refractionDiffuseColor, refractionMul);
 #		else
 	return lerp(ShallowColor.xyz, DeepColor.xyz, fresnel) * GetLdotN(normal);
-#		endif
+#		endif  // REFRACTIONS
 }
 
 float3 GetSunColor(float3 normal, float3 viewDirection)
@@ -500,13 +500,13 @@ float3 GetSunColor(float3 normal, float3 viewDirection)
 	float3 sunDirection = SunColor.xyz * SunDir.w;
 	float sunMul = pow(saturate(dot(normal, float3(-0.099, -0.099, 0.99))), ShallowColor.w);
 	return (reflectionMul * sunDirection) * DeepColor.w + WaterParams.z * (sunMul * sunDirection);
-#		endif
+#		endif  // defined(INTERIOR) || defined(UNDERWATER)
 }
-#	endif
+#	endif      // defined (FLOWMAP) && !defined(BLEND_NORMALS)
 
 #	if defined(WATER_BLENDING)
 #		include "WaterBlending/WaterBlending.hlsli"
-#	endif
+#	endif  // WATER_BLENDING
 
 PS_OUTPUT main(PS_INPUT input)
 {
@@ -537,8 +537,8 @@ PS_OUTPUT main(PS_INPUT input)
 	distanceMul = saturate(
 		planeMul * float4(length(depthAdjustedViewDirection).xx, abs(viewSurfaceAngle).xx) /
 		FogParam.z);
-#			endif
-#		endif
+#			endif  // defined(VERTEX_ALPHA_DEPTH)
+#		endif      // defined(DEPTH)
 
 #		if defined(UNDERWATER)
 	float4 depthControl = float4(0, 1, 1, 0);
@@ -548,7 +548,7 @@ PS_OUTPUT main(PS_INPUT input)
 	float4 depthControl = float4(0, 0, 1, 0);
 #		else
 	float4 depthControl = DepthControl * (distanceMul - 1) + 1;
-#		endif
+#		endif  // UNDERWATER
 
 	float3 normal = GetWaterNormal(input, distanceFactor, depthControl.z);
 
@@ -589,8 +589,8 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 finalColorPreFog =
 		lerp(diffuseColor, specularColor, specularFraction) + sunColor * depthControl.w;
 	float3 finalColor = lerp(finalColorPreFog, input.FogParam.xyz, input.FogParam.w);
-#			endif
-#		endif
+#			endif  // UNDERWATER
+#		endif      // defined(SPECULAR) && (NUM_SPECULAR_LIGHTS != 0)
 
 	psout.Lighting = saturate(float4(finalColor * PosAdjust.w, isSpecular));
 #		if defined(WATER_BLENDING)
@@ -611,12 +611,12 @@ PS_OUTPUT main(PS_INPUT input)
 			psout.Lighting.xyz = lerp(psout.Lighting.xyz, background.xyz, blendFactor);
 			psout.Lighting.w = lerp(psout.Lighting.w, background.w, blendFactor);
 		}
-#				endif
+#				endif  // VERTEX_ALPHA_DEPTH
 	}
-#			endif
-#		endif
+#			endif      // DEPTH
+#		endif          // WATER_BLENDING
 
-#	endif
+#	endif              // defined(SPECULAR) && (NUM_SPECULAR_LIGHTS != 0)
 
 #	if defined(STENCIL)
 	float3 viewDirection = normalize(input.WorldPosition.xyz);
@@ -626,9 +626,9 @@ PS_OUTPUT main(PS_INPUT input)
 	psout.WaterMask = float4(0, 0, VdotN, 0);
 
 	psout.MotionVector = GetSSMotionVector(input.WorldPosition, input.PreviousWorldPosition);
-#	endif
+#	endif  // STENCIL
 
 	return psout;
 }
 
-#endif
+#endif  // VSHADER

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -80,6 +80,9 @@ const std::vector<Feature*>& Feature::GetFeatureList()
 
 	static std::vector<Feature*> featuresVR = {
 		GrassLighting::GetSingleton(),
+		GrassCollision::GetSingleton(),
+		ScreenSpaceShadows::GetSingleton(),
+		WaterBlending::GetSingleton(),
 		ExtendedMaterials::GetSingleton(),
 	};
 

--- a/src/Features/Clustered.h
+++ b/src/Features/Clustered.h
@@ -2,7 +2,7 @@
 
 #include <shared_mutex>
 
-#include <DirectXMath.h>
+#include <SimpleMath.h>
 #include <d3d11.h>
 
 #include "Buffer.h"
@@ -20,8 +20,8 @@ public:
 
 	struct alignas(16) LightSData
 	{
-		DirectX::XMVECTOR color;
-		DirectX::XMVECTOR positionWS[2];
+		Vector4 color;
+		Vector4 positionWS[2];
 		float radius;
 		uint32_t shadow;
 		float mask;

--- a/src/Features/DistantTreeLighting.cpp
+++ b/src/Features/DistantTreeLighting.cpp
@@ -89,9 +89,7 @@ void DistantTreeLighting::ModifyDistantTree(const RE::BSShader*, const uint32_t 
 
 		RE::NiPoint3 eyePosition{};
 		if (REL::Module::IsVR()) {
-			// find center of eye position
-			eyePosition = state->GetVRRuntimeData().posAdjust.getEye() + state->GetVRRuntimeData().posAdjust.getEye(1);
-			eyePosition /= 2;
+			eyePosition = state->GetVRRuntimeData().posAdjust.getEye();
 		} else
 			eyePosition = state->GetRuntimeData().posAdjust.getEye();
 		perPassData.EyePosition.x = position.x - eyePosition.x;

--- a/src/Features/GrassCollision.cpp
+++ b/src/Features/GrassCollision.cpp
@@ -129,9 +129,7 @@ void GrassCollision::UpdateCollisions()
 					CollisionSData data{};
 					RE::NiPoint3 eyePosition{};
 					if (REL::Module::IsVR()) {
-						// find center of eye position
-						eyePosition = state->GetVRRuntimeData().posAdjust.getEye() + state->GetVRRuntimeData().posAdjust.getEye(1);
-						eyePosition /= 2;
+						eyePosition = state->GetVRRuntimeData().posAdjust.getEye();
 					} else
 						eyePosition = state->GetRuntimeData().posAdjust.getEye();
 					data.centre.x = centerPos.x - eyePosition.x;
@@ -203,11 +201,9 @@ void GrassCollision::ModifyGrass(const RE::BSShader*, const uint32_t)
 		auto bound = shaderState.cachedPlayerBound;
 		RE::NiPoint3 eyePosition{};
 		if (REL::Module::IsVR()) {
-			// find center of eye position
-			eyePosition = state->GetVRRuntimeData().posAdjust.getEye() + state->GetVRRuntimeData().posAdjust.getEye(1);
-			eyePosition /= 2;
+			eyePosition = state->GetVRRuntimeData().posAdjust.getEye(0);
 		} else
-			eyePosition = state->GetRuntimeData().posAdjust.getEye();
+			eyePosition = state->GetRuntimeData().posAdjust.getEye(0);
 		perFrameData.boundCentre.x = bound.center.x - eyePosition.x;
 		perFrameData.boundCentre.y = bound.center.y - eyePosition.y;
 		perFrameData.boundCentre.z = bound.center.z - eyePosition.z;

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -266,7 +266,7 @@ void ScreenSpaceShadows::ModifyLighting(const RE::BSShader*, const uint32_t)
 						if (!REL::Module::IsVR())
 							data.ProjMatrix[eyeIndex] = shadowState->GetRuntimeData().cameraData.getEye(eyeIndex).projMat;
 						else
-							data.ProjMatrix[eyeIndex] = shadowState->GetVRRuntimeData().cameraData.getEye(eyeIndex).projMat;			
+							data.ProjMatrix[eyeIndex] = shadowState->GetVRRuntimeData().cameraData.getEye(eyeIndex).projMat;
 						data.InvProjMatrix[eyeIndex] = XMMatrixInverse(nullptr, data.ProjMatrix[eyeIndex]);
 
 						auto& direction = dirLight->GetWorldDirection();
@@ -279,7 +279,6 @@ void ScreenSpaceShadows::ModifyLighting(const RE::BSShader*, const uint32_t)
 							viewMatrix[eyeIndex] = shadowState->GetRuntimeData().cameraData.getEye(eyeIndex).viewMat;
 						else
 							viewMatrix[eyeIndex] = shadowState->GetVRRuntimeData().cameraData.getEye(eyeIndex).viewMat;
-						
 
 						auto invDirLightDirectionWS = XMLoadFloat3(&position);
 						data.InvDirLightDirectionVS[eyeIndex] = XMVector3TransformCoord(invDirLightDirectionWS, viewMatrix[eyeIndex]);

--- a/src/Features/ScreenSpaceShadows.h
+++ b/src/Features/ScreenSpaceShadows.h
@@ -34,17 +34,20 @@ struct ScreenSpaceShadows : Feature
 		uint32_t pad[2];
 	};
 
+#pragma warning(push)
+#pragma warning(disable: 4324)  // ignore warning about padded due to alignment from DirectX datatypes (e.g., XMVECTOR, XMMATRIX).
 	struct alignas(16) RaymarchCB
 	{
-		DirectX::XMFLOAT2 BufferDim;
-		DirectX::XMFLOAT2 RcpBufferDim;
-		DirectX::XMMATRIX ProjMatrix;
-		DirectX::XMMATRIX InvProjMatrix;
-		DirectX::XMFLOAT4 DynamicRes;
-		DirectX::XMVECTOR InvDirLightDirectionVS;
+		Vector2 BufferDim;
+		Vector2 RcpBufferDim;
+		Matrix ProjMatrix[2];
+		Matrix InvProjMatrix[2];
+		Vector4 DynamicRes;
+		Vector4 InvDirLightDirectionVS[2];
 		float ShadowDistance = 10000;
 		Settings Settings;
 	};
+#pragma warning(pop)
 
 	Settings settings;
 

--- a/src/Features/WaterBlending.cpp
+++ b/src/Features/WaterBlending.cpp
@@ -38,7 +38,7 @@ void WaterBlending::Draw(const RE::BSShader* shader, const uint32_t)
 			if (auto cell = player->GetParentCell()) {
 				if (!cell->IsInteriorCell()) {
 					auto height = cell->GetExteriorWaterHeight();
-					data.waterHeight = height - shadowState->GetRuntimeData().posAdjust.getEye().z;
+					data.waterHeight = height - (!REL::Module::IsVR() ? shadowState->GetRuntimeData().posAdjust.getEye(0).z : shadowState->GetVRRuntimeData().posAdjust.getEye(0).z);
 				}
 			}
 		}

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -84,7 +84,8 @@ namespace SIE
 				       type == RE::BSShader::Type::Particle ||
 				       type == RE::BSShader::Type::Water;
 			return type == RE::BSShader::Type::Lighting ||
-			       type == RE::BSShader::Type::Grass;
+			       type == RE::BSShader::Type::Grass ||
+			       type == RE::BSShader::Type::Water;
 		}
 
 		inline static bool IsSupportedShader(const RE::BSShader& shader)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,6 +4,8 @@
   "description": "",
   "license": "MIT",
   "dependencies": [
+    "directxmath",
+    "directxtk",
     "fmt",
     "rapidcsv",
     "spdlog",


### PR DESCRIPTION
This is a broken but mostly ported SSS branch. The cpp port and hlsl appear to correctly work for flat, but in VR there is a doubling of the sun as a point light. This occurs in each eye at separate locations and is not playable.

Taking grass as an example:
- Each object is casting two shadows, one in each eye, and are slightly offset from each other. Left eye looks more correct than right eye based on sun position.
- Shadows will rotate in opposite directions as the HMD moves.

Some online research says this can be fixed with orthographic projection for the sunlight, but I was not able to fix it by creating an orthographic projection instead of the built in projection for sunlight since the distance should be infinite. Some more theory. https://www.scratchapixel.com/lessons/3d-basic-rendering/perspective-and-orthographic-projection-matrix/orthographic-projection-matrix.html

NOTE: I will force push to this branch to clean up history once this is fixed. This is being posted in bad history state because I will be on vacation. If you figure out the issue, PR to me so I can rebase your branch and build a good history.