### PR TITLE
build: added automatic plugin deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 dist/
 .vs*/
+CMakeUserPresets.json

--- a/Build Release.bat
+++ b/Build Release.bat
@@ -1,15 +1,8 @@
 @echo off
 
-RMDIR dist /S /Q
-
 cmake -S . --preset=ALL --check-stamp-file "build\CMakeFiles\generate.stamp"
 if %ERRORLEVEL% NEQ 0 exit 1
 cmake --build build --config Release
 if %ERRORLEVEL% NEQ 0 exit 1
-
-xcopy "build\release\*.dll" "dist\SKSE\Plugins\" /I /Y
-xcopy "build\release\*.pdb" "dist\SKSE\Plugins\" /I /Y
-
-xcopy "package" "dist" /I /Y /E
 
 pause

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,24 @@ project(
 )
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
+# ########################################################################################################################
+# ## Build options
+# ########################################################################################################################
+message("Options:")
+option(AUTO_PLUGIN_DEPLOYMENT "Copy the build output and addons to env:CommunityShadersOutputDir." OFF)
+option(ZIP_TO_DIST "Zip the base mod and addons to their own 7z file in dist." ON)
+message("\tAuto plugin deployment: ${AUTO_PLUGIN_DEPLOYMENT}")
+message("\tZip to dist: ${ZIP_TO_DIST}")
+
+# #######################################################################################################################
+# # Add CMake features
+# #######################################################################################################################
 include(XSEPlugin)
 
+# #######################################################################################################################
+# # Find dependencies
+# #######################################################################################################################
 find_package(magic_enum CONFIG REQUIRED)
 find_package(xbyak CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
@@ -56,4 +72,63 @@ if(MSVC_VERSION GREATER_EQUAL 1936 AND MSVC_IDE) # 17.6+
   </ItemDefinitionGroup>
 </Project>
 ]==] @ONLY)
