### PR TITLE
fix: always populate right eye WS for particles

### DIFF
--- a/features/Grass Lighting/Shaders/RunGrass.hlsl
+++ b/features/Grass Lighting/Shaders/RunGrass.hlsl
@@ -499,12 +499,17 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 #		if defined(LIGHT_LIMIT_FIX)
 	float3 viewPosition = mul(CameraView[eyeIndex], float4(input.WorldPosition.xyz, 1)).xyz;
+	float2 screenUV = ViewToUV(viewPosition, true, eyeIndex);
 
 	float clampedDepth = clamp(viewPosition.z, GetNearPlane(), GetFarPlane());
 
 	uint clusterZ = uint(max((log2(clampedDepth) - log2(GetNearPlane())) * 24.0 / log2(GetFarPlane() / GetNearPlane()), 0.0));
 	uint2 clusterDim = ceil(perPassLLF[0].BufferDim / float2(16, 8));
+#			if !defined(VR)
 	uint3 cluster = uint3(uint2(input.HPosition.xy / clusterDim), clusterZ);
+#			else
+	uint3 cluster = uint3(uint2((screenUV * perPassLLF[0].BufferDim) / clusterDim), clusterZ);
+#			endif  // !VR
 	uint clusterIndex = cluster.x + (16 * cluster.y) + (16 * 8 * cluster.z);
 
 	uint lightCount = lightGrid[clusterIndex].lightCount;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -157,7 +157,7 @@ cbuffer VS_PerFrame : register(b12)
 	float3 PreviousBonesPivot[1] : packoffset(c41);
 #		endif  // SKINNED
 #	else
-	row_major float3x3 ScreenProj[2] : packoffset(c0);
+	row_major float4x4 ScreenProj[2] : packoffset(c0);
 	row_major float4x4 ViewProj[2] : packoffset(c16);
 #		if defined(SKINNED)
 	float3 BonesPivot[2] : packoffset(c80);
@@ -1775,7 +1775,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 		uint clusterZ = uint(max((log2(clampedDepth) - log2(GetNearPlane())) * 16.0 / log2(GetFarPlane() / GetNearPlane()), 0.0));
 		uint2 clusterDim = ceil(perPassLLF[0].BufferDim / float2(32, 16));
+#		if !defined(VR)
 		uint3 cluster = uint3(uint2(input.Position.xy / clusterDim), clusterZ);
+#		else
+		uint3 cluster = uint3(uint2((screenUV * perPassLLF[0].BufferDim) / clusterDim), clusterZ);
+#		endif  // !VR
 		uint clusterIndex = cluster.x + (32 * cluster.y) + (32 * 16 * cluster.z);
 
 		lightCount = lightGrid[clusterIndex].lightCount;
@@ -2055,7 +2059,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	float clampedDepth = clamp(viewPosition.z, GetNearPlane(), GetFarPlane());
 	uint clusterZ = uint(max((log2(clampedDepth) - log2(GetNearPlane())) * 16.0 / log2(GetFarPlane() / GetNearPlane()), 0.0));
 	uint2 clusterDim = ceil(perPassLLF[0].BufferDim / float2(32, 16));
+#		if !defined(VR)
 	uint3 cluster = uint3(uint2(input.Position.xy / clusterDim), clusterZ);
