### PR TITLE
docs: improve compilation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ SKSE core plugin for community-driven advanced graphics modifications.
 ## Requirements
 
 - [PowerShell](https://github.com/PowerShell/PowerShell/releases/latest)
+  - Any version of PowerShell will work, including the version installed on Windows by default
 - [Visual Studio Community 2022](https://visualstudio.microsoft.com/)
   - Desktop development with C++
 - [CMake](https://cmake.org/)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ SKSE core plugin for community-driven advanced graphics modifications.
 - [Git](https://git-scm.com/downloads)
   - Edit the `PATH` environment variable and add the Git.exe install path as a new value
 - [Vcpkg](https://github.com/microsoft/vcpkg)
-  - Install vcpkg by running `git clone https://github.com/microsoft/vcpkg` and `.\vcpkg\bootstrap-vcpkg.bat` in a command terminal
+  - Install vcpkg using the directions in vcpkg's [Quick Start Guide](https://github.com/microsoft/vcpkg#quick-start-windows)
   - After install, add a new environment variable named `VCPKG_ROOT` with the value as the path to the folder containing vcpkg
 
 ## User Requirements

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SKSE core plugin for community-driven advanced graphics modifications.
 
 ## Requirements
 
-- Any terminal of your choice (ex: PowerShell)
+- Any terminal of your choice (e.g., PowerShell)
 - [Visual Studio Community 2022](https://visualstudio.microsoft.com/)
   - Desktop development with C++
 - [CMake](https://cmake.org/)
@@ -32,7 +32,7 @@ SKSE core plugin for community-driven advanced graphics modifications.
 - Close the cmd window
 
 ## Building
-Open PowerShell and run the following commands:
+Open terminal (e.g., PowerShell) and run the following commands:
 
 ```
 git clone https://github.com/doodlum/skyrim-community-shaders.git

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ SKSE core plugin for community-driven advanced graphics modifications.
 
 ## Requirements
 
-- [PowerShell](https://github.com/PowerShell/PowerShell/releases/latest)
-  - Any version of PowerShell will work, including the version installed on Windows by default
+- Any terminal of your choice (ex: PowerShell)
 - [Visual Studio Community 2022](https://visualstudio.microsoft.com/)
   - Desktop development with C++
 - [CMake](https://cmake.org/)
@@ -16,7 +15,7 @@ SKSE core plugin for community-driven advanced graphics modifications.
 - [Git](https://git-scm.com/downloads)
   - Edit the `PATH` environment variable and add the Git.exe install path as a new value
 - [Vcpkg](https://github.com/microsoft/vcpkg)
-  - Install vcpkg by running `git clone https://github.com/microsoft/vcpkg` and `.\vcpkg\bootstrap-vcpkg.bat` in PowerShell
+  - Install vcpkg by running `git clone https://github.com/microsoft/vcpkg` and `.\vcpkg\bootstrap-vcpkg.bat` in a command terminal
   - After install, add a new environment variable named `VCPKG_ROOT` with the value as the path to the folder containing vcpkg
 
 ## User Requirements

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ SKSE core plugin for community-driven advanced graphics modifications.
 - [Visual Studio Community 2022](https://visualstudio.microsoft.com/)
   - Desktop development with C++
 - [CMake](https://cmake.org/)
-  - Edit the `PATH` enviornment variable and add the cmake.exe install path as a new value
-  - Instructions for finding and editing the `PATH` enviornment variable can be found [here](https://www.java.com/en/download/help/path.html)
+  - Edit the `PATH` environment variable and add the cmake.exe install path as a new value
+  - Instructions for finding and editing the `PATH` environment variable can be found [here](https://www.java.com/en/download/help/path.html)
 - [Git](https://git-scm.com/downloads)
-  - Edit the `PATH` enviornment variable and add the Git.exe install path as a new value
+  - Edit the `PATH` environment variable and add the Git.exe install path as a new value
 - [Vcpkg](https://github.com/microsoft/vcpkg)
   - Install vcpkg by running `git clone https://github.com/microsoft/vcpkg` and `.\vcpkg\bootstrap-vcpkg.bat` in PowerShell
   - After install, add a new environment variable named `VCPKG_ROOT` with the value as the path to the folder containing vcpkg

--- a/README.md
+++ b/README.md
@@ -6,15 +6,17 @@ SKSE core plugin for community-driven advanced graphics modifications.
 
 ## Requirements
 
-- [CMake](https://cmake.org/)
-  - Add this to your `PATH`
 - [PowerShell](https://github.com/PowerShell/PowerShell/releases/latest)
-- [Vcpkg](https://github.com/microsoft/vcpkg)
-  - Add the environment variable `VCPKG_ROOT` with the value as the path to the folder containing vcpkg
 - [Visual Studio Community 2022](https://visualstudio.microsoft.com/)
   - Desktop development with C++
-- [CommonLibSSENG](https://github.com/alandtse/commonlibvr/tree/ng)
-  - Add this as as an environment variable `CommonLibSSEPath`
+- [CMake](https://cmake.org/)
+  - Edit the `PATH` enviornment variable and add the cmake.exe install path as a new value
+  - Instructions for finding and editing the `PATH` enviornment variable can be found [here](https://www.java.com/en/download/help/path.html)
+- [Git](https://git-scm.com/downloads)
+  - Edit the `PATH` enviornment variable and add the Git.exe install path as a new value
+- [Vcpkg](https://github.com/microsoft/vcpkg)
+  - Install vcpkg by running `git clone https://github.com/microsoft/vcpkg` and `.\vcpkg\bootstrap-vcpkg.bat` in PowerShell
+  - After install, add a new environment variable named `VCPKG_ROOT` with the value as the path to the folder containing vcpkg
 
 ## User Requirements
 
@@ -30,6 +32,7 @@ SKSE core plugin for community-driven advanced graphics modifications.
 - Close the cmd window
 
 ## Building
+Open PowerShell and run the following commands:
 
 ```
 git clone https://github.com/doodlum/skyrim-community-shaders.git


### PR DESCRIPTION
Rework of Readme's instructions to help clarify installation and configuration of requirements to compile Community Shaders.