### PR TITLE
refactor: Consolidate multiline strings in feature code

### DIFF
--- a/src/Features/DistantTreeLighting.cpp
+++ b/src/Features/DistantTreeLighting.cpp
@@ -50,7 +50,7 @@ void DistantTreeLighting::DrawSettings()
 			ImGui::BeginTooltip();
 			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
 			ImGui::Text(
-				"Subsurface Scattering (SSS) amount "
+				"Subsurface Scattering (SSS) amount. "
 				"Soft lighting controls how evenly lit an object is. "
 				"Back lighting illuminates the back face of an object. "
 				"Combined to model the transport of light through the surface. ");

--- a/src/Features/DistantTreeLighting.cpp
+++ b/src/Features/DistantTreeLighting.cpp
@@ -16,9 +16,10 @@ void DistantTreeLighting::DrawSettings()
 		if (ImGui::IsItemHovered()) {
 			ImGui::BeginTooltip();
 			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-			ImGui::Text("Enables advanced lighting simulation on tree LOD.\n");
-			ImGui::Text("Requires DynDOLOD.\n");
-			ImGui::Text("See https://dyndolod.info/ for more information.");
+			ImGui::Text(
+				"Enables advanced lighting simulation on tree LOD. "
+				"Requires DynDOLOD. "
+				"See https://dyndolod.info/ for more information. ");
 			ImGui::PopTextWrapPos();
 			ImGui::EndTooltip();
 		}
@@ -48,10 +49,11 @@ void DistantTreeLighting::DrawSettings()
 		if (ImGui::IsItemHovered()) {
 			ImGui::BeginTooltip();
 			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-			ImGui::Text("Subsurface Scattering (SSS) amount\n");
-			ImGui::Text("Soft lighting controls how evenly lit an object is.\n");
-			ImGui::Text("Back lighting illuminates the back face of an object.\n");
-			ImGui::Text("Combined to model the transport of light through the surface.");
+			ImGui::Text(
+				"Subsurface Scattering (SSS) amount "
+				"Soft lighting controls how evenly lit an object is. "
+				"Back lighting illuminates the back face of an object. "
+				"Combined to model the transport of light through the surface. ");
 			ImGui::PopTextWrapPos();
 			ImGui::EndTooltip();
 		}

--- a/src/Features/ExtendedMaterials.cpp
+++ b/src/Features/ExtendedMaterials.cpp
@@ -33,9 +33,13 @@ void ExtendedMaterials::DrawSettings()
 		if (ImGui::IsItemHovered()) {
 			ImGui::BeginTooltip();
 			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-			ImGui::Text("Enables support for the Complex Material specification which makes use of the environment mask.\n");
-			ImGui::Text("This includes parallax, as well as more realistic metals and specular reflections.\n");
-			ImGui::Text("May lead to some warped textures on modded content which have an invalid alpha channel in their environment mask.");
+			ImGui::Text(
+				"Enables support for the Complex Material specification which makes use of the environment mask. "
+				"This includes parallax, as well as more realistic metals and specular reflections. "
+				"May lead to some warped textures on modded content which have an invalid alpha channel in their environment mask. ");
+			// ImGui::Text("Enables support for the Complex Material specification which makes use of the environment mask.\n");
+			// ImGui::Text("This includes parallax, as well as more realistic metals and specular reflections.\n");
+			// ImGui::Text("May lead to some warped textures on modded content which have an invalid alpha channel in their environment mask.");
 			ImGui::PopTextWrapPos();
 			ImGui::EndTooltip();
 		}
@@ -63,8 +67,11 @@ void ExtendedMaterials::DrawSettings()
 		if (ImGui::IsItemHovered()) {
 			ImGui::BeginTooltip();
 			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-			ImGui::Text("Enables terrain parallax using the alpha channel of each landscape texture.\n");
-			ImGui::Text("Therefore, all landscape textures must support parallax for this effect to work properly.");
+			ImGui::Text(
+				"Enables terrain parallax using the alpha channel of each landscape texture. "
+				"Therefore, all landscape textures must support parallax for this effect to work properly. ");
+			// ImGui::Text("Enables terrain parallax using the alpha channel of each landscape texture.\n");
+			// ImGui::Text("Therefore, all landscape textures must support parallax for this effect to work properly.");
 			ImGui::PopTextWrapPos();
 			ImGui::EndTooltip();
 		}
