### PR TITLE
feat: add feature-level restore defaults option

### DIFF
--- a/src/Feature.h
+++ b/src/Feature.h
@@ -24,6 +24,8 @@ struct Feature
 	virtual void Load(json& o_json);
 	virtual void Save(json& o_json) = 0;
 
+	virtual void RestoreDefaultSettings() = 0;
+
 	virtual bool ValidateCache(CSimpleIniA& a_ini);
 	virtual void WriteDiskCacheInfo(CSimpleIniA& a_ini);
 	virtual void ClearShaderCache() {}

--- a/src/Features/DistantTreeLighting.cpp
+++ b/src/Features/DistantTreeLighting.cpp
@@ -62,6 +62,22 @@ void DistantTreeLighting::DrawSettings()
 		ImGui::Spacing();
 		ImGui::TreePop();
 	}
+
+	ImGui::Spacing();
+	ImGui::Spacing();
+
+	if (ImGui::Button("Restore Defaults", { -1, 0 })) {
+		DistantTreeLighting::GetSingleton()->RestoreDefaultSettings();
+	}
+	if (ImGui::IsItemHovered()) {
+		ImGui::BeginTooltip();
+		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		ImGui::Text(
+			"Restores the feature's settings back to their default values. "
+			"You will still need to Save Settings to make these changes permanent. ");
+		ImGui::PopTextWrapPos();
+		ImGui::EndTooltip();
+	}
 }
 
 enum class DistantTreeShaderTechniques
@@ -160,6 +176,11 @@ void DistantTreeLighting::Load(json& o_json)
 void DistantTreeLighting::Save(json& o_json)
 {
 	o_json[GetName()] = settings;
+}
+
+void DistantTreeLighting::RestoreDefaultSettings()
+{
+	settings = {};
 }
 
 void DistantTreeLighting::SetupResources()

--- a/src/Features/DistantTreeLighting.h
+++ b/src/Features/DistantTreeLighting.h
@@ -47,4 +47,6 @@ struct DistantTreeLighting : Feature
 
 	virtual void Load(json& o_json);
 	virtual void Save(json& o_json);
+
+	virtual void RestoreDefaultSettings();
 };

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -485,3 +485,7 @@ void DynamicCubemaps::Load(json& o_json)
 void DynamicCubemaps::Save(json&)
 {
 }
+
+void DynamicCubemaps::RestoreDefaultSettings()
+{
+}

--- a/src/Features/DynamicCubemaps.h
+++ b/src/Features/DynamicCubemaps.h
@@ -85,6 +85,8 @@ public:
 	virtual void Load(json& o_json);
 	virtual void Save(json& o_json);
 
+	virtual void RestoreDefaultSettings();
+
 	std::vector<std::string> iniVRCubeMapSettings{
 		{ "bAutoWaterSilhouetteReflections:Water" },  //IniSettings 0x1eaa018
 		{ "bForceHighDetailReflections:Water" },      //IniSettings 0x1eaa030

--- a/src/Features/ExtendedMaterials.cpp
+++ b/src/Features/ExtendedMaterials.cpp
@@ -163,6 +163,22 @@ void ExtendedMaterials::DrawSettings()
 
 		ImGui::TreePop();
 	}
+
+	ImGui::Spacing();
+	ImGui::Spacing();
+
+	if (ImGui::Button("Restore Defaults", { -1, 0 })) {
+		ExtendedMaterials::GetSingleton()->RestoreDefaultSettings();
+	}
+	if (ImGui::IsItemHovered()) {
+		ImGui::BeginTooltip();
+		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		ImGui::Text(
+			"Restores the feature's settings back to their default values. "
+			"You will still need to Save Settings to make these changes permanent. ");
+		ImGui::PopTextWrapPos();
+		ImGui::EndTooltip();
+	}
 }
 
 void ExtendedMaterials::ModifyLighting(const RE::BSShader*, const uint32_t)
@@ -241,6 +257,11 @@ void ExtendedMaterials::Load(json& o_json)
 void ExtendedMaterials::Save(json& o_json)
 {
 	o_json[GetName()] = settings;
+}
+
+void ExtendedMaterials::RestoreDefaultSettings()
+{
+	settings = {};
 }
 
 bool ExtendedMaterials::HasShaderDefine(RE::BSShader::Type shaderType)

--- a/src/Features/ExtendedMaterials.h
+++ b/src/Features/ExtendedMaterials.h
@@ -58,4 +58,6 @@ struct ExtendedMaterials : Feature
 
 	virtual void Load(json& o_json);
 	virtual void Save(json& o_json);
+
+	virtual void RestoreDefaultSettings();
 };

