### PR TITLE
chore: use progress bar instead of text

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -571,9 +571,14 @@ void Menu::DrawOverlay()
 	compiledShaders = shaderCache.GetCompletedTasks();
 	totalShaders = shaderCache.GetTotalTasks();
 
+	auto state = State::GetSingleton();
+
 	auto failed = shaderCache.GetFailedTasks();
 	auto hide = shaderCache.IsHideErrors();
 	auto stats = shaderCache.GetShaderStatsString();
+	auto progressTitle = state->IsDeveloperMode() ? fmt::format("Compiling Shaders: {}", stats) : fmt::format("Compiling Shaders: {}", shaderCache.GetShaderStatsString(true).c_str());
+	auto percent = (float)compiledShaders / (float)totalShaders;
+	auto progressOverlay = fmt::format("{}/{} ({:2.1f}%)", compiledShaders, totalShaders, 100 * percent);
 	if (shaderCache.IsCompiling()) {
 		ImGui::SetNextWindowBgAlpha(1);
 		ImGui::SetNextWindowPos(ImVec2(10, 10));
@@ -581,8 +586,8 @@ void Menu::DrawOverlay()
 			ImGui::End();
 			return;
 		}
-
-		ImGui::Text(fmt::format("Compiling Shaders: {}", stats).c_str());
+		ImGui::TextUnformatted(progressTitle.c_str());
+		ImGui::ProgressBar(percent, ImVec2(0.0f, 0.0f), progressOverlay.c_str());
 
 		ImGui::End();
 	} else if (failed && !hide) {

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -575,8 +575,7 @@ void Menu::DrawOverlay()
 
 	auto failed = shaderCache.GetFailedTasks();
 	auto hide = shaderCache.IsHideErrors();
-	auto stats = shaderCache.GetShaderStatsString();
-	auto progressTitle = state->IsDeveloperMode() ? fmt::format("Compiling Shaders: {}", stats) : fmt::format("Compiling Shaders: {}", shaderCache.GetShaderStatsString(true).c_str());
+	auto progressTitle = fmt::format("Compiling Shaders: {}", shaderCache.GetShaderStatsString(!state->IsDeveloperMode()).c_str());
 	auto percent = (float)compiledShaders / (float)totalShaders;
 	auto progressOverlay = fmt::format("{}/{} ({:2.1f}%)", compiledShaders, totalShaders, 100 * percent);
 	if (shaderCache.IsCompiling()) {

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1449,9 +1449,9 @@ namespace SIE
 		return ShaderCompilationTask::Status::Pending;
 	}
 
-	std::string ShaderCache::GetShaderStatsString()
+	std::string ShaderCache::GetShaderStatsString(bool a_timeOnly)
 	{
-		return compilationSet.GetStatsString();
+		return compilationSet.GetStatsString(a_timeOnly);
 	}
 
 	bool ShaderCache::IsCompiling()
@@ -1767,8 +1767,12 @@ namespace SIE
 		return remaining / rate;
 	}
 
-	std::string CompilationSet::GetStatsString()
+	std::string CompilationSet::GetStatsString(bool a_timeOnly)
 	{
+		if (a_timeOnly)
+			return fmt::format("{}/{}",
+				GetHumanTime(totalMs),
+				GetHumanTime(GetEta() + totalMs));
 		return fmt::format("{}/{} (successful/total)\tfailed: {}\tcachehits: {}\nElapsed/Estimated Time: {}/{}",
 			(std::uint64_t)completedTasks,
 			(std::uint64_t)totalTasks,

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -66,7 +66,7 @@ namespace SIE
 		void Clear();
 		std::string GetHumanTime(double a_totalms);
 		double GetEta();
-		std::string GetStatsString();
+		std::string GetStatsString(bool a_timeOnly = false);
 		std::atomic<uint64_t> completedTasks = 0;
 		std::atomic<uint64_t> totalTasks = 0;
 		std::atomic<uint64_t> failedTasks = 0;
@@ -132,7 +132,7 @@ namespace SIE
 		ID3DBlob* GetCompletedShader(const SIE::ShaderCompilationTask& a_task);
 		ID3DBlob* GetCompletedShader(ShaderClass shaderClass, const RE::BSShader& shader, uint32_t descriptor);
 		ShaderCompilationTask::Status GetShaderStatus(const std::string a_key);
-		std::string GetShaderStatsString();
+		std::string GetShaderStatsString(bool a_timeOnly = false);
 
 		RE::BSGraphics::VertexShader* GetVertexShader(const RE::BSShader& shader, uint32_t descriptor);
 		RE::BSGraphics::PixelShader* GetPixelShader(const RE::BSShader& shader,


### PR DESCRIPTION
Replacing Compiling Shaders text with a progress bar. Debug mode will provide the original text with failures/hits.