### PR TITLE
feat: improve ShaderCache

### DIFF
--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -2,11 +2,14 @@
 
 #include <RE/B/BSShader.h>
 
+#include <chrono>
 #include <condition_variable>
 #include <unordered_map>
 #include <unordered_set>
 
 static constexpr REL::Version SHADER_CACHE_VERSION = { 0, 0, 0, 11 };
+
+using namespace std::chrono;
 
 namespace SIE
 {
@@ -21,11 +24,18 @@ namespace SIE
 	class ShaderCompilationTask
 	{
 	public:
+		enum Status
+		{
+			Pending,
+			Failed,
+			Completed
+		};
 		ShaderCompilationTask(ShaderClass shaderClass, const RE::BSShader& shader,
 			uint32_t descriptor);
 		void Perform() const;
 
 		size_t GetId() const;
+		std::string GetString() const;
 
 		bool operator==(const ShaderCompilationTask& other) const;
 
@@ -54,14 +64,23 @@ namespace SIE
 		void Add(const ShaderCompilationTask& task);
 		void Complete(const ShaderCompilationTask& task);
 		void Clear();
+		std::string GetHumanTime(double a_totalms);
+		double GetEta();
+		std::string GetStatsString();
 		std::atomic<uint64_t> completedTasks = 0;
 		std::atomic<uint64_t> totalTasks = 0;
-		std::mutex mutex;
+		std::atomic<uint64_t> failedTasks = 0;
+		std::atomic<uint64_t> cacheHitTasks = 0;  // number of compiles of a previously seen shader combo
+		std::mutex compilationMutex;
 
 	private:
 		std::unordered_set<ShaderCompilationTask> availableTasks;
 		std::unordered_set<ShaderCompilationTask> tasksInProgress;
+		std::unordered_set<ShaderCompilationTask> processedTasks;  // completed or failed
 		std::condition_variable conditionVariable;
+		std::chrono::steady_clock::time_point lastReset = high_resolution_clock::now();
+		std::chrono::steady_clock::time_point lastCalculation = high_resolution_clock::now();
+		double totalMs = (double)duration_cast<std::chrono::milliseconds>(lastReset - lastReset).count();
 	};
 
 	class ShaderCache
@@ -92,6 +111,7 @@ namespace SIE
 			return IsSupportedShader(shader.shaderType.get());
 		}
 
+		bool IsCompiling();
 		bool IsEnabled() const;
 		void SetEnabled(bool value);
 		bool IsAsync() const;
@@ -107,6 +127,13 @@ namespace SIE
 
 		void Clear();
 
+		bool AddCompletedShader(ShaderClass shaderClass, const RE::BSShader& shader, uint32_t descriptor, ID3DBlob* a_blob);
+		ID3DBlob* GetCompletedShader(const std::string a_key);
+		ID3DBlob* GetCompletedShader(const SIE::ShaderCompilationTask& a_task);
+		ID3DBlob* GetCompletedShader(ShaderClass shaderClass, const RE::BSShader& shader, uint32_t descriptor);
+		ShaderCompilationTask::Status GetShaderStatus(const std::string a_key);
+		std::string GetShaderStatsString();
+
 		RE::BSGraphics::VertexShader* GetVertexShader(const RE::BSShader& shader, uint32_t descriptor);
 		RE::BSGraphics::PixelShader* GetPixelShader(const RE::BSShader& shader,
 			uint32_t descriptor);
@@ -116,8 +143,15 @@ namespace SIE
 		RE::BSGraphics::PixelShader* MakeAndAddPixelShader(const RE::BSShader& shader,
 			uint32_t descriptor);
 
+		uint64_t GetCachedHitTasks();
 		uint64_t GetCompletedTasks();
+		uint64_t GetFailedTasks();
 		uint64_t GetTotalTasks();
+		void IncCacheHitTasks();
+		void ToggleErrorMessages();
+		bool IsHideErrors();
+
+		int32_t compilationThreadCount = std::max(static_cast<int32_t>(std::thread::hardware_concurrency()) - 1, 1);
 
 	private:
 		ShaderCache();
@@ -136,10 +170,13 @@ namespace SIE
 		bool isDiskCache = false;
 		bool isAsync = true;
 		bool isDump = false;
+		bool hideError = false;
 
 		eastl::vector<std::jthread> compilationThreads;
 		std::mutex vertexShadersMutex;
 		std::mutex pixelShadersMutex;
 		CompilationSet compilationSet;
+		std::unordered_map<std::string, std::pair<ID3DBlob*, ShaderCompilationTask::Status>> shaderMap{};
+		std::mutex mapMutex;
 	};
 }

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -87,9 +87,11 @@ void State::Load()
 		if (advanced["Log Level"].is_number_integer()) {
 			logLevel = static_cast<spdlog::level::level_enum>((int)advanced["Log Level"]);
 			//logLevel = static_cast<spdlog::level::level_enum>(max(spdlog::level::trace, min(spdlog::level::off, (int)advanced["Log Level"])));
-			if (advanced["Shader Defines"].is_string())
-				SetDefines(advanced["Shader Defines"]);
 		}
+		if (advanced["Shader Defines"].is_string())
+			SetDefines(advanced["Shader Defines"]);
+		if (advanced["Compiler Threads"].is_number_integer())
+			shaderCache.compilationThreadCount = std::clamp(advanced["Compiler Threads"].get<int32_t>(), 1, static_cast<int32_t>(std::thread::hardware_concurrency()));
 	}
 
 	if (settings["General"].is_object()) {
@@ -142,6 +144,7 @@ void State::Save()
 	advanced["Dump Shaders"] = shaderCache.IsDump();
 	advanced["Log Level"] = logLevel;
 	advanced["Shader Defines"] = shaderDefinesString;
+	advanced["Compiler Threads"] = shaderCache.compilationThreadCount;
 	settings["Advanced"] = advanced;
 
 	json general;

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -123,7 +123,7 @@ void MessageHandler(SKSE::MessagingInterface::Message* message)
 
 				auto& shaderCache = SIE::ShaderCache::Instance();
 
-				while (shaderCache.GetCompletedTasks() != shaderCache.GetTotalTasks()) {
+				while (shaderCache.IsCompiling()) {
 					std::this_thread::sleep_for(100ms);
 				}
 


### PR DESCRIPTION
* Add error message when compiler failure detected. Error may be hidden but menu will be in red font to indicate failure state.
* Add statistics to compilation message and advanced options, including estimated completion time and data on failures and cache hits.
* Add setting to change the Compiler Thread count. This may allow users to avoid crashes and unresponsiveness.
* Enable permutation hashing. Approximately 3.8K shaders in 1.5.97 appear redundant and are not recompiled.
* Fix logic to detect failed shaders appropriately and avoid infinite compilation bug.
* Fix bug where Shader Defines would not load if loglevel was malformed.

closes #71