### PR TITLE
feat: allow override for complex grass lighting

### DIFF
--- a/features/Grass Lighting/Shaders/Features/GrassLighting.ini
+++ b/features/Grass Lighting/Shaders/Features/GrassLighting.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 1-3-3
+Version = 1-4-0

--- a/features/Grass Lighting/Shaders/RunGrass.hlsl
+++ b/features/Grass Lighting/Shaders/RunGrass.hlsl
@@ -431,7 +431,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		worldNormal = normalize(mul(normalColor, CalculateTBN(worldNormal, -input.WorldPosition, input.TexCoord.xy)));
 	}
 
-	if (!complex || (complex && OverrideComplexGrassSettings))
+	if (!complex || OverrideComplexGrassSettings)
 		baseColor.xyz *= BasicGrassBrightness;
 
 	float3 dirLightColor = DirLightColor.xyz;

--- a/features/Grass Lighting/Shaders/RunGrass.hlsl
+++ b/features/Grass Lighting/Shaders/RunGrass.hlsl
@@ -106,8 +106,9 @@ cbuffer PerFrame : register(
 	float SpecularStrength;
 	float SubsurfaceScatteringAmount;
 	bool EnableDirLightFix;
+	bool OverrideComplexGrassSettings;
 	float BasicGrassBrightness;
-	float pad[2];
+	float pad[1];
 }
 
 #ifdef VSHADER
@@ -430,7 +431,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		worldNormal = normalize(mul(normalColor, CalculateTBN(worldNormal, -input.WorldPosition, input.TexCoord.xy)));
 	}
 
-	if (!complex)
+	if (!complex || (complex && OverrideComplexGrassSettings))
 		baseColor.xyz *= BasicGrassBrightness;
 
 	float3 dirLightColor = DirLightColor.xyz;

--- a/src/Features/GrassLighting.cpp
+++ b/src/Features/GrassLighting.cpp
@@ -9,6 +9,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	SpecularStrength,
 	SubsurfaceScatteringAmount,
 	EnableDirLightFix,
+	OverrideComplexGrassSettings,
 	BasicGrassBrightness)
 
 enum class GrassShaderTechniques
@@ -71,6 +72,19 @@ void GrassLighting::DrawSettings()
 			ImGui::EndTooltip();
 		}
 
+		ImGui::Checkbox("Override Complex Grass Lighting Settings", (bool*)&settings.OverrideComplexGrassSettings);
+		if (ImGui::IsItemHovered()) {
+			ImGui::BeginTooltip();
+			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			ImGui::Text(
+				"Override the settings set by the grass mesh author. "
+				"Complex grass authors can define the brightness for their grass meshes. "
+				"However, some authors may not account for the extra lights available from Community Shaders. "
+				"This option will treat their grass settings like non-complex grass. "
+				"This was the default in Community Shaders < 0.7.0");
+			ImGui::PopTextWrapPos();
+			ImGui::EndTooltip();
+		}
 		ImGui::Spacing();
 		ImGui::Spacing();
 		ImGui::TextWrapped("Basic Grass");

--- a/src/Features/GrassLighting.h
+++ b/src/Features/GrassLighting.h
@@ -20,6 +20,7 @@ struct GrassLighting : Feature
 		float SpecularStrength = 0.5f;
 		float SubsurfaceScatteringAmount = 1.0f;
 		uint EnableDirLightFix = true;
+		uint OverrideComplexGrassSettings = false;
 		float BasicGrassBrightness = 0.666f;
 	};
 
@@ -28,7 +29,7 @@ struct GrassLighting : Feature
 		DirectX::XMFLOAT3X4 DirectionalAmbient;
 		float SunlightScale;
 		Settings Settings;
-		float pad[2];
+		float pad[1];
 	};
 
 	Settings settings;


### PR DESCRIPTION
Override the settings set by the grass mesh author. Complex grass authors can define the brightness for their grass meshes. However, some authors may not account for the extra lights available from Community Shaders. This option will treat their grass settings like non-complex grass. This was the default in Community Shaders < 0.7.0.