@@ -73,9 +80,13 @@ void ExtendedMaterials::DrawSettings()
 		if (ImGui::IsItemHovered()) {
 			ImGui::BeginTooltip();
 			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-			ImGui::Text("Doubles the sample count and approximates the intersection point using Parallax Occlusion Mapping.\n");
-			ImGui::Text("Significantly improves the quality and removes aliasing.\n");
-			ImGui::Text("TAA or the Skyrim Upscaler is recommended when using this option due to CRPM artifacts.");
+			ImGui::Text(
+				"Doubles the sample count and approximates the intersection point using Parallax Occlusion Mapping. "
+				"Significantly improves the quality and removes aliasing. "
+				"TAA or the Skyrim Upscaler is recommended when using this option due to CRPM artifacts. ");
+			// ImGui::Text("Doubles the sample count and approximates the intersection point using Parallax Occlusion Mapping.\n");
+			// ImGui::Text("Significantly improves the quality and removes aliasing.\n");
+			// ImGui::Text("TAA or the Skyrim Upscaler is recommended when using this option due to CRPM artifacts.");
 			ImGui::PopTextWrapPos();
 			ImGui::EndTooltip();
 		}
@@ -104,8 +115,11 @@ void ExtendedMaterials::DrawSettings()
 		if (ImGui::IsItemHovered()) {
 			ImGui::BeginTooltip();
 			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-			ImGui::Text("The range that parallax blends from Parallax Occlusion Mapping (POM) to bump mapping, and bump mapping to nothing.\n");
-			ImGui::Text("This value should be set as low as possible due to the performance impact of blending POM and relief mapping.");
+			ImGui::Text(
+				"The range that parallax blends from Parallax Occlusion Mapping (POM) to bump mapping, and bump mapping to nothing. "
+				"This value should be set as low as possible due to the performance impact of blending POM and relief mapping. ");
+			// ImGui::Text("The range that parallax blends from Parallax Occlusion Mapping (POM) to bump mapping, and bump mapping to nothing.\n");
+			// ImGui::Text("This value should be set as low as possible due to the performance impact of blending POM and relief mapping.");
 			ImGui::PopTextWrapPos();
 			ImGui::EndTooltip();
 		}
@@ -129,8 +143,11 @@ void ExtendedMaterials::DrawSettings()
 		if (ImGui::IsItemHovered()) {
 			ImGui::BeginTooltip();
 			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-			ImGui::Text("Enables cheap soft shadows when using parallax.\n");
-			ImGui::Text("This applies to all directional and point lights.");
+			ImGui::Text(
+				"Enables cheap soft shadows when using parallax. "
+				"This applies to all directional and point lights. ");
+			// ImGui::Text("Enables cheap soft shadows when using parallax.\n");
+			// ImGui::Text("This applies to all directional and point lights.");
 			ImGui::PopTextWrapPos();
 			ImGui::EndTooltip();
 		}

--- a/src/Features/ExtendedMaterials.cpp
+++ b/src/Features/ExtendedMaterials.cpp
@@ -37,9 +37,6 @@ void ExtendedMaterials::DrawSettings()
 				"Enables support for the Complex Material specification which makes use of the environment mask. "
 				"This includes parallax, as well as more realistic metals and specular reflections. "
 				"May lead to some warped textures on modded content which have an invalid alpha channel in their environment mask. ");
-			// ImGui::Text("Enables support for the Complex Material specification which makes use of the environment mask.\n");
-			// ImGui::Text("This includes parallax, as well as more realistic metals and specular reflections.\n");
-			// ImGui::Text("May lead to some warped textures on modded content which have an invalid alpha channel in their environment mask.");
 			ImGui::PopTextWrapPos();
 			ImGui::EndTooltip();
 		}
