### PR TITLE
fix: black reflections on water for amd

### DIFF
--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -20,5 +20,5 @@ float3 GetDynamicCubemap(float3 N, float3 V, float roughness, float3 F0, float c
 	float3 Fr = max(1.0.xxx - roughness.xxx, F0) - F0;
 	float3 S = Fr * pow(1.0 - NoV, 5.0);
 
-	return lerp(specularIrradiance * F0 + (specularIrradiance * (S * specularBRDF.x + specularBRDF.y)), specularIrradiance * ((F0 + S) * specularBRDF.x + specularBRDF.y), complexMaterial);
+	return lerp(saturate(specularIrradiance * F0 + (specularIrradiance * (S * specularBRDF.x + specularBRDF.y))), saturate(specularIrradiance * ((F0 + S) * specularBRDF.x + specularBRDF.y)), complexMaterial);
 }

--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -20,5 +20,5 @@ float3 GetDynamicCubemap(float3 N, float3 V, float roughness, float3 F0, float c
 	float3 Fr = max(1.0.xxx - roughness.xxx, F0) - F0;
 	float3 S = Fr * pow(1.0 - NoV, 5.0);
 
-	return lerp(saturate(specularIrradiance * F0 + (specularIrradiance * (S * specularBRDF.x + specularBRDF.y))), saturate(specularIrradiance * ((F0 + S) * specularBRDF.x + specularBRDF.y)), complexMaterial);
+	return lerp(max(0, specularIrradiance * F0 + (specularIrradiance * (S * specularBRDF.x + specularBRDF.y))), max(0, specularIrradiance * ((F0 + S) * specularBRDF.x + specularBRDF.y)), complexMaterial);
 }

--- a/features/Grass Lighting/Shaders/RunGrass.hlsl
+++ b/features/Grass Lighting/Shaders/RunGrass.hlsl
@@ -522,7 +522,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 	diffuseColor += lightsDiffuseColor;
 
-	float3 color = diffuseColor * baseColor.xyz * input.VertexColor.xyz;
+	float3 color = max(0, diffuseColor * baseColor.xyz * input.VertexColor.xyz);
 
 	if (complex) {
 		specularColor += lightsSpecularColor;

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -392,7 +392,7 @@ float3 GetWaterSpecularColor(PS_INPUT input, float3 normal, float3 viewDirection
 			float4 ssrReflectionColor2 = RawSSRReflectionTex.Sample(RawSSRReflectionSampler, ssrReflectionUv);
 			float4 ssrReflectionColor = lerp(ssrReflectionColor2, ssrReflectionColor1, SSRParams.y);
 
-			finalSsrReflectionColor = ssrReflectionColor.xyz;
+			finalSsrReflectionColor = max(0, ssrReflectionColor.xyz);
 			ssrFraction = saturate(ssrReflectionColor.w * (SSRParams.x * distanceFactor));
 		}
 #		endif


### PR DESCRIPTION
Fixes bugged flickering black squares on water surfaces and probably other cubemap issues as well.

