### PR TITLE
feat: add LLF support to effect and waters shaders

### DIFF
--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -32,7 +32,7 @@ StructuredBuffer<StructuredLight> lights : register(t17);
 StructuredBuffer<uint> lightList : register(t18);       //MAX_CLUSTER_LIGHTS * 16^3
 StructuredBuffer<LightGrid> lightGrid : register(t19);  //16^3
 
-#if !defined(SCREEN_SPACE_SHADOWS)
+#if !defined(SCREEN_SPACE_SHADOWS) && !defined(EFFECT)
 Texture2D<float4> TexDepthSampler : register(t20);
 #endif  // SCREEN_SPACE_SHADOWS
 

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -1,131 +1,133 @@
+#define EFFECT
+
 struct VS_INPUT
 {
-	float4 Position : POSITION0;
+	float4 Position											: POSITION0;
 #if defined(TEXCOORD)
-#	if defined(STRIP_PARTICLES)
-	float3
-#	else
+#if defined(STRIP_PARTICLES)
+    float3 
+#else
 	float2
-#	endif
-		TexCoord0 : TEXCOORD0;
+#endif
+		TexCoord0											: TEXCOORD0;
 #endif
 #if defined(NORMALS) || defined(MOTIONVECTORS_NORMALS)
-	float4 Normal : NORMAL0;
+    float4 Normal											: NORMAL0;
 #endif
 #if defined(BINORMAL_TANGENT)
-	float4 Bitangent : BINORMAL0;
+    float4 Bitangent										: BINORMAL0;
 #endif
 #if defined(VC)
-	float4 Color : COLOR0;
+	float4 Color											: COLOR0;
 #endif
 #if defined(SKINNED)
-	float4 BoneWeights : BLENDWEIGHT0;
-	float4 BoneIndices : BLENDINDICES0;
+	float4 BoneWeights										: BLENDWEIGHT0;
+	float4 BoneIndices										: BLENDINDICES0;
 #endif
 };
 
 struct VS_OUTPUT
 {
-	float4 Position : SV_POSITION0;
-	float4 TexCoord0 : TEXCOORD0;
+	float4 Position											: SV_POSITION0;
+	float4 TexCoord0										: TEXCOORD0;
+	float4 WorldPosition									: POSITION1;
 #if defined(VC)
-	float4 Color : COLOR0;
+    float4 Color											: COLOR0;
 #endif
 #if !defined(MOTIONVECTORS_NORMALS)
-	float4 FogParam : COLOR1;
+	float4 FogParam											: COLOR1;
 #endif
 #if defined(MOTIONVECTORS_NORMALS) && defined(MEMBRANE) && !defined(SKINNED) && defined(NORMALS)
-	float3 ScreenSpaceNormal : TEXCOORD1;
+	float3 ScreenSpaceNormal								: TEXCOORD1;
 #elif (defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS))) || (defined(PROJECTED_UV) && defined(NORMALS))
-	float3 TBN0 : TEXCOORD1;
+	float3 TBN0												: TEXCOORD1;
 #endif
 #if defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS))
-	float FogAlpha : TEXCOORD5;
+	float FogAlpha											: TEXCOORD5;
 #endif
 #if (defined(MEMBRANE) && defined(SKINNED) && !defined(NORMALS)) || (defined(PROJECTED_UV) && defined(NORMALS) && !defined(MEMBRANE))
-	float3 TBN1 : TEXCOORD2;
+	float3 TBN1												: TEXCOORD2;
 #endif
 #if (defined(MEMBRANE) && defined(SKINNED) && !defined(NORMALS))
-	float3 TBN2 : TEXCOORD3;
+	float3 TBN2												: TEXCOORD3;
 #endif
 #if defined(MEMBRANE)
-	float4 ViewVector : TEXCOORD4;
+	float4 ViewVector										: TEXCOORD4;
 #endif
 #if defined(LIGHTING)
-	float3 MSPosition : TEXCOORD6;
+	float3 MSPosition										: TEXCOORD6;
 #endif
 #if !(defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS)))
-	float FogAlpha : TEXCOORD5;
+	float FogAlpha											: TEXCOORD5;
 #endif
 #if defined(MOTIONVECTORS_NORMALS)
-#	if !(defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS)))
-	float3 ScreenSpaceNormal : TEXCOORD7;
-#	endif
-	float4 WorldPosition : POSITION1;
-	float4 PreviousWorldPosition : POSITION2;
-#	if (defined(MEMBRANE) && defined(SKINNED) && !defined(NORMALS))
-	float3 ScreenSpaceNormal : TEXCOORD7;
-#	endif
+#if !(defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS)))
+	float3 ScreenSpaceNormal								: TEXCOORD7;
+#endif
+	float4 PreviousWorldPosition							: POSITION2;
+#if (defined(MEMBRANE) && defined(SKINNED) && !defined(NORMALS))
+	float3 ScreenSpaceNormal								: TEXCOORD7;
+#endif
 #endif
 };
 
 #ifdef VSHADER
-cbuffer PerFrame : register(b12)
+cbuffer PerFrame											: register(b12)
 {
-	row_major float4x3 ScreenProj : packoffset(c0);
-	row_major float4x4 ViewProj : packoffset(c8);
-#	if defined(SKINNED)
-	float3 BonesPivot : packoffset(c40);
-#		if defined(MOTIONVECTORS_NORMALS)
-	float3 PreviousBonesPivot : packoffset(c41);
-#		endif
-#	endif
+	row_major float4x3 ScreenProj							: packoffset(c0);
+	row_major float4x4 ViewProj								: packoffset(c8);
+#if defined (SKINNED)
+	float3 BonesPivot										: packoffset(c40);
+#if defined(MOTIONVECTORS_NORMALS)
+	float3 PreviousBonesPivot								: packoffset(c41);
+#endif
+#endif
 };
 
-cbuffer PerTechnique : register(b0)
+cbuffer PerTechnique										: register(b0)
 {
-	float4 FogParam : packoffset(c0);
-	float4 FogNearColor : packoffset(c1);
-	float4 FogFarColor : packoffset(c2);
+	float4 FogParam											: packoffset(c0);
+	float4 FogNearColor										: packoffset(c1);
+	float4 FogFarColor										: packoffset(c2);
 };
 
-cbuffer PerMaterial : register(b1)
+cbuffer PerMaterial											: register(b1)
 {
-	float4 TexcoordOffset : packoffset(c0);
-	float4 SoftMateralVSParams : packoffset(c1);
-	float4 FalloffData : packoffset(c2);
+	float4 TexcoordOffset									: packoffset(c0);
+	float4 SoftMateralVSParams								: packoffset(c1);
+	float4 FalloffData										: packoffset(c2);
 };
 
-cbuffer PerGeometry : register(b2)
+cbuffer PerGeometry											: register(b2)
 {
-	row_major float3x4 World : packoffset(c0);
-	row_major float3x4 PreviousWorld : packoffset(c3);
-	float4 MatProj[3] : packoffset(c6);
-	float4 EyePosition : packoffset(c12);
-	float4 PosAdjust : packoffset(c13);
-	float4 TexcoordOffsetMembrane : packoffset(c14);
+	row_major float3x4 World								: packoffset(c0);
+	row_major float3x4 PreviousWorld						: packoffset(c3);
+	float4 MatProj[3]										: packoffset(c6);
+	float4 EyePosition										: packoffset(c12);
+	float4 PosAdjust										: packoffset(c13);
+	float4 TexcoordOffsetMembrane							: packoffset(c14);
 }
 
-cbuffer IndexedTexcoordBuffer : register(b11)
+cbuffer IndexedTexcoordBuffer								: register(b11)
 {
-	float4 IndexedTexCoord[128] : packoffset(c0);
+	float4 IndexedTexCoord[128]								: packoffset(c0);
 }
 
-#	if defined(SKINNED)
-#		if defined(MOTIONVECTORS_NORMALS)
-cbuffer PreviousBonesBuffer : register(b9)
+#if defined (SKINNED)
+#if defined(MOTIONVECTORS_NORMALS)
+cbuffer PreviousBonesBuffer									: register(b9)
 {
-	float4 PreviousBones[240] : packoffset(c0);
+	float4 PreviousBones[240]								: packoffset(c0);
 }
-#		endif
+#endif
 
-cbuffer BonesBuffer : register(b10)
+cbuffer BonesBuffer											: register(b10)
 {
-	float4 Bones[240] : packoffset(c0);
+	float4 Bones[240]										: packoffset(c0);
 }
-#	endif
+#endif
 
