### PR TITLE
feat: add TESTCUBEMAP define testmode

### DIFF
--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/UpdateCubemapCS.hlsl
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/UpdateCubemapCS.hlsl
@@ -1,3 +1,4 @@
+#include "../Common/VR.hlsl"
 RWTexture2DArray<float4> DynamicCubemap : register(u0);
 
 Texture2D<float> DepthTexture : register(t0);
@@ -138,10 +139,7 @@ void main(uint3 ThreadID : SV_DispatchThreadID)
 
     if (IsSaturated(uv) && viewDirection.z < 0.0) { // Check that the view direction exists in screenspace and that it is in front of the camera
 		uv = GetDynamicResolutionAdjustedScreenPosition(uv);
-
-#	if defined(VR)
-		uv.x *= 0.5;
-#	endif
+		uv = ConvertToStereoUV(uv, 0);
 
 		float2 textureDims;
 		DepthTexture.GetDimensions(textureDims.x, textureDims.y);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2046,8 +2046,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	color.xyz = Lin2sRGB(color.xyz);
 #	endif
 
-#	if defined(ENVMAP)
-	//color.xyz  = specularTexture.SampleLevel(SampEnvSampler, envSamplingPoint, 0).xyz;
+#	if defined(ENVMAP) && defined(TESTCUBEMAP)
+	color.xyz = specularTexture.SampleLevel(SampEnvSampler, envSamplingPoint, 0).xyz;
 #	endif
 
 #	if defined(LANDSCAPE) && !defined(LOD_LAND_BLEND)


### PR DESCRIPTION
This will force cubemaps on all materials that use them without
distortion.

Under Advanced -> Shader Defines add `TESTCUBEMAP` and then rebuild
shaders. This may require deleting the disk cache before clearing shader
cache.