### PR TITLE
refactor: move opt in for shaders to virtual feature function

### DIFF
--- a/src/Feature.h
+++ b/src/Feature.h
@@ -7,6 +7,9 @@ struct Feature
 
 	virtual std::string GetName() = 0;
 	virtual std::string GetShortName() = 0;
+	virtual std::string_view GetShaderDefineName() { return ""; }
+
+	virtual bool HasShaderDefine(RE::BSShader::Type) { return false; }
 
 	virtual void SetupResources() = 0;
 	virtual void Reset() = 0;

--- a/src/Features/ExtendedMaterials.cpp
+++ b/src/Features/ExtendedMaterials.cpp
@@ -237,3 +237,13 @@ void ExtendedMaterials::Save(json& o_json)
 {
 	o_json[GetName()] = settings;
 }
+
+bool ExtendedMaterials::HasShaderDefine(RE::BSShader::Type shaderType)
+{
+	switch (shaderType) {
+	case RE::BSShader::Type::Lighting:
+		return true;
+	default:
+		return false;
+	}
+}

--- a/src/Features/ExtendedMaterials.h
+++ b/src/Features/ExtendedMaterials.h
@@ -13,6 +13,9 @@ struct ExtendedMaterials : Feature
 
 	virtual inline std::string GetName() { return "Complex Parallax Materials"; }
 	virtual inline std::string GetShortName() { return "ComplexParallaxMaterials"; }
+	inline std::string_view GetShaderDefineName() override { return "COMPLEX_PARALLAX_MATERIALS"; }
+
+	bool HasShaderDefine(RE::BSShader::Type shaderType) override;
 
 	struct Settings
 	{

--- a/src/Features/GrassCollision.cpp
+++ b/src/Features/GrassCollision.cpp
@@ -336,3 +336,13 @@ void GrassCollision::Reset()
 {
 	updatePerFrame = true;
 }
+
+bool GrassCollision::HasShaderDefine(RE::BSShader::Type shaderType)
+{
+	switch (shaderType) {
+	case RE::BSShader::Type::Grass:
+		return true;
+	default:
+		return false;
+	}
+}

--- a/src/Features/GrassCollision.h
+++ b/src/Features/GrassCollision.h
@@ -13,6 +13,9 @@ struct GrassCollision : Feature
 
 	virtual inline std::string GetName() { return "Grass Collision"; }
 	virtual inline std::string GetShortName() { return "GrassCollision"; }
+	inline std::string_view GetShaderDefineName() override { return "GRASS_COLLISION"; }
+
+	bool HasShaderDefine(RE::BSShader::Type shaderType) override;
 
 	struct Settings
 	{

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -958,3 +958,14 @@ void LightLimitFix::UpdateLights()
 	ID3D11UnorderedAccessView* null_uavs[3] = { nullptr };
 	context->CSSetUnorderedAccessViews(0, ARRAYSIZE(null_uavs), null_uavs, nullptr);
 }
+
+bool LightLimitFix::HasShaderDefine(RE::BSShader::Type shaderType)
+{
+	switch (shaderType) {
+	case RE::BSShader::Type::Lighting:
+	case RE::BSShader::Type::Grass:
+		return true;
+	default:
+		return false;
+	}
+}

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -24,6 +24,9 @@ public:
 	}
 	virtual inline std::string GetName() { return "Light Limit Fix"; }
 	virtual inline std::string GetShortName() { return "LightLimitFix"; }
