### PR TITLE
fix: set bLandSpecular to support Terrain Parallax

### DIFF
--- a/src/Features/ExtendedMaterials.cpp
+++ b/src/Features/ExtendedMaterials.cpp
@@ -14,6 +14,18 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ShadowsStartFade,
 	ShadowsEndFade)
 
+void ExtendedMaterials::DataLoaded()
+{
+	if (&settings.EnableTerrain) {
+		if (auto bLandSpecular = RE::INISettingCollection::GetSingleton()->GetSetting("bLandSpecular:Landscape"); bLandSpecular) {
+			if (!bLandSpecular->data.b) {
+				logger::info("[CPM] Changing bLandSpecular from {} to {} to support Terrain Parallax", bLandSpecular->data.b, true);
+				bLandSpecular->data.b = true;
+			}
+		}
+	}
+}
+
 void ExtendedMaterials::DrawSettings()
 {
 	if (ImGui::TreeNodeEx("Complex Material", ImGuiTreeNodeFlags_DefaultOpen)) {
@@ -43,7 +55,11 @@ void ExtendedMaterials::DrawSettings()
 			ImGui::EndTooltip();
 		}
 
-		ImGui::Checkbox("Enable Terrain", (bool*)&settings.EnableTerrain);
+		if (ImGui::Checkbox("Enable Terrain", (bool*)&settings.EnableTerrain)) {
+			if (settings.EnableTerrain) {
+				DataLoaded();
+			}
+		}
 		if (ImGui::IsItemHovered()) {
 			ImGui::BeginTooltip();
 			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);

--- a/src/Features/ExtendedMaterials.h
+++ b/src/Features/ExtendedMaterials.h
@@ -47,6 +47,8 @@ struct ExtendedMaterials : Feature
 	virtual void SetupResources();
 	virtual inline void Reset() {}
 
+	void DataLoaded();
+
 	virtual void DrawSettings();
 
 	void ModifyLighting(const RE::BSShader* shader, const uint32_t descriptor);

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -130,6 +130,8 @@ void MessageHandler(SKSE::MessagingInterface::Message* message)
 
 				if (LightLimitFix::GetSingleton()->loaded)
 					LightLimitFix::GetSingleton()->DataLoaded();
+				if (ExtendedMaterials::GetSingleton()->loaded)
+					ExtendedMaterials::GetSingleton()->DataLoaded();
 			}
 
 			break;

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -98,9 +98,6 @@ void MessageHandler(SKSE::MessagingInterface::Message* message)
 				shaderCache.SetAsync(true);
 				shaderCache.SetDiskCache(true);
 				shaderCache.SetDump(false);
-
-				State::GetSingleton()->Load();
-
 				shaderCache.ValidateDiskCache();
 
 				if (LightLimitFix::GetSingleton()->loaded) {


### PR DESCRIPTION
bLandSpecular may be disabled by certain mod lists and is necessary for
terrain parallax. This will force the setting to true when Terrain
Parallax is enabled.