@@ -70,8 +67,6 @@ void ExtendedMaterials::DrawSettings()
 			ImGui::Text(
 				"Enables terrain parallax using the alpha channel of each landscape texture. "
 				"Therefore, all landscape textures must support parallax for this effect to work properly. ");
-			// ImGui::Text("Enables terrain parallax using the alpha channel of each landscape texture.\n");
-			// ImGui::Text("Therefore, all landscape textures must support parallax for this effect to work properly.");
 			ImGui::PopTextWrapPos();
 			ImGui::EndTooltip();
 		}
@@ -84,9 +79,6 @@ void ExtendedMaterials::DrawSettings()
 				"Doubles the sample count and approximates the intersection point using Parallax Occlusion Mapping. "
 				"Significantly improves the quality and removes aliasing. "
 				"TAA or the Skyrim Upscaler is recommended when using this option due to CRPM artifacts. ");
-			// ImGui::Text("Doubles the sample count and approximates the intersection point using Parallax Occlusion Mapping.\n");
-			// ImGui::Text("Significantly improves the quality and removes aliasing.\n");
-			// ImGui::Text("TAA or the Skyrim Upscaler is recommended when using this option due to CRPM artifacts.");
 			ImGui::PopTextWrapPos();
 			ImGui::EndTooltip();
 		}
@@ -118,8 +110,6 @@ void ExtendedMaterials::DrawSettings()
 			ImGui::Text(
 				"The range that parallax blends from Parallax Occlusion Mapping (POM) to bump mapping, and bump mapping to nothing. "
 				"This value should be set as low as possible due to the performance impact of blending POM and relief mapping. ");
-			// ImGui::Text("The range that parallax blends from Parallax Occlusion Mapping (POM) to bump mapping, and bump mapping to nothing.\n");
-			// ImGui::Text("This value should be set as low as possible due to the performance impact of blending POM and relief mapping.");
 			ImGui::PopTextWrapPos();
 			ImGui::EndTooltip();
 		}
@@ -146,8 +136,6 @@ void ExtendedMaterials::DrawSettings()
 			ImGui::Text(
 				"Enables cheap soft shadows when using parallax. "
 				"This applies to all directional and point lights. ");
-			// ImGui::Text("Enables cheap soft shadows when using parallax.\n");
-			// ImGui::Text("This applies to all directional and point lights.");
 			ImGui::PopTextWrapPos();
 			ImGui::EndTooltip();
 		}

--- a/src/Features/GrassLighting.cpp
+++ b/src/Features/GrassLighting.cpp
@@ -48,10 +48,15 @@ void GrassLighting::DrawSettings()
 		if (ImGui::IsItemHovered()) {
 			ImGui::BeginTooltip();
 			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-			ImGui::Text("Subsurface Scattering (SSS) amount\n");
-			ImGui::Text("Soft lighting controls how evenly lit an object is.\n");
-			ImGui::Text("Back lighting illuminates the back face of an object.\n");
-			ImGui::Text("Combined to model the transport of light through the surface.");
+			ImGui::Text(
+				"Subsurface Scattering (SSS) amount "
+				"Soft lighting controls how evenly lit an object is. "
+				"Back lighting illuminates the back face of an object. "
+				"Combined to model the transport of light through the surface. ");
+			// ImGui::Text("Subsurface Scattering (SSS) amount\n");
+			// ImGui::Text("Soft lighting controls how evenly lit an object is.\n");
+			// ImGui::Text("Back lighting illuminates the back face of an object.\n");
+			// ImGui::Text("Combined to model the transport of light through the surface.");
 			ImGui::PopTextWrapPos();
 			ImGui::EndTooltip();
 		}

