### PR TITLE
fix: add dependency for commonlibng simplemath

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "dependencies": [
     "fmt",
+    "directxtk",
     "rapidcsv",
     "spdlog",
     "magic-enum",


### PR DESCRIPTION
I switched to [simplemath ](https://github.com/Microsoft/DirectXTK/wiki/SimpleMath)in CommonLib instead of requiring directx. This may fix a compile error if you're on the latest.