+endif()
+
+# #######################################################################################################################
+# # Automatic deployment
+# #######################################################################################################################
+
+file(GLOB FEATURE_PATHS LIST_DIRECTORIES true ${CMAKE_SOURCE_DIR}/features/*)
+
+# Automatic deployment to CommunityShaders output directory.
+if (AUTO_PLUGIN_DEPLOYMENT)
+	foreach(DEPLOY_TARGET $ENV{CommunityShadersOutputDir})
+		message("Copying package folder with dll/pdb with all features to ${DEPLOY_TARGET}")
+		add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/package "${DEPLOY_TARGET}"
+			COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${PROJECT_NAME}> "${DEPLOY_TARGET}/SKSE/Plugins/"
+			COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_PDB_FILE:${PROJECT_NAME}> "${DEPLOY_TARGET}/SKSE/Plugins/"
+		)
+		foreach(FEATURE_PATH ${FEATURE_PATHS})
+			add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+				COMMAND ${CMAKE_COMMAND} -E copy_directory ${FEATURE_PATH} "${DEPLOY_TARGET}"
+			)
+		endforeach()
+	endforeach()
+	if (NOT DEFINED ENV{CommunityShadersOutputDir})
+		message("When using AUTO_PLUGIN_DEPLOYMENT option, you need to set environment variable 'CommunityShadersOutputDir'")
+	endif()
+endif()
+
+# Zip base CommunityShaders and all addons as their own 7z in dist folder
+if(ZIP_TO_DIST)
+	set(ZIP_DIR "${CMAKE_CURRENT_BINARY_DIR}/zip")
+	file(REMOVE_RECURSE ${CMAKE_BINARY_DIR}/test/)
+	add_custom_target(build-time-make-directory ALL
+		COMMAND ${CMAKE_COMMAND} -E remove_directory "${ZIP_DIR}" ${CMAKE_SOURCE_DIR}/dist
+		COMMAND ${CMAKE_COMMAND} -E make_directory "${ZIP_DIR}" ${CMAKE_SOURCE_DIR}/dist
+	)
+
+	message("Copying base CommunityShader into ${ZIP_DIR}.")
+	add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/package "${ZIP_DIR}"
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${PROJECT_NAME}> "${ZIP_DIR}/SKSE/Plugins/"
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_PDB_FILE:${PROJECT_NAME}> "${ZIP_DIR}/SKSE/Plugins/"
+	)
+
+	set(TARGET_ZIP "${PROJECT_NAME}.7z")
+	message("Zipping ${ZIP_DIR} to ${CMAKE_SOURCE_DIR}/dist/${TARGET_ZIP}")
+	ADD_CUSTOM_COMMAND(TARGET ${PROJECT_NAME} POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E tar cf ${CMAKE_SOURCE_DIR}/dist/${TARGET_ZIP} --format=7zip -- .
+		WORKING_DIRECTORY ${ZIP_DIR}
+	)
+
+	foreach(FEATURE_PATH ${FEATURE_PATHS})
+		get_filename_component(FEATURE ${FEATURE_PATH} NAME)
+		message("Zipping ${FEATURE_PATH} to ${CMAKE_SOURCE_DIR}/dist/${FEATURE}.7z")
+		add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E tar cf ${CMAKE_SOURCE_DIR}/dist/${FEATURE}.7z --format=7zip -- .
+			WORKING_DIRECTORY ${FEATURE_PATH}
+		)
+	endforeach()
 endif()

--- a/CMakeUserPresets.json.template
+++ b/CMakeUserPresets.json.template
@@ -1,0 +1,15 @@
+{
+	"version": 3,
+	"configurePresets": [
+		{
+			"name": "ALL-WITH-AUTO-DEPLOYMENT",
+			"cacheVariables": {
+				"AUTO_PLUGIN_DEPLOYMENT": "ON"
+			},
+			"environment": {
+				"CommunityShadersOutputDir": "F:/MySkyrimModpack/mods/CommunityShaders;F:/SteamLibrary/steamapps/common/SkyrimVR/Data;F:/SteamLibrary/steamapps/common/Skyrim Special Edition/Data"
+			},
+			"inherits": "ALL"
+		}
+	]
+}

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -200,10 +200,10 @@ void LightLimitFix::SetLightPosition(LightLimitFix::LightData& a_light, RE::NiPo
 	for (int eyeIndex = 0; eyeIndex < eyeCount; eyeIndex++) {
 		auto eyePosition = eyeCount == 1 ?
 		                       state->GetRuntimeData().posAdjust.getEye(eyeIndex) :
-                               state->GetVRRuntimeData().posAdjust.getEye(eyeIndex);
+		                       state->GetVRRuntimeData().posAdjust.getEye(eyeIndex);
 		auto viewMatrix = eyeCount == 1 ?
 		                      state->GetRuntimeData().cameraData.getEye(eyeIndex).viewMat :
-                              state->GetVRRuntimeData().cameraData.getEye(eyeIndex).viewMat;
+		                      state->GetVRRuntimeData().cameraData.getEye(eyeIndex).viewMat;
 		auto worldPos = a_initialPosition - eyePosition;
 		a_light.positionWS[eyeIndex].x = worldPos.x;
 		a_light.positionWS[eyeIndex].y = worldPos.y;
@@ -316,7 +316,7 @@ void LightLimitFix::Bind()
 
 	auto reflections = (!REL::Module::IsVR() ?
 							   RE::BSGraphics::RendererShadowState::GetSingleton()->GetRuntimeData().cubeMapRenderTarget :
-                               RE::BSGraphics::RendererShadowState::GetSingleton()->GetVRRuntimeData().cubeMapRenderTarget) == RE::RENDER_TARGETS_CUBEMAP::kREFLECTIONS;
+							   RE::BSGraphics::RendererShadowState::GetSingleton()->GetVRRuntimeData().cubeMapRenderTarget) == RE::RENDER_TARGETS_CUBEMAP::kREFLECTIONS;
 
 	if (reflections || accumulator->GetRuntimeData().activeShadowSceneNode != RE::BSShaderManager::State::GetSingleton().shadowSceneNode[0]) {
 		PerPass perPassData{};
@@ -629,12 +629,12 @@ bool LightLimitFix::AddCachedParticleLights(eastl::vector<LightData>& lightsData
 		auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
 		auto eyePosition = eyeCount == 1 ?
 		                       state->GetRuntimeData().posAdjust.getEye(a_eyeIndex) :
-                               state->GetVRRuntimeData().posAdjust.getEye(a_eyeIndex);
+		                       state->GetVRRuntimeData().posAdjust.getEye(a_eyeIndex);
 		cachedParticleLight.position = { light.positionWS[a_eyeIndex].x + eyePosition.x, light.positionWS[a_eyeIndex].y + eyePosition.y, light.positionWS[a_eyeIndex].z + eyePosition.z };
 		for (int eyeIndex = 0; eyeIndex < eyeCount; eyeIndex++) {
 			auto viewMatrix = eyeCount == 1 ?
 			                      state->GetRuntimeData().cameraData.getEye(eyeIndex).viewMat :
-                                  state->GetVRRuntimeData().cameraData.getEye(eyeIndex).viewMat;
+			                      state->GetVRRuntimeData().cameraData.getEye(eyeIndex).viewMat;
 			light.positionVS[eyeIndex] = DirectX::SimpleMath::Vector3::Transform(light.positionWS[eyeIndex], viewMatrix);
 		}
 		for (int eyeIndex = 0; eyeIndex < eyeCount; eyeIndex++) {
@@ -758,7 +758,7 @@ void LightLimitFix::UpdateLights()
 		auto eyeIndex = 0;  // only calculate for left eye
 		auto eyePosition = eyeCount == 1 ?
 		                       state->GetRuntimeData().posAdjust.getEye(eyeIndex) :
-                               state->GetVRRuntimeData().posAdjust.getEye(eyeIndex);
+		                       state->GetVRRuntimeData().posAdjust.getEye(eyeIndex);
 
 		for (const auto& particleLight : particleLights) {
 			if (const auto particleSystem = netimmerse_cast<RE::NiParticleSystem*>(particleLight.first);


### PR DESCRIPTION
fixes #63

Added 2 options to CMake:
- AUTO_PLUGIN_DEPLOYMENT (default OFF), requires a ENV variable (CommunityShadersOutputDir)
This copies first package folder in root, then the DLL and PDB, then all addons (No orders on addons for now)
- ZIP_TO_DIST (default ON)
```
[cmake] Copying base CommunityShader into D:/dev/private/skyrim-community-shaders/build/zip.
[cmake] Zipping D:/dev/private/skyrim-community-shaders/build/zip to D:/dev/private/skyrim-community-shaders/dist/CommunityShaders.7z
[cmake] Zipping D:/dev/private/skyrim-community-shaders/features/Complex Parallax Materials to D:/dev/private/skyrim-community-shaders/dist/Complex Parallax Materials.7z
[cmake] Zipping D:/dev/private/skyrim-community-shaders/features/Grass Collision to D:/dev/private/skyrim-community-shaders/dist/Grass Collision.7z
[cmake] Zipping D:/dev/private/skyrim-community-shaders/features/Grass Lighting to D:/dev/private/skyrim-community-shaders/dist/Grass Lighting.7z
[cmake] Zipping D:/dev/private/skyrim-community-shaders/features/Light Limit Fix to D:/dev/private/skyrim-community-shaders/dist/Light Limit Fix.7z
[cmake] Zipping D:/dev/private/skyrim-community-shaders/features/Light Limit Fix Extended Lights to D:/dev/private/skyrim-community-shaders/dist/Light Limit Fix Extended Lights.7z
[cmake] Zipping D:/dev/private/skyrim-community-shaders/features/Screen-Space Shadows to D:/dev/private/skyrim-community-shaders/dist/Screen-Space Shadows.7z
[cmake] Zipping D:/dev/private/skyrim-community-shaders/features/Tree LOD Lighting to D:/dev/private/skyrim-community-shaders/dist/Tree LOD Lighting.7z
[cmake] Zipping D:/dev/private/skyrim-community-shaders/features/Water Blending to D:/dev/private/skyrim-community-shaders/dist/Water Blending.7z
```
![image](https://github.com/doodlum/skyrim-community-shaders/assets/964655/193ba46f-0bba-48bd-98b0-34e265fb1424)
