### PR TITLE
fix: remove forced settings for shadercache

### DIFF
--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -94,10 +94,6 @@ void MessageHandler(SKSE::MessagingInterface::Message* message)
 
 				auto& shaderCache = SIE::ShaderCache::Instance();
 
-				shaderCache.SetEnabled(true);
-				shaderCache.SetAsync(true);
-				shaderCache.SetDiskCache(true);
-				shaderCache.SetDump(false);
 				shaderCache.ValidateDiskCache();
 
 				if (LightLimitFix::GetSingleton()->loaded) {


### PR DESCRIPTION
Fixes regression from 0b49ae9. ShaderCache settings would always be default.

Removing redundant load settings exposed where we were setting default settings for ShaderCache. This is unnecessary due to default values and the fact we ship a config file that is fully populated.