### PR TITLE
chore: break apart menu multiline strings

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -338,10 +338,11 @@ void Menu::DrawSettings()
 			if (ImGui::IsItemHovered()) {
 				ImGui::BeginTooltip();
 				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-				ImGui::Text("The Disk Cache is a collection of compiled shaders on disk, which are automatically created when shaders are added to the Shader Cache.");
-				ImGui::Text("If you do not have a Disk Cache, or it is outdated or invalid, you will see \"Compiling Shaders\" in the upper-left corner.");
-				ImGui::Text("After this has completed you will no longer see this message apart from when loading from the Disk Cache.");
-				ImGui::Text("Only delete the Disk Cache manually if you are encountering issues.");
+				ImGui::Text(
+					"The Disk Cache is a collection of compiled shaders on disk, which are automatically created when shaders are added to the Shader Cache. "
+					"If you do not have a Disk Cache, or it is outdated or invalid, you will see \"Compiling Shaders\" in the upper-left corner. "
+					"After this has completed you will no longer see this message apart from when loading from the Disk Cache. "
+					"Only delete the Disk Cache manually if you are encountering issues. ");
 				ImGui::PopTextWrapPos();
 				ImGui::EndTooltip();
 			}

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -545,8 +545,8 @@ void Menu::DrawSettings()
 				ImGui::Text(
 					"Sets number of seconds before toggling between default USER and TEST config. "
 					"0 disables. Non-zero will enable testing mode. "
-					"Enabling will save current settings as TEST config."
-					"This has no impact if no settings are changed.");
+					"Enabling will save current settings as TEST config. "
+					"This has no impact if no settings are changed. ");
 				ImGui::PopTextWrapPos();
 				ImGui::EndTooltip();
 			}

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -323,9 +323,10 @@ void Menu::DrawSettings()
 			if (ImGui::IsItemHovered()) {
 				ImGui::BeginTooltip();
 				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-				ImGui::Text("The Shader Cache is the collection of compiled shaders which replace the vanilla shaders at runtime.");
-				ImGui::Text("Clearing the shader cache will mean that shaders are recompiled only when the game re-encounters them.");
-				ImGui::Text("This is only needed for hot-loading shaders for development purposes.");
+				ImGui::Text(
+					"The Shader Cache is the collection of compiled shaders which replace the vanilla shaders at runtime. "
+					"Clearing the shader cache will mean that shaders are recompiled only when the game re-encounters them. "
+					"This is only needed for hot-loading shaders for development purposes. ");
 				ImGui::PopTextWrapPos();
 				ImGui::EndTooltip();
 			}


### PR DESCRIPTION
# Change Summary
This fixes #87 
Following the discussion in #87 , in `Menu.cpp` I've changed the multiline handling in **tooltips that use multiple text fields** (consecutive uses of `ImGui::Text()`).

According to the above, I identified and modified the tooltips for the below features:
- `Clear Shader Cache` button
- `Clear Disk Cache` button
- `Test Interval` slider

---

In the modified tooltips, I also maintained the habit of adding an **extra space at the end of the final string**, which was **already present** in the `Toggle Error Message` button tooltip:
https://github.com/doodlum/skyrim-community-shaders/blob/b105489c7fec25838b53b272b1446289f9fafe5b/src/Menu.cpp#L361-L365 ...and the `Compiler Threads` slider tooltip: https://github.com/doodlum/skyrim-community-shaders/blob/b105489c7fec25838b53b272b1446289f9fafe5b/src/Menu.cpp#L513-L515

# Possible Additional Changes (Pending maintainers' request)
In `menu.cpp` I found the following **multi-sentence, single-string tooltips ** but was **unsure whether they required modification** (please note that entire paragraphs - not individual sentences - are wrapped in double quotes):

- The `Enable Async` checkbox tooltip (line **407**):
https://github.com/doodlum/skyrim-community-shaders/blob/2fcc62f89dfe96cea92afb532fa395f8396d59dc/src/Menu.cpp#L401-L410

- The `Dump Shaders` checkbox tooltip (line **466**):
https://github.com/doodlum/skyrim-community-shaders/blob/2fcc62f89dfe96cea92afb532fa395f8396d59dc/src/Menu.cpp#L460-L469

- The `Log Level` combo box tooltip (line **488**):
https://github.com/doodlum/skyrim-community-shaders/blob/2fcc62f89dfe96cea92afb532fa395f8396d59dc/src/Menu.cpp#L481-L491

- ...and the `Shader Defines` tooltip (line **500**):
https://github.com/doodlum/skyrim-community-shaders/blob/2fcc62f89dfe96cea92afb532fa395f8396d59dc/src/Menu.cpp#L494-L503

Please let me know if the above tooltips should also be modified to match the proposed changes.

---

Please let me know if other changes are required.

Additionally, if this PR is approved and merged, I'd like this contribution to count towards my [Hacktoberfest 2023](https://hacktoberfest.com/) progress.
If the above changes are approved and merged, could the `hacktoberfest-accepted` label be added to the PR/MR?


Thank you for considering these changes.