### PR TITLE
fix: clear imgui inputs when window focus lost (alt-tabbing)

### DIFF
--- a/include/PCH.h
+++ b/include/PCH.h
@@ -45,6 +45,14 @@ namespace stl
 		T::func = trampoline.write_call<5>(a_src, T::thunk);
 	}
 
+	template <class T>
+	void write_thunk_call_6(std::uintptr_t a_src)
+	{
+		SKSE::AllocTrampoline(14);
+		auto& trampoline = SKSE::GetTrampoline();
+		T::func = *(uintptr_t*)trampoline.write_call<6>(a_src, T::thunk);
+	}
+
 	template <class F, size_t index, class T>
 	void write_vfunc()
 	{

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -309,6 +309,33 @@ namespace Hooks
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
+	struct WndProcHandler_Hook
+	{
+		static LRESULT thunk(HWND a_hwnd, UINT a_msg, WPARAM a_wParam, LPARAM a_lParam)
+		{
+			if (a_msg == WM_KILLFOCUS) {
+				Menu::GetSingleton()->OnFocusLost();
+				auto& io = ImGui::GetIO();
+				io.ClearInputKeys();
+				io.ClearEventsQueue();
+			}
+			return func(a_hwnd, a_msg, a_wParam, a_lParam);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	struct RegisterClassA_Hook
+	{
+		static ATOM thunk(WNDCLASSA* a_wndClass)
+		{
+			WndProcHandler_Hook::func = reinterpret_cast<uintptr_t>(a_wndClass->lpfnWndProc);
+			a_wndClass->lpfnWndProc = &WndProcHandler_Hook::thunk;
+
+			return func(a_wndClass);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
 	void Install()
 	{
 		SKSE::AllocTrampoline(14);
@@ -329,6 +356,9 @@ namespace Hooks
 		stl::write_vfunc<0x2, BSImagespaceShaderISSAOCompositeSAO_SetupTechnique>(RE::VTABLE_BSImagespaceShaderISSAOCompositeSAO[0]);
 		stl::write_vfunc<0x2, BSImagespaceShaderISSAOCompositeFog_SetupTechnique>(RE::VTABLE_BSImagespaceShaderISSAOCompositeFog[0]);
 		stl::write_vfunc<0x2, BSImagespaceShaderISSAOCompositeSAOFog_SetupTechnique>(RE::VTABLE_BSImagespaceShaderISSAOCompositeSAOFog[0]);
+
+		logger::info("Hooking WndProcHandler");
+		stl::write_thunk_call_6<RegisterClassA_Hook>(REL::VariantID(75591, 77226, 0xDC4B90).address() + REL::VariantOffset(0x8E, 0x15C, 0x99).offset());
 
 		//logger::info("Hooking D3D11CreateDeviceAndSwapChain");
 		//*(FARPROC*)&ptrD3D11CreateDeviceAndSwapChain = GetProcAddress(GetModuleHandleA("d3d11.dll"), "D3D11CreateDeviceAndSwapChain");

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -944,7 +944,7 @@ void Menu::addToEventQueue(KeyEvent e)
 	_keyEventQueue.emplace_back(e);
 }
 
-void Menu::OnFocusLost()  //todo implement wndproc hook to catch WM_KILLFOCUS
+void Menu::OnFocusLost()
 {
 	std::unique_lock<std::shared_mutex> mutex(_inputEventMutex);
 	_keyEventQueue.clear();


### PR DESCRIPTION
Implemented wndproc hook to catch WM_KILLFOCUS and call 
```
Menu::GetSingleton()->OnFocusLost();
auto& io = ImGui::GetIO();
io.ClearInputKeys();
io.ClearEventsQueue();
```
Got some added info from "FiveLimbedCat/ProfJack" on discord, that we should also clear the io inputkeys

Got the addresses and offsets from Open Animation Replacer. Had to convert it to use the thunk/func version instead though!

Tested this on skyrim 1.6.1170.0

Now it will clear all ImGui input states when alt-tabbing

Link to diskussion on discord here:
https://discord.com/channels/1080142797870485606/1082470343119216751/1201664684261130250