-#	if defined(SKINNED)
+#if defined (SKINNED)
 float3x4 GetBoneTransformMatrix(float4 bones[240], int4 actualIndices, float3 pivot, float4 weights)
 {
 	float3x4 pivotMatrix = transpose(float4x3(0.0.xxx, 0.0.xxx, 0.0.xxx, pivot));
@@ -154,7 +156,8 @@ float3x4 GetBoneTransformMatrix(float4 bones[240], int4 actualIndices, float3 pi
 float3x3 GetBoneRSMatrix(float4 bones[240], int4 actualIndices, float4 weights)
 {
 	float3x3 result;
-	for (int rowIndex = 0; rowIndex < 3; ++rowIndex) {
+	for (int rowIndex = 0; rowIndex < 3; ++rowIndex)
+	{
 		result[rowIndex] = weights.xxx * bones[actualIndices.x + rowIndex].xyz +
 		                   weights.yyy * bones[actualIndices.y + rowIndex].xyz +
 		                   weights.zzz * bones[actualIndices.z + rowIndex].xyz +
@@ -162,12 +165,12 @@ float3x3 GetBoneRSMatrix(float4 bones[240], int4 actualIndices, float4 weights)
 	}
 	return result;
 }
-#	endif
+#endif
 
-#	define M_HALFPI 1.57079637;
-#	define M_PI 3.141593
+#define M_HALFPI 1.57079637;
+#define M_PI 3.141593
 
-#	if defined(PROJECTED_UV)
+#if defined(PROJECTED_UV)
 float GetProjectedU(float3 worldPosition, float4 texCoordOffset)
 {
 	float projUvTmp = min(abs(worldPosition.x), abs(worldPosition.y)) *
@@ -180,22 +183,29 @@ float GetProjectedU(float3 worldPosition, float4 texCoordOffset)
 				-0.330299497) +
 		0.999866009;
 	float projUvTmp5;
-	if (abs(worldPosition.x) > abs(worldPosition.y)) {
+	if (abs(worldPosition.x) > abs(worldPosition.y))
+	{
 		projUvTmp5 = projUvTmp * projUvTmp2 * -2 + M_HALFPI;
-	} else {
+	}
+	else
+	{
 		projUvTmp5 = 0;
 	}
 	float projUvTmp6 = projUvTmp * projUvTmp2 + projUvTmp5;
 	float projUvTmp7;
-	if (worldPosition.y < -worldPosition.y) {
+	if (worldPosition.y < -worldPosition.y)
+	{
 		projUvTmp7 = -M_PI;
-	} else {
+	}
+	else
+	{
 		projUvTmp7 = 0;
 	}
 	float projUvTmp4 = projUvTmp6 + projUvTmp7;
 	float minCoord = min(worldPosition.x, worldPosition.y);
 	float maxCoord = max(worldPosition.x, worldPosition.y);
-	if (minCoord < -minCoord && maxCoord >= -maxCoord) {
+	if (minCoord < -minCoord && maxCoord >= -maxCoord)
+	{
 		projUvTmp4 = -projUvTmp4;
 	}
 	return abs(0.318309158 * projUvTmp4) * texCoordOffset.w + texCoordOffset.y;
@@ -205,7 +215,7 @@ float GetProjectedV(float3 worldPosition)
 {
 	return (-PosAdjust.x + (PosAdjust.z + worldPosition.z)) / PosAdjust.y;
 }
-#	endif
+#endif
 
 VS_OUTPUT main(VS_INPUT input)
 {
@@ -217,335 +227,483 @@ VS_OUTPUT main(VS_INPUT input)
 	precise float3x3 world3x3 =
 		transpose(float3x3(transpose(World)[0], transpose(World)[1], transpose(World)[2]));
 
-#	if defined(SKY_OBJECT)
+#if defined(SKY_OBJECT)
 	float4x4 viewProj = float4x4(ViewProj[0], ViewProj[1], ViewProj[3], ViewProj[3]);
-#	else
+#else
 	float4x4 viewProj = ViewProj;
-#	endif
-
-#	if defined(SKINNED)
+#endif
+	
+#if defined (SKINNED)
 	precise int4 actualIndices = 765.01.xxxx * input.BoneIndices.xyzw;
-#		if defined(MOTIONVECTORS_NORMALS)
+#if defined(MOTIONVECTORS_NORMALS)
 	float3x4 previousBoneTransformMatrix =
 		GetBoneTransformMatrix(PreviousBones, actualIndices, PreviousBonesPivot, input.BoneWeights);
 	precise float4 previousWorldPosition =
 		float4(mul(inputPosition, transpose(previousBoneTransformMatrix)), 1);
-#		endif
+#endif
 	float3x4 boneTransformMatrix =
 		GetBoneTransformMatrix(Bones, actualIndices, BonesPivot, input.BoneWeights);
 	precise float4 worldPosition = float4(mul(inputPosition, transpose(boneTransformMatrix)), 1);
 	float4 viewPos = mul(viewProj, worldPosition);
-#	else
+#else
 	precise float4 worldPosition = float4(mul(World, inputPosition), 1);
 	precise float4 previousWorldPosition = float4(mul(PreviousWorld, inputPosition), 1);
 	precise float4x4 modelView = mul(viewProj, world4x4);
 	float4 viewPos = mul(modelView, inputPosition);
-#	endif
+#endif
 
 	vsout.Position = viewPos;
 
-#	if defined(SKINNED)
+#if defined(SKINNED)
 	float3x3 boneRSMatrix = GetBoneRSMatrix(Bones, actualIndices, input.BoneWeights);
 	float3x3 boneRSMatrixTr = transpose(boneRSMatrix);
-#	endif
+#endif
 
-#	if defined(NORMALS) || defined(MOTIONVECTORS_NORMALS)
+#if defined(NORMALS) || defined(MOTIONVECTORS_NORMALS)
 	float3 normal = input.Normal.xyz * 2 - 1;
 
-#		if defined(SKINNED)
+#if defined(SKINNED)
 	float3 worldNormal = normalize(mul(normal, boneRSMatrixTr));
-#		else
+#else
 	float3 worldNormal = normalize(mul(world3x3, normal));
-#		endif
-#	endif
+#endif
+#endif
 
-#	if defined(VC)
+#if defined(VC)
 	vsout.Color = input.Color;
-#	endif
-
-#	if !defined(MOTIONVECTORS_NORMALS)
+#endif
+	
+#if !defined(MOTIONVECTORS_NORMALS)
 	float fogColorParam = min(FogParam.w,
 		exp2(FogParam.z * log2(saturate(length(viewPos.xyz) * FogParam.y - FogParam.x))));
 
 	vsout.FogParam.xyz = lerp(FogNearColor.xyz, FogFarColor.xyz, fogColorParam);
 	vsout.FogParam.w = fogColorParam;
-#	endif
+#endif
 
 	float4 texCoord = float4(0, 0, 1, 0);
-
-#	if defined(MEMBRANE)
+	
+#if defined (MEMBRANE)
 	float4 texCoordOffset = TexcoordOffsetMembrane;
-#	else
+#else
 	float4 texCoordOffset = TexcoordOffset;
-#	endif
+#endif
 
-#	if defined(TEXCOORD_INDEX)
-#		if defined(NORMALS)
+#if defined(TEXCOORD_INDEX)
+#if defined(NORMALS)
 	uint index = input.TexCoord0.z;
-#		else
+#else
 	uint index = input.Position.w;
-#		endif
-#	endif
-
-#	if defined(PROJECTED_UV)
-#		if defined(NORMALS) && !defined(MEMBRANE)
+#endif
+#endif
+	
+#if defined (PROJECTED_UV)
+#if defined(NORMALS) && !defined(MEMBRANE)
 	texCoord.x = dot(MatProj[0].xyz, inputPosition.xyz);
-#		else
+#else
 	texCoord.x = GetProjectedU(worldPosition.xyz, texCoordOffset);
-#		endif
-#	else
-#		if defined(TEXTURE)
+#endif
+#else
+#if defined(TEXTURE)
 	float u = input.TexCoord0.x;
-#			if defined(TEXCOORD_INDEX)
+#if defined(TEXCOORD_INDEX)
 	u = IndexedTexCoord[index].y * u + IndexedTexCoord[index].x;
-#			endif
+#endif
 	texCoord.x = u * texCoordOffset.z + texCoordOffset.x;
-#		endif
-#	endif
-#	if defined(PROJECTED_UV)
-#		if defined(NORMALS) && !defined(MEMBRANE)
+#endif
+#endif
+#if defined (PROJECTED_UV)
+#if defined(NORMALS) && !defined(MEMBRANE)
 	texCoord.y = dot(MatProj[1].xyz, inputPosition.xyz);
-#		else
+#else
 	texCoord.y = GetProjectedV(worldPosition.xyz);
-#		endif
-#	else
-#		if defined(TEXTURE)
+#endif
+#else
+#if defined(TEXTURE)
 	float v = input.TexCoord0.y;
-#			if defined(TEXCOORD_INDEX)
+#if defined(TEXCOORD_INDEX)
 	v = IndexedTexCoord[index].w * v + IndexedTexCoord[index].z;
-#			endif
+#endif
 	texCoord.y = v * texCoordOffset.w + texCoordOffset.y;
-#		endif
-#	endif
-#	if defined(PROJECTED_UV) && !defined(NORMALS)
+#endif
+#endif
+#if defined(PROJECTED_UV) && !defined(NORMALS)
 	texCoord.w = input.TexCoord0.y;
-#	elif defined(SOFT)
+#elif defined(SOFT)
 	texCoord.w = viewPos.w / SoftMateralVSParams.x;
-#	elif defined(MEMBRANE) && !defined(NORMALS)
+#elif defined(MEMBRANE) && !defined(NORMALS)
 	texCoord.w = input.TexCoord0.y;
-#	endif
-#	if defined(PROJECTED_UV) && !defined(NORMALS)
+#endif
+#if defined(PROJECTED_UV) && !defined(NORMALS)
 	texCoord.z = input.TexCoord0.x;
-#	elif defined(FALLOFF)
+#elif defined(FALLOFF)
 	float3 inverseWorldDirection = normalize(-worldPosition.xyz);
 	float WdotN = dot(worldNormal, inverseWorldDirection);
 	float falloff = saturate((-FalloffData.x + abs(WdotN)) / (FalloffData.y - FalloffData.x));
 	float falloffParam = (falloff * falloff) * (3 - falloff * 2);
 	texCoord.z = lerp(FalloffData.z, FalloffData.w, falloffParam);
-#	elif defined(MEMBRANE) && !defined(NORMALS)
+#elif defined(MEMBRANE) && !defined(NORMALS)
 	texCoord.z = input.TexCoord0.x;
-#	endif
+#endif
 	vsout.TexCoord0 = texCoord;
 
 	float3 eyePosition = 0.0.xxx;
-#	if defined(MEMBRANE) && defined(TEXTURE) && !defined(SKINNED)
+#if defined(MEMBRANE) && defined(TEXTURE) && !defined(SKINNED)
 	eyePosition = EyePosition.xyz;
-#	endif
+#endif
 
 	float3 viewPosition = inputPosition.xyz;
-#	if defined(SKINNED)
+#if defined(SKINNED)
 	viewPosition = worldPosition.xyz;
-#	endif
+#endif
 
-#	if defined(MEMBRANE)
-#		if defined(SKINNED)
-#			if defined(NORMALS)
+#if defined(MEMBRANE)
+#if defined(SKINNED)
+#if defined(NORMALS)
 	vsout.TBN0.xyz = worldNormal;
-#			else
+#else
 	float3x3 tbnTr = float3x3(normalize(boneRSMatrixTr[0]), normalize(boneRSMatrixTr[1]),
 		normalize(boneRSMatrixTr[2]));
-#				if defined(MOTIONVECTORS_NORMALS)
+#if defined(MOTIONVECTORS_NORMALS)
 	tbnTr[2] = worldNormal;
-#				endif
+#endif
 	float3x3 tbn = transpose(tbnTr);
 	vsout.TBN0.xyz = tbn[0];
 	vsout.TBN1.xyz = tbn[1];
 	vsout.TBN2.xyz = tbn[2];
-#			endif
-#		endif
+#endif
+#endif
 
 	vsout.ViewVector.xyz = normalize(eyePosition - viewPosition);
 	vsout.ViewVector.w = 1;
-#	endif
+#endif
 
-#	if !defined(SKINNED) && defined(NORMALS) && !(defined(MOTIONVECTORS_NORMALS) && defined(MEMBRANE) && !defined(SKINNED) && defined(NORMALS))
-#		if defined(MEMBRANE)
+#if !defined(SKINNED) && defined(NORMALS) && !(defined(MOTIONVECTORS_NORMALS) && defined(MEMBRANE) && !defined(SKINNED) && defined(NORMALS))
+#if defined(MEMBRANE)
 	vsout.TBN0.xyz = normal;
-#		elif defined(PROJECTED_UV)
+#elif defined(PROJECTED_UV)
 	vsout.TBN0.xyz = input.Normal.xyz;
-#		endif
-#	endif
-
-#	if defined(MOTIONVECTORS_NORMALS) && !(defined(MEMBRANE) && defined(SKINNED) && defined(NORMALS))
-#		if defined(SKINNED) && !defined(MEMBRANE)
+#endif
+#endif
+	
+#if defined(MOTIONVECTORS_NORMALS) && !(defined(MEMBRANE) && defined(SKINNED) && defined(NORMALS))
+#if defined(SKINNED) && !defined(MEMBRANE)
 	float3 screenSpaceNormal = normal;
-#		elif defined(FALLOFF) || (defined(SKINNED) && defined(MEMBRANE))
+#elif defined(FALLOFF) || (defined(SKINNED) && defined(MEMBRANE))
 	float3 screenSpaceNormal = worldNormal;
-#		else
+#else
 	float4x3 modelScreen = mul(ScreenProj, world3x3);
 	float3 screenSpaceNormal = normalize(mul(modelScreen, normal)).xyz;
-#		endif
+#endif
 
 	vsout.ScreenSpaceNormal = screenSpaceNormal;
-#	endif
+#endif
 
-#	if defined(LIGHTING)
+#if defined(LIGHTING)
 	vsout.MSPosition = viewPosition;
-#	endif
+#endif
 
 	vsout.FogAlpha.x = FogNearColor.w;
 
-#	if defined(PROJECTED_UV) && defined(NORMALS) && !defined(MEMBRANE)
+#if defined(PROJECTED_UV) && defined(NORMALS) && !defined(MEMBRANE)
 	vsout.TBN1.xyz = MatProj[2].xyz;
-#	endif
-
-#	if defined(MOTIONVECTORS_NORMALS)
+#endif
+	
 	vsout.WorldPosition = worldPosition;
+#if defined(MOTIONVECTORS_NORMALS)
 	vsout.PreviousWorldPosition = previousWorldPosition;
-#	endif
+#endif
 
 	return vsout;
 }
 #endif
 
 typedef VS_OUTPUT PS_INPUT;
-SamplerState SampBaseSampler : register(s0);
+SamplerState SampBaseSampler						: register(s0);
+SamplerState SampNormalSampler						: register(s1);
+SamplerState SampNoiseSampler						: register(s2);
+SamplerState SampDepthSampler						: register(s3);
+SamplerState SampGrayscaleSampler					: register(s4);
 
-Texture2D<float4> TexBaseSampler : register(t0);
+Texture2D<float4> TexBaseSampler					: register(t0);
+Texture2D<float4> TexNormalSampler					: register(t1);
+Texture2D<float4> TexNoiseSampler					: register(t2);
+Texture2D<float4> TexDepthSampler					: register(t3);
+Texture2D<float4> TexGrayscaleSampler				: register(t4);
 
 struct PS_OUTPUT
 {
-	float4 Color : SV_Target0;
+    float4 Color : SV_Target0;
 #if defined(MOTIONVECTORS_NORMALS)
-	float2 MotionVectors : SV_Target1;
-	float4 ScreenSpaceNormals : SV_Target2;
+	float2 MotionVectors							: SV_Target1;
+	float4 ScreenSpaceNormals						: SV_Target2;
 #else
-	float4 Normal : SV_Target1;
-	float4 Color2 : SV_Target2;
+    float4 Normal : SV_Target1;
+    float4 Color2 : SV_Target2;
 #endif
 };
 
 #ifdef PSHADER
-cbuffer PerFrame : register(b12)
-{
-	row_major float4x4 ScreenProj : packoffset(c12);
-	row_major float4x4 PreviousScreenProj : packoffset(c16);
-};
 
-cbuffer AlphaTestRefBuffer : register(b11)
+#include "Common/Color.hlsl"
+#include "Common/FrameBuffer.hlsl"
+#include "Common/MotionBlur.hlsl"
+#include "Common/Permutation.hlsl"
+
+cbuffer AlphaTestRefBuffer							: register(b11)
 {
-	float AlphaTestRef : packoffset(c0);
+    float AlphaTestRef1								: packoffset(c0);
 }
 
-cbuffer PerMaterial : register(b1)
+cbuffer PerTechnique								: register(b0)
 {
-	float4 BaseColor : packoffset(c0);
-	float4 LightingInfluence : packoffset(c2);
+    float4 CameraData								: packoffset(c0);
+    float2 VPOSOffset								: packoffset(c1);
+    float2 FilteringParam							: packoffset(c1.z);
 };
 
-cbuffer PerGeometry : register(b2)
+cbuffer PerMaterial									: register(b1)
 {
-	float4 PLightPositionX : packoffset(c0);
-	float4 PLightPositionY : packoffset(c1);
-	float4 PLightPositionZ : packoffset(c2);
-	float4 PLightingRadiusInverseSquared : packoffset(c3);
-	float4 PLightColorR : packoffset(c4);
-	float4 PLightColorG : packoffset(c5);
-	float4 PLightColorB : packoffset(c6);
-	float4 DLightColor : packoffset(c7);
-	float4 PropertyColor : packoffset(c8);
+    float4 BaseColor								: packoffset(c0);
+    float4 BaseColorScale							: packoffset(c1);
+    float4 LightingInfluence						: packoffset(c2);
 };
 
-#	if defined(LIGHTING)
+cbuffer PerGeometry									: register(b2)
+{
+    float4 PLightPositionX							: packoffset(c0);
+    float4 PLightPositionY							: packoffset(c1);
+    float4 PLightPositionZ							: packoffset(c2);
+    float4 PLightingRadiusInverseSquared			: packoffset(c3);
+    float4 PLightColorR								: packoffset(c4);
+    float4 PLightColorG								: packoffset(c5);
+    float4 PLightColorB								: packoffset(c6);
+    float4 DLightColor								: packoffset(c7);
+    float4 PropertyColor							: packoffset(c8);
+    float4 AlphaTestRef								: packoffset(c9);
+    float4 MembraneRimColor							: packoffset(c10);
+    float4 MembraneVars								: packoffset(c11);
+};
+
+#	if defined(MEMBRANE) || !defined(LIGHTING)
+#		undef LIGHT_LIMIT_FIX
+#	endif
+
+#	if defined(LIGHT_LIMIT_FIX)
+#		include "LightLimitFix/LightLimitFix.hlsli"
+#	endif
+
+#if defined(LIGHTING)
 float3 GetLightingColor(float3 msPosition)
 {
-	float4 lightDistX = PLightPositionX - msPosition.xxxx;
-	float4 lightDistXSquared = lightDistX * lightDistX;
-	float4 lightDistY = PLightPositionY - msPosition.yyyy;
-	float4 lightDistYSquared = lightDistY * lightDistY;
-	float4 lightDistZ = PLightPositionZ - msPosition.zzzz;
-	float4 lightDistZSquared = lightDistZ * lightDistZ;
-
-	float4 lightDistanceSquared = lightDistXSquared + lightDistYSquared + lightDistZSquared;
+	float4 lightDistanceSquared = (PLightPositionY - msPosition.yyyy) * (PLightPositionY - msPosition.yyyy) 
+		+ (PLightPositionX - msPosition.xxxx) * (PLightPositionX - msPosition.xxxx) 
+		+ (PLightPositionZ - msPosition.zzzz) * (PLightPositionZ - msPosition.zzzz);
 	float4 lightFadeMul = 1.0.xxxx - saturate(PLightingRadiusInverseSquared * lightDistanceSquared);
 
-	float3 color;
-	color.x = DLightColor.x + dot(PLightColorR * lightFadeMul, 1.0.xxxx);
-	color.y = DLightColor.y + dot(PLightColorG * lightFadeMul, 1.0.xxxx);
-	color.z = DLightColor.z + dot(PLightColorB * lightFadeMul, 1.0.xxxx);
+	float3 color = DLightColor.xyz;
+	color.x += dot(PLightColorR * lightFadeMul, 1.0.xxxx);
+	color.z += dot(PLightColorB * lightFadeMul, 1.0.xxxx);
+	color.y += dot(PLightColorG * lightFadeMul, 1.0.xxxx);
 
 	return color;
 }
-#	endif
+#endif
 
 PS_OUTPUT main(PS_INPUT input)
 {
 	PS_OUTPUT psout;
 
-	float4 baseColorMul = BaseColor;
-#	if defined(VC)
+	float4 fogMul = float4(input.FogAlpha.xxx, 1);
+
+#if defined(MEMBRANE)
+	float noiseAlpha = TexNoiseSampler.Sample(SampNoiseSampler, input.TexCoord0.zw).w;
+#if defined(VC)
+	noiseAlpha *= input.Color.w;
+#endif
+	if (noiseAlpha - AlphaTestRef.x < 0)
+	{
+        discard;
+	}
+#if defined(ALPHA_TEST)
+#endif
+
+#if defined(NORMALS)
+	float3 normal = input.TBN0;
+#else
+    float3 normal = TexNormalSampler.Sample(SampNormalSampler, input.TexCoord0.zw).xzy * 2 - 1;
+#if defined(SKINNED)
+	normal = mul(normal, transpose(float3x3(input.TBN0, input.TBN1, input.TBN2)));
+#endif
+#endif
+    float NdotV = dot(normal, input.ViewVector.xyz);
+    float membraneColorMul = pow(saturate(1 - NdotV), MembraneVars.x);
+    float4 membraneColor = MembraneRimColor * membraneColorMul;
+#endif
+
+	float softMul = 1;
+#if defined(SOFT)
+    float depth = TexDepthSampler.Load(int3(input.Position.xy, 0)).x;
+    softMul = saturate(-input.TexCoord0.w + LightingInfluence.y / ((1 - depth) * CameraData.z + CameraData.y));
+#endif
+	
+#if defined(MEMBRANE)
+	float4 baseColorMul = float4(1, 1, 1, 1);
+#else
+    float4 baseColorMul = BaseColor;
+#if defined(VC)
 	baseColorMul *= input.Color;
-#	endif
-
+#endif
+#endif
+	
+	float4 baseTexColor = float4(1, 1, 1, 1);
 	float4 baseColor = float4(1, 1, 1, 1);
-#	if defined(TEXTURE)
-	baseColor *= TexBaseSampler.Sample(SampBaseSampler, input.TexCoord0.xy);
+#if defined(TEXTURE)
+	baseTexColor = TexBaseSampler.Sample(SampBaseSampler, input.TexCoord0.xy);
+	baseColor *= baseTexColor;
+#if defined(IGNORE_TEX_ALPHA) || defined(GRAYSCALE_TO_ALPHA)
+	baseColor.w = 1;
+#endif
+#endif
+#if defined(MEMBRANE)
+	baseColor.w *= input.ViewVector.w;
+#else
+    baseColor.w *= input.TexCoord0.z;
+#endif
+	
+    baseColor *= baseColorMul;
+	baseColor.w *= softMul;
+
+#if defined(SOFT)
+    if (baseColor.w - 0.003 < 0)
+    {
+        discard;
+    }
+#endif
+
+    float lightingInfluence = LightingInfluence.x;
+    float3 propertyColor = PropertyColor.xyz;
+#if defined(LIGHTING)
+	propertyColor = GetLightingColor(input.MSPosition);
+#elif defined(MEMBRANE)
+	propertyColor *= 0;
+	lightingInfluence = 0;
+#endif
+
+#	if defined(LIGHT_LIMIT_FIX)
+	uint eyeIndex = 0;
+	uint lightCount = 0;
+	if (LightingInfluence.x > 0.0)
+	{
+		float3 viewPosition = mul(CameraView[eyeIndex], float4(input.WorldPosition.xyz, 1)).xyz;
+		float2 screenUV = ViewToUV(viewPosition, true, eyeIndex);
+		
+		uint clusterIndex = 0;
+		if (GetClusterIndex(screenUV, viewPosition.z, clusterIndex)) {	
+			lightCount = lightGrid[clusterIndex].lightCount;	
+			uint lightOffset = lightGrid[clusterIndex].offset;
+			[loop] for (uint i = 0; i < lightCount; i++)
+			{
+				uint light_index = lightList[lightOffset + i];
+				StructuredLight light = lights[light_index];
+				float3 lightDirection = light.positionWS[eyeIndex].xyz - input.WorldPosition.xyz;
+				float lightDist = length(lightDirection);
+				float intensityFactor = saturate(lightDist / light.radius);
+				float intensityMultiplier = 1 - intensityFactor * intensityFactor;
+				float3 lightColor = light.color.xyz * intensityMultiplier;
+				propertyColor += lightColor;
+			}	
+		}
+	}
 #	endif
-	baseColor.w *= input.TexCoord0.z;
+	
+#if defined(GRAYSCALE_TO_COLOR)
+	baseColor.xyz = BaseColorScale.x * TexGrayscaleSampler.Sample(SampGrayscaleSampler, float2(baseTexColor.y, baseColorMul.x)).xyz;
+#endif
+	
+    float alpha = PropertyColor.w * baseColor.w;
+	
+#if defined(GRAYSCALE_TO_ALPHA)
+	alpha = TexGrayscaleSampler.Sample(SampGrayscaleSampler, float2(baseTexColor.w, alpha)).w;
+#endif
+	
+#if defined(BLOOD)
+	baseColor.w = baseColor.y;
+    float deltaY = saturate(baseColor.y - AlphaTestRef.x);
+    float bloodMul = baseColor.z;
+    if (deltaY < AlphaTestRef.y)
+    {
+        bloodMul *= (deltaY / AlphaTestRef.y);
+    }
+    baseColor.xyz = saturate(float3(2, 1, 1) - bloodMul.xxx) * (-bloodMul * AlphaTestRef.z + 1);
+#endif
+	
+#if defined(MEMBRANE)
+	baseColor.xyz = (PropertyColor.xyz + baseColor.xyz) * alpha + membraneColor.xyz * membraneColor.w;
+	alpha += membraneColor.w;
+#endif
+	
+    float3 lightColor = lerp(baseColor.xyz, propertyColor * baseColor.xyz, lightingInfluence.xxx);
 
-	baseColor *= baseColorMul;
+#if !defined (MOTIONVECTORS_NORMALS)
+    if (alpha * fogMul.w - AlphaTestRef1 < 0)
+    {
+        discard;
+    }
+#endif
 
-#	if !defined(MOTIONVECTORS_NORMALS)
-	if (PropertyColor.w * baseColor.w - AlphaTestRef < 0) {
-		discard;
+#if !defined (MOTIONVECTORS_NORMALS)
+#if defined(ADDBLEND)
+	float3 blendedColor = lightColor * (1 - input.FogParam.www);
+#elif defined(MULTBLEND) || defined(MULTBLEND_DECAL)
+	float3 blendedColor = lerp(lightColor, 1.0.xxx, saturate(1.5 * input.FogParam.w).xxx);
+#else
+	float3 blendedColor = lerp(lightColor, input.FogParam.xyz, input.FogParam.www);
+#endif
+#else
+	float3 blendedColor = lightColor.xyz;
+#endif
+	
+    float4 finalColor = float4(blendedColor, alpha);
+#if defined(MULTBLEND_DECAL)
+	finalColor.xyz *= alpha;
+#elif !defined(MULTBLEND)
+	finalColor *= fogMul;
+#endif
+	psout.Color = finalColor;	
+	#	if defined(LIGHT_LIMIT_FIX) && defined(LLFDEBUG)
+	if (perPassLLF[0].EnableLightsVisualisation) {
+		if (perPassLLF[0].LightsVisualisationMode == 0) {
+			psout.Color.xyz = TurboColormap(0.0);
+		} else if (perPassLLF[0].LightsVisualisationMode == 1) {
+			psout.Color.xyz = TurboColormap(0.0);
+		} else {
+			psout.Color.xyz = TurboColormap((float)lightCount / 128.0);
+		}
 	}
 #	endif
 
-	float3 propertyColor = PropertyColor.xyz;
-#	if defined(LIGHTING)
-	propertyColor = GetLightingColor(input.MSPosition);
-#	endif
-
-	float3 lightColor = lerp(baseColor.xyz, propertyColor * baseColor.xyz, LightingInfluence.xxx);
-
-#	if !defined(MOTIONVECTORS_NORMALS)
-#		if defined(ADDBLEND)
-	float3 blendedColor = lightColor * (1 - input.FogParam.www);
-#		elif defined(MULTBLEND)
-	float3 blendedColor = lerp(lightColor, 1.0.xxx, saturate(1.5 * input.FogParam.w).xxx);
-#		else
-	float3 blendedColor = lerp(lightColor, input.FogParam.xyz, input.FogParam.www);
-#		endif
-#	else
-	float3 blendedColor = lightColor.xyz;
-#	endif
-
-	float4 finalColor = float4(blendedColor, PropertyColor.w * baseColor.w);
-#	if !defined(MULTBLEND)
-	finalColor *= float4(input.FogAlpha.xxx, 1);
-#	endif
-	psout.Color = finalColor;
-
-#	if defined(MOTIONVECTORS_NORMALS)
-	float4 screenPosition = mul(ScreenProj, input.WorldPosition);
-	screenPosition.xy = screenPosition.xy / screenPosition.ww;
-	float4 previousScreenPosition = mul(PreviousScreenProj, input.PreviousWorldPosition);
-	previousScreenPosition.xy = previousScreenPosition.xy / previousScreenPosition.ww;
-	float2 screenMotionVector = float2(-0.5, 0.5) * (screenPosition.xy - previousScreenPosition.xy);
+#if defined (MOTIONVECTORS_NORMALS)
+	float2 screenMotionVector = GetSSMotionVector(input.WorldPosition, input.PreviousWorldPosition, 0);
 
 	psout.MotionVectors = screenMotionVector;
 
+#if (defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS)))
+	float3 screenSpaceNormal = normalize(input.TBN0);
+#else
 	float3 screenSpaceNormal = normalize(input.ScreenSpaceNormal);
+#endif
+
 	screenSpaceNormal.z = max(0.001, sqrt(8 + -8 * screenSpaceNormal.z));
 	screenSpaceNormal.xy /= screenSpaceNormal.zz;
 	psout.ScreenSpaceNormals.xy = screenSpaceNormal.xy + 0.5.xx;
 	psout.ScreenSpaceNormals.zw = 0.0.xx;
-#	else
+#else
 	psout.Normal.xyz = float3(1, 0, 0);
 	psout.Normal.w = finalColor.w;
 
 	psout.Color2 = finalColor;
-#	endif
+#endif
 
 	return psout;
 }

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -2,132 +2,132 @@
 
 struct VS_INPUT
 {
-	float4 Position											: POSITION0;
+	float4 Position : POSITION0;
 #if defined(TEXCOORD)
-#if defined(STRIP_PARTICLES)
-    float3 
-#else
+#	if defined(STRIP_PARTICLES)
+	float3
+#	else
 	float2
-#endif
-		TexCoord0											: TEXCOORD0;
+#	endif
+		TexCoord0 : TEXCOORD0;
 #endif
 #if defined(NORMALS) || defined(MOTIONVECTORS_NORMALS)
-    float4 Normal											: NORMAL0;
+	float4 Normal : NORMAL0;
 #endif
 #if defined(BINORMAL_TANGENT)
-    float4 Bitangent										: BINORMAL0;
+	float4 Bitangent : BINORMAL0;
 #endif
 #if defined(VC)
-	float4 Color											: COLOR0;
+	float4 Color : COLOR0;
 #endif
 #if defined(SKINNED)
-	float4 BoneWeights										: BLENDWEIGHT0;
-	float4 BoneIndices										: BLENDINDICES0;
+	float4 BoneWeights : BLENDWEIGHT0;
+	float4 BoneIndices : BLENDINDICES0;
 #endif
 };
 
 struct VS_OUTPUT
 {
-	float4 Position											: SV_POSITION0;
-	float4 TexCoord0										: TEXCOORD0;
-	float4 WorldPosition									: POSITION1;
+	float4 Position : SV_POSITION0;
+	float4 TexCoord0 : TEXCOORD0;
+	float4 WorldPosition : POSITION1;
 #if defined(VC)
-    float4 Color											: COLOR0;
+	float4 Color : COLOR0;
 #endif
 #if !defined(MOTIONVECTORS_NORMALS)
-	float4 FogParam											: COLOR1;
+	float4 FogParam : COLOR1;
 #endif
 #if defined(MOTIONVECTORS_NORMALS) && defined(MEMBRANE) && !defined(SKINNED) && defined(NORMALS)
-	float3 ScreenSpaceNormal								: TEXCOORD1;
+	float3 ScreenSpaceNormal : TEXCOORD1;
 #elif (defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS))) || (defined(PROJECTED_UV) && defined(NORMALS))
-	float3 TBN0												: TEXCOORD1;
+	float3 TBN0 : TEXCOORD1;
 #endif
 #if defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS))
-	float FogAlpha											: TEXCOORD5;
+	float FogAlpha : TEXCOORD5;
 #endif
 #if (defined(MEMBRANE) && defined(SKINNED) && !defined(NORMALS)) || (defined(PROJECTED_UV) && defined(NORMALS) && !defined(MEMBRANE))
-	float3 TBN1												: TEXCOORD2;
+	float3 TBN1 : TEXCOORD2;
 #endif
 #if (defined(MEMBRANE) && defined(SKINNED) && !defined(NORMALS))
-	float3 TBN2												: TEXCOORD3;
+	float3 TBN2 : TEXCOORD3;
 #endif
 #if defined(MEMBRANE)
-	float4 ViewVector										: TEXCOORD4;
+	float4 ViewVector : TEXCOORD4;
 #endif
 #if defined(LIGHTING)
-	float3 MSPosition										: TEXCOORD6;
+	float3 MSPosition : TEXCOORD6;
 #endif
 #if !(defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS)))
-	float FogAlpha											: TEXCOORD5;
+	float FogAlpha : TEXCOORD5;
 #endif
 #if defined(MOTIONVECTORS_NORMALS)
-#if !(defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS)))
-	float3 ScreenSpaceNormal								: TEXCOORD7;
-#endif
-	float4 PreviousWorldPosition							: POSITION2;
-#if (defined(MEMBRANE) && defined(SKINNED) && !defined(NORMALS))
-	float3 ScreenSpaceNormal								: TEXCOORD7;
-#endif
+#	if !(defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS)))
+	float3 ScreenSpaceNormal : TEXCOORD7;
+#	endif
+	float4 PreviousWorldPosition : POSITION2;
+#	if (defined(MEMBRANE) && defined(SKINNED) && !defined(NORMALS))
+	float3 ScreenSpaceNormal : TEXCOORD7;
+#	endif
 #endif
 };
 
 #ifdef VSHADER
-cbuffer PerFrame											: register(b12)
+cbuffer PerFrame : register(b12)
 {
-	row_major float4x3 ScreenProj							: packoffset(c0);
-	row_major float4x4 ViewProj								: packoffset(c8);
-#if defined (SKINNED)
-	float3 BonesPivot										: packoffset(c40);
-#if defined(MOTIONVECTORS_NORMALS)
-	float3 PreviousBonesPivot								: packoffset(c41);
-#endif
-#endif
+	row_major float4x3 ScreenProj : packoffset(c0);
+	row_major float4x4 ViewProj : packoffset(c8);
+#	if defined(SKINNED)
+	float3 BonesPivot : packoffset(c40);
+#		if defined(MOTIONVECTORS_NORMALS)
+	float3 PreviousBonesPivot : packoffset(c41);
+#		endif
+#	endif
 };
 
-cbuffer PerTechnique										: register(b0)
+cbuffer PerTechnique : register(b0)
 {
-	float4 FogParam											: packoffset(c0);
-	float4 FogNearColor										: packoffset(c1);
-	float4 FogFarColor										: packoffset(c2);
+	float4 FogParam : packoffset(c0);
+	float4 FogNearColor : packoffset(c1);
+	float4 FogFarColor : packoffset(c2);
 };
 
-cbuffer PerMaterial											: register(b1)
+cbuffer PerMaterial : register(b1)
 {
-	float4 TexcoordOffset									: packoffset(c0);
-	float4 SoftMateralVSParams								: packoffset(c1);
-	float4 FalloffData										: packoffset(c2);
+	float4 TexcoordOffset : packoffset(c0);
+	float4 SoftMateralVSParams : packoffset(c1);
+	float4 FalloffData : packoffset(c2);
 };
 
-cbuffer PerGeometry											: register(b2)
+cbuffer PerGeometry : register(b2)
 {
-	row_major float3x4 World								: packoffset(c0);
-	row_major float3x4 PreviousWorld						: packoffset(c3);
-	float4 MatProj[3]										: packoffset(c6);
-	float4 EyePosition										: packoffset(c12);
-	float4 PosAdjust										: packoffset(c13);
-	float4 TexcoordOffsetMembrane							: packoffset(c14);
+	row_major float3x4 World : packoffset(c0);
+	row_major float3x4 PreviousWorld : packoffset(c3);
+	float4 MatProj[3] : packoffset(c6);
+	float4 EyePosition : packoffset(c12);
+	float4 PosAdjust : packoffset(c13);
+	float4 TexcoordOffsetMembrane : packoffset(c14);
 }
 
-cbuffer IndexedTexcoordBuffer								: register(b11)
+cbuffer IndexedTexcoordBuffer : register(b11)
 {
-	float4 IndexedTexCoord[128]								: packoffset(c0);
+	float4 IndexedTexCoord[128] : packoffset(c0);
 }
 
-#if defined (SKINNED)
-#if defined(MOTIONVECTORS_NORMALS)
-cbuffer PreviousBonesBuffer									: register(b9)
+#	if defined(SKINNED)
+#		if defined(MOTIONVECTORS_NORMALS)
+cbuffer PreviousBonesBuffer : register(b9)
 {
-	float4 PreviousBones[240]								: packoffset(c0);
+	float4 PreviousBones[240] : packoffset(c0);
 }
-#endif
+#		endif
 
-cbuffer BonesBuffer											: register(b10)
+cbuffer BonesBuffer : register(b10)
 {
-	float4 Bones[240]										: packoffset(c0);
+	float4 Bones[240] : packoffset(c0);
 }
-#endif
+#	endif
 
-#if defined (SKINNED)
+#	if defined(SKINNED)
 float3x4 GetBoneTransformMatrix(float4 bones[240], int4 actualIndices, float3 pivot, float4 weights)
 {
 	float3x4 pivotMatrix = transpose(float4x3(0.0.xxx, 0.0.xxx, 0.0.xxx, pivot));
@@ -156,8 +156,7 @@ float3x4 GetBoneTransformMatrix(float4 bones[240], int4 actualIndices, float3 pi
 float3x3 GetBoneRSMatrix(float4 bones[240], int4 actualIndices, float4 weights)
 {
 	float3x3 result;
-	for (int rowIndex = 0; rowIndex < 3; ++rowIndex)
-	{
+	for (int rowIndex = 0; rowIndex < 3; ++rowIndex) {
 		result[rowIndex] = weights.xxx * bones[actualIndices.x + rowIndex].xyz +
 		                   weights.yyy * bones[actualIndices.y + rowIndex].xyz +
 		                   weights.zzz * bones[actualIndices.z + rowIndex].xyz +
@@ -165,12 +164,12 @@ float3x3 GetBoneRSMatrix(float4 bones[240], int4 actualIndices, float4 weights)
 	}
 	return result;
 }
-#endif
+#	endif
 
-#define M_HALFPI 1.57079637;
-#define M_PI 3.141593
+#	define M_HALFPI 1.57079637;
+#	define M_PI 3.141593
 
-#if defined(PROJECTED_UV)
+#	if defined(PROJECTED_UV)
 float GetProjectedU(float3 worldPosition, float4 texCoordOffset)
 {
 	float projUvTmp = min(abs(worldPosition.x), abs(worldPosition.y)) *
@@ -183,29 +182,22 @@ float GetProjectedU(float3 worldPosition, float4 texCoordOffset)
 				-0.330299497) +
 		0.999866009;
 	float projUvTmp5;
-	if (abs(worldPosition.x) > abs(worldPosition.y))
-	{
+	if (abs(worldPosition.x) > abs(worldPosition.y)) {
 		projUvTmp5 = projUvTmp * projUvTmp2 * -2 + M_HALFPI;
-	}
-	else
-	{
+	} else {
 		projUvTmp5 = 0;
 	}
 	float projUvTmp6 = projUvTmp * projUvTmp2 + projUvTmp5;
 	float projUvTmp7;
-	if (worldPosition.y < -worldPosition.y)
-	{
+	if (worldPosition.y < -worldPosition.y) {
 		projUvTmp7 = -M_PI;
-	}
-	else
-	{
+	} else {
 		projUvTmp7 = 0;
 	}
 	float projUvTmp4 = projUvTmp6 + projUvTmp7;
 	float minCoord = min(worldPosition.x, worldPosition.y);
 	float maxCoord = max(worldPosition.x, worldPosition.y);
-	if (minCoord < -minCoord && maxCoord >= -maxCoord)
-	{
+	if (minCoord < -minCoord && maxCoord >= -maxCoord) {
 		projUvTmp4 = -projUvTmp4;
 	}
 	return abs(0.318309158 * projUvTmp4) * texCoordOffset.w + texCoordOffset.y;
@@ -215,7 +207,7 @@ float GetProjectedV(float3 worldPosition)
 {
 	return (-PosAdjust.x + (PosAdjust.z + worldPosition.z)) / PosAdjust.y;
 }
-#endif
+#	endif
 
 VS_OUTPUT main(VS_INPUT input)
 {
@@ -227,262 +219,262 @@ VS_OUTPUT main(VS_INPUT input)
 	precise float3x3 world3x3 =
 		transpose(float3x3(transpose(World)[0], transpose(World)[1], transpose(World)[2]));
 
-#if defined(SKY_OBJECT)
+#	if defined(SKY_OBJECT)
 	float4x4 viewProj = float4x4(ViewProj[0], ViewProj[1], ViewProj[3], ViewProj[3]);
-#else
+#	else
 	float4x4 viewProj = ViewProj;
-#endif
-	
-#if defined (SKINNED)
+#	endif
+
+#	if defined(SKINNED)
 	precise int4 actualIndices = 765.01.xxxx * input.BoneIndices.xyzw;
-#if defined(MOTIONVECTORS_NORMALS)
+#		if defined(MOTIONVECTORS_NORMALS)
 	float3x4 previousBoneTransformMatrix =
 		GetBoneTransformMatrix(PreviousBones, actualIndices, PreviousBonesPivot, input.BoneWeights);
 	precise float4 previousWorldPosition =
 		float4(mul(inputPosition, transpose(previousBoneTransformMatrix)), 1);
-#endif
+#		endif
 	float3x4 boneTransformMatrix =
 		GetBoneTransformMatrix(Bones, actualIndices, BonesPivot, input.BoneWeights);
 	precise float4 worldPosition = float4(mul(inputPosition, transpose(boneTransformMatrix)), 1);
 	float4 viewPos = mul(viewProj, worldPosition);
-#else
+#	else
 	precise float4 worldPosition = float4(mul(World, inputPosition), 1);
 	precise float4 previousWorldPosition = float4(mul(PreviousWorld, inputPosition), 1);
 	precise float4x4 modelView = mul(viewProj, world4x4);
 	float4 viewPos = mul(modelView, inputPosition);
-#endif
+#	endif
 
 	vsout.Position = viewPos;
 
-#if defined(SKINNED)
+#	if defined(SKINNED)
 	float3x3 boneRSMatrix = GetBoneRSMatrix(Bones, actualIndices, input.BoneWeights);
 	float3x3 boneRSMatrixTr = transpose(boneRSMatrix);
-#endif
+#	endif
 
-#if defined(NORMALS) || defined(MOTIONVECTORS_NORMALS)
+#	if defined(NORMALS) || defined(MOTIONVECTORS_NORMALS)
 	float3 normal = input.Normal.xyz * 2 - 1;
 
-#if defined(SKINNED)
+#		if defined(SKINNED)
 	float3 worldNormal = normalize(mul(normal, boneRSMatrixTr));
-#else
+#		else
 	float3 worldNormal = normalize(mul(world3x3, normal));
-#endif
-#endif
+#		endif
+#	endif
 
-#if defined(VC)
+#	if defined(VC)
 	vsout.Color = input.Color;
-#endif
-	
-#if !defined(MOTIONVECTORS_NORMALS)
+#	endif
+
+#	if !defined(MOTIONVECTORS_NORMALS)
 	float fogColorParam = min(FogParam.w,
 		exp2(FogParam.z * log2(saturate(length(viewPos.xyz) * FogParam.y - FogParam.x))));
 
 	vsout.FogParam.xyz = lerp(FogNearColor.xyz, FogFarColor.xyz, fogColorParam);
 	vsout.FogParam.w = fogColorParam;
-#endif
+#	endif
 
 	float4 texCoord = float4(0, 0, 1, 0);
-	
-#if defined (MEMBRANE)
-	float4 texCoordOffset = TexcoordOffsetMembrane;
-#else
-	float4 texCoordOffset = TexcoordOffset;
-#endif
 
-#if defined(TEXCOORD_INDEX)
-#if defined(NORMALS)
+#	if defined(MEMBRANE)
+	float4 texCoordOffset = TexcoordOffsetMembrane;
+#	else
+	float4 texCoordOffset = TexcoordOffset;
+#	endif
+
+#	if defined(TEXCOORD_INDEX)
+#		if defined(NORMALS)
 	uint index = input.TexCoord0.z;
-#else
+#		else
 	uint index = input.Position.w;
-#endif
-#endif
-	
-#if defined (PROJECTED_UV)
-#if defined(NORMALS) && !defined(MEMBRANE)
+#		endif
+#	endif
+
+#	if defined(PROJECTED_UV)
+#		if defined(NORMALS) && !defined(MEMBRANE)
 	texCoord.x = dot(MatProj[0].xyz, inputPosition.xyz);
-#else
+#		else
 	texCoord.x = GetProjectedU(worldPosition.xyz, texCoordOffset);
-#endif
-#else
-#if defined(TEXTURE)
+#		endif
+#	else
+#		if defined(TEXTURE)
 	float u = input.TexCoord0.x;
-#if defined(TEXCOORD_INDEX)
+#			if defined(TEXCOORD_INDEX)
 	u = IndexedTexCoord[index].y * u + IndexedTexCoord[index].x;
-#endif
+#			endif
 	texCoord.x = u * texCoordOffset.z + texCoordOffset.x;
-#endif
-#endif
-#if defined (PROJECTED_UV)
-#if defined(NORMALS) && !defined(MEMBRANE)
+#		endif
+#	endif
+#	if defined(PROJECTED_UV)
+#		if defined(NORMALS) && !defined(MEMBRANE)
 	texCoord.y = dot(MatProj[1].xyz, inputPosition.xyz);
-#else
+#		else
 	texCoord.y = GetProjectedV(worldPosition.xyz);
-#endif
-#else
-#if defined(TEXTURE)
+#		endif
+#	else
+#		if defined(TEXTURE)
 	float v = input.TexCoord0.y;
-#if defined(TEXCOORD_INDEX)
+#			if defined(TEXCOORD_INDEX)
 	v = IndexedTexCoord[index].w * v + IndexedTexCoord[index].z;
-#endif
+#			endif
 	texCoord.y = v * texCoordOffset.w + texCoordOffset.y;
-#endif
-#endif
-#if defined(PROJECTED_UV) && !defined(NORMALS)
+#		endif
+#	endif
+#	if defined(PROJECTED_UV) && !defined(NORMALS)
 	texCoord.w = input.TexCoord0.y;
-#elif defined(SOFT)
+#	elif defined(SOFT)
 	texCoord.w = viewPos.w / SoftMateralVSParams.x;
-#elif defined(MEMBRANE) && !defined(NORMALS)
+#	elif defined(MEMBRANE) && !defined(NORMALS)
 	texCoord.w = input.TexCoord0.y;
-#endif
-#if defined(PROJECTED_UV) && !defined(NORMALS)
+#	endif
+#	if defined(PROJECTED_UV) && !defined(NORMALS)
 	texCoord.z = input.TexCoord0.x;
-#elif defined(FALLOFF)
+#	elif defined(FALLOFF)
 	float3 inverseWorldDirection = normalize(-worldPosition.xyz);
 	float WdotN = dot(worldNormal, inverseWorldDirection);
 	float falloff = saturate((-FalloffData.x + abs(WdotN)) / (FalloffData.y - FalloffData.x));
 	float falloffParam = (falloff * falloff) * (3 - falloff * 2);
 	texCoord.z = lerp(FalloffData.z, FalloffData.w, falloffParam);
-#elif defined(MEMBRANE) && !defined(NORMALS)
+#	elif defined(MEMBRANE) && !defined(NORMALS)
 	texCoord.z = input.TexCoord0.x;
-#endif
+#	endif
 	vsout.TexCoord0 = texCoord;
 
 	float3 eyePosition = 0.0.xxx;
-#if defined(MEMBRANE) && defined(TEXTURE) && !defined(SKINNED)
+#	if defined(MEMBRANE) && defined(TEXTURE) && !defined(SKINNED)
 	eyePosition = EyePosition.xyz;
-#endif
+#	endif
 
 	float3 viewPosition = inputPosition.xyz;
-#if defined(SKINNED)
+#	if defined(SKINNED)
 	viewPosition = worldPosition.xyz;
-#endif
+#	endif
 
-#if defined(MEMBRANE)
-#if defined(SKINNED)
-#if defined(NORMALS)
+#	if defined(MEMBRANE)
+#		if defined(SKINNED)
+#			if defined(NORMALS)
 	vsout.TBN0.xyz = worldNormal;
-#else
+#			else
 	float3x3 tbnTr = float3x3(normalize(boneRSMatrixTr[0]), normalize(boneRSMatrixTr[1]),
 		normalize(boneRSMatrixTr[2]));
-#if defined(MOTIONVECTORS_NORMALS)
+#				if defined(MOTIONVECTORS_NORMALS)
 	tbnTr[2] = worldNormal;
-#endif
+#				endif
 	float3x3 tbn = transpose(tbnTr);
 	vsout.TBN0.xyz = tbn[0];
 	vsout.TBN1.xyz = tbn[1];
 	vsout.TBN2.xyz = tbn[2];
-#endif
-#endif
+#			endif
+#		endif
 
 	vsout.ViewVector.xyz = normalize(eyePosition - viewPosition);
 	vsout.ViewVector.w = 1;
-#endif
+#	endif
 
-#if !defined(SKINNED) && defined(NORMALS) && !(defined(MOTIONVECTORS_NORMALS) && defined(MEMBRANE) && !defined(SKINNED) && defined(NORMALS))
-#if defined(MEMBRANE)
+#	if !defined(SKINNED) && defined(NORMALS) && !(defined(MOTIONVECTORS_NORMALS) && defined(MEMBRANE) && !defined(SKINNED) && defined(NORMALS))
+#		if defined(MEMBRANE)
 	vsout.TBN0.xyz = normal;
-#elif defined(PROJECTED_UV)
+#		elif defined(PROJECTED_UV)
 	vsout.TBN0.xyz = input.Normal.xyz;
-#endif
-#endif
-	
-#if defined(MOTIONVECTORS_NORMALS) && !(defined(MEMBRANE) && defined(SKINNED) && defined(NORMALS))
-#if defined(SKINNED) && !defined(MEMBRANE)
+#		endif
+#	endif
+
+#	if defined(MOTIONVECTORS_NORMALS) && !(defined(MEMBRANE) && defined(SKINNED) && defined(NORMALS))
+#		if defined(SKINNED) && !defined(MEMBRANE)
 	float3 screenSpaceNormal = normal;
-#elif defined(FALLOFF) || (defined(SKINNED) && defined(MEMBRANE))
+#		elif defined(FALLOFF) || (defined(SKINNED) && defined(MEMBRANE))
 	float3 screenSpaceNormal = worldNormal;
-#else
+#		else
 	float4x3 modelScreen = mul(ScreenProj, world3x3);
 	float3 screenSpaceNormal = normalize(mul(modelScreen, normal)).xyz;
-#endif
+#		endif
 
 	vsout.ScreenSpaceNormal = screenSpaceNormal;
-#endif
+#	endif
 
-#if defined(LIGHTING)
+#	if defined(LIGHTING)
 	vsout.MSPosition = viewPosition;
-#endif
+#	endif
 
 	vsout.FogAlpha.x = FogNearColor.w;
 
-#if defined(PROJECTED_UV) && defined(NORMALS) && !defined(MEMBRANE)
+#	if defined(PROJECTED_UV) && defined(NORMALS) && !defined(MEMBRANE)
 	vsout.TBN1.xyz = MatProj[2].xyz;
-#endif
-	
+#	endif
+
 	vsout.WorldPosition = worldPosition;
-#if defined(MOTIONVECTORS_NORMALS)
+#	if defined(MOTIONVECTORS_NORMALS)
 	vsout.PreviousWorldPosition = previousWorldPosition;
-#endif
+#	endif
 
 	return vsout;
 }
 #endif
 
 typedef VS_OUTPUT PS_INPUT;
-SamplerState SampBaseSampler						: register(s0);
-SamplerState SampNormalSampler						: register(s1);
-SamplerState SampNoiseSampler						: register(s2);
-SamplerState SampDepthSampler						: register(s3);
-SamplerState SampGrayscaleSampler					: register(s4);
+SamplerState SampBaseSampler : register(s0);
+SamplerState SampNormalSampler : register(s1);
+SamplerState SampNoiseSampler : register(s2);
+SamplerState SampDepthSampler : register(s3);
+SamplerState SampGrayscaleSampler : register(s4);
 
-Texture2D<float4> TexBaseSampler					: register(t0);
-Texture2D<float4> TexNormalSampler					: register(t1);
-Texture2D<float4> TexNoiseSampler					: register(t2);
-Texture2D<float4> TexDepthSampler					: register(t3);
-Texture2D<float4> TexGrayscaleSampler				: register(t4);
+Texture2D<float4> TexBaseSampler : register(t0);
+Texture2D<float4> TexNormalSampler : register(t1);
+Texture2D<float4> TexNoiseSampler : register(t2);
+Texture2D<float4> TexDepthSampler : register(t3);
+Texture2D<float4> TexGrayscaleSampler : register(t4);
 
 struct PS_OUTPUT
 {
-    float4 Color : SV_Target0;
+	float4 Color : SV_Target0;
 #if defined(MOTIONVECTORS_NORMALS)
-	float2 MotionVectors							: SV_Target1;
-	float4 ScreenSpaceNormals						: SV_Target2;
+	float2 MotionVectors : SV_Target1;
+	float4 ScreenSpaceNormals : SV_Target2;
 #else
-    float4 Normal : SV_Target1;
-    float4 Color2 : SV_Target2;
+	float4 Normal : SV_Target1;
+	float4 Color2 : SV_Target2;
 #endif
 };
 
 #ifdef PSHADER
 
-#include "Common/Color.hlsl"
-#include "Common/FrameBuffer.hlsl"
-#include "Common/MotionBlur.hlsl"
-#include "Common/Permutation.hlsl"
+#	include "Common/Color.hlsl"
+#	include "Common/FrameBuffer.hlsl"
+#	include "Common/MotionBlur.hlsl"
+#	include "Common/Permutation.hlsl"
 
-cbuffer AlphaTestRefBuffer							: register(b11)
+cbuffer AlphaTestRefBuffer : register(b11)
 {
-    float AlphaTestRef1								: packoffset(c0);
+	float AlphaTestRef1 : packoffset(c0);
 }
 
-cbuffer PerTechnique								: register(b0)
+cbuffer PerTechnique : register(b0)
 {
-    float4 CameraData								: packoffset(c0);
-    float2 VPOSOffset								: packoffset(c1);
-    float2 FilteringParam							: packoffset(c1.z);
+	float4 CameraData : packoffset(c0);
+	float2 VPOSOffset : packoffset(c1);
+	float2 FilteringParam : packoffset(c1.z);
 };
 
-cbuffer PerMaterial									: register(b1)
+cbuffer PerMaterial : register(b1)
 {
-    float4 BaseColor								: packoffset(c0);
-    float4 BaseColorScale							: packoffset(c1);
-    float4 LightingInfluence						: packoffset(c2);
+	float4 BaseColor : packoffset(c0);
+	float4 BaseColorScale : packoffset(c1);
+	float4 LightingInfluence : packoffset(c2);
 };
 
-cbuffer PerGeometry									: register(b2)
+cbuffer PerGeometry : register(b2)
 {
-    float4 PLightPositionX							: packoffset(c0);
-    float4 PLightPositionY							: packoffset(c1);
-    float4 PLightPositionZ							: packoffset(c2);
-    float4 PLightingRadiusInverseSquared			: packoffset(c3);
-    float4 PLightColorR								: packoffset(c4);
-    float4 PLightColorG								: packoffset(c5);
-    float4 PLightColorB								: packoffset(c6);
-    float4 DLightColor								: packoffset(c7);
-    float4 PropertyColor							: packoffset(c8);
-    float4 AlphaTestRef								: packoffset(c9);
-    float4 MembraneRimColor							: packoffset(c10);
-    float4 MembraneVars								: packoffset(c11);
+	float4 PLightPositionX : packoffset(c0);
+	float4 PLightPositionY : packoffset(c1);
+	float4 PLightPositionZ : packoffset(c2);
+	float4 PLightingRadiusInverseSquared : packoffset(c3);
+	float4 PLightColorR : packoffset(c4);
+	float4 PLightColorG : packoffset(c5);
+	float4 PLightColorB : packoffset(c6);
+	float4 DLightColor : packoffset(c7);
+	float4 PropertyColor : packoffset(c8);
+	float4 AlphaTestRef : packoffset(c9);
+	float4 MembraneRimColor : packoffset(c10);
+	float4 MembraneVars : packoffset(c11);
 };
 
 #	if defined(MEMBRANE) || !defined(LIGHTING)
@@ -493,12 +485,10 @@ cbuffer PerGeometry									: register(b2)
 #		include "LightLimitFix/LightLimitFix.hlsli"
 #	endif
 
-#if defined(LIGHTING)
+#	if defined(LIGHTING)
 float3 GetLightingColor(float3 msPosition)
 {
-	float4 lightDistanceSquared = (PLightPositionY - msPosition.yyyy) * (PLightPositionY - msPosition.yyyy) 
-		+ (PLightPositionX - msPosition.xxxx) * (PLightPositionX - msPosition.xxxx) 
-		+ (PLightPositionZ - msPosition.zzzz) * (PLightPositionZ - msPosition.zzzz);
+	float4 lightDistanceSquared = (PLightPositionY - msPosition.yyyy) * (PLightPositionY - msPosition.yyyy) + (PLightPositionX - msPosition.xxxx) * (PLightPositionX - msPosition.xxxx) + (PLightPositionZ - msPosition.zzzz) * (PLightPositionZ - msPosition.zzzz);
 	float4 lightFadeMul = 1.0.xxxx - saturate(PLightingRadiusInverseSquared * lightDistanceSquared);
 
 	float3 color = DLightColor.xyz;
@@ -508,7 +498,7 @@ float3 GetLightingColor(float3 msPosition)
 
 	return color;
 }
-#endif
+#	endif
 
 PS_OUTPUT main(PS_INPUT input)
 {
@@ -516,91 +506,88 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float4 fogMul = float4(input.FogAlpha.xxx, 1);
 
-#if defined(MEMBRANE)
+#	if defined(MEMBRANE)
 	float noiseAlpha = TexNoiseSampler.Sample(SampNoiseSampler, input.TexCoord0.zw).w;
-#if defined(VC)
+#		if defined(VC)
 	noiseAlpha *= input.Color.w;
-#endif
-	if (noiseAlpha - AlphaTestRef.x < 0)
-	{
-        discard;
+#		endif
+	if (noiseAlpha - AlphaTestRef.x < 0) {
+		discard;
 	}
-#if defined(ALPHA_TEST)
-#endif
+#		if defined(ALPHA_TEST)
+#		endif
 
-#if defined(NORMALS)
+#		if defined(NORMALS)
 	float3 normal = input.TBN0;
-#else
-    float3 normal = TexNormalSampler.Sample(SampNormalSampler, input.TexCoord0.zw).xzy * 2 - 1;
-#if defined(SKINNED)
+#		else
+	float3 normal = TexNormalSampler.Sample(SampNormalSampler, input.TexCoord0.zw).xzy * 2 - 1;
+#			if defined(SKINNED)
 	normal = mul(normal, transpose(float3x3(input.TBN0, input.TBN1, input.TBN2)));
-#endif
-#endif
-    float NdotV = dot(normal, input.ViewVector.xyz);
-    float membraneColorMul = pow(saturate(1 - NdotV), MembraneVars.x);
-    float4 membraneColor = MembraneRimColor * membraneColorMul;
-#endif
+#			endif
+#		endif
+	float NdotV = dot(normal, input.ViewVector.xyz);
+	float membraneColorMul = pow(saturate(1 - NdotV), MembraneVars.x);
+	float4 membraneColor = MembraneRimColor * membraneColorMul;
+#	endif
 
 	float softMul = 1;
-#if defined(SOFT)
-    float depth = TexDepthSampler.Load(int3(input.Position.xy, 0)).x;
-    softMul = saturate(-input.TexCoord0.w + LightingInfluence.y / ((1 - depth) * CameraData.z + CameraData.y));
-#endif
-	
-#if defined(MEMBRANE)
+#	if defined(SOFT)
+	float depth = TexDepthSampler.Load(int3(input.Position.xy, 0)).x;
+	softMul = saturate(-input.TexCoord0.w + LightingInfluence.y / ((1 - depth) * CameraData.z + CameraData.y));
+#	endif
+
+#	if defined(MEMBRANE)
 	float4 baseColorMul = float4(1, 1, 1, 1);
-#else
-    float4 baseColorMul = BaseColor;
-#if defined(VC)
+#	else
+	float4 baseColorMul = BaseColor;
+#		if defined(VC)
 	baseColorMul *= input.Color;
-#endif
-#endif
-	
+#		endif
+#	endif
+
 	float4 baseTexColor = float4(1, 1, 1, 1);
 	float4 baseColor = float4(1, 1, 1, 1);
-#if defined(TEXTURE)
+#	if defined(TEXTURE)
 	baseTexColor = TexBaseSampler.Sample(SampBaseSampler, input.TexCoord0.xy);
 	baseColor *= baseTexColor;
-#if defined(IGNORE_TEX_ALPHA) || defined(GRAYSCALE_TO_ALPHA)
+#		if defined(IGNORE_TEX_ALPHA) || defined(GRAYSCALE_TO_ALPHA)
 	baseColor.w = 1;
-#endif
-#endif
-#if defined(MEMBRANE)
+#		endif
+#	endif
+#	if defined(MEMBRANE)
 	baseColor.w *= input.ViewVector.w;
-#else
-    baseColor.w *= input.TexCoord0.z;
-#endif
-	
-    baseColor *= baseColorMul;
+#	else
+	baseColor.w *= input.TexCoord0.z;
+#	endif
+
+	baseColor *= baseColorMul;
 	baseColor.w *= softMul;
 
-#if defined(SOFT)
-    if (baseColor.w - 0.003 < 0)
-    {
-        discard;
-    }
-#endif
+#	if defined(SOFT)
+	if (baseColor.w - 0.003 < 0) {
+		discard;
+	}
+#	endif
 
-    float lightingInfluence = LightingInfluence.x;
-    float3 propertyColor = PropertyColor.xyz;
-#if defined(LIGHTING)
+	float lightingInfluence = LightingInfluence.x;
+	float3 propertyColor = PropertyColor.xyz;
+#	if defined(LIGHTING)
 	propertyColor = GetLightingColor(input.MSPosition);
-#elif defined(MEMBRANE)
+#	elif defined(MEMBRANE)
 	propertyColor *= 0;
 	lightingInfluence = 0;
-#endif
+#	endif
 
 #	if defined(LIGHT_LIMIT_FIX)
 	uint eyeIndex = 0;
 	uint lightCount = 0;
-	if (LightingInfluence.x > 0.0)
-	{
+	if (LightingInfluence.x > 0.0) {
 		float3 viewPosition = mul(CameraView[eyeIndex], float4(input.WorldPosition.xyz, 1)).xyz;
 		float2 screenUV = ViewToUV(viewPosition, true, eyeIndex);
-		
+
 		uint clusterIndex = 0;
-		if (GetClusterIndex(screenUV, viewPosition.z, clusterIndex)) {	
-			lightCount = lightGrid[clusterIndex].lightCount;	
+		if (GetClusterIndex(screenUV, viewPosition.z, clusterIndex)) {
+			lightCount = lightGrid[clusterIndex].lightCount;
 			uint lightOffset = lightGrid[clusterIndex].offset;
 			[loop] for (uint i = 0; i < lightCount; i++)
 			{
@@ -612,66 +599,64 @@ PS_OUTPUT main(PS_INPUT input)
 				float intensityMultiplier = 1 - intensityFactor * intensityFactor;
 				float3 lightColor = light.color.xyz * intensityMultiplier;
 				propertyColor += lightColor;
-			}	
+			}
 		}
 	}
 #	endif
-	
-#if defined(GRAYSCALE_TO_COLOR)
+
+#	if defined(GRAYSCALE_TO_COLOR)
 	baseColor.xyz = BaseColorScale.x * TexGrayscaleSampler.Sample(SampGrayscaleSampler, float2(baseTexColor.y, baseColorMul.x)).xyz;
-#endif
-	
-    float alpha = PropertyColor.w * baseColor.w;
-	
-#if defined(GRAYSCALE_TO_ALPHA)
+#	endif
+
+	float alpha = PropertyColor.w * baseColor.w;
+
+#	if defined(GRAYSCALE_TO_ALPHA)
 	alpha = TexGrayscaleSampler.Sample(SampGrayscaleSampler, float2(baseTexColor.w, alpha)).w;
-#endif
-	
-#if defined(BLOOD)
+#	endif
+
+#	if defined(BLOOD)
 	baseColor.w = baseColor.y;
-    float deltaY = saturate(baseColor.y - AlphaTestRef.x);
-    float bloodMul = baseColor.z;
-    if (deltaY < AlphaTestRef.y)
-    {
-        bloodMul *= (deltaY / AlphaTestRef.y);
-    }
-    baseColor.xyz = saturate(float3(2, 1, 1) - bloodMul.xxx) * (-bloodMul * AlphaTestRef.z + 1);
-#endif
-	
-#if defined(MEMBRANE)
+	float deltaY = saturate(baseColor.y - AlphaTestRef.x);
+	float bloodMul = baseColor.z;
+	if (deltaY < AlphaTestRef.y) {
+		bloodMul *= (deltaY / AlphaTestRef.y);
+	}
+	baseColor.xyz = saturate(float3(2, 1, 1) - bloodMul.xxx) * (-bloodMul * AlphaTestRef.z + 1);
+#	endif
+
+#	if defined(MEMBRANE)
 	baseColor.xyz = (PropertyColor.xyz + baseColor.xyz) * alpha + membraneColor.xyz * membraneColor.w;
 	alpha += membraneColor.w;
-#endif
-	
-    float3 lightColor = lerp(baseColor.xyz, propertyColor * baseColor.xyz, lightingInfluence.xxx);
+#	endif
 
-#if !defined (MOTIONVECTORS_NORMALS)
-    if (alpha * fogMul.w - AlphaTestRef1 < 0)
-    {
-        discard;
-    }
-#endif
+	float3 lightColor = lerp(baseColor.xyz, propertyColor * baseColor.xyz, lightingInfluence.xxx);
 
-#if !defined (MOTIONVECTORS_NORMALS)
-#if defined(ADDBLEND)
+#	if !defined(MOTIONVECTORS_NORMALS)
+	if (alpha * fogMul.w - AlphaTestRef1 < 0) {
+		discard;
+	}
+#	endif
+
+#	if !defined(MOTIONVECTORS_NORMALS)
+#		if defined(ADDBLEND)
 	float3 blendedColor = lightColor * (1 - input.FogParam.www);
-#elif defined(MULTBLEND) || defined(MULTBLEND_DECAL)
+#		elif defined(MULTBLEND) || defined(MULTBLEND_DECAL)
 	float3 blendedColor = lerp(lightColor, 1.0.xxx, saturate(1.5 * input.FogParam.w).xxx);
-#else
+#		else
 	float3 blendedColor = lerp(lightColor, input.FogParam.xyz, input.FogParam.www);
-#endif
-#else
+#		endif
+#	else
 	float3 blendedColor = lightColor.xyz;
-#endif
-	
-    float4 finalColor = float4(blendedColor, alpha);
-#if defined(MULTBLEND_DECAL)
+#	endif
+
+	float4 finalColor = float4(blendedColor, alpha);
+#	if defined(MULTBLEND_DECAL)
 	finalColor.xyz *= alpha;
-#elif !defined(MULTBLEND)
+#	elif !defined(MULTBLEND)
 	finalColor *= fogMul;
-#endif
-	psout.Color = finalColor;	
-	#	if defined(LIGHT_LIMIT_FIX) && defined(LLFDEBUG)
+#	endif
+	psout.Color = finalColor;
+#	if defined(LIGHT_LIMIT_FIX) && defined(LLFDEBUG)
 	if (perPassLLF[0].EnableLightsVisualisation) {
 		if (perPassLLF[0].LightsVisualisationMode == 0) {
 			psout.Color.xyz = TurboColormap(0.0);
@@ -683,27 +668,27 @@ PS_OUTPUT main(PS_INPUT input)
 	}
 #	endif
 
-#if defined (MOTIONVECTORS_NORMALS)
+#	if defined(MOTIONVECTORS_NORMALS)
 	float2 screenMotionVector = GetSSMotionVector(input.WorldPosition, input.PreviousWorldPosition, 0);
 
 	psout.MotionVectors = screenMotionVector;
 
-#if (defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS)))
+#		if (defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS)))
 	float3 screenSpaceNormal = normalize(input.TBN0);
-#else
+#		else
 	float3 screenSpaceNormal = normalize(input.ScreenSpaceNormal);
-#endif
+#		endif
 
 	screenSpaceNormal.z = max(0.001, sqrt(8 + -8 * screenSpaceNormal.z));
 	screenSpaceNormal.xy /= screenSpaceNormal.zz;
 	psout.ScreenSpaceNormals.xy = screenSpaceNormal.xy + 0.5.xx;
 	psout.ScreenSpaceNormals.zw = 0.0.xx;
-#else
+#	else
 	psout.Normal.xyz = float3(1, 0, 0);
 	psout.Normal.w = finalColor.w;
 
 	psout.Color2 = finalColor;
-#endif
+#	endif
 
 	return psout;
 }

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -2,132 +2,132 @@
 
 struct VS_INPUT
 {
-	float4 Position : POSITION0;
+	float4 Position											: POSITION0;
 #if defined(TEXCOORD)
-#	if defined(STRIP_PARTICLES)
-	float3
-#	else
+#if defined(STRIP_PARTICLES)
+    float3 
+#else
 	float2
-#	endif
-		TexCoord0 : TEXCOORD0;
+#endif
+		TexCoord0											: TEXCOORD0;
 #endif
 #if defined(NORMALS) || defined(MOTIONVECTORS_NORMALS)
-	float4 Normal : NORMAL0;
+    float4 Normal											: NORMAL0;
 #endif
 #if defined(BINORMAL_TANGENT)
-	float4 Bitangent : BINORMAL0;
+    float4 Bitangent										: BINORMAL0;
 #endif
 #if defined(VC)
-	float4 Color : COLOR0;
+	float4 Color											: COLOR0;
 #endif
 #if defined(SKINNED)
-	float4 BoneWeights : BLENDWEIGHT0;
-	float4 BoneIndices : BLENDINDICES0;
+	float4 BoneWeights										: BLENDWEIGHT0;
+	float4 BoneIndices										: BLENDINDICES0;
 #endif
 };
 
 struct VS_OUTPUT
 {
-	float4 Position : SV_POSITION0;
-	float4 TexCoord0 : TEXCOORD0;
-	float4 WorldPosition : POSITION1;
+	float4 Position											: SV_POSITION0;
+	float4 TexCoord0										: TEXCOORD0;
+	float4 WorldPosition									: POSITION1;
 #if defined(VC)
-	float4 Color : COLOR0;
+    float4 Color											: COLOR0;
 #endif
 #if !defined(MOTIONVECTORS_NORMALS)
-	float4 FogParam : COLOR1;
+	float4 FogParam											: COLOR1;
 #endif
 #if defined(MOTIONVECTORS_NORMALS) && defined(MEMBRANE) && !defined(SKINNED) && defined(NORMALS)
-	float3 ScreenSpaceNormal : TEXCOORD1;
+	float3 ScreenSpaceNormal								: TEXCOORD1;
 #elif (defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS))) || (defined(PROJECTED_UV) && defined(NORMALS))
-	float3 TBN0 : TEXCOORD1;
+	float3 TBN0												: TEXCOORD1;
 #endif
 #if defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS))
-	float FogAlpha : TEXCOORD5;
+	float FogAlpha											: TEXCOORD5;
 #endif
 #if (defined(MEMBRANE) && defined(SKINNED) && !defined(NORMALS)) || (defined(PROJECTED_UV) && defined(NORMALS) && !defined(MEMBRANE))
-	float3 TBN1 : TEXCOORD2;
+	float3 TBN1												: TEXCOORD2;
 #endif
 #if (defined(MEMBRANE) && defined(SKINNED) && !defined(NORMALS))
-	float3 TBN2 : TEXCOORD3;
+	float3 TBN2												: TEXCOORD3;
 #endif
 #if defined(MEMBRANE)
-	float4 ViewVector : TEXCOORD4;
+	float4 ViewVector										: TEXCOORD4;
 #endif
 #if defined(LIGHTING)
-	float3 MSPosition : TEXCOORD6;
+	float3 MSPosition										: TEXCOORD6;
 #endif
 #if !(defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS)))
-	float FogAlpha : TEXCOORD5;
+	float FogAlpha											: TEXCOORD5;
 #endif
 #if defined(MOTIONVECTORS_NORMALS)
-#	if !(defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS)))
-	float3 ScreenSpaceNormal : TEXCOORD7;
-#	endif
-	float4 PreviousWorldPosition : POSITION2;
-#	if (defined(MEMBRANE) && defined(SKINNED) && !defined(NORMALS))
-	float3 ScreenSpaceNormal : TEXCOORD7;
-#	endif
+#if !(defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS)))
+	float3 ScreenSpaceNormal								: TEXCOORD7;
+#endif
+	float4 PreviousWorldPosition							: POSITION2;
+#if (defined(MEMBRANE) && defined(SKINNED) && !defined(NORMALS))
+	float3 ScreenSpaceNormal								: TEXCOORD7;
+#endif
 #endif
 };
 
 #ifdef VSHADER
-cbuffer PerFrame : register(b12)
+cbuffer PerFrame											: register(b12)
 {
-	row_major float4x3 ScreenProj : packoffset(c0);
-	row_major float4x4 ViewProj : packoffset(c8);
-#	if defined(SKINNED)
-	float3 BonesPivot : packoffset(c40);
-#		if defined(MOTIONVECTORS_NORMALS)
-	float3 PreviousBonesPivot : packoffset(c41);
-#		endif
-#	endif
+	row_major float4x3 ScreenProj							: packoffset(c0);
+	row_major float4x4 ViewProj								: packoffset(c8);
+#if defined (SKINNED)
+	float3 BonesPivot										: packoffset(c40);
+#if defined(MOTIONVECTORS_NORMALS)
+	float3 PreviousBonesPivot								: packoffset(c41);
+#endif
+#endif
 };
 
-cbuffer PerTechnique : register(b0)
+cbuffer PerTechnique										: register(b0)
 {
-	float4 FogParam : packoffset(c0);
-	float4 FogNearColor : packoffset(c1);
-	float4 FogFarColor : packoffset(c2);
+	float4 FogParam											: packoffset(c0);
+	float4 FogNearColor										: packoffset(c1);
+	float4 FogFarColor										: packoffset(c2);
 };
 
-cbuffer PerMaterial : register(b1)
+cbuffer PerMaterial											: register(b1)
 {
-	float4 TexcoordOffset : packoffset(c0);
-	float4 SoftMateralVSParams : packoffset(c1);
-	float4 FalloffData : packoffset(c2);
+	float4 TexcoordOffset									: packoffset(c0);
+	float4 SoftMateralVSParams								: packoffset(c1);
+	float4 FalloffData										: packoffset(c2);
 };
 
-cbuffer PerGeometry : register(b2)
+cbuffer PerGeometry											: register(b2)
 {
-	row_major float3x4 World : packoffset(c0);
-	row_major float3x4 PreviousWorld : packoffset(c3);
-	float4 MatProj[3] : packoffset(c6);
-	float4 EyePosition : packoffset(c12);
-	float4 PosAdjust : packoffset(c13);
-	float4 TexcoordOffsetMembrane : packoffset(c14);
+	row_major float3x4 World								: packoffset(c0);
+	row_major float3x4 PreviousWorld						: packoffset(c3);
+	float4 MatProj[3]										: packoffset(c6);
+	float4 EyePosition										: packoffset(c12);
+	float4 PosAdjust										: packoffset(c13);
+	float4 TexcoordOffsetMembrane							: packoffset(c14);
 }
 
-cbuffer IndexedTexcoordBuffer : register(b11)
+cbuffer IndexedTexcoordBuffer								: register(b11)
 {
-	float4 IndexedTexCoord[128] : packoffset(c0);
+	float4 IndexedTexCoord[128]								: packoffset(c0);
 }
 
-#	if defined(SKINNED)
-#		if defined(MOTIONVECTORS_NORMALS)
-cbuffer PreviousBonesBuffer : register(b9)
+#if defined (SKINNED)
+#if defined(MOTIONVECTORS_NORMALS)
+cbuffer PreviousBonesBuffer									: register(b9)
 {
-	float4 PreviousBones[240] : packoffset(c0);
+	float4 PreviousBones[240]								: packoffset(c0);
 }
-#		endif
+#endif
 
-cbuffer BonesBuffer : register(b10)
+cbuffer BonesBuffer											: register(b10)
 {
-	float4 Bones[240] : packoffset(c0);
+	float4 Bones[240]										: packoffset(c0);
 }
-#	endif
+#endif
 
-#	if defined(SKINNED)
+#if defined (SKINNED)
 float3x4 GetBoneTransformMatrix(float4 bones[240], int4 actualIndices, float3 pivot, float4 weights)
 {
 	float3x4 pivotMatrix = transpose(float4x3(0.0.xxx, 0.0.xxx, 0.0.xxx, pivot));
@@ -156,7 +156,8 @@ float3x4 GetBoneTransformMatrix(float4 bones[240], int4 actualIndices, float3 pi
 float3x3 GetBoneRSMatrix(float4 bones[240], int4 actualIndices, float4 weights)
 {
 	float3x3 result;
-	for (int rowIndex = 0; rowIndex < 3; ++rowIndex) {
+	for (int rowIndex = 0; rowIndex < 3; ++rowIndex)
+	{
 		result[rowIndex] = weights.xxx * bones[actualIndices.x + rowIndex].xyz +
 		                   weights.yyy * bones[actualIndices.y + rowIndex].xyz +
 		                   weights.zzz * bones[actualIndices.z + rowIndex].xyz +
@@ -164,12 +165,12 @@ float3x3 GetBoneRSMatrix(float4 bones[240], int4 actualIndices, float4 weights)
 	}
 	return result;
 }
-#	endif
+#endif
 
-#	define M_HALFPI 1.57079637;
-#	define M_PI 3.141593
+#define M_HALFPI 1.57079637;
+#define M_PI 3.141593
 
-#	if defined(PROJECTED_UV)
+#if defined(PROJECTED_UV)
 float GetProjectedU(float3 worldPosition, float4 texCoordOffset)
 {
 	float projUvTmp = min(abs(worldPosition.x), abs(worldPosition.y)) *
@@ -182,22 +183,29 @@ float GetProjectedU(float3 worldPosition, float4 texCoordOffset)
 				-0.330299497) +
 		0.999866009;
 	float projUvTmp5;
-	if (abs(worldPosition.x) > abs(worldPosition.y)) {
+	if (abs(worldPosition.x) > abs(worldPosition.y))
+	{
 		projUvTmp5 = projUvTmp * projUvTmp2 * -2 + M_HALFPI;
-	} else {
+	}
+	else
+	{
 		projUvTmp5 = 0;
 	}
 	float projUvTmp6 = projUvTmp * projUvTmp2 + projUvTmp5;
 	float projUvTmp7;
-	if (worldPosition.y < -worldPosition.y) {
+	if (worldPosition.y < -worldPosition.y)
+	{
 		projUvTmp7 = -M_PI;
-	} else {
+	}
+	else
+	{
 		projUvTmp7 = 0;
 	}
 	float projUvTmp4 = projUvTmp6 + projUvTmp7;
 	float minCoord = min(worldPosition.x, worldPosition.y);
 	float maxCoord = max(worldPosition.x, worldPosition.y);
-	if (minCoord < -minCoord && maxCoord >= -maxCoord) {
+	if (minCoord < -minCoord && maxCoord >= -maxCoord)
+	{
 		projUvTmp4 = -projUvTmp4;
 	}
 	return abs(0.318309158 * projUvTmp4) * texCoordOffset.w + texCoordOffset.y;
@@ -207,7 +215,7 @@ float GetProjectedV(float3 worldPosition)
 {
 	return (-PosAdjust.x + (PosAdjust.z + worldPosition.z)) / PosAdjust.y;
 }
-#	endif
+#endif
 
 VS_OUTPUT main(VS_INPUT input)
 {
@@ -219,262 +227,262 @@ VS_OUTPUT main(VS_INPUT input)
 	precise float3x3 world3x3 =
 		transpose(float3x3(transpose(World)[0], transpose(World)[1], transpose(World)[2]));
 
-#	if defined(SKY_OBJECT)
+#if defined(SKY_OBJECT)
 	float4x4 viewProj = float4x4(ViewProj[0], ViewProj[1], ViewProj[3], ViewProj[3]);
-#	else
+#else
 	float4x4 viewProj = ViewProj;
-#	endif
-
-#	if defined(SKINNED)
+#endif
+	
+#if defined (SKINNED)
 	precise int4 actualIndices = 765.01.xxxx * input.BoneIndices.xyzw;
-#		if defined(MOTIONVECTORS_NORMALS)
+#if defined(MOTIONVECTORS_NORMALS)
 	float3x4 previousBoneTransformMatrix =
 		GetBoneTransformMatrix(PreviousBones, actualIndices, PreviousBonesPivot, input.BoneWeights);
 	precise float4 previousWorldPosition =
 		float4(mul(inputPosition, transpose(previousBoneTransformMatrix)), 1);
-#		endif
+#endif
 	float3x4 boneTransformMatrix =
 		GetBoneTransformMatrix(Bones, actualIndices, BonesPivot, input.BoneWeights);
 	precise float4 worldPosition = float4(mul(inputPosition, transpose(boneTransformMatrix)), 1);
 	float4 viewPos = mul(viewProj, worldPosition);
-#	else
+#else
 	precise float4 worldPosition = float4(mul(World, inputPosition), 1);
 	precise float4 previousWorldPosition = float4(mul(PreviousWorld, inputPosition), 1);
 	precise float4x4 modelView = mul(viewProj, world4x4);
 	float4 viewPos = mul(modelView, inputPosition);
-#	endif
+#endif
 
 	vsout.Position = viewPos;
 
-#	if defined(SKINNED)
+#if defined(SKINNED)
 	float3x3 boneRSMatrix = GetBoneRSMatrix(Bones, actualIndices, input.BoneWeights);
 	float3x3 boneRSMatrixTr = transpose(boneRSMatrix);
-#	endif
+#endif
 
-#	if defined(NORMALS) || defined(MOTIONVECTORS_NORMALS)
+#if defined(NORMALS) || defined(MOTIONVECTORS_NORMALS)
 	float3 normal = input.Normal.xyz * 2 - 1;
 
-#		if defined(SKINNED)
+#if defined(SKINNED)
 	float3 worldNormal = normalize(mul(normal, boneRSMatrixTr));
-#		else
+#else
 	float3 worldNormal = normalize(mul(world3x3, normal));
-#		endif
-#	endif
+#endif
+#endif
 
-#	if defined(VC)
+#if defined(VC)
 	vsout.Color = input.Color;
-#	endif
-
-#	if !defined(MOTIONVECTORS_NORMALS)
+#endif
+	
+#if !defined(MOTIONVECTORS_NORMALS)
 	float fogColorParam = min(FogParam.w,
 		exp2(FogParam.z * log2(saturate(length(viewPos.xyz) * FogParam.y - FogParam.x))));
 
 	vsout.FogParam.xyz = lerp(FogNearColor.xyz, FogFarColor.xyz, fogColorParam);
 	vsout.FogParam.w = fogColorParam;
-#	endif
+#endif
 
 	float4 texCoord = float4(0, 0, 1, 0);
-
-#	if defined(MEMBRANE)
+	
+#if defined (MEMBRANE)
 	float4 texCoordOffset = TexcoordOffsetMembrane;
-#	else
+#else
 	float4 texCoordOffset = TexcoordOffset;
-#	endif
+#endif
 
-#	if defined(TEXCOORD_INDEX)
-#		if defined(NORMALS)
+#if defined(TEXCOORD_INDEX)
+#if defined(NORMALS)
 	uint index = input.TexCoord0.z;
-#		else
+#else
 	uint index = input.Position.w;
-#		endif
-#	endif
-
-#	if defined(PROJECTED_UV)
-#		if defined(NORMALS) && !defined(MEMBRANE)
+#endif
+#endif
+	
+#if defined (PROJECTED_UV)
+#if defined(NORMALS) && !defined(MEMBRANE)
 	texCoord.x = dot(MatProj[0].xyz, inputPosition.xyz);
-#		else
+#else
 	texCoord.x = GetProjectedU(worldPosition.xyz, texCoordOffset);
-#		endif
-#	else
-#		if defined(TEXTURE)
+#endif
+#else
+#if defined(TEXTURE)
 	float u = input.TexCoord0.x;
-#			if defined(TEXCOORD_INDEX)
+#if defined(TEXCOORD_INDEX)
 	u = IndexedTexCoord[index].y * u + IndexedTexCoord[index].x;
-#			endif
+#endif
 	texCoord.x = u * texCoordOffset.z + texCoordOffset.x;
-#		endif
-#	endif
-#	if defined(PROJECTED_UV)
-#		if defined(NORMALS) && !defined(MEMBRANE)
+#endif
+#endif
+#if defined (PROJECTED_UV)
+#if defined(NORMALS) && !defined(MEMBRANE)
 	texCoord.y = dot(MatProj[1].xyz, inputPosition.xyz);
-#		else
+#else
 	texCoord.y = GetProjectedV(worldPosition.xyz);
-#		endif
-#	else
-#		if defined(TEXTURE)
+#endif
+#else
+#if defined(TEXTURE)
 	float v = input.TexCoord0.y;
-#			if defined(TEXCOORD_INDEX)
+#if defined(TEXCOORD_INDEX)
 	v = IndexedTexCoord[index].w * v + IndexedTexCoord[index].z;
-#			endif
+#endif
 	texCoord.y = v * texCoordOffset.w + texCoordOffset.y;
-#		endif
-#	endif
-#	if defined(PROJECTED_UV) && !defined(NORMALS)
+#endif
+#endif
+#if defined(PROJECTED_UV) && !defined(NORMALS)
 	texCoord.w = input.TexCoord0.y;
-#	elif defined(SOFT)
+#elif defined(SOFT)
 	texCoord.w = viewPos.w / SoftMateralVSParams.x;
-#	elif defined(MEMBRANE) && !defined(NORMALS)
+#elif defined(MEMBRANE) && !defined(NORMALS)
 	texCoord.w = input.TexCoord0.y;
-#	endif
-#	if defined(PROJECTED_UV) && !defined(NORMALS)
+#endif
+#if defined(PROJECTED_UV) && !defined(NORMALS)
 	texCoord.z = input.TexCoord0.x;
-#	elif defined(FALLOFF)
+#elif defined(FALLOFF)
 	float3 inverseWorldDirection = normalize(-worldPosition.xyz);
 	float WdotN = dot(worldNormal, inverseWorldDirection);
 	float falloff = saturate((-FalloffData.x + abs(WdotN)) / (FalloffData.y - FalloffData.x));
 	float falloffParam = (falloff * falloff) * (3 - falloff * 2);
 	texCoord.z = lerp(FalloffData.z, FalloffData.w, falloffParam);
-#	elif defined(MEMBRANE) && !defined(NORMALS)
+#elif defined(MEMBRANE) && !defined(NORMALS)
 	texCoord.z = input.TexCoord0.x;
-#	endif
+#endif
 	vsout.TexCoord0 = texCoord;
 
 	float3 eyePosition = 0.0.xxx;
-#	if defined(MEMBRANE) && defined(TEXTURE) && !defined(SKINNED)
+#if defined(MEMBRANE) && defined(TEXTURE) && !defined(SKINNED)
 	eyePosition = EyePosition.xyz;
-#	endif
+#endif
 
 	float3 viewPosition = inputPosition.xyz;
-#	if defined(SKINNED)
+#if defined(SKINNED)
 	viewPosition = worldPosition.xyz;
-#	endif
+#endif
 
-#	if defined(MEMBRANE)
-#		if defined(SKINNED)
-#			if defined(NORMALS)
+#if defined(MEMBRANE)
+#if defined(SKINNED)
+#if defined(NORMALS)
 	vsout.TBN0.xyz = worldNormal;
-#			else
+#else
 	float3x3 tbnTr = float3x3(normalize(boneRSMatrixTr[0]), normalize(boneRSMatrixTr[1]),
 		normalize(boneRSMatrixTr[2]));
-#				if defined(MOTIONVECTORS_NORMALS)
+#if defined(MOTIONVECTORS_NORMALS)
 	tbnTr[2] = worldNormal;
-#				endif
+#endif
 	float3x3 tbn = transpose(tbnTr);
 	vsout.TBN0.xyz = tbn[0];
 	vsout.TBN1.xyz = tbn[1];
 	vsout.TBN2.xyz = tbn[2];
-#			endif
-#		endif
+#endif
+#endif
 
 	vsout.ViewVector.xyz = normalize(eyePosition - viewPosition);
 	vsout.ViewVector.w = 1;
-#	endif
+#endif
 
-#	if !defined(SKINNED) && defined(NORMALS) && !(defined(MOTIONVECTORS_NORMALS) && defined(MEMBRANE) && !defined(SKINNED) && defined(NORMALS))
-#		if defined(MEMBRANE)
+#if !defined(SKINNED) && defined(NORMALS) && !(defined(MOTIONVECTORS_NORMALS) && defined(MEMBRANE) && !defined(SKINNED) && defined(NORMALS))
+#if defined(MEMBRANE)
 	vsout.TBN0.xyz = normal;
-#		elif defined(PROJECTED_UV)
+#elif defined(PROJECTED_UV)
 	vsout.TBN0.xyz = input.Normal.xyz;
-#		endif
-#	endif
-
-#	if defined(MOTIONVECTORS_NORMALS) && !(defined(MEMBRANE) && defined(SKINNED) && defined(NORMALS))
-#		if defined(SKINNED) && !defined(MEMBRANE)
+#endif
+#endif
+	
+#if defined(MOTIONVECTORS_NORMALS) && !(defined(MEMBRANE) && defined(SKINNED) && defined(NORMALS))
+#if defined(SKINNED) && !defined(MEMBRANE)
 	float3 screenSpaceNormal = normal;
-#		elif defined(FALLOFF) || (defined(SKINNED) && defined(MEMBRANE))
+#elif defined(FALLOFF) || (defined(SKINNED) && defined(MEMBRANE))
 	float3 screenSpaceNormal = worldNormal;
-#		else
+#else
 	float4x3 modelScreen = mul(ScreenProj, world3x3);
 	float3 screenSpaceNormal = normalize(mul(modelScreen, normal)).xyz;
-#		endif
+#endif
 
 	vsout.ScreenSpaceNormal = screenSpaceNormal;
-#	endif
+#endif
 
-#	if defined(LIGHTING)
+#if defined(LIGHTING)
 	vsout.MSPosition = viewPosition;
-#	endif
+#endif
 
 	vsout.FogAlpha.x = FogNearColor.w;
 
-#	if defined(PROJECTED_UV) && defined(NORMALS) && !defined(MEMBRANE)
+#if defined(PROJECTED_UV) && defined(NORMALS) && !defined(MEMBRANE)
 	vsout.TBN1.xyz = MatProj[2].xyz;
-#	endif
-
+#endif
+	
 	vsout.WorldPosition = worldPosition;
-#	if defined(MOTIONVECTORS_NORMALS)
+#if defined(MOTIONVECTORS_NORMALS)
 	vsout.PreviousWorldPosition = previousWorldPosition;
-#	endif
+#endif
 
 	return vsout;
 }
 #endif
 
 typedef VS_OUTPUT PS_INPUT;
-SamplerState SampBaseSampler : register(s0);
-SamplerState SampNormalSampler : register(s1);
-SamplerState SampNoiseSampler : register(s2);
-SamplerState SampDepthSampler : register(s3);
-SamplerState SampGrayscaleSampler : register(s4);
+SamplerState SampBaseSampler						: register(s0);
+SamplerState SampNormalSampler						: register(s1);
+SamplerState SampNoiseSampler						: register(s2);
+SamplerState SampDepthSampler						: register(s3);
+SamplerState SampGrayscaleSampler					: register(s4);
 
-Texture2D<float4> TexBaseSampler : register(t0);
-Texture2D<float4> TexNormalSampler : register(t1);
-Texture2D<float4> TexNoiseSampler : register(t2);
-Texture2D<float4> TexDepthSampler : register(t3);
-Texture2D<float4> TexGrayscaleSampler : register(t4);
+Texture2D<float4> TexBaseSampler					: register(t0);
+Texture2D<float4> TexNormalSampler					: register(t1);
+Texture2D<float4> TexNoiseSampler					: register(t2);
+Texture2D<float4> TexDepthSampler					: register(t3);
+Texture2D<float4> TexGrayscaleSampler				: register(t4);
 
 struct PS_OUTPUT
 {
-	float4 Color : SV_Target0;
+    float4 Color : SV_Target0;
 #if defined(MOTIONVECTORS_NORMALS)
-	float2 MotionVectors : SV_Target1;
-	float4 ScreenSpaceNormals : SV_Target2;
+	float2 MotionVectors							: SV_Target1;
+	float4 ScreenSpaceNormals						: SV_Target2;
 #else
-	float4 Normal : SV_Target1;
-	float4 Color2 : SV_Target2;
+    float4 Normal : SV_Target1;
+    float4 Color2 : SV_Target2;
 #endif
 };
 
 #ifdef PSHADER
 
-#	include "Common/Color.hlsl"
-#	include "Common/FrameBuffer.hlsl"
-#	include "Common/MotionBlur.hlsl"
-#	include "Common/Permutation.hlsl"
+#include "Common/Color.hlsl"
+#include "Common/FrameBuffer.hlsl"
+#include "Common/MotionBlur.hlsl"
+#include "Common/Permutation.hlsl"
 
-cbuffer AlphaTestRefBuffer : register(b11)
+cbuffer AlphaTestRefBuffer							: register(b11)
 {
-	float AlphaTestRef1 : packoffset(c0);
+    float AlphaTestRef1								: packoffset(c0);
 }
 
-cbuffer PerTechnique : register(b0)
+cbuffer PerTechnique								: register(b0)
 {
-	float4 CameraData : packoffset(c0);
-	float2 VPOSOffset : packoffset(c1);
-	float2 FilteringParam : packoffset(c1.z);
+    float4 CameraData								: packoffset(c0);
+    float2 VPOSOffset								: packoffset(c1);
+    float2 FilteringParam							: packoffset(c1.z);
 };
 
-cbuffer PerMaterial : register(b1)
+cbuffer PerMaterial									: register(b1)
 {
-	float4 BaseColor : packoffset(c0);
-	float4 BaseColorScale : packoffset(c1);
-	float4 LightingInfluence : packoffset(c2);
+    float4 BaseColor								: packoffset(c0);
+    float4 BaseColorScale							: packoffset(c1);
+    float4 LightingInfluence						: packoffset(c2);
 };
 
-cbuffer PerGeometry : register(b2)
+cbuffer PerGeometry									: register(b2)
 {
-	float4 PLightPositionX : packoffset(c0);
-	float4 PLightPositionY : packoffset(c1);
-	float4 PLightPositionZ : packoffset(c2);
-	float4 PLightingRadiusInverseSquared : packoffset(c3);
-	float4 PLightColorR : packoffset(c4);
-	float4 PLightColorG : packoffset(c5);
-	float4 PLightColorB : packoffset(c6);
-	float4 DLightColor : packoffset(c7);
-	float4 PropertyColor : packoffset(c8);
-	float4 AlphaTestRef : packoffset(c9);
-	float4 MembraneRimColor : packoffset(c10);
-	float4 MembraneVars : packoffset(c11);
+    float4 PLightPositionX							: packoffset(c0);
+    float4 PLightPositionY							: packoffset(c1);
+    float4 PLightPositionZ							: packoffset(c2);
+    float4 PLightingRadiusInverseSquared			: packoffset(c3);
+    float4 PLightColorR								: packoffset(c4);
+    float4 PLightColorG								: packoffset(c5);
+    float4 PLightColorB								: packoffset(c6);
+    float4 DLightColor								: packoffset(c7);
+    float4 PropertyColor							: packoffset(c8);
+    float4 AlphaTestRef								: packoffset(c9);
+    float4 MembraneRimColor							: packoffset(c10);
+    float4 MembraneVars								: packoffset(c11);
 };
 
 #	if defined(MEMBRANE) || !defined(LIGHTING)
@@ -485,10 +493,12 @@ cbuffer PerGeometry : register(b2)
 #		include "LightLimitFix/LightLimitFix.hlsli"
 #	endif
 
-#	if defined(LIGHTING)
+#if defined(LIGHTING)
 float3 GetLightingColor(float3 msPosition)
 {
-	float4 lightDistanceSquared = (PLightPositionY - msPosition.yyyy) * (PLightPositionY - msPosition.yyyy) + (PLightPositionX - msPosition.xxxx) * (PLightPositionX - msPosition.xxxx) + (PLightPositionZ - msPosition.zzzz) * (PLightPositionZ - msPosition.zzzz);
+	float4 lightDistanceSquared = (PLightPositionY - msPosition.yyyy) * (PLightPositionY - msPosition.yyyy) 
+		+ (PLightPositionX - msPosition.xxxx) * (PLightPositionX - msPosition.xxxx) 
+		+ (PLightPositionZ - msPosition.zzzz) * (PLightPositionZ - msPosition.zzzz);
 	float4 lightFadeMul = 1.0.xxxx - saturate(PLightingRadiusInverseSquared * lightDistanceSquared);
 
 	float3 color = DLightColor.xyz;
@@ -498,7 +508,7 @@ float3 GetLightingColor(float3 msPosition)
 
 	return color;
 }
-#	endif
+#endif
 
 PS_OUTPUT main(PS_INPUT input)
 {
@@ -506,88 +516,87 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float4 fogMul = float4(input.FogAlpha.xxx, 1);
 
-#	if defined(MEMBRANE)
+#if defined(MEMBRANE)
 	float noiseAlpha = TexNoiseSampler.Sample(SampNoiseSampler, input.TexCoord0.zw).w;
-#		if defined(VC)
+#if defined(VC)
 	noiseAlpha *= input.Color.w;
-#		endif
-	if (noiseAlpha - AlphaTestRef.x < 0) {
-		discard;
+#endif
+	if (noiseAlpha - AlphaTestRef.x < 0)
+	{
+        discard;
 	}
-#		if defined(ALPHA_TEST)
-#		endif
+#if defined(ALPHA_TEST)
+#endif
 
-#		if defined(NORMALS)
+#if defined(NORMALS)
 	float3 normal = input.TBN0;
-#		else
-	float3 normal = TexNormalSampler.Sample(SampNormalSampler, input.TexCoord0.zw).xzy * 2 - 1;
-#			if defined(SKINNED)
+#else
+    float3 normal = TexNormalSampler.Sample(SampNormalSampler, input.TexCoord0.zw).xzy * 2 - 1;
+#if defined(SKINNED)
 	normal = mul(normal, transpose(float3x3(input.TBN0, input.TBN1, input.TBN2)));
-#			endif
-#		endif
-	float NdotV = dot(normal, input.ViewVector.xyz);
-	float membraneColorMul = pow(saturate(1 - NdotV), MembraneVars.x);
-	float4 membraneColor = MembraneRimColor * membraneColorMul;
-#	endif
+#endif
+#endif
+    float NdotV = dot(normal, input.ViewVector.xyz);
+    float membraneColorMul = pow(saturate(1 - NdotV), MembraneVars.x);
+    float4 membraneColor = MembraneRimColor * membraneColorMul;
+#endif
 
 	float softMul = 1;
-#	if defined(SOFT)
-	float depth = TexDepthSampler.Load(int3(input.Position.xy, 0)).x;
-	softMul = saturate(-input.TexCoord0.w + LightingInfluence.y / ((1 - depth) * CameraData.z + CameraData.y));
-#	endif
-
-#	if defined(MEMBRANE)
+#if defined(SOFT)
+    float depth = TexDepthSampler.Load(int3(input.Position.xy, 0)).x;
+    softMul = saturate(-input.TexCoord0.w + LightingInfluence.y / ((1 - depth) * CameraData.z + CameraData.y));
+#endif
+	
+#if defined(MEMBRANE)
 	float4 baseColorMul = float4(1, 1, 1, 1);
-#	else
-	float4 baseColorMul = BaseColor;
-#		if defined(VC)
+#else
+    float4 baseColorMul = BaseColor;
+#if defined(VC)
 	baseColorMul *= input.Color;
-#		endif
-#	endif
-
+#endif
+#endif
+	
 	float4 baseTexColor = float4(1, 1, 1, 1);
 	float4 baseColor = float4(1, 1, 1, 1);
-#	if defined(TEXTURE)
+#if defined(TEXTURE)
 	baseTexColor = TexBaseSampler.Sample(SampBaseSampler, input.TexCoord0.xy);
 	baseColor *= baseTexColor;
-#		if defined(IGNORE_TEX_ALPHA) || defined(GRAYSCALE_TO_ALPHA)
+#if defined(IGNORE_TEX_ALPHA) || defined(GRAYSCALE_TO_ALPHA)
 	baseColor.w = 1;
-#		endif
-#	endif
-#	if defined(MEMBRANE)
+#endif
+#endif
+#if defined(MEMBRANE)
 	baseColor.w *= input.ViewVector.w;
-#	else
-	baseColor.w *= input.TexCoord0.z;
-#	endif
-
-	baseColor *= baseColorMul;
+#else
+    baseColor.w *= input.TexCoord0.z;
+#endif
+	
+    baseColor *= baseColorMul;
 	baseColor.w *= softMul;
 
-#	if defined(SOFT)
-	if (baseColor.w - 0.003 < 0) {
-		discard;
-	}
-#	endif
+#if defined(SOFT)
+    if (baseColor.w - 0.003 < 0)
+    {
+        discard;
+    }
+#endif
 
-	float lightingInfluence = LightingInfluence.x;
-	float3 propertyColor = PropertyColor.xyz;
-#	if defined(LIGHTING)
+    float lightingInfluence = LightingInfluence.x;
+    float3 propertyColor = PropertyColor.xyz;
+#if defined(LIGHTING)
 	propertyColor = GetLightingColor(input.MSPosition);
-#	elif defined(MEMBRANE)
-	propertyColor *= 0;
-	lightingInfluence = 0;
-#	endif
 
 #	if defined(LIGHT_LIMIT_FIX)
 	uint eyeIndex = 0;
 	uint lightCount = 0;
-	if (LightingInfluence.x > 0.0) {
+	if (LightingInfluence.x > 0.0)
+	{
 		float3 viewPosition = mul(CameraView[eyeIndex], float4(input.WorldPosition.xyz, 1)).xyz;
 		float2 screenUV = ViewToUV(viewPosition, true, eyeIndex);
-
+		
 		uint clusterIndex = 0;
-		if (GetClusterIndex(screenUV, viewPosition.z, clusterIndex)) {
-			lightCount = lightGrid[clusterIndex].lightCount;
+		if (perPassLLF[0].EnableGlobalLights && GetClusterIndex(screenUV, viewPosition.z, clusterIndex)) {	
+			lightCount = lightGrid[clusterIndex].lightCount;	
 			uint lightOffset = lightGrid[clusterIndex].offset;
 			[loop] for (uint i = 0; i < lightCount; i++)
 			{
@@ -599,64 +608,70 @@ PS_OUTPUT main(PS_INPUT input)
 				float intensityMultiplier = 1 - intensityFactor * intensityFactor;
 				float3 lightColor = light.color.xyz * intensityMultiplier;
 				propertyColor += lightColor;
-			}
+			}	
 		}
 	}
 #	endif
-
-#	if defined(GRAYSCALE_TO_COLOR)
+#elif defined(MEMBRANE)
+	propertyColor *= 0;
+	lightingInfluence = 0;
+#endif
+	
+#if defined(GRAYSCALE_TO_COLOR)
 	baseColor.xyz = BaseColorScale.x * TexGrayscaleSampler.Sample(SampGrayscaleSampler, float2(baseTexColor.y, baseColorMul.x)).xyz;
-#	endif
-
-	float alpha = PropertyColor.w * baseColor.w;
-
-#	if defined(GRAYSCALE_TO_ALPHA)
+#endif
+	
+    float alpha = PropertyColor.w * baseColor.w;
+	
+#if defined(GRAYSCALE_TO_ALPHA)
 	alpha = TexGrayscaleSampler.Sample(SampGrayscaleSampler, float2(baseTexColor.w, alpha)).w;
-#	endif
-
-#	if defined(BLOOD)
+#endif
+	
+#if defined(BLOOD)
 	baseColor.w = baseColor.y;
-	float deltaY = saturate(baseColor.y - AlphaTestRef.x);
-	float bloodMul = baseColor.z;
-	if (deltaY < AlphaTestRef.y) {
-		bloodMul *= (deltaY / AlphaTestRef.y);
-	}
-	baseColor.xyz = saturate(float3(2, 1, 1) - bloodMul.xxx) * (-bloodMul * AlphaTestRef.z + 1);
-#	endif
-
-#	if defined(MEMBRANE)
+    float deltaY = saturate(baseColor.y - AlphaTestRef.x);
+    float bloodMul = baseColor.z;
+    if (deltaY < AlphaTestRef.y)
+    {
+        bloodMul *= (deltaY / AlphaTestRef.y);
+    }
+    baseColor.xyz = saturate(float3(2, 1, 1) - bloodMul.xxx) * (-bloodMul * AlphaTestRef.z + 1);
+#endif
+	
+#if defined(MEMBRANE)
 	baseColor.xyz = (PropertyColor.xyz + baseColor.xyz) * alpha + membraneColor.xyz * membraneColor.w;
 	alpha += membraneColor.w;
-#	endif
+#endif
+	
+    float3 lightColor = lerp(baseColor.xyz, propertyColor * baseColor.xyz, lightingInfluence.xxx);
 
-	float3 lightColor = lerp(baseColor.xyz, propertyColor * baseColor.xyz, lightingInfluence.xxx);
+#if !defined (MOTIONVECTORS_NORMALS)
+    if (alpha * fogMul.w - AlphaTestRef1 < 0)
+    {
+        discard;
+    }
+#endif
 
-#	if !defined(MOTIONVECTORS_NORMALS)
-	if (alpha * fogMul.w - AlphaTestRef1 < 0) {
-		discard;
-	}
-#	endif
-
-#	if !defined(MOTIONVECTORS_NORMALS)
-#		if defined(ADDBLEND)
+#if !defined (MOTIONVECTORS_NORMALS)
+#if defined(ADDBLEND)
 	float3 blendedColor = lightColor * (1 - input.FogParam.www);
-#		elif defined(MULTBLEND) || defined(MULTBLEND_DECAL)
+#elif defined(MULTBLEND) || defined(MULTBLEND_DECAL)
 	float3 blendedColor = lerp(lightColor, 1.0.xxx, saturate(1.5 * input.FogParam.w).xxx);
-#		else
+#else
 	float3 blendedColor = lerp(lightColor, input.FogParam.xyz, input.FogParam.www);
-#		endif
-#	else
+#endif
+#else
 	float3 blendedColor = lightColor.xyz;
-#	endif
-
-	float4 finalColor = float4(blendedColor, alpha);
-#	if defined(MULTBLEND_DECAL)
+#endif
+	
+    float4 finalColor = float4(blendedColor, alpha);
+#if defined(MULTBLEND_DECAL)
 	finalColor.xyz *= alpha;
-#	elif !defined(MULTBLEND)
+#elif !defined(MULTBLEND)
 	finalColor *= fogMul;
-#	endif
-	psout.Color = finalColor;
-#	if defined(LIGHT_LIMIT_FIX) && defined(LLFDEBUG)
+#endif
+	psout.Color = finalColor;	
+	#	if defined(LIGHT_LIMIT_FIX) && defined(LLFDEBUG)
 	if (perPassLLF[0].EnableLightsVisualisation) {
 		if (perPassLLF[0].LightsVisualisationMode == 0) {
 			psout.Color.xyz = TurboColormap(0.0);
@@ -668,27 +683,27 @@ PS_OUTPUT main(PS_INPUT input)
 	}
 #	endif
 
-#	if defined(MOTIONVECTORS_NORMALS)
+#if defined (MOTIONVECTORS_NORMALS)
 	float2 screenMotionVector = GetSSMotionVector(input.WorldPosition, input.PreviousWorldPosition, 0);
 
 	psout.MotionVectors = screenMotionVector;
 
-#		if (defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS)))
+#if (defined(MEMBRANE) && (defined(SKINNED) || defined(NORMALS)))
 	float3 screenSpaceNormal = normalize(input.TBN0);
-#		else
+#else
 	float3 screenSpaceNormal = normalize(input.ScreenSpaceNormal);
-#		endif
+#endif
 
 	screenSpaceNormal.z = max(0.001, sqrt(8 + -8 * screenSpaceNormal.z));
 	screenSpaceNormal.xy /= screenSpaceNormal.zz;
 	psout.ScreenSpaceNormals.xy = screenSpaceNormal.xy + 0.5.xx;
 	psout.ScreenSpaceNormals.zw = 0.0.xx;
-#	else
+#else
 	psout.Normal.xyz = float3(1, 0, 0);
 	psout.Normal.w = finalColor.w;
 
 	psout.Color2 = finalColor;
-#	endif
+#endif
 
 	return psout;
 }

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1332,15 +1332,13 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #		endif  // SNOW
 #	endif      // LANDSCAPE
 
-#	if !defined(LANDSCAPE)
-	float4 backLightColor = 1.0;
-	if (shaderDescriptors[0].PixelShaderDescriptor & _BackLighting)
-		backLightColor = TexBackLightSampler.Sample(SampBackLightSampler, uv);
+#		if defined(BACK_LIGHTING)
+	float4 backLightColor = TexBackLightSampler.Sample(SampBackLightSampler, uv);
+#		endif  // BACK_LIGHTING
 
-	float4 rimSoftLightColor = 1.0;
-	if ((shaderDescriptors[0].PixelShaderDescriptor & _SoftLighting) || (shaderDescriptors[0].PixelShaderDescriptor & _RimLighting))
-		rimSoftLightColor = TexRimSoftLightWorldMapOverlaySampler.Sample(SampRimSoftLightWorldMapOverlaySampler, uv);
-#	endif  // !defined (LANDSCAPE)
+#		if defined(RIM_LIGHTING) || defined(SOFT_LIGHTING)
+	float4 rimSoftLightColor = TexRimSoftLightWorldMapOverlaySampler.Sample(SampRimSoftLightWorldMapOverlaySampler, uv);
+#		endif  // RIM_LIGHTING || SOFT_LIGHTING
 
 	float numLights = min(7, NumLightNumShadowLight.x);
 	float numShadowLights = min(4, NumLightNumShadowLight.y);
@@ -1356,15 +1354,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #	endif      // defined (MODELSPACENORMALS) && !defined (SKINNED)
 
 	float2 baseShadowUV = 1.0.xx;
-	float4 shadowColor;
-	if (shaderDescriptors[0].PixelShaderDescriptor & _DefShadow) {
-		if ((shaderDescriptors[0].PixelShaderDescriptor & _ShadowDir) || numShadowLights > 0) {
-			baseShadowUV = input.Position.xy * DynamicResolutionParams2.xy;
-			float2 shadowUV = min(float2(DynamicResolutionParams2.z, DynamicResolutionParams1.y), max(0.0.xx, DynamicResolutionParams1.xy * (baseShadowUV * VPOSOffset.xy + VPOSOffset.zw)));
-			shadowColor = TexShadowMaskSampler.Sample(SampShadowMaskSampler, shadowUV);
-		} else {
-			shadowColor = 1.0.xxxx;
-		}
+	float4 shadowColor = 1.0;
+	if (shaderDescriptors[0].PixelShaderDescriptor & _DefShadow && (shaderDescriptors[0].PixelShaderDescriptor & _ShadowDir) || numShadowLights > 0) {
+		baseShadowUV = input.Position.xy * DynamicResolutionParams2.xy;
+		float2 shadowUV = min(float2(DynamicResolutionParams2.z, DynamicResolutionParams1.y), max(0.0.xx, DynamicResolutionParams1.xy * (baseShadowUV * VPOSOffset.xy + VPOSOffset.zw)));
+		shadowColor = TexShadowMaskSampler.Sample(SampShadowMaskSampler, shadowUV);
 	}
 
 	float texProjTmp = 0;
@@ -1383,9 +1377,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	texProjTmp += (-0.5 + input.Color.w) * 2.5;
 #		endif  // LODOBJECTSHD
 #		if defined(SPARKLE)
-	if (texProjTmp < 0) {
+	if (texProjTmp < 0)
 		discard;
-	}
 
 	modelNormal.xyz = projectedNormal;
 #			if defined(SNOW)
@@ -1543,8 +1536,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #		endif
 
 #		if (!defined(DRAW_IN_WORLDSPACE))
-	if (!input.WorldSpace)
-		normalizedDirLightDirectionWS = normalize(mul(input.World[eyeIndex], float4(normalizedDirLightDirectionWS, 0)));
+	normalizedDirLightDirectionWS = lerp(normalize(mul(input.World[eyeIndex], float4(DirLightDirection, 0))), normalizedDirLightDirectionWS, input.WorldSpace);
 #		endif
 #	endif
 
@@ -1561,10 +1553,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	cellInt = round(cellF);
 
 	uint waterTile = (uint)clamp(cellInt.x + (cellInt.y * 5), 0, 24);  // remap xy to 0-24
-	float waterHeight = -2147483648;                                   // lowest 32-bit integer
-
-	if (cellInt.x < 5 && cellInt.x >= 0 && cellInt.y < 5 && cellInt.y >= 0)
-		waterHeight = lightingData[0].WaterHeight[waterTile];
+	float waterHeight = lerp(-2147483648, lightingData[0].WaterHeight[waterTile], cellInt.x < 5 && cellInt.x >= 0 && cellInt.y < 5 && cellInt.y >= 0);                        
 #	endif
 
 #	if defined(WETNESS_EFFECTS)
@@ -1599,11 +1588,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		puddle = FBM(puddleCoords, 3, 1.0) * 0.5 + 0.5;
 		puddle = lerp(0.2, 1.0, puddle);
 		puddle *= wetness;
-		if (shaderDescriptors[0].PixelShaderDescriptor & _DefShadow) {
-			if (shaderDescriptors[0].PixelShaderDescriptor & _ShadowDir) {
-				float upAngle = saturate(dot(float3(0, 0, 1), normalizedDirLightDirectionWS.xyz));
-				puddle *= lerp(1.0, shadowColor.x, upAngle * 0.2);
-			}
+		if (shaderDescriptors[0].PixelShaderDescriptor & _DefShadow && shaderDescriptors[0].PixelShaderDescriptor & _ShadowDir) {
+			float upAngle = saturate(dot(float3(0, 0, 1), normalizedDirLightDirectionWS.xyz));
+			puddle *= lerp(1.0, shadowColor.x, upAngle * 0.2);
 		}
 	}
 
@@ -1627,8 +1614,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	float wetnessGlossinessSpecular = puddle;
 
 #		if !defined(LOD)
-	if (input.WorldPosition.z < waterHeight)
-		wetnessGlossinessSpecular *= shoreFactor;
+wetnessGlossinessSpecular = lerp(wetnessGlossinessSpecular, wetnessGlossinessSpecular * shoreFactor, input.WorldPosition.z < waterHeight);
 #		endif
 
 #		if !defined(MODELSPACENORMALS)
@@ -1681,9 +1667,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 			float3 normalizedLightDirection = normalize(lightDirection);
 			float3 normalizedLightDirectionWS = normalizedLightDirection;
 #		if (defined(SKINNED) || !defined(MODELSPACENORMALS)) && !defined(DRAW_IN_WORLDSPACE)
-			if (!input.WorldSpace) {
-				normalizedLightDirectionWS = normalize(mul(input.World[eyeIndex], float4(normalizedLightDirection, 0)));
-			}
+			normalizedLightDirectionWS = lerp(normalize(mul(input.World[eyeIndex], float4(normalizedLightDirection, 0))), normalizedLightDirectionWS, input.WorldSpace);
 #		endif
 
 #		if defined(LIGHT_LIMIT_FIX)
@@ -1702,10 +1686,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 			if (perPassParallax[0].EnableShadows) {
 				float3 lightDirectionTS = mul(normalizedLightDirection, tbn).xyz;
 
-				bool lightIsLit = true;
-
-				if (shadowComponent.x == 0)
-					lightIsLit = false;
+				bool lightIsLit = shadowComponent.x > 0.0;
 
 #			if defined(PARALLAX)
 				if (perPassParallax[0].EnableParallax)
@@ -1755,92 +1736,90 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	if (perPassLLF[0].EnableGlobalLights && GetClusterIndex(screenUV, viewPosition.z, clusterIndex)) {
 		lightCount = lightGrid[clusterIndex].lightCount;
 
-		if (lightCount) {
-			uint lightOffset = lightGrid[clusterIndex].offset;
-			float shadowQualityScale = saturate(1.0 - ((float)lightCount / 128.0));
+		uint lightOffset = lightGrid[clusterIndex].offset;
+		float shadowQualityScale = saturate(1.0 - ((float)lightCount / 128.0));
 
 #			if defined(ANISO_LIGHTING)
-			input.TBN0.z = worldSpaceVertexNormal[0];
-			input.TBN1.z = worldSpaceVertexNormal[1];
-			input.TBN2.z = worldSpaceVertexNormal[2];
+		input.TBN0.z = worldSpaceVertexNormal[0];
+		input.TBN1.z = worldSpaceVertexNormal[1];
+		input.TBN2.z = worldSpaceVertexNormal[2];
 #			endif
 
-			[loop] for (uint i = 0; i < lightCount; i++)
-			{
-				uint light_index = lightList[lightOffset + i];
-				StructuredLight light = lights[light_index];
+		[loop] for (uint i = 0; i < lightCount; i++)
+		{
+			uint light_index = lightList[lightOffset + i];
+			StructuredLight light = lights[light_index];
 
-				float3 lightDirection = light.positionWS[eyeIndex].xyz - input.WorldPosition.xyz;
-				float lightDist = length(lightDirection);
-				float intensityFactor = saturate(lightDist / light.radius);
-				if (intensityFactor == 1)
-					continue;
+			float3 lightDirection = light.positionWS[eyeIndex].xyz - input.WorldPosition.xyz;
+			float lightDist = length(lightDirection);
+			float intensityFactor = saturate(lightDist / light.radius);
+			if (intensityFactor == 1)
+				continue;
 
-				float intensityMultiplier = 1 - intensityFactor * intensityFactor;
-				float3 lightColor = light.color.xyz * intensityMultiplier;
-				float3 nsLightColor = lightColor;
-				float3 normalizedLightDirection = normalize(lightDirection);
+			float intensityMultiplier = 1 - intensityFactor * intensityFactor;
+			float3 lightColor = light.color.xyz * intensityMultiplier;
+			float3 nsLightColor = lightColor;
+			float3 normalizedLightDirection = normalize(lightDirection);
 
-				if (!FrameParams.z && FrameParams.y) {
-					float3 normalizedLightDirectionVS = WorldToView(normalizedLightDirection, true, eyeIndex);
-					if (light.firstPersonShadow || perPassLLF[0].EnableContactShadows) {
-						float radius = light.firstPersonShadow ? light.radius : 0.0;
-						float contactShadow = ContactShadows(viewPosition, screenUV, screenNoise, normalizedLightDirectionVS, shadowQualityScale, radius, eyeIndex);
-						if (light.firstPersonShadow) {
-							lightColor *= contactShadow;
-						} else {
+			if (!FrameParams.z && FrameParams.y) {
+				float3 normalizedLightDirectionVS = WorldToView(normalizedLightDirection, true, eyeIndex);
+				if (light.firstPersonShadow || perPassLLF[0].EnableContactShadows) {
+					float radius = light.firstPersonShadow ? light.radius : 0.0;
+					float contactShadow = ContactShadows(viewPosition, screenUV, screenNoise, normalizedLightDirectionVS, shadowQualityScale, radius, eyeIndex);
+					if (light.firstPersonShadow) {
+						lightColor *= contactShadow;
+					} else {
 #			if !defined(MODELSPACENORMALS)
-							float shadowIntensityFactor = saturate(dot(worldSpaceVertexNormal, normalizedLightDirection.xyz) * PI);
-							lightColor *= lerp(lerp(1.0, contactShadow, shadowIntensityFactor), 1.0, !frontFace * 0.2);
+						float shadowIntensityFactor = saturate(dot(worldSpaceVertexNormal, normalizedLightDirection.xyz) * PI);
+						lightColor *= lerp(lerp(1.0, contactShadow, shadowIntensityFactor), 1.0, !frontFace * 0.2);
 #			else
-							lightColor *= lerp(contactShadow, 1.0, !frontFace * 0.2);
+						lightColor *= lerp(contactShadow, 1.0, !frontFace * 0.2);
 #			endif
-						}
 					}
 				}
+			}
 
 #			if defined(CPM_AVAILABLE)
-				if (perPassParallax[0].EnableShadows) {
-					float3 lightDirectionTS = mul(normalizedLightDirection, tbn).xyz;
+			if (perPassParallax[0].EnableShadows) {
+				float3 lightDirectionTS = mul(normalizedLightDirection, tbn).xyz;
 
 #				if defined(PARALLAX)
-					if (perPassParallax[0].EnableParallax)
-						lightColor *= GetParallaxSoftShadowMultiplier(uv, mipLevel, lightDirectionTS, sh0, TexParallaxSampler, SampParallaxSampler, 0, parallaxShadowQuality);
+				if (perPassParallax[0].EnableParallax)
+					lightColor *= GetParallaxSoftShadowMultiplier(uv, mipLevel, lightDirectionTS, sh0, TexParallaxSampler, SampParallaxSampler, 0, parallaxShadowQuality);
 #				elif defined(LANDSCAPE)
-					if (perPassParallax[0].EnableTerrainParallax)
-						lightColor *= GetParallaxSoftShadowMultiplierTerrain(input, terrainUVs, mipLevel, lightDirectionTS, sh0, parallaxShadowQuality);
+				if (perPassParallax[0].EnableTerrainParallax)
+					lightColor *= GetParallaxSoftShadowMultiplierTerrain(input, terrainUVs, mipLevel, lightDirectionTS, sh0, parallaxShadowQuality);
 #				elif defined(ENVMAP)
-					if (complexMaterialParallax)
-						lightColor *= GetParallaxSoftShadowMultiplier(uv, mipLevel, lightDirectionTS, sh0, TexEnvMaskSampler, SampEnvMaskSampler, 3, parallaxShadowQuality);
+				if (complexMaterialParallax)
+					lightColor *= GetParallaxSoftShadowMultiplier(uv, mipLevel, lightDirectionTS, sh0, TexEnvMaskSampler, SampEnvMaskSampler, 3, parallaxShadowQuality);
 #				endif
-				}
+			}
 #			endif
 
-				float lightAngle = dot(worldSpaceNormal.xyz, normalizedLightDirection.xyz);
-				float3 lightDiffuseColor = lightColor * saturate(lightAngle.xxx);
+			float lightAngle = dot(worldSpaceNormal.xyz, normalizedLightDirection.xyz);
+			float3 lightDiffuseColor = lightColor * saturate(lightAngle.xxx);
 
 #			if defined(SOFT_LIGHTING)
-				lightDiffuseColor += nsLightColor * GetSoftLightMultiplier(dot(worldSpaceNormal.xyz, lightDirection.xyz)) * rimSoftLightColor.xyz;
+			lightDiffuseColor += nsLightColor * GetSoftLightMultiplier(dot(worldSpaceNormal.xyz, lightDirection.xyz)) * rimSoftLightColor.xyz;
 #			endif
 
 #			if defined(RIM_LIGHTING)
-				lightDiffuseColor += nsLightColor * GetRimLightMultiplier(normalizedLightDirection, viewDirection, worldSpaceNormal.xyz) * rimSoftLightColor.xyz;
+			lightDiffuseColor += nsLightColor * GetRimLightMultiplier(normalizedLightDirection, viewDirection, worldSpaceNormal.xyz) * rimSoftLightColor.xyz;
 #			endif
 
 #			if defined(BACK_LIGHTING)
-				lightDiffuseColor += (saturate(-lightAngle) * backLightColor.xyz) * nsLightColor;
+			lightDiffuseColor += (saturate(-lightAngle) * backLightColor.xyz) * nsLightColor;
 #			endif
 
 #			if defined(SPECULAR) || (defined(SPARKLE) && !defined(SNOW))
-				lightsSpecularColor += GetLightSpecularInput(input, normalizedLightDirection, viewDirection, worldSpaceNormal.xyz, lightColor, shininess, uv);
+			lightsSpecularColor += GetLightSpecularInput(input, normalizedLightDirection, viewDirection, worldSpaceNormal.xyz, lightColor, shininess, uv);
 #			endif
-				lightsDiffuseColor += lightDiffuseColor;
+			lightsDiffuseColor += lightDiffuseColor;
 
 #			if defined(WETNESS_EFFECTS)
-				if (waterRoughnessSpecular < 1.0)
-					wetnessSpecular += GetWetnessSpecular(wetnessNormal, normalizedLightDirection, worldSpaceViewDirection, lightColor, waterRoughnessSpecular);
+			if (waterRoughnessSpecular < 1.0)
+				wetnessSpecular += GetWetnessSpecular(wetnessNormal, normalizedLightDirection, worldSpaceViewDirection, lightColor, waterRoughnessSpecular);
 #			endif
-			}
 		}
 	}
 #		endif

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -570,7 +570,7 @@ PS_OUTPUT main(PS_INPUT input)
 		finalColor += lightColor;
 	}
 
-	finalColor *= fresnel * (1.0 / 3.14);
+	finalColor *= fresnel;
 
 	isSpecular = true;
 #		else
@@ -582,16 +582,16 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float3 specularLighting = 0;
 
-#			if defined(LIGHT_LIMIT_FIX)
+#		if defined(LIGHT_LIMIT_FIX)
 	uint eyeIndex = 0;
 	uint lightCount = 0;
 
 	float3 viewPosition = mul(CameraView[eyeIndex], float4(input.WPosition.xyz, 1)).xyz;
 	float2 screenUV = ViewToUV(viewPosition, true, eyeIndex);
-
+	
 	uint clusterIndex = 0;
-	if (perPassLLF[0].EnableGlobalLights && GetClusterIndex(screenUV, viewPosition.z, clusterIndex)) {
-		lightCount = lightGrid[clusterIndex].lightCount;
+	if (perPassLLF[0].EnableGlobalLights && GetClusterIndex(screenUV, viewPosition.z, clusterIndex)) {	
+		lightCount = lightGrid[clusterIndex].lightCount;	
 		uint lightOffset = lightGrid[clusterIndex].offset;
 		[loop] for (uint i = 0; i < lightCount; i++)
 		{
@@ -611,10 +611,10 @@ PS_OUTPUT main(PS_INPUT input)
 
 			float3 lightColor = light.color.xyz * pow(HdotN, FresnelRI.z);
 			specularLighting += lightColor * intensityMultiplier;
-		}
+		}	
 	}
-	specularColor += specularLighting;
-#			endif
+	specularColor += specularLighting * 3;
+#		endif
 
 #			if defined(UNDERWATER)
 	float3 finalSpecularColor = lerp(ShallowColor.xyz, specularColor, 0.5);

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -582,16 +582,16 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float3 specularLighting = 0;
 
-#		if defined(LIGHT_LIMIT_FIX)
+#			if defined(LIGHT_LIMIT_FIX)
 	uint eyeIndex = 0;
 	uint lightCount = 0;
 
 	float3 viewPosition = mul(CameraView[eyeIndex], float4(input.WPosition.xyz, 1)).xyz;
 	float2 screenUV = ViewToUV(viewPosition, true, eyeIndex);
-	
+
 	uint clusterIndex = 0;
-	if (GetClusterIndex(screenUV, viewPosition.z, clusterIndex)) {	
-		lightCount = lightGrid[clusterIndex].lightCount;	
+	if (GetClusterIndex(screenUV, viewPosition.z, clusterIndex)) {
+		lightCount = lightGrid[clusterIndex].lightCount;
 		uint lightOffset = lightGrid[clusterIndex].offset;
 		[loop] for (uint i = 0; i < lightCount; i++)
 		{
@@ -611,10 +611,10 @@ PS_OUTPUT main(PS_INPUT input)
 
 			float3 lightColor = light.color.xyz * pow(HdotN, FresnelRI.z);
 			specularLighting += lightColor * intensityMultiplier;
-		}	
+		}
 	}
 	specularColor += specularLighting;
-#		endif
+#			endif
 
 #			if defined(UNDERWATER)
 	float3 finalSpecularColor = lerp(ShallowColor.xyz, specularColor, 0.5);

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -582,16 +582,16 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float3 specularLighting = 0;
 
-#			if defined(LIGHT_LIMIT_FIX)
+#		if defined(LIGHT_LIMIT_FIX)
 	uint eyeIndex = 0;
 	uint lightCount = 0;
 
 	float3 viewPosition = mul(CameraView[eyeIndex], float4(input.WPosition.xyz, 1)).xyz;
 	float2 screenUV = ViewToUV(viewPosition, true, eyeIndex);
-
+	
 	uint clusterIndex = 0;
-	if (GetClusterIndex(screenUV, viewPosition.z, clusterIndex)) {
-		lightCount = lightGrid[clusterIndex].lightCount;
+	if (perPassLLF[0].EnableGlobalLights && GetClusterIndex(screenUV, viewPosition.z, clusterIndex)) {	
+		lightCount = lightGrid[clusterIndex].lightCount;	
 		uint lightOffset = lightGrid[clusterIndex].offset;
 		[loop] for (uint i = 0; i < lightCount; i++)
 		{
@@ -611,10 +611,10 @@ PS_OUTPUT main(PS_INPUT input)
 
 			float3 lightColor = light.color.xyz * pow(HdotN, FresnelRI.z);
 			specularLighting += lightColor * intensityMultiplier;
-		}
+		}	
 	}
 	specularColor += specularLighting;
-#			endif
+#		endif
 
 #			if defined(UNDERWATER)
 	float3 finalSpecularColor = lerp(ShallowColor.xyz, specularColor, 0.5);

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -2,6 +2,8 @@
 #include "Common/MotionBlur.hlsl"
 #include "Common/Permutation.hlsl"
 
+#define WATER
+
 struct VS_INPUT
 {
 #if defined(SPECULAR) || defined(UNDERWATER) || defined(STENCIL) || defined(SIMPLE)
@@ -402,7 +404,7 @@ float3 GetWaterSpecularColor(PS_INPUT input, float3 normal, float3 viewDirection
 }
 
 #		if defined(DEPTH)
-float GetScreenDepth(float2 screenPosition)
+float GetScreenDepthWater(float2 screenPosition)
 {
 	float depth = DepthTex.Load(float3(screenPosition, 0)).x;
 	return (CameraData.w / (-depth * CameraData.z + CameraData.x));
@@ -443,9 +445,9 @@ float3 GetWaterDiffuseColor(PS_INPUT input, float3 normal, float3 viewDirection,
 		float2(refractionNormal.x, refractionNormal.w - refractionNormal.y) / refractionNormal.ww;
 
 #			if defined(DEPTH)
-	float depth = GetScreenDepth(DynamicResolutionParams1.xy * (DynamicResolutionParams2.xy * input.HPosition.xy));
+	float depth = GetScreenDepthWater(DynamicResolutionParams1.xy * (DynamicResolutionParams2.xy * input.HPosition.xy));
 	float refractionDepth =
-		GetScreenDepth(DynamicResolutionParams1.xy * (refractionUvRaw / VPOSOffset.xy));
+		GetScreenDepthWater(DynamicResolutionParams1.xy * (refractionUvRaw / VPOSOffset.xy));
 	float refractionDepthMul = length(
 		float3((refractionDepth * ((VPOSOffset.zw + refractionUvRaw) * 2 - 1)) /
 				   ProjData.xy,
@@ -501,6 +503,10 @@ float3 GetSunColor(float3 normal, float3 viewDirection)
 #		include "WaterBlending/WaterBlending.hlsli"
 #	endif
 
+#	if defined(LIGHT_LIMIT_FIX)
+#		include "LightLimitFix/LightLimitFix.hlsli"
+#	endif
+
 PS_OUTPUT main(PS_INPUT input)
 {
 	PS_OUTPUT psout;
@@ -521,7 +527,7 @@ PS_OUTPUT main(PS_INPUT input)
 #			else
 	distanceMul = 0;
 
-	float depth = GetScreenDepth(
+	float depth = GetScreenDepthWater(
 		DynamicResolutionParams1.xy * (DynamicResolutionParams2.xy * input.HPosition.xy));
 	float2 depthOffset =
 		DynamicResolutionParams2.xy * input.HPosition.xy * VPOSOffset.xy + VPOSOffset.zw;
@@ -564,7 +570,7 @@ PS_OUTPUT main(PS_INPUT input)
 		finalColor += lightColor;
 	}
 
-	finalColor *= fresnel;
+	finalColor *= fresnel * (1.0 / 3.14);
 
 	isSpecular = true;
 #		else
@@ -574,6 +580,42 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 diffuseColor =
 		GetWaterDiffuseColor(input, normal, viewDirection, distanceMul, depthControl.y, fresnel);
 
+	float3 specularLighting = 0;
+
+#		if defined(LIGHT_LIMIT_FIX)
+	uint eyeIndex = 0;
+	uint lightCount = 0;
+
+	float3 viewPosition = mul(CameraView[eyeIndex], float4(input.WPosition.xyz, 1)).xyz;
+	float2 screenUV = ViewToUV(viewPosition, true, eyeIndex);
+	
+	uint clusterIndex = 0;
+	if (GetClusterIndex(screenUV, viewPosition.z, clusterIndex)) {	
+		lightCount = lightGrid[clusterIndex].lightCount;	
+		uint lightOffset = lightGrid[clusterIndex].offset;
+		[loop] for (uint i = 0; i < lightCount; i++)
+		{
+			uint light_index = lightList[lightOffset + i];
+			StructuredLight light = lights[light_index];
+
+			float3 lightDirection = light.positionWS[eyeIndex].xyz - input.WPosition.xyz;
+			float lightDist = length(lightDirection);
+			float intensityFactor = saturate(lightDist / light.radius);
+
+			float intensityMultiplier = 1 - intensityFactor * intensityFactor;
+
+			float3 normalizedLightDirection = normalize(lightDirection);
+
+			float3 H = normalize(normalizedLightDirection - viewDirection);
+			float HdotN = saturate(dot(H, normal));
+
+			float3 lightColor = light.color.xyz * pow(HdotN, FresnelRI.z);
+			specularLighting += lightColor * intensityMultiplier;
+		}	
+	}
+	specularColor += specularLighting;
+#		endif
+
 #			if defined(UNDERWATER)
 	float3 finalSpecularColor = lerp(ShallowColor.xyz, specularColor, 0.5);
 	float3 finalColor = saturate(1 - input.WPosition.w * 0.002) *
@@ -582,9 +624,7 @@ PS_OUTPUT main(PS_INPUT input)
 #			else
 	float3 sunColor = GetSunColor(normal, viewDirection);
 	float specularFraction = lerp(1, fresnel * depthControl.x, distanceFactor);
-
-	float3 finalColorPreFog =
-		lerp(diffuseColor, specularColor, specularFraction) + sunColor * depthControl.w;
+	float3 finalColorPreFog = lerp(diffuseColor, specularColor, specularFraction) + sunColor * depthControl.w;
 	float3 finalColor = lerp(finalColorPreFog, input.FogParam.xyz, input.FogParam.w);
 #			endif
 #		endif

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -582,16 +582,16 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float3 specularLighting = 0;
 
-#		if defined(LIGHT_LIMIT_FIX)
+#			if defined(LIGHT_LIMIT_FIX)
 	uint eyeIndex = 0;
 	uint lightCount = 0;
 
 	float3 viewPosition = mul(CameraView[eyeIndex], float4(input.WPosition.xyz, 1)).xyz;
 	float2 screenUV = ViewToUV(viewPosition, true, eyeIndex);
-	
+
 	uint clusterIndex = 0;
-	if (perPassLLF[0].EnableGlobalLights && GetClusterIndex(screenUV, viewPosition.z, clusterIndex)) {	
-		lightCount = lightGrid[clusterIndex].lightCount;	
+	if (perPassLLF[0].EnableGlobalLights && GetClusterIndex(screenUV, viewPosition.z, clusterIndex)) {
+		lightCount = lightGrid[clusterIndex].lightCount;
 		uint lightOffset = lightGrid[clusterIndex].offset;
 		[loop] for (uint i = 0; i < lightCount; i++)
 		{
@@ -611,10 +611,10 @@ PS_OUTPUT main(PS_INPUT input)
 
 			float3 lightColor = light.color.xyz * pow(HdotN, FresnelRI.z);
 			specularLighting += lightColor * intensityMultiplier;
-		}	
+		}
 	}
 	specularColor += specularLighting * 3;
-#		endif
+#			endif
 
 #			if defined(UNDERWATER)
 	float3 finalSpecularColor = lerp(ShallowColor.xyz, specularColor, 0.5);

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -607,21 +607,14 @@ enum class GrassShaderTechniques
 	RenderDepth = 8,
 };
 
-void LightLimitFix::Draw(const RE::BSShader* shader, const uint32_t descriptor)
+void LightLimitFix::Draw(const RE::BSShader* shader, const uint32_t)
 {
 	switch (shader->shaderType.get()) {
 	case RE::BSShader::Type::Lighting:
-		{
-			Bind();
-		}
-		break;
 	case RE::BSShader::Type::Grass:
-		{
-			const auto technique = descriptor & 0b1111;
-			if (technique != static_cast<uint32_t>(GrassShaderTechniques::RenderDepth)) {
-				Bind();
-			}
-		}
+	case RE::BSShader::Type::Effect:
+	case RE::BSShader::Type::Water:
+		Bind();
 		break;
 	}
 }
@@ -1027,6 +1020,9 @@ bool LightLimitFix::HasShaderDefine(RE::BSShader::Type shaderType)
 	case RE::BSShader::Type::Lighting:
 	case RE::BSShader::Type::Grass:
 		return true;
+	case RE::BSShader::Type::Effect:
+	case RE::BSShader::Type::Water:
+		return !REL::Module::IsVR();
 	default:
 		return false;
 	}

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -187,7 +187,7 @@ public:
 		{
 			static bool thunk(RE::BSShaderProperty* a_property, RE::BSLight* a_light)
 			{
-				return func(a_property, a_light) && (!netimmerse_cast<RE::BSLightingShaderProperty*>(a_property) || (a_light->portalStrict || !a_light->portalGraph || skyrim_cast<RE::BSShadowLight*>(a_light)));
+				return func(a_property, a_light) && ((REL::Module::IsVR() && !netimmerse_cast<RE::BSLightingShaderProperty*>(a_property)) || (a_light->portalStrict || !a_light->portalGraph || skyrim_cast<RE::BSShadowLight*>(a_light)));
 			}
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
@@ -196,7 +196,7 @@ public:
 		{
 			static bool thunk(RE::BSShaderProperty* a_property, RE::BSLight* a_light)
 			{
-				return func(a_property, a_light) && (!netimmerse_cast<RE::BSLightingShaderProperty*>(a_property) || (a_light->portalStrict || !a_light->portalGraph || skyrim_cast<RE::BSShadowLight*>(a_light)));
+				return func(a_property, a_light) && ((REL::Module::IsVR() && !netimmerse_cast<RE::BSLightingShaderProperty*>(a_property)) || (a_light->portalStrict || !a_light->portalGraph || skyrim_cast<RE::BSShadowLight*>(a_light)));
 			}
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
@@ -205,7 +205,7 @@ public:
 		{
 			static bool thunk(RE::BSShaderProperty* a_property, RE::BSLight* a_light)
 			{
-				return func(a_property, a_light) && (!netimmerse_cast<RE::BSLightingShaderProperty*>(a_property) || (a_light->portalStrict || !a_light->portalGraph || skyrim_cast<RE::BSShadowLight*>(a_light)));
+				return func(a_property, a_light) && ((REL::Module::IsVR() && !netimmerse_cast<RE::BSLightingShaderProperty*>(a_property)) || (a_light->portalStrict || !a_light->portalGraph || skyrim_cast<RE::BSShadowLight*>(a_light)));
 			}
 			static inline REL::Relocation<decltype(thunk)> func;
 		};

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -287,119 +287,147 @@ namespace SIE
 			defines[lastIndex] = { nullptr, nullptr };
 		}
 
-		enum class EffectShaderFlags
-		{
-			Vc = 1 << 0,
-			TexCoord = 1 << 1,
-			TexCoordIndex = 1 << 2,
-			Skinned = 1 << 3,
-			Normals = 1 << 4,
-			BinormalTangent = 1 << 5,
-			Texture = 1 << 6,
-			IndexedTexture = 1 << 7,
-			Falloff = 1 << 8,
-			AddBlend = 1 << 10,
-			MultBlend = 1 << 11,
-			Particles = 1 << 12,
-			StripParticles = 1 << 13,
-			Blood = 1 << 14,
-			Membrane = 1 << 15,
-			Lighting = 1 << 16,
-			ProjectedUv = 1 << 17,
-			Soft = 1 << 18,
-			GrayscaleToColor = 1 << 19,
-			GrayscaleToAlpha = 1 << 20,
-			IgnoreTexAlpha = 1 << 21,
-			MultBlendDecal = 1 << 22,
-			AlphaTest = 1 << 23,
-			SkyObject = 1 << 24,
-			MsnSpuSkinned = 1 << 25,
-			MotionVectorsNormals = 1 << 26,
-		};
-
 		static void GetEffectShaderDefines(uint32_t descriptor, D3D_SHADER_MACRO* defines)
 		{
-			int lastIndex = 0;
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::Vc)) {
-				defines[lastIndex++] = { "VC", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Vc))
+			{
+				defines[0] = { "VC", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::TexCoord)) {
-				defines[lastIndex++] = { "TEXCOORD", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::TexCoord))
+			{
+				defines[0] = { "TEXCOORD", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::TexCoordIndex)) {
-				defines[lastIndex++] = { "TEXCOORD_INDEX", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::TexCoordIndex))
+			{
+				defines[0] = { "TEXCOORD_INDEX", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::Skinned)) {
-				defines[lastIndex++] = { "SKINNED", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Skinned))
+			{
+				defines[0] = { "SKINNED", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::Normals)) {
-				defines[lastIndex++] = { "NORMALS", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Normals))
+			{
+				defines[0] = { "NORMALS", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::BinormalTangent)) {
-				defines[lastIndex++] = { "BINORMAL_TANGENT", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::BinormalTangent))
+			{
+				defines[0] = { "BINORMAL_TANGENT", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::Texture)) {
-				defines[lastIndex++] = { "TEXTURE", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Texture))
+			{
+				defines[0] = { "TEXTURE", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::IndexedTexture)) {
-				defines[lastIndex++] = { "INDEXED_TEXTURE", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::IndexedTexture))
+			{
+				defines[0] = { "INDEXED_TEXTURE", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::Falloff)) {
-				defines[lastIndex++] = { "FALLOFF", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Falloff))
+			{
+				defines[0] = { "FALLOFF", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::AddBlend)) {
-				defines[lastIndex++] = { "ADDBLEND", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::AddBlend))
+			{
+				defines[0] = { "ADDBLEND", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::MultBlend)) {
-				defines[lastIndex++] = { "MULTBLEND", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::MultBlend))
+			{
+				defines[0] = { "MULTBLEND", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::Particles)) {
-				defines[lastIndex++] = { "PARTICLES", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Particles))
+			{
+				defines[0] = { "PARTICLES", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::StripParticles)) {
-				defines[lastIndex++] = { "STRIP_PARTICLES", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::StripParticles))
+			{
+				defines[0] = { "STRIP_PARTICLES", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::Blood)) {
-				defines[lastIndex++] = { "BLOOD", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Blood))
+			{
+				defines[0] = { "BLOOD", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::Membrane)) {
-				defines[lastIndex++] = { "MEMBRANE", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Membrane))
+			{
+				defines[0] = { "MEMBRANE", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::Lighting)) {
-				defines[lastIndex++] = { "LIGHTING", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Lighting))
+			{
+				defines[0] = { "LIGHTING", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::ProjectedUv)) {
-				defines[lastIndex++] = { "PROJECTED_UV", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::ProjectedUv))
+			{
+				defines[0] = { "PROJECTED_UV", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::Soft)) {
-				defines[lastIndex++] = { "SOFT", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Soft))
+			{
+				defines[0] = { "SOFT", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::GrayscaleToColor)) {
-				defines[lastIndex++] = { "GRAYSCALE_TO_COLOR", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::GrayscaleToColor))
+			{
+				defines[0] = { "GRAYSCALE_TO_COLOR", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::GrayscaleToAlpha)) {
-				defines[lastIndex++] = { "GRAYSCALE_TO_ALPHA", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::GrayscaleToAlpha))
+			{
+				defines[0] = { "GRAYSCALE_TO_ALPHA", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::IgnoreTexAlpha)) {
-				defines[lastIndex++] = { "IGNORE_TEX_ALPHA", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::IgnoreTexAlpha))
+			{
+				defines[0] = { "IGNORE_TEX_ALPHA", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::MultBlendDecal)) {
-				defines[lastIndex++] = { "MULTBLEND_DECAL", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::MultBlendDecal))
+			{
+				defines[0] = { "MULTBLEND_DECAL", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::AlphaTest)) {
-				defines[lastIndex++] = { "ALPHA_TEST", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::AlphaTest))
+			{
+				defines[0] = { "ALPHA_TEST", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::SkyObject)) {
-				defines[lastIndex++] = { "SKY_OBJECT", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::SkyObject))
+			{
+				defines[0] = { "SKY_OBJECT", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::MsnSpuSkinned)) {
-				defines[lastIndex++] = { "MSN_SPU_SKINNED", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::MsnSpuSkinned))
+			{
+				defines[0] = { "MSN_SPU_SKINNED", nullptr };
+				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(EffectShaderFlags::MotionVectorsNormals)) {
-				defines[lastIndex++] = { "MOTIONVECTORS_NORMALS", nullptr };
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::MotionVectorsNormals))
+			{
+				defines[0] = { "MOTIONVECTORS_NORMALS", nullptr };
+				++defines;
 			}
 
-			defines[lastIndex] = { nullptr, nullptr };
+			for (auto* feature : Feature::GetFeatureList()) {
+				if (feature->loaded && feature->HasShaderDefine(RE::BSShader::Type::Effect)) {
+					defines[0] = { feature->GetShaderDefineName().data(), nullptr };
+					++defines;
+				}
+			}
+
+			defines[0] = { nullptr, nullptr };
 		}
 
 		static void GetWaterShaderDefines(uint32_t descriptor, D3D_SHADER_MACRO* defines)
@@ -491,6 +519,9 @@ namespace SIE
 				break;
 			case RE::BSShader::Type::Particle:
 				GetParticleShaderDefines(descriptor, defines);
+				break;
+			case RE::BSShader::Type::Effect:
+				GetEffectShaderDefines(descriptor, defines);
 				break;
 			}
 		}

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -289,133 +289,107 @@ namespace SIE
 
 		static void GetEffectShaderDefines(uint32_t descriptor, D3D_SHADER_MACRO* defines)
 		{
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Vc))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Vc)) {
 				defines[0] = { "VC", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::TexCoord))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::TexCoord)) {
 				defines[0] = { "TEXCOORD", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::TexCoordIndex))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::TexCoordIndex)) {
 				defines[0] = { "TEXCOORD_INDEX", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Skinned))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Skinned)) {
 				defines[0] = { "SKINNED", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Normals))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Normals)) {
 				defines[0] = { "NORMALS", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::BinormalTangent))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::BinormalTangent)) {
 				defines[0] = { "BINORMAL_TANGENT", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Texture))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Texture)) {
 				defines[0] = { "TEXTURE", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::IndexedTexture))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::IndexedTexture)) {
 				defines[0] = { "INDEXED_TEXTURE", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Falloff))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Falloff)) {
 				defines[0] = { "FALLOFF", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::AddBlend))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::AddBlend)) {
 				defines[0] = { "ADDBLEND", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::MultBlend))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::MultBlend)) {
 				defines[0] = { "MULTBLEND", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Particles))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Particles)) {
 				defines[0] = { "PARTICLES", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::StripParticles))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::StripParticles)) {
 				defines[0] = { "STRIP_PARTICLES", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Blood))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Blood)) {
 				defines[0] = { "BLOOD", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Membrane))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Membrane)) {
 				defines[0] = { "MEMBRANE", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Lighting))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Lighting)) {
 				defines[0] = { "LIGHTING", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::ProjectedUv))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::ProjectedUv)) {
 				defines[0] = { "PROJECTED_UV", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Soft))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::Soft)) {
 				defines[0] = { "SOFT", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::GrayscaleToColor))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::GrayscaleToColor)) {
 				defines[0] = { "GRAYSCALE_TO_COLOR", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::GrayscaleToAlpha))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::GrayscaleToAlpha)) {
 				defines[0] = { "GRAYSCALE_TO_ALPHA", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::IgnoreTexAlpha))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::IgnoreTexAlpha)) {
 				defines[0] = { "IGNORE_TEX_ALPHA", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::MultBlendDecal))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::MultBlendDecal)) {
 				defines[0] = { "MULTBLEND_DECAL", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::AlphaTest))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::AlphaTest)) {
 				defines[0] = { "ALPHA_TEST", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::SkyObject))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::SkyObject)) {
 				defines[0] = { "SKY_OBJECT", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::MsnSpuSkinned))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::MsnSpuSkinned)) {
 				defines[0] = { "MSN_SPU_SKINNED", nullptr };
 				++defines;
 			}
