### PR TITLE
Triplanar Mapping for Projected Textures

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -952,11 +952,12 @@ float2 ComputeTriplanarUV(float3 InputPosition)
 	float3 posDDX = ddx(InputPosition.xyz);
 	float3 posDDY = ddy(InputPosition.xyz);
 	return (((0.1 * (abs(posDDX.z) + abs(posDDY.z)) < abs(posDDX.x) + abs(posDDY.x)) &&
-			 (0.1 * (abs(posDDX.z) + abs(posDDY.z)) < abs(posDDX.y) + abs(posDDY.y))) ? InputPosition.xy :
-			((0.5 * (abs(posDDX.x) + abs(posDDY.x)) < abs(posDDX.y) + abs(posDDY.y))  ? InputPosition.yz : InputPosition.xz));
+				(0.1 * (abs(posDDX.z) + abs(posDDY.z)) < abs(posDDX.y) + abs(posDDY.y))) ?
+				InputPosition.xy :
+				((0.5 * (abs(posDDX.x) + abs(posDDY.x)) < abs(posDDX.y) + abs(posDDY.y)) ? InputPosition.yz : InputPosition.xz));
 }
 
-#if defined(LOD)
+#	if defined(LOD)
 #		undef COMPLEX_PARALLAX_MATERIALS
 #		undef WATER_BLENDING
 #		undef LIGHT_LIMIT_FIX
@@ -1154,8 +1155,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #		else
 	float2 triplanarUv = ComputeTriplanarUV(input.InputPosition.xyz);
 	diffuseUv = ProjectedUVParams2.yy * triplanarUv;
-#		endif // VR
-#	endif  // SPARKLE
+#		endif  // VR
+#	endif      // SPARKLE
 
 #	if defined(CPM_AVAILABLE)
 
@@ -1175,7 +1176,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	diffuseUv = ProjectedUVParams2.yy * (input.TexCoord0.zw + (uv - uvOriginal));
 #			else
 	diffuseUv = ProjectedUVParams2.yy * (triplanarUv + (uv - uvOriginal));
-#			endif // VR
+#			endif  // VR
 #		else
 	diffuseUv = uv;
 #		endif  // SPARKLE
@@ -1453,7 +1454,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		float2 projNormalUv = ProjectedUVParams3.x * ProjectedUVParams.zz * ComputeTriplanarUV(input.InputPosition.xyz);
 #			else
 		float2 projNormalUv = ProjectedUVParams3.x * projNoiseUv;
-#			endif // VR
+#			endif  // VR
 		float3 projNormal = TransformNormal(TexProjNormalSampler.Sample(SampProjNormalSampler, projNormalUv).xyz);
 		float2 projDetailUv = ProjectedUVParams3.y * projNoiseUv;
 		float3 projDetail = TexProjDetail.Sample(SampProjDetailSampler, projDetailUv).xyz;


### PR DESCRIPTION
Triplanar mapping for projected diffuse textures (introduced by Better Dynamic Snow / Simplicity Of Snow / Shaders Of Solstheim).

Fixes texture striping when projection is parallel to object geometry, most notably for snow on Windhelm architecture.

Uses screen space derivatives because geometry normals don't help. Uses UV based triplanar mapping for performance.

Works for VR and flat screen, although it needs to hook into different code paths for each platform. The function "ComputeTriplanarUV" does the math.