### PR TITLE
feat: simplify feature loading

### DIFF
--- a/src/Feature.h
+++ b/src/Feature.h
@@ -13,12 +13,17 @@ struct Feature
 
 	virtual void DrawSettings() = 0;
 	virtual void Draw(const RE::BSShader* shader, const uint32_t descriptor) = 0;
+	virtual void DrawDeferred() {}
+
+	virtual void DataLoaded() {}
+	virtual void PostPostLoad() {}
 
 	virtual void Load(json& o_json);
 	virtual void Save(json& o_json) = 0;
 
 	virtual bool ValidateCache(CSimpleIniA& a_ini);
 	virtual void WriteDiskCacheInfo(CSimpleIniA& a_ini);
+	virtual void ClearShaderCache() {}
 
 	// Cat: add all the features in here
 	static const std::vector<Feature*>& GetFeatureList();

--- a/src/Features/ExtendedMaterials.h
+++ b/src/Features/ExtendedMaterials.h
@@ -47,7 +47,7 @@ struct ExtendedMaterials : Feature
 	virtual void SetupResources();
 	virtual inline void Reset() {}
 
-	void DataLoaded();
+	virtual void DataLoaded() override;
 
 	virtual void DrawSettings();
 

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -570,6 +570,12 @@ void LightLimitFix::Draw(const RE::BSShader* shader, const uint32_t descriptor)
 	}
 }
 
+void LightLimitFix::PostPostLoad()
+{
+	ParticleLights::GetSingleton()->GetConfigs();
+	LightLimitFix::InstallHooks();
+}
+
 void LightLimitFix::DataLoaded()
 {
 	auto iMagicLightMaxCount = RE::GameSettingCollection::GetSingleton()->GetSetting("iMagicLightMaxCount");

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -115,7 +115,8 @@ public:
 	virtual void DrawSettings();
 	virtual void Draw(const RE::BSShader* shader, const uint32_t descriptor);
 
-	void DataLoaded();
+	virtual void PostPostLoad() override;
+	virtual void DataLoaded() override;
 
 	float CalculateLightDistance(float3 a_lightPosition, float a_radius);
 	bool AddCachedParticleLights(eastl::vector<LightData>& lightsData, LightLimitFix::LightData& light, ParticleLights::Config* a_config = nullptr, RE::BSGeometry* a_geometry = nullptr, double timer = 0.0f);

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -187,7 +187,7 @@ uint32_t GetTechnique(uint32_t descriptor)
 	return 0x3F & (descriptor >> 24);
 }
 
-void ScreenSpaceShadows::ClearComputeShader()
+void ScreenSpaceShadows::ClearShaderCache()
 {
 	if (raymarchProgram) {
 		raymarchProgram->Release();

--- a/src/Features/ScreenSpaceShadows.h
+++ b/src/Features/ScreenSpaceShadows.h
@@ -71,7 +71,7 @@ struct ScreenSpaceShadows : Feature
 	void ModifyGrass(const RE::BSShader* shader, const uint32_t descriptor);
 	void ModifyDistantTree(const RE::BSShader*, const uint32_t descriptor);
 
-	void ClearComputeShader();
+	virtual void ClearShaderCache() override;
 	ID3D11ComputeShader* GetComputeShader();
 	ID3D11ComputeShader* GetComputeShaderHorizontalBlur();
 	ID3D11ComputeShader* GetComputeShaderVerticalBlur();

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -318,7 +318,11 @@ void Menu::DrawSettings()
 			ImGui::TableNextColumn();
 			if (ImGui::Button("Clear Shader Cache", { -1, 0 })) {
 				shaderCache.Clear();
-				ScreenSpaceShadows::GetSingleton()->ClearComputeShader();
+				for (auto* feature : Feature::GetFeatureList()) {
+					if (feature->loaded) {
+						feature->ClearShaderCache();
+					}
+				}
 			}
 			if (ImGui::IsItemHovered()) {
 				ImGui::BeginTooltip();

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -39,6 +39,15 @@ void State::Draw()
 	currentShader = nullptr;
 }
 
+void State::DrawDeferred()
+{
+	for (auto* feature : Feature::GetFeatureList()) {
+		if (feature->loaded) {
+			feature->DrawDeferred();
+		}
+	}
+}
+
 void State::Reset()
 {
 	for (auto* feature : Feature::GetFeatureList())

--- a/src/State.h
+++ b/src/State.h
@@ -27,6 +27,7 @@ public:
 	bool upscalerLoaded = false;
 
 	void Draw();
+	void DrawDeferred();
 	void Reset();
 	void Setup();
 

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -96,9 +96,10 @@ void MessageHandler(SKSE::MessagingInterface::Message* message)
 
 				shaderCache.ValidateDiskCache();
 
-				if (LightLimitFix::GetSingleton()->loaded) {
-					ParticleLights::GetSingleton()->GetConfigs();
-					LightLimitFix::InstallHooks();
+				for (auto* feature : Feature::GetFeatureList()) {
+					if (feature->loaded) {
+						feature->PostPostLoad();
+					}
 				}
 			}
 
@@ -124,10 +125,11 @@ void MessageHandler(SKSE::MessagingInterface::Message* message)
 					shaderCache.WriteDiskCacheInfo();
 				}
 
-				if (LightLimitFix::GetSingleton()->loaded)
-					LightLimitFix::GetSingleton()->DataLoaded();
-				if (ExtendedMaterials::GetSingleton()->loaded)
-					ExtendedMaterials::GetSingleton()->DataLoaded();
+				for (auto* feature : Feature::GetFeatureList()) {
+					if (feature->loaded) {
+						feature->DataLoaded();
+					}
+				}
 			}
 
 			break;


### PR DESCRIPTION
Simplify feature loading by adding optional virtual functions in Feature.h that can be overriden by features. This will reduce the need to modify State.cpp, XSEPlugin.cpp & Menu.cpp when adding new features etc

Added to `Feature.h`:
- `DataLoaded` <-- Called by SKSE `kDataLoaded` event
- `PostPostLoad` <-- Called by SKSE `kPostPostLoad` event
- `ClearShaderCache` <-- Called by imgui clear shader cache button
- `DrawDeferred` <-- This one is not called yet, that is in the subsurface-scattering branch

Fixed almost all tasks of #97

Link to build for this PR -> https://github.com/FlayaN/skyrim-community-shaders/releases/tag/untagged-626eeecf0c4665d55ff6

Created this as a draft due to this should maybe wait until subsurface-scattering is in dev (Or maybe remove the DrawDeferred part of the PR), would like some feedback if this is what you meant on your issue @alandtse 