--- a/src/Features/GrassCollision.cpp
+++ b/src/Features/GrassCollision.cpp
@@ -73,6 +73,22 @@ void GrassCollision::DrawSettings()
 		ImGui::Text(std::format("Total Collisions : {}", currentCollisionCount).c_str());
 		ImGui::TreePop();
 	}
+
+	ImGui::Spacing();
+	ImGui::Spacing();
+
+	if (ImGui::Button("Restore Defaults", { -1, 0 })) {
+		GrassCollision::GetSingleton()->RestoreDefaultSettings();
+	}
+	if (ImGui::IsItemHovered()) {
+		ImGui::BeginTooltip();
+		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		ImGui::Text(
+			"Restores the feature's settings back to their default values. "
+			"You will still need to Save Settings to make these changes permanent. ");
+		ImGui::PopTextWrapPos();
+		ImGui::EndTooltip();
+	}
 }
 
 static bool GetShapeBound(RE::NiAVObject* a_node, RE::NiPoint3& centerPos, float& radius)
@@ -325,6 +341,11 @@ void GrassCollision::Load(json& o_json)
 void GrassCollision::Save(json& o_json)
 {
 	o_json[GetName()] = settings;
+}
+
+void GrassCollision::RestoreDefaultSettings()
+{
+	settings = {};
 }
 
 void GrassCollision::SetupResources()

--- a/src/Features/GrassCollision.h
+++ b/src/Features/GrassCollision.h
@@ -64,4 +64,6 @@ struct GrassCollision : Feature
 
 	virtual void Load(json& o_json);
 	virtual void Save(json& o_json);
+
+	virtual void RestoreDefaultSettings();
 };

--- a/src/Features/GrassLighting.cpp
+++ b/src/Features/GrassLighting.cpp
@@ -100,6 +100,22 @@ void GrassLighting::DrawSettings()
 
 		ImGui::TreePop();
 	}
+
+	ImGui::Spacing();
+	ImGui::Spacing();
+
+	if (ImGui::Button("Restore Defaults", { -1, 0 })) {
+		GrassLighting::GetSingleton()->RestoreDefaultSettings();
+	}
+	if (ImGui::IsItemHovered()) {
+		ImGui::BeginTooltip();
+		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		ImGui::Text(
+			"Restores the feature's settings back to their default values. "
+			"You will still need to Save Settings to make these changes permanent. ");
+		ImGui::PopTextWrapPos();
+		ImGui::EndTooltip();
+	}
 }
 
 void GrassLighting::ModifyGrass(const RE::BSShader*, const uint32_t descriptor)
@@ -154,6 +170,11 @@ void GrassLighting::Load(json& o_json)
 void GrassLighting::Save(json& o_json)
 {
 	o_json[GetName()] = settings;
+}
+
+void GrassLighting::RestoreDefaultSettings()
+{
+	settings = {};
 }
 
 void GrassLighting::SetupResources()

--- a/src/Features/GrassLighting.h
+++ b/src/Features/GrassLighting.h
@@ -45,4 +45,6 @@ struct GrassLighting : Feature
 
 	virtual void Load(json& o_json);
 	virtual void Save(json& o_json);
+
+	virtual void RestoreDefaultSettings();
 };

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -157,6 +157,22 @@ void LightLimitFix::DrawSettings()
 
 		ImGui::TreePop();
 	}
+
+	ImGui::Spacing();
+	ImGui::Spacing();
+
+	if (ImGui::Button("Restore Defaults", { -1, 0 })) {
+		LightLimitFix::GetSingleton()->RestoreDefaultSettings();
+	}
+	if (ImGui::IsItemHovered()) {
+		ImGui::BeginTooltip();
+		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		ImGui::Text(
+			"Restores the feature's settings back to their default values. "
+			"You will still need to Save Settings to make these changes permanent. ");
+		ImGui::PopTextWrapPos();
+		ImGui::EndTooltip();
+	}
 }
 
 void LightLimitFix::SetupResources()
@@ -285,6 +301,11 @@ void LightLimitFix::Load(json& o_json)
 void LightLimitFix::Save(json& o_json)
 {
 	o_json[GetName()] = settings;
+}
+
+void LightLimitFix::RestoreDefaultSettings()
+{
+	settings = {};
 }
 
 void LightLimitFix::BSLightingShader_SetupGeometry_Before(RE::BSRenderPass*)

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -124,6 +124,8 @@ public:
 	virtual void Load(json& o_json);
 	virtual void Save(json& o_json);
 
+	virtual void RestoreDefaultSettings();
+
 	virtual void DrawSettings();
 	virtual void Draw(const RE::BSShader* shader, const uint32_t descriptor);
 

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -128,6 +128,22 @@ void ScreenSpaceShadows::DrawSettings()
 
 		ImGui::TreePop();
 	}
