### PR TITLE
fix: enable bEnableImprovedSnow for SSS

### DIFF
--- a/src/Features/SubsurfaceScattering.cpp
+++ b/src/Features/SubsurfaceScattering.cpp
@@ -3,6 +3,21 @@
 
 #include "State.h"
 
+void SubsurfaceScattering::DataLoaded()
+{
+	if (!REL::Module::IsVR()) {
+		if (auto bEnableImprovedSnow = RE::INIPrefSettingCollection::GetSingleton()->GetSetting("bEnableImprovedSnow:Display"); bEnableImprovedSnow) {
+			if (!bEnableImprovedSnow->data.b) {
+				logger::info("[SSS] Changing bEnableImprovedSnow from {} to {} to support Subsurface Scattering", bEnableImprovedSnow->data.b, true);
+				bEnableImprovedSnow->data.b = true;
+			}
+		}
+	} else {  // VR does not bEnableImprovedSnow but the value is at 143423e18 and is checked by the engine.
+		bool* bEnableImprovedSnow = reinterpret_cast<bool*>(REL::Offset(0x3423e18).address());
+		*bEnableImprovedSnow = true;
+		logger::info("[SSS] Enabling bEnableImprovedSnow to support Subsurface Scattering");
+	}
+}
 void SubsurfaceScattering::DrawSettings()
 {
 }
@@ -171,7 +186,6 @@ void SubsurfaceScattering::DrawDeferred()
 			data.RcpBufferDim.y = 1.0f / (float)deferredTexture->desc.Height;
 
 			data.FrameCount = viewport->uiFrameCount * (Util::UnkOuterStruct::GetSingleton()->GetTAA() || State::GetSingleton()->upscalerLoaded);
-
 
 			data.DynamicRes.x = viewport->GetRuntimeData().dynamicResolutionCurrentWidthScale;
 			data.DynamicRes.y = viewport->GetRuntimeData().dynamicResolutionCurrentHeightScale;

--- a/src/Features/SubsurfaceScattering.h
+++ b/src/Features/SubsurfaceScattering.h
@@ -48,6 +48,7 @@ public:
 	virtual void SetupResources();
 	virtual inline void Reset() {}
 
+	virtual void DataLoaded();
 	virtual void DrawSettings();
 
 	virtual void Draw(const RE::BSShader* shader, const uint32_t descriptor);

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -8,6 +8,7 @@
 #include "Features/ExtendedMaterials.h"
 #include "Features/LightLimitFIx/ParticleLights.h"
 #include "Features/LightLimitFix.h"
+#include "Features/SubsurfaceScattering.h"
 #define DLLEXPORT __declspec(dllexport)
 
 std::list<std::string> errors;
@@ -132,6 +133,8 @@ void MessageHandler(SKSE::MessagingInterface::Message* message)
 					LightLimitFix::GetSingleton()->DataLoaded();
 				if (ExtendedMaterials::GetSingleton()->loaded)
 					ExtendedMaterials::GetSingleton()->DataLoaded();
+				if (SubsurfaceScattering::GetSingleton()->loaded)
+					SubsurfaceScattering::GetSingleton()->DataLoaded();
 			}
 
 			break;


### PR DESCRIPTION
bEnableImprovedSnow is required for SubsurfaceScattering. Note that this setting was removed in VR although references still exist. The impact to VR is unknown.