--- a/src/Features/GrassLighting.cpp
+++ b/src/Features/GrassLighting.cpp
@@ -49,7 +49,7 @@ void GrassLighting::DrawSettings()
 			ImGui::BeginTooltip();
 			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
 			ImGui::Text(
-				"Subsurface Scattering (SSS) amount "
+				"Subsurface Scattering (SSS) amount. "
 				"Soft lighting controls how evenly lit an object is. "
 				"Back lighting illuminates the back face of an object. "
 				"Combined to model the transport of light through the surface. ");

--- a/src/Features/GrassLighting.cpp
+++ b/src/Features/GrassLighting.cpp
@@ -53,10 +53,6 @@ void GrassLighting::DrawSettings()
 				"Soft lighting controls how evenly lit an object is. "
 				"Back lighting illuminates the back face of an object. "
 				"Combined to model the transport of light through the surface. ");
-			// ImGui::Text("Subsurface Scattering (SSS) amount\n");
-			// ImGui::Text("Soft lighting controls how evenly lit an object is.\n");
-			// ImGui::Text("Back lighting illuminates the back face of an object.\n");
-			// ImGui::Text("Combined to model the transport of light through the surface.");
 			ImGui::PopTextWrapPos();
 			ImGui::EndTooltip();
 		}

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -137,9 +137,13 @@ void LightLimitFix::DrawSettings()
 			if (ImGui::IsItemHovered()) {
 				ImGui::BeginTooltip();
 				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-				ImGui::Text(" - Visualise the light limit. Red when the \"strict\" light limit is reached (portal-strict lights).\n");
-				ImGui::Text(" - Visualise the number of strict lights. \n");
-				ImGui::Text(" - Visualise the number of clustered lights.");
+				ImGui::Text(
+					" - Visualise the light limit. Red when the \"strict\" light limit is reached (portal-strict lights). "
+					" - Visualise the number of strict lights. "
+					" - Visualise the number of clustered lights. ");
+				// ImGui::Text(" - Visualise the light limit. Red when the \"strict\" light limit is reached (portal-strict lights).\n");
+				// ImGui::Text(" - Visualise the number of strict lights. \n");
+				// ImGui::Text(" - Visualise the number of clustered lights.");
 				ImGui::PopTextWrapPos();
 				ImGui::EndTooltip();
 			}

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -141,9 +141,6 @@ void LightLimitFix::DrawSettings()
 					" - Visualise the light limit. Red when the \"strict\" light limit is reached (portal-strict lights). "
 					" - Visualise the number of strict lights. "
 					" - Visualise the number of clustered lights. ");
-				// ImGui::Text(" - Visualise the light limit. Red when the \"strict\" light limit is reached (portal-strict lights).\n");
-				// ImGui::Text(" - Visualise the number of strict lights. \n");
-				// ImGui::Text(" - Visualise the number of clustered lights.");
 				ImGui::PopTextWrapPos();
 				ImGui::EndTooltip();
 			}


### PR DESCRIPTION
Summary of Changes
---
Following our discussion in https://github.com/doodlum/skyrim-community-shaders/pull/119#issuecomment-1752174502, I searched for and handled consecutive `ImGui::Text()` calls in the feature code 
(in the **src** folder).
I used [git grep](https://git-scm.com/docs/git-grep) to find module files that have `ImGui::Text()` calls and consolidated tooltips that use consecutive `ImGui::Text()` calls.

I modified tooltips in the following modules:
- `DistantTreeLighting`:
  * Complex Tree LOD Tooltip
  * Subsurface Scattering tooltip

- `ExtendedMaterials`:
  * Complex Material Checkbox tooltip
  * Enable Parallax tooltip
  * High Quality checkbox tooltip
  * Blend Range slider tooltip
  * Enable Shadows checkbox tooltip

- `GrassLighting`:
  * Subsurface Scattering (SSS) Amount slider tooltip

- `LightLimitFix`:
  * Lights Visualization Mode combo box tooltip


---
I noticed all tooltips above originally contained newline characters, `\n`.
I removed them in my changes, but I commented out the original tooltips for reference in case I need to preserve the newline characters. 
If the newlines don't need to be preserved, I can remove the commented-out code and update the PR.

Thank you for considering these changes.