-			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::MotionVectorsNormals))
-			{
+			if (descriptor & static_cast<uint32_t>(ShaderCache::EffectShaderFlags::MotionVectorsNormals)) {
 				defines[0] = { "MOTIONVECTORS_NORMALS", nullptr };
 				++defines;
 			}

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -102,7 +102,8 @@ namespace SIE
 				       type == RE::BSShader::Type::Sky ||
 				       type == RE::BSShader::Type::Grass ||
 				       type == RE::BSShader::Type::Particle ||
-				       type == RE::BSShader::Type::Water;
+				       type == RE::BSShader::Type::Water ||
+					   type == RE::BSShader::Type::Effect;
 			return type == RE::BSShader::Type::Lighting ||
 			       type == RE::BSShader::Type::Grass;
 		}
@@ -228,6 +229,36 @@ namespace SIE
 			Cubemap = 1 << 8,
 			Flowmap = 1 << 9,
 			BlendNormals = 1 << 10,
+		};
+
+		enum class EffectShaderFlags
+		{
+			Vc = 1 << 0,
+			TexCoord = 1 << 1,
+			TexCoordIndex = 1 << 2,
+			Skinned = 1 << 3,
+			Normals = 1 << 4,
+			BinormalTangent = 1 << 5,
+			Texture = 1 << 6,
+			IndexedTexture = 1 << 7,
+			Falloff = 1 << 8,
+			AddBlend = 1 << 10,
+			MultBlend = 1 << 11,
+			Particles = 1 << 12,
+			StripParticles = 1 << 13,
+			Blood = 1 << 14,
+			Membrane = 1 << 15,
+			Lighting = 1 << 16,
+			ProjectedUv = 1 << 17,
+			Soft = 1 << 18,
+			GrayscaleToColor = 1 << 19,
+			GrayscaleToAlpha = 1 << 20,
+			IgnoreTexAlpha = 1 << 21,
+			MultBlendDecal = 1 << 22,
+			AlphaTest = 1 << 23,
+			SkyObject = 1 << 24,
+			MsnSpuSkinned = 1 << 25,
+			MotionVectorsNormals = 1 << 26,
 		};
 
 		uint blockedKeyIndex = (uint)-1;  // index in shaderMap; negative value indicates disabled

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -103,7 +103,7 @@ namespace SIE
 				       type == RE::BSShader::Type::Grass ||
 				       type == RE::BSShader::Type::Particle ||
 				       type == RE::BSShader::Type::Water ||
-					   type == RE::BSShader::Type::Effect;
+				       type == RE::BSShader::Type::Effect;
 			return type == RE::BSShader::Type::Lighting ||
 			       type == RE::BSShader::Type::Grass;
 		}


### PR DESCRIPTION
- Effect shaders should work 1:1 compared to vanilla
- Water shaders should work differently, since they have access to high quality normal maps. I found that vanilla water specularity is way too bright, so I've darkened it to match the new lighting on non-strict portal lights. Might improve performance vs vanilla because it reduces draw calls on water.
- VR is detected so that these flatrim-specific changes should not affect it.
- Some shadercache code has been refactored to be accessible elsewhere.