+	inline std::string_view GetShaderDefineName() override { return "LIGHT_LIMIT_FIX"; }
+
+	bool HasShaderDefine(RE::BSShader::Type shaderType) override;
 
 	struct LightData
 	{

--- a/src/Features/RainWetnessEffects.cpp
+++ b/src/Features/RainWetnessEffects.cpp
@@ -347,3 +347,13 @@ void RainWetnessEffects::Save(json& o_json)
 {
 	o_json[GetName()] = settings;
 }
+
+bool RainWetnessEffects::HasShaderDefine(RE::BSShader::Type shaderType)
+{
+	switch (shaderType) {
+	case RE::BSShader::Type::Lighting:
+		return true;
+	default:
+		return false;
+	}
+}

--- a/src/Features/RainWetnessEffects.h
+++ b/src/Features/RainWetnessEffects.h
@@ -14,6 +14,9 @@ public:
 
 	virtual inline std::string GetName() { return "Rain Wetness Effects"; }
 	virtual inline std::string GetShortName() { return "RainWetnessEffects"; }
+	inline std::string_view GetShaderDefineName() override { return "RAIN_WETNESS_EFFECTS"; }
+
+	bool HasShaderDefine(RE::BSShader::Type shaderType) override;
 
 	struct Settings
 	{

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -510,3 +510,15 @@ void ScreenSpaceShadows::Reset()
 {
 	renderedScreenCamera = false;
 }
+
+bool ScreenSpaceShadows::HasShaderDefine(RE::BSShader::Type shaderType)
+{
+	switch (shaderType) {
+	case RE::BSShader::Type::Lighting:
+	case RE::BSShader::Type::Grass:
+	case RE::BSShader::Type::DistantTree:
+		return true;
+	default:
+		return false;
+	}
+}

--- a/src/Features/ScreenSpaceShadows.h
+++ b/src/Features/ScreenSpaceShadows.h
@@ -13,6 +13,9 @@ struct ScreenSpaceShadows : Feature
 
 	virtual inline std::string GetName() { return "Screen-Space Shadows"; }
 	virtual inline std::string GetShortName() { return "ScreenSpaceShadows"; }
+	inline std::string_view GetShaderDefineName() override { return "SCREEN_SPACE_SHADOWS"; }
+
+	bool HasShaderDefine(RE::BSShader::Type shaderType) override;
 
 	struct Settings
 	{

--- a/src/Features/WaterBlending.cpp
+++ b/src/Features/WaterBlending.cpp
@@ -124,3 +124,13 @@ void WaterBlending::Save(json& o_json)
 {
 	o_json[GetName()] = settings;
 }
+
+bool WaterBlending::HasShaderDefine(RE::BSShader::Type shaderType)
+{
+	switch (shaderType) {
+	case RE::BSShader::Type::Water:
+		return true;
+	default:
+		return false;
+	}
+}

--- a/src/Features/WaterBlending.h
+++ b/src/Features/WaterBlending.h
@@ -14,6 +14,9 @@ public:
 
 	virtual inline std::string GetName() { return "Water Blending"; }
 	virtual inline std::string GetShortName() { return "WaterBlending"; }
+	inline std::string_view GetShaderDefineName() override { return "WATER_BLENDING"; }
+
+	bool HasShaderDefine(RE::BSShader::Type shaderType) override;
 
 	struct Settings
 	{

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -8,11 +8,7 @@
 #include "State.h"
 
 #include "Feature.h"
-#include "Features/ExtendedMaterials.h"
 #include "Features/LightLimitFix/ParticleLights.h"
-#include "Features/RainWetnessEffects.h"
-#include "Features/ScreenSpaceShadows.h"
-#include "Features/WaterBlending.h"
 
 #define SETTING_MENU_TOGGLEKEY "Toggle Key"
 #define SETTING_MENU_SKIPKEY "Skip Compilation Key"


### PR DESCRIPTION
Added virtual `GetShaderDefineName` to feature.h that can be overriden by each feature to specify the Shader define name for each feature.

Added virtual `HasShaderDefine` to feature.h to specify if `RE::BSShader::Type` is implemented by that feature, this is used in ShaderCache.cpp to know if it should add a define for each loaded feature

This PR will not require updating ShaderCache.cpp for each new/updated feature, can instead be fully controlled by the feature instead

Has tested basic functionality for each feature
Can download a release for this PR here https://github.com/FlayaN/skyrim-community-shaders/releases/tag/untagged-db023c4d6153eaa50ba7