### PR TITLE
A workflow for building releases on tag push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,63 @@
+name: build Community Shaders for dist
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+permissions:
+  contents: write
+
+env:
+  VCPKG_COMMIT_ID: 9edb1b8e590cc086563301d735cae4b6e732d2d2
+  CMAKE_BUILD_TYPE: Release
+
+jobs:
+  compile:
+    name: build plugin
+    runs-on: windows-latest
+    steps:
+        - uses: actions/checkout@v3
+          with:
+            submodules: 'true'
+  
+        - uses: actions/cache@v3
+          with:
+              path: |
+                  build
+              key: ${{ runner.os }}-cmake-${{ hashFiles('CMakeLists.txt') }}
+              restore-keys: |
+                ${{ runner.os }}-cmake-
+                ${{ runner.os }}-
+                  
+        - uses: ilammy/msvc-dev-cmd@v1.10.0
+
+        - uses: lukka/run-vcpkg@v11
+          with:
+              vcpkgGitCommitId: ${{ env.VCPKG_COMMIT_ID }}
+        
+        - name: check the stamp file
+          run: cmake -S . --preset=ALL --check-stamp-file "build\CMakeFiles\generate.stamp"
+        
+        - name: run cmake to build
+          run: cmake --build build --config Release
+
+        - name: copy build artifacts into place
+          shell: bash
+          run: |
+              mkdir -p CommunityShaders/SKSE/Plugins
+              cp -p build/release/*.dll CommunityShaders/SKSE/Plugins
+              cp -p build/release/*.pdb CommunityShaders/SKSE/Plugins
+              cp -rp package/* CommunityShaders/
+
+        - name: 7zip compress it
+          run: 7z a "CommunityShaders_${{ github.ref_name }}.7z" ./CommunityShaders
+
+        - name: create a tagged release and upload the archive
+          uses: ncipollo/release-action@v1
+          env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            name: Community Shaders ${{ github.ref_name }}
+            tag: ${{ github.ref_name }}
+            draft: true
+            artifacts: "CommunityShaders_${{ github.ref_name }}.7z"


### PR DESCRIPTION
This should help automate building test releases for both branches and the mainline. It takes a lot longer than building on a typical programmer PC with fast disks and warm caches, but it will generate reproducible builds and maybe reduce some of the by-hand work CS contributors are doing.

The workflow generates a mod structure identical to the one the bat files generates, then compresses the result into a 7zip archive. The archive is then uploaded as an asset to a draft GitHub release named for the tag. To publish the release on GitHub, a human must edit the release notes and press the publish button.

This workflow caches the cmake `build` directory. The vcpkg action caches the vcpkg binary artifacts. Most of the build time is currently spent rebuilding CommonLibSSE-NG because it's pulled in as a git submodule. Figuring out how to cache that build artifact on its own would speed this up a lot. (Maybe pulling it in as a vcpkg release instead? But that decision is above my pay grade.)

ETA: GPL is fine by me.