### PR TITLE
Disable contact shadows in LLF for VR

### DIFF
--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -31,7 +31,13 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 void LightLimitFix::DrawSettings()
 {
 	if (ImGui::TreeNodeEx("Shadows", ImGuiTreeNodeFlags_DefaultOpen)) {
+		ImGui::BeginDisabled(REL::Module::IsVR());
 		ImGui::Checkbox("Enable Contact Shadows", &settings.EnableContactShadows);
+		if(REL::Module::IsVR() && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+		{
+			ImGui::SetTooltip("Disabled for VR");
+		}
+		ImGui::EndDisabled();
 		ImGui::Checkbox("Extend First-Person Shadows", &settings.ExtendFirstPersonShadows);
 
 		ImGui::TreePop();
@@ -180,7 +186,13 @@ void LightLimitFix::Reset()
 void LightLimitFix::Load(json& o_json)
 {
 	if (o_json[GetName()].is_object())
+	{
 		settings = o_json[GetName()];
+		if (REL::Module::IsVR())
+		{
+			settings.EnableContactShadows = false;
+		}
+	}
 	Feature::Load(o_json);
 }
 

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -33,8 +33,7 @@ void LightLimitFix::DrawSettings()
 	if (ImGui::TreeNodeEx("Shadows", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::BeginDisabled(REL::Module::IsVR());
 		ImGui::Checkbox("Enable Contact Shadows", &settings.EnableContactShadows);
-		if(REL::Module::IsVR() && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
-		{
+		if (REL::Module::IsVR() && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
 			ImGui::SetTooltip("Disabled for VR");
 		}
 		ImGui::EndDisabled();
@@ -185,11 +184,9 @@ void LightLimitFix::Reset()
 
 void LightLimitFix::Load(json& o_json)
 {
-	if (o_json[GetName()].is_object())
-	{
+	if (o_json[GetName()].is_object()) {
 		settings = o_json[GetName()];
-		if (REL::Module::IsVR())
-		{
+		if (REL::Module::IsVR()) {
 			settings.EnableContactShadows = false;
 		}
 	}


### PR DESCRIPTION
Disable contact shadows in LightLimitFix for VR

Sets LightLimitFix::Settings::EnableContactShadows to false when loading settings, so still disabled if set to true manually in `CommunityShaders.json -> Light Limit Fix:EnableContactShadows`

![image](https://github.com/doodlum/skyrim-community-shaders/assets/964655/71e4b4a7-0f26-4f91-b343-231e3f41119a)

Also makes the setting disabled and shows a hovertext like shown above (Only in VR) in ImGui