### PR TITLE
feat: add testing mode

### DIFF
--- a/src/Menu.h
+++ b/src/Menu.h
@@ -3,6 +3,9 @@
 #include "imgui.h"
 #include "imgui_impl_dx11.h"
 #include "imgui_impl_win32.h"
+#include <chrono>
+
+using namespace std::chrono;
 
 class Menu : public RE::BSTEventSink<RE::InputEvent*>
 {
@@ -30,7 +33,12 @@ private:
 	uint32_t skipCompilationKey = VK_ESCAPE;
 	bool settingToggleKey = false;
 	bool settingSkipCompilationKey = false;
-	float fontScale = 0.f;  // exponential
+	float fontScale = 0.f;         // exponential
+	uint32_t testInterval = 0;     // Seconds to wait before toggling user/test settings
+	bool inTestMode = false;       // Whether we're in test mode
+	bool usingTestConfig = false;  // Whether we're using the test config
+
+	std::chrono::steady_clock::time_point lastTestSwitch = high_resolution_clock::now();  // Time of last test switch
 
 	Menu() {}
 	const char* KeyIdToString(uint32_t key);

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -63,11 +63,11 @@ void State::Setup()
 	SetupResources();
 }
 
-void State::Load()
+void State::Load(bool a_test)
 {
 	auto& shaderCache = SIE::ShaderCache::Instance();
 
-	std::string configPath = userConfigPath;
+	std::string configPath = a_test ? testConfigPath : userConfigPath;
 	std::ifstream i(configPath);
 	if (!i.is_open()) {
 		logger::info("Unable to open user config file ({}); trying default ({})", configPath, defaultConfigPath);
@@ -146,10 +146,10 @@ void State::Load()
 		logger::info("Skyrim Upscaler not detected");
 }
 
-void State::Save()
+void State::Save(bool a_test)
 {
 	auto& shaderCache = SIE::ShaderCache::Instance();
-	std::ofstream o(userConfigPath);
+	std::ofstream o{ a_test ? testConfigPath : userConfigPath };
 	json settings;
 
 	Menu::GetSingleton()->Save(settings);

--- a/src/State.h
+++ b/src/State.h
@@ -21,6 +21,7 @@ public:
 	spdlog::level::level_enum logLevel = spdlog::level::info;
 	std::string shaderDefinesString = "";
 	std::vector<std::pair<std::string, std::string>> shaderDefines{};  // data structure to parse string into; needed to avoid dangling pointers
+	const std::string testConfigPath = "Data\\SKSE\\Plugins\\CommunityShadersTEST.json";
 	const std::string userConfigPath = "Data\\SKSE\\Plugins\\CommunityShadersUSER.json";
 	const std::string defaultConfigPath = "Data\\SKSE\\Plugins\\CommunityShaders.json";
 
@@ -31,8 +32,8 @@ public:
 	void Reset();
 	void Setup();
 
-	void Load();
-	void Save();
+	void Load(bool a_test = false);
+	void Save(bool a_test = false);
 
 	bool ValidateCache(CSimpleIniA& a_ini);
 	void WriteDiskCacheInfo(CSimpleIniA& a_ini);


### PR DESCRIPTION
Add mode that automatically toggles between test settings and the saved user settings. Use to compare changes between two settings.

To enable:
1. Change settings from your saved user settings.
2. Under Advanced -> Test Interval, change the value to a nonzero value.
3. Disable by reverting Test Interval back to 0.