+#		else
+	uint3 cluster = uint3(uint2((screenUV * perPassLLF[0].BufferDim) / clusterDim), clusterZ);
+#		endif  // !VR
 	uint clusterIndex = cluster.x + (32 * cluster.y) + (32 * 16 * cluster.z);
 	float level = (float)lightCount;
 	float3 col;

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -682,7 +682,7 @@ void LightLimitFix::UpdateLights()
 						if ((radiusDiff + positionDiff) > settings.ParticleLightsOptimisationClusterRadius || !settings.EnableParticleLightsOptimization) {
 							light.radius /= (float)clusteredLights;
 							light.positionWS[eyeIndex] /= (float)clusteredLights;
-
+							light.positionWS[1] = light.positionWS[0];  // naive implementation; may be removed if we actually iterate
 							currentLightCount += AddCachedParticleLights(lightsData, light, particleLight.second.second, eyeIndex);
 
 							clusteredLights = 0;
@@ -710,7 +710,7 @@ void LightLimitFix::UpdateLights()
 				if (clusteredLights) {
 					light.radius /= (float)clusteredLights;
 					light.positionWS[eyeIndex] /= (float)clusteredLights;
-
+					light.positionWS[1] = light.positionWS[0];  // naive implementation; may be removed if we actually iterate
 					currentLightCount += AddCachedParticleLights(lightsData, light, particleLight.second.second, eyeIndex);
 				}
 

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -682,7 +682,11 @@ void LightLimitFix::UpdateLights()
 						if ((radiusDiff + positionDiff) > settings.ParticleLightsOptimisationClusterRadius || !settings.EnableParticleLightsOptimization) {
 							light.radius /= (float)clusteredLights;
 							light.positionWS[eyeIndex] /= (float)clusteredLights;
-							light.positionWS[1] = light.positionWS[0];  // naive implementation; may be removed if we actually iterate
+							light.positionWS[1] = light.positionWS[0];
+							auto offset = eyePosition - state->GetVRRuntimeData().posAdjust.getEye(1);
+							light.positionWS[1].x += offset.x;
+							light.positionWS[1].y += offset.y;
+							light.positionWS[1].z += offset.z;
 							currentLightCount += AddCachedParticleLights(lightsData, light, particleLight.second.second, eyeIndex);
 
 							clusteredLights = 0;
@@ -710,7 +714,11 @@ void LightLimitFix::UpdateLights()
 				if (clusteredLights) {
 					light.radius /= (float)clusteredLights;
 					light.positionWS[eyeIndex] /= (float)clusteredLights;
-					light.positionWS[1] = light.positionWS[0];  // naive implementation; may be removed if we actually iterate
+					light.positionWS[1] = light.positionWS[0];
+					auto offset = eyePosition - state->GetVRRuntimeData().posAdjust.getEye(1);
+					light.positionWS[1].x += offset.x;
+					light.positionWS[1].y += offset.y;
+					light.positionWS[1].z += offset.z;
 					currentLightCount += AddCachedParticleLights(lightsData, light, particleLight.second.second, eyeIndex);
 				}
 

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -683,10 +683,12 @@ void LightLimitFix::UpdateLights()
 							light.radius /= (float)clusteredLights;
 							light.positionWS[eyeIndex] /= (float)clusteredLights;
 							light.positionWS[1] = light.positionWS[0];
-							auto offset = eyePosition - state->GetVRRuntimeData().posAdjust.getEye(1);
-							light.positionWS[1].x += offset.x;
-							light.positionWS[1].y += offset.y;
-							light.positionWS[1].z += offset.z;
+							if (eyeCount == 2) {
+								auto offset = eyePosition - state->GetVRRuntimeData().posAdjust.getEye(1);
+								light.positionWS[1].x += offset.x;
+								light.positionWS[1].y += offset.y;
+								light.positionWS[1].z += offset.z;
+							}
 							currentLightCount += AddCachedParticleLights(lightsData, light, particleLight.second.second, eyeIndex);
 
 							clusteredLights = 0;
@@ -715,10 +717,12 @@ void LightLimitFix::UpdateLights()
 					light.radius /= (float)clusteredLights;
 					light.positionWS[eyeIndex] /= (float)clusteredLights;
 					light.positionWS[1] = light.positionWS[0];
-					auto offset = eyePosition - state->GetVRRuntimeData().posAdjust.getEye(1);
-					light.positionWS[1].x += offset.x;
-					light.positionWS[1].y += offset.y;
-					light.positionWS[1].z += offset.z;
+					if (eyeCount == 2) {
+						auto offset = eyePosition - state->GetVRRuntimeData().posAdjust.getEye(1);
+						light.positionWS[1].x += offset.x;
+						light.positionWS[1].y += offset.y;
+						light.positionWS[1].z += offset.z;
+					}
 					currentLightCount += AddCachedParticleLights(lightsData, light, particleLight.second.second, eyeIndex);
 				}
 


### PR DESCRIPTION
Testing indicates the WS position should be the same for the clustering algorithm. Instead of doing a pass, this just makes that assumption so both eyes have the same WS position for each light.