+
+	ImGui::Spacing();
+	ImGui::Spacing();
+
+	if (ImGui::Button("Restore Defaults", { -1, 0 })) {
+		ScreenSpaceShadows::GetSingleton()->RestoreDefaultSettings();
+	}
+	if (ImGui::IsItemHovered()) {
+		ImGui::BeginTooltip();
+		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		ImGui::Text(
+			"Restores the feature's settings back to their default values. "
+			"You will still need to Save Settings to make these changes permanent. ");
+		ImGui::PopTextWrapPos();
+		ImGui::EndTooltip();
+	}
 }
 
 enum class GrassShaderTechniques
@@ -498,6 +514,11 @@ void ScreenSpaceShadows::Load(json& o_json)
 void ScreenSpaceShadows::Save(json& o_json)
 {
 	o_json[GetName()] = settings;
+}
+
+void ScreenSpaceShadows::RestoreDefaultSettings()
+{
+	settings = {};
 }
 
 void ScreenSpaceShadows::SetupResources()

--- a/src/Features/ScreenSpaceShadows.h
+++ b/src/Features/ScreenSpaceShadows.h
@@ -84,4 +84,6 @@ struct ScreenSpaceShadows : Feature
 
 	virtual void Load(json& o_json);
 	virtual void Save(json& o_json);
+
+	virtual void RestoreDefaultSettings();
 };

--- a/src/Features/WaterBlending.cpp
+++ b/src/Features/WaterBlending.cpp
@@ -51,6 +51,22 @@ void WaterBlending::DrawSettings()
 
 		ImGui::TreePop();
 	}
+
+	ImGui::Spacing();
+	ImGui::Spacing();
+
+	if (ImGui::Button("Restore Defaults", { -1, 0 })) {
+		WaterBlending::GetSingleton()->RestoreDefaultSettings();
+	}
+	if (ImGui::IsItemHovered()) {
+		ImGui::BeginTooltip();
+		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		ImGui::Text(
+			"Restores the feature's settings back to their default values. "
+			"You will still need to Save Settings to make these changes permanent. ");
+		ImGui::PopTextWrapPos();
+		ImGui::EndTooltip();
+	}
 }
 
 void WaterBlending::Draw(const RE::BSShader* shader, const uint32_t)
@@ -111,6 +127,11 @@ void WaterBlending::Load(json& o_json)
 void WaterBlending::Save(json& o_json)
 {
 	o_json[GetName()] = settings;
+}
+
+void WaterBlending::RestoreDefaultSettings()
+{
+	settings = {};
 }
 
 bool WaterBlending::HasShaderDefine(RE::BSShader::Type)

--- a/src/Features/WaterBlending.h
+++ b/src/Features/WaterBlending.h
@@ -44,4 +44,6 @@ public:
 
 	virtual void Load(json& o_json);
 	virtual void Save(json& o_json);
+
+	virtual void RestoreDefaultSettings();
 };

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -41,6 +41,22 @@ void WetnessEffects::DrawSettings()
 
 		ImGui::TreePop();
 	}
+
+	ImGui::Spacing();
+	ImGui::Spacing();
+
+	if (ImGui::Button("Restore Defaults", { -1, 0 })) {
+		WetnessEffects::GetSingleton()->RestoreDefaultSettings();
+	}
+	if (ImGui::IsItemHovered()) {
+		ImGui::BeginTooltip();
+		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		ImGui::Text(
+			"Restores the feature's settings back to their default values. "
+			"You will still need to Save Settings to make these changes permanent. ");
+		ImGui::PopTextWrapPos();
+		ImGui::EndTooltip();
+	}
 }
 
 float WetnessEffects::CalculateWeatherTransitionPercentage(RE::TESWeather* weather, float skyCurrentWeatherPct, float beginFade)
@@ -169,4 +185,9 @@ void WetnessEffects::Load(json& o_json)
 void WetnessEffects::Save(json& o_json)
 {
 	o_json[GetName()] = settings;
+}
+
+void WetnessEffects::RestoreDefaultSettings()
+{
+	settings = {};
 }

--- a/src/Features/WetnessEffects.h
+++ b/src/Features/WetnessEffects.h
@@ -52,6 +52,8 @@ public:
 	virtual void Load(json& o_json);
 	virtual void Save(json& o_json);
 
+	virtual void RestoreDefaultSettings();
+
 	float CalculateWeatherTransitionPercentage(RE::TESWeather* weather, float skyCurrentWeatherPct, float beginFade);
 	float CalculateWetness(RE::TESWeather* weather, RE::Sky* sky);
 };


### PR DESCRIPTION
Added option to restore defaults at the feature level for all features except dynamic cubemaps.
* Implemented virtual function on the Feature base class and then implemented it on all of the features. 
* Added a button to all feature settings menus to restore defaults - except for dynamic cubemaps
* Tested with a debugger attached to make sure that ImGui behaved