### PR TITLE
refactor: extract common UI codes, including restore default button, and hovered tooltip formatting

### DIFF
--- a/src/Features/DistantTreeLighting.cpp
+++ b/src/Features/DistantTreeLighting.cpp
@@ -13,15 +13,11 @@ void DistantTreeLighting::DrawSettings()
 {
 	if (ImGui::TreeNodeEx("Complex Tree LOD", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Checkbox("Enable Complex Tree LOD", (bool*)&settings.EnableComplexTreeLOD);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Enables advanced lighting simulation on tree LOD. "
 				"Requires DynDOLOD. "
 				"See https://dyndolod.info/ for more information. ");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Spacing();
@@ -31,12 +27,8 @@ void DistantTreeLighting::DrawSettings()
 
 	if (ImGui::TreeNodeEx("Lights", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Checkbox("Enable Directional Light Fix", (bool*)&settings.EnableDirLightFix);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Fix for trees not being affected by sunlight scale.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Spacing();
@@ -46,16 +38,12 @@ void DistantTreeLighting::DrawSettings()
 
 	if (ImGui::TreeNodeEx("Effects", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::SliderFloat("SSS Amount", &settings.SubsurfaceScatteringAmount, 0.0f, 1.0f);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Subsurface Scattering (SSS) amount. "
 				"Soft lighting controls how evenly lit an object is. "
 				"Back lighting illuminates the back face of an object. "
 				"Combined to model the transport of light through the surface. ");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Spacing();

--- a/src/Features/DistantTreeLighting.cpp
+++ b/src/Features/DistantTreeLighting.cpp
@@ -62,22 +62,6 @@ void DistantTreeLighting::DrawSettings()
 		ImGui::Spacing();
 		ImGui::TreePop();
 	}
-
-	ImGui::Spacing();
-	ImGui::Spacing();
-
-	if (ImGui::Button("Restore Defaults", { -1, 0 })) {
-		DistantTreeLighting::GetSingleton()->RestoreDefaultSettings();
-	}
-	if (ImGui::IsItemHovered()) {
-		ImGui::BeginTooltip();
-		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-		ImGui::Text(
-			"Restores the feature's settings back to their default values. "
-			"You will still need to Save Settings to make these changes permanent. ");
-		ImGui::PopTextWrapPos();
-		ImGui::EndTooltip();
-	}
 }
 
 enum class DistantTreeShaderTechniques

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -12,13 +12,9 @@ void DynamicCubemaps::DrawSettings()
 					if (auto setting = RE::INISettingCollection::GetSingleton()->GetSetting(settingName); setting) {
 						ImGui::TableNextColumn();
 						ImGui::Checkbox(settingName.c_str(), &setting->data.b);
-						if (ImGui::IsItemHovered()) {
-							ImGui::BeginTooltip();
-							ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+						if (auto _tt = Util::HoverTooltipWrapper()) {
 							//ImGui::Text(fmt::format(fmt::runtime("{} {0:x}"), settingName, &setting->data.b).c_str());
 							ImGui::Text(settingName.c_str());
-							ImGui::PopTextWrapPos();
-							ImGui::EndTooltip();
 						}
 					}
 				}
@@ -28,13 +24,9 @@ void DynamicCubemaps::DrawSettings()
 					bool* setting = reinterpret_cast<bool*>(address);
 					ImGui::TableNextColumn();
 					ImGui::Checkbox(settingName.c_str(), setting);
-					if (ImGui::IsItemHovered()) {
-						ImGui::BeginTooltip();
-						ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+					if (auto _tt = Util::HoverTooltipWrapper()) {
 						ImGui::Text(settingName.c_str());
 						//ImGui::Text(fmt::format(fmt::runtime("{} {0:x}"), settingName, address).c_str());
-						ImGui::PopTextWrapPos();
-						ImGui::EndTooltip();
 					}
 				}
 				ImGui::EndTable();

--- a/src/Features/ExtendedMaterials.cpp
+++ b/src/Features/ExtendedMaterials.cpp
@@ -1,5 +1,7 @@
 #include "ExtendedMaterials.h"
 
+#include "Util.h"
+
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ExtendedMaterials::Settings,
 	EnableParallax,
@@ -30,15 +32,11 @@ void ExtendedMaterials::DrawSettings()
 {
 	if (ImGui::TreeNodeEx("Complex Material", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Checkbox("Enable Complex Material", (bool*)&settings.EnableComplexMaterial);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Enables support for the Complex Material specification which makes use of the environment mask. "
 				"This includes parallax, as well as more realistic metals and specular reflections. "
 				"May lead to some warped textures on modded content which have an invalid alpha channel in their environment mask. ");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Spacing();
@@ -48,12 +46,8 @@ void ExtendedMaterials::DrawSettings()
 
 	if (ImGui::TreeNodeEx("Contact Refinement Parallax Mapping", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Checkbox("Enable Parallax", (bool*)&settings.EnableParallax);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Enables parallax on standard meshes made for parallax.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		if (ImGui::Checkbox("Enable Terrain", (bool*)&settings.EnableTerrain)) {
@@ -61,66 +55,42 @@ void ExtendedMaterials::DrawSettings()
 				DataLoaded();
 			}
 		}
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Enables terrain parallax using the alpha channel of each landscape texture. "
 				"Therefore, all landscape textures must support parallax for this effect to work properly. ");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Checkbox("Enable High Quality", (bool*)&settings.EnableHighQuality);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Doubles the sample count and approximates the intersection point using Parallax Occlusion Mapping. "
 				"Significantly improves the quality and removes aliasing. "
 				"TAA or the Skyrim Upscaler is recommended when using this option due to CRPM artifacts. ");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Spacing();
 		ImGui::Spacing();
 		ImGui::SliderInt("Max Distance", (int*)&settings.MaxDistance, 0, 4096);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("The furthest distance from the camera which uses parallax.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::SliderFloat("CRPM Range", &settings.CRPMRange, 0.0f, 1.0f);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("The percentage of the max distance which uses Contact Refinement Parallax Mapping (CRPM).");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::SliderFloat("Blend Range", &settings.BlendRange, 0.0f, settings.CRPMRange);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"The range that parallax blends from Parallax Occlusion Mapping (POM) to bump mapping, and bump mapping to nothing. "
 				"This value should be set as low as possible due to the performance impact of blending POM and relief mapping. ");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::SliderFloat("Height", &settings.Height, 0, 0.2f);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("The range between the highest and lowest point a surface can be offset by.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Spacing();
@@ -130,35 +100,23 @@ void ExtendedMaterials::DrawSettings()
 
 	if (ImGui::TreeNodeEx("Approximate Soft Shadows", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Checkbox("Enable Shadows", (bool*)&settings.EnableShadows);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Enables cheap soft shadows when using parallax. "
 				"This applies to all directional and point lights. ");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Spacing();
 		ImGui::Spacing();
 		ImGui::TextWrapped("Modifying the shadow start and end fade can improve performance and hide obvious texture tiling.");
 		ImGui::SliderInt("Start Fade", (int*)&settings.ShadowsStartFade, 0, settings.ShadowsEndFade);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Distance shadows start to fade.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::SliderInt("End Fade", (int*)&settings.ShadowsEndFade, settings.ShadowsStartFade, 4096);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Distance shadows finish fading.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::TreePop();

--- a/src/Features/ExtendedMaterials.cpp
+++ b/src/Features/ExtendedMaterials.cpp
@@ -163,22 +163,6 @@ void ExtendedMaterials::DrawSettings()
 
 		ImGui::TreePop();
 	}
-
-	ImGui::Spacing();
-	ImGui::Spacing();
-
-	if (ImGui::Button("Restore Defaults", { -1, 0 })) {
-		ExtendedMaterials::GetSingleton()->RestoreDefaultSettings();
-	}
-	if (ImGui::IsItemHovered()) {
-		ImGui::BeginTooltip();
-		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-		ImGui::Text(
-			"Restores the feature's settings back to their default values. "
-			"You will still need to Save Settings to make these changes permanent. ");
-		ImGui::PopTextWrapPos();
-		ImGui::EndTooltip();
-	}
 }
 
 void ExtendedMaterials::ModifyLighting(const RE::BSShader*, const uint32_t)

--- a/src/Features/GrassCollision.cpp
+++ b/src/Features/GrassCollision.cpp
@@ -18,52 +18,32 @@ void GrassCollision::DrawSettings()
 {
 	if (ImGui::TreeNodeEx("Grass Collision", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Checkbox("Enable Grass Collision", (bool*)&settings.EnableGrassCollision);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Allows player collision to modify grass position.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Spacing();
 		ImGui::SliderFloat("Radius Multiplier", &settings.RadiusMultiplier, 0.0f, 8.0f);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Distance from collision centres to apply collision.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::SliderFloat("Max Distance from Player", &settings.maxDistance, 0.0f, 1500.0f);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Distance from player to apply collision (NPCs). 0 to disable NPC collisions.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::SliderFloat("Displacement Multiplier", &settings.DisplacementMultiplier, 0.0f, 32.0f);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Strength of each collision on grass position.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		if (ImGui::SliderInt("Calculation Frame Interval", (int*)&settings.frameInterval, 0, 30)) {
 			if (settings.frameInterval)  // increment so mod math works (e.g., skip 1 frame means frame % 2).
 				settings.frameInterval++;
 		}
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("How many frames to skip before calculating positions again. 0 means calculate every frame (most smooth/costly).");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::TreePop();

--- a/src/Features/GrassCollision.cpp
+++ b/src/Features/GrassCollision.cpp
@@ -73,22 +73,6 @@ void GrassCollision::DrawSettings()
 		ImGui::Text(std::format("Total Collisions : {}", currentCollisionCount).c_str());
 		ImGui::TreePop();
 	}
-
-	ImGui::Spacing();
-	ImGui::Spacing();
-
-	if (ImGui::Button("Restore Defaults", { -1, 0 })) {
-		GrassCollision::GetSingleton()->RestoreDefaultSettings();
-	}
-	if (ImGui::IsItemHovered()) {
-		ImGui::BeginTooltip();
-		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-		ImGui::Text(
-			"Restores the feature's settings back to their default values. "
-			"You will still need to Save Settings to make these changes permanent. ");
-		ImGui::PopTextWrapPos();
-		ImGui::EndTooltip();
-	}
 }
 
 static bool GetShapeBound(RE::NiAVObject* a_node, RE::NiPoint3& centerPos, float& radius)

--- a/src/Features/GrassLighting.cpp
+++ b/src/Features/GrassLighting.cpp
@@ -100,22 +100,6 @@ void GrassLighting::DrawSettings()
 
 		ImGui::TreePop();
 	}
-
-	ImGui::Spacing();
-	ImGui::Spacing();
-
-	if (ImGui::Button("Restore Defaults", { -1, 0 })) {
-		GrassLighting::GetSingleton()->RestoreDefaultSettings();
-	}
-	if (ImGui::IsItemHovered()) {
-		ImGui::BeginTooltip();
-		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-		ImGui::Text(
-			"Restores the feature's settings back to their default values. "
-			"You will still need to Save Settings to make these changes permanent. ");
-		ImGui::PopTextWrapPos();
-		ImGui::EndTooltip();
-	}
 }
 
 void GrassLighting::ModifyGrass(const RE::BSShader*, const uint32_t descriptor)

--- a/src/Features/GrassLighting.cpp
+++ b/src/Features/GrassLighting.cpp
@@ -22,21 +22,13 @@ void GrassLighting::DrawSettings()
 	if (ImGui::TreeNodeEx("Complex Grass", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::TextWrapped("Specular highlights for complex grass");
 		ImGui::SliderFloat("Glossiness", &settings.Glossiness, 1.0f, 100.0f);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Specular highlight glossiness.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::SliderFloat("Specular Strength", &settings.SpecularStrength, 0.0f, 1.0f);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Specular highlight strength.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Spacing();
@@ -46,16 +38,12 @@ void GrassLighting::DrawSettings()
 
 	if (ImGui::TreeNodeEx("Effects", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::SliderFloat("SSS Amount", &settings.SubsurfaceScatteringAmount, 0.0f, 2.0f);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Subsurface Scattering (SSS) amount. "
 				"Soft lighting controls how evenly lit an object is. "
 				"Back lighting illuminates the back face of an object. "
 				"Combined to model the transport of light through the surface. ");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Spacing();
@@ -65,37 +53,25 @@ void GrassLighting::DrawSettings()
 
 	if (ImGui::TreeNodeEx("Lighting", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Checkbox("Enable Directional Light Fix", (bool*)&settings.EnableDirLightFix);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Fix for grass not being affected by sunlight scale.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Checkbox("Override Complex Grass Lighting Settings", (bool*)&settings.OverrideComplexGrassSettings);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Override the settings set by the grass mesh author. "
 				"Complex grass authors can define the brightness for their grass meshes. "
 				"However, some authors may not account for the extra lights available from Community Shaders. "
 				"This option will treat their grass settings like non-complex grass. "
 				"This was the default in Community Shaders < 0.7.0");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 		ImGui::Spacing();
 		ImGui::Spacing();
 		ImGui::TextWrapped("Basic Grass");
 		ImGui::SliderFloat("Brightness", &settings.BasicGrassBrightness, 0.0f, 1.0f);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Darkens the grass textures to look better with the new lighting");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::TreePop();

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -157,22 +157,6 @@ void LightLimitFix::DrawSettings()
 
 		ImGui::TreePop();
 	}
-
-	ImGui::Spacing();
-	ImGui::Spacing();
-
-	if (ImGui::Button("Restore Defaults", { -1, 0 })) {
-		LightLimitFix::GetSingleton()->RestoreDefaultSettings();
-	}
-	if (ImGui::IsItemHovered()) {
-		ImGui::BeginTooltip();
-		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-		ImGui::Text(
-			"Restores the feature's settings back to their default values. "
-			"You will still need to Save Settings to make these changes permanent. ");
-		ImGui::PopTextWrapPos();
-		ImGui::EndTooltip();
-	}
 }
 
 void LightLimitFix::SetupResources()

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -28,68 +28,40 @@ void LightLimitFix::DrawSettings()
 {
 	if (ImGui::TreeNodeEx("Particle Lights", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Checkbox("Enable Particle Lights", &settings.EnableParticleLights);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Enables Particle Lights.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Checkbox("Enable Culling", &settings.EnableParticleLightsCulling);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Significantly improves performance by not rendering empty textures. Only disable if you are encountering issues.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Checkbox("Enable Detection", &settings.EnableParticleLightsDetection);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Adds particle lights to the player light level, so that NPCs can detect them for stealth and gameplay.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Checkbox("Enable Optimization", &settings.EnableParticleLightsOptimization);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Merges vertices which are close enough to each other to significantly improve performance.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 		ImGui::SliderInt("Optimisation Cluster Radius", (int*)&settings.ParticleLightsOptimisationClusterRadius, 1, 64);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Radius to use for clustering lights.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 		ImGui::Spacing();
 		ImGui::Spacing();
 
 		ImGui::TextWrapped("Particle Lights Color");
 		ImGui::SliderFloat("Brightness", &settings.ParticleLightsBrightness, 0.0, 1.0, "%.2f");
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Particle light brightness.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::SliderFloat("Saturation", &settings.ParticleLightsSaturation, 1.0, 2.0, "%.2f");
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Particle light saturation.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Spacing();
@@ -99,21 +71,13 @@ void LightLimitFix::DrawSettings()
 
 	if (ImGui::TreeNodeEx("Shadows", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Checkbox("Enable Contact Shadows", &settings.EnableContactShadows);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("All lights cast small shadows. Performance impact.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Checkbox("Enable First-Person Shadows", &settings.EnableFirstPersonShadows);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Torches and light spells will cast shadows in first-person. Performance impact.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Spacing();
@@ -123,26 +87,18 @@ void LightLimitFix::DrawSettings()
 
 	if (ImGui::TreeNodeEx("Light Limit Visualization", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Checkbox("Enable Lights Visualisation", &settings.EnableLightsVisualisation);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Enables visualization of the light limit\n");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		{
 			static const char* comboOptions[] = { "Light Limit", "Strict Lights Count", "Clustered Lights Count" };
 			ImGui::Combo("Lights Visualisation Mode", (int*)&settings.LightsVisualisationMode, comboOptions, 3);
-			if (ImGui::IsItemHovered()) {
-				ImGui::BeginTooltip();
-				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text(
 					" - Visualise the light limit. Red when the \"strict\" light limit is reached (portal-strict lights). "
 					" - Visualise the number of strict lights. "
 					" - Visualise the number of clustered lights. ");
-				ImGui::PopTextWrapPos();
-				ImGui::EndTooltip();
 			}
 		}
 

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -22,21 +22,13 @@ void ScreenSpaceShadows::DrawSettings()
 {
 	if (ImGui::TreeNodeEx("General", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Checkbox("Enable Screen-Space Shadows", &settings.Enabled);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Enables screen-space shadows.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::SliderInt("Max Samples", (int*)&settings.MaxSamples, 1, 512);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Controls the accuracy of traced shadows.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Spacing();
@@ -46,21 +38,13 @@ void ScreenSpaceShadows::DrawSettings()
 
 	if (ImGui::TreeNodeEx("Blur Filter", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::SliderFloat("Blur Radius", &settings.BlurRadius, 0, 1);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Blur radius.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::SliderFloat("Blur Depth Dropoff", &settings.BlurDropoff, 0.001f, 0.1f);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Blur depth dropoff.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Spacing();
@@ -70,29 +54,17 @@ void ScreenSpaceShadows::DrawSettings()
 
 	if (ImGui::TreeNodeEx("Near Shadows", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::SliderFloat("Near Distance", &settings.NearDistance, 0, 128);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Near Shadow Distance.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::SliderFloat("Near Thickness", &settings.NearThickness, 0, 128);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Near Shadow Thickness.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 		ImGui::SliderFloat("Near Hardness", &settings.NearHardness, 0, 64);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Near Shadow Hardness.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Spacing();
@@ -102,28 +74,16 @@ void ScreenSpaceShadows::DrawSettings()
 
 	if (ImGui::TreeNodeEx("Far Shadows", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::SliderFloat("Far Distance Scale", &settings.FarDistanceScale, 0, 1);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Far Shadow Distance Scale.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 		ImGui::SliderFloat("Far Thickness Scale", &settings.FarThicknessScale, 0, 1);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Far Shadow Thickness Scale.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 		ImGui::SliderFloat("Far Hardness", &settings.FarHardness, 0, 64);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Far Shadow Hardness.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::TreePop();

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -128,22 +128,6 @@ void ScreenSpaceShadows::DrawSettings()
 
 		ImGui::TreePop();
 	}
-
-	ImGui::Spacing();
-	ImGui::Spacing();
-
-	if (ImGui::Button("Restore Defaults", { -1, 0 })) {
-		ScreenSpaceShadows::GetSingleton()->RestoreDefaultSettings();
-	}
-	if (ImGui::IsItemHovered()) {
-		ImGui::BeginTooltip();
-		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-		ImGui::Text(
-			"Restores the feature's settings back to their default values. "
-			"You will still need to Save Settings to make these changes permanent. ");
-		ImGui::PopTextWrapPos();
-		ImGui::EndTooltip();
-	}
 }
 
 enum class GrassShaderTechniques

--- a/src/Features/WaterBlending.cpp
+++ b/src/Features/WaterBlending.cpp
@@ -12,41 +12,25 @@ void WaterBlending::DrawSettings()
 {
 	if (ImGui::TreeNodeEx("Water Blending", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Checkbox("Enable Water Blending", (bool*)&settings.EnableWaterBlending);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Enables blending water into the terrain and objects on the water's surface.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::SliderFloat("Water Blend Range", &settings.WaterBlendRange, 0, 3);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Water Blend Range.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::Spacing();
 		ImGui::Spacing();
 		ImGui::Checkbox("Enable Water Blending SSR", (bool*)&settings.EnableWaterBlendingSSR);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Enables blending screen-space reflections (SSR) as they are faded out near where the terrain touches large water sources.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::SliderFloat("SSR Blend Range", &settings.SSRBlendRange, 0, 3);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Screen-space Reflection (SSR) Blend Range.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::TreePop();

--- a/src/Features/WaterBlending.cpp
+++ b/src/Features/WaterBlending.cpp
@@ -51,22 +51,6 @@ void WaterBlending::DrawSettings()
 
 		ImGui::TreePop();
 	}
-
-	ImGui::Spacing();
-	ImGui::Spacing();
-
-	if (ImGui::Button("Restore Defaults", { -1, 0 })) {
-		WaterBlending::GetSingleton()->RestoreDefaultSettings();
-	}
-	if (ImGui::IsItemHovered()) {
-		ImGui::BeginTooltip();
-		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-		ImGui::Text(
-			"Restores the feature's settings back to their default values. "
-			"You will still need to Save Settings to make these changes permanent. ");
-		ImGui::PopTextWrapPos();
-		ImGui::EndTooltip();
-	}
 }
 
 void WaterBlending::Draw(const RE::BSShader* shader, const uint32_t)

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -24,12 +24,8 @@ void WetnessEffects::DrawSettings()
 {
 	if (ImGui::TreeNodeEx("Wetness Effects", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Checkbox("Enable Wetness", (bool*)&settings.EnableWetnessEffects);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Enables a wetness effect near water and when it is raining.");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::SliderFloat("Rain Wetness", &settings.MaxRainWetness, 0.0f, 1.0f);
@@ -43,13 +39,9 @@ void WetnessEffects::DrawSettings()
 	if (ImGui::TreeNodeEx("Advanced", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::SliderFloat("Min Rain Wetness", &settings.MinRainWetness, 0.0f, 0.9f);
 		ImGui::SliderFloat("Skin Wetness", &settings.SkinWetness, 0.0f, 1.0f);
-		if (ImGui::IsItemHovered()) {
-			ImGui::BeginTooltip();
-			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"The level of wetness for character skin and hair during rain. ");
-			ImGui::PopTextWrapPos();
-			ImGui::EndTooltip();
 		}
 
 		ImGui::SliderInt("Shore Range", (int*)&settings.ShoreRange, 1, 64);

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -59,22 +59,6 @@ void WetnessEffects::DrawSettings()
 
 		ImGui::TreePop();
 	}
-
-	ImGui::Spacing();
-	ImGui::Spacing();
-
-	if (ImGui::Button("Restore Defaults", { -1, 0 })) {
-		WetnessEffects::GetSingleton()->RestoreDefaultSettings();
-	}
-	if (ImGui::IsItemHovered()) {
-		ImGui::BeginTooltip();
-		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-		ImGui::Text(
-			"Restores the feature's settings back to their default values. "
-			"You will still need to Save Settings to make these changes permanent. ");
-		ImGui::PopTextWrapPos();
-		ImGui::EndTooltip();
-	}
 }
 
 float WetnessEffects::CalculateWeatherTransitionPercentage(RE::TESWeather* weather, float skyCurrentWeatherPct, float beginFade)

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -164,31 +164,23 @@ void Menu::DrawSettings()
 					}
 				}
 			}
-			if (ImGui::IsItemHovered()) {
-				ImGui::BeginTooltip();
-				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text(
 					"The Shader Cache is the collection of compiled shaders which replace the vanilla shaders at runtime. "
 					"Clearing the shader cache will mean that shaders are recompiled only when the game re-encounters them. "
 					"This is only needed for hot-loading shaders for development purposes. ");
-				ImGui::PopTextWrapPos();
-				ImGui::EndTooltip();
 			}
 
 			ImGui::TableNextColumn();
 			if (ImGui::Button("Clear Disk Cache", { -1, 0 })) {
 				shaderCache.DeleteDiskCache();
 			}
-			if (ImGui::IsItemHovered()) {
-				ImGui::BeginTooltip();
-				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text(
 					"The Disk Cache is a collection of compiled shaders on disk, which are automatically created when shaders are added to the Shader Cache. "
 					"If you do not have a Disk Cache, or it is outdated or invalid, you will see \"Compiling Shaders\" in the upper-left corner. "
 					"After this has completed you will no longer see this message apart from when loading from the Disk Cache. "
 					"Only delete the Disk Cache manually if you are encountering issues. ");
-				ImGui::PopTextWrapPos();
-				ImGui::EndTooltip();
 			}
 
 			if (shaderCache.GetFailedTasks()) {
@@ -197,16 +189,12 @@ void Menu::DrawSettings()
 				if (ImGui::Button("Toggle Error Message", { -1, 0 })) {
 					shaderCache.ToggleErrorMessages();
 				}
-				if (ImGui::IsItemHovered()) {
-					ImGui::BeginTooltip();
-					ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+				if (auto _tt = Util::HoverTooltipWrapper()) {
 					ImGui::Text(
 						"Hide or show the shader failure message. "
 						"Your installation is broken and will likely see errors in game. "
 						"Please double check you have updated all features and that your load order is correct. "
 						"See CommunityShaders.log for details and check the NexusMods page or Discord server. ");
-					ImGui::PopTextWrapPos();
-					ImGui::EndTooltip();
 				}
 			}
 			ImGui::EndTable();
@@ -221,12 +209,8 @@ void Menu::DrawSettings()
 				if (ImGui::Checkbox("Enable Shaders", &useCustomShaders)) {
 					shaderCache.SetEnabled(useCustomShaders);
 				}
-				if (ImGui::IsItemHovered()) {
-					ImGui::BeginTooltip();
-					ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+				if (auto _tt = Util::HoverTooltipWrapper()) {
 					ImGui::Text("Disabling this effectively disables all features.");
-					ImGui::PopTextWrapPos();
-					ImGui::EndTooltip();
 				}
 
 				bool useDiskCache = shaderCache.IsDiskCache();
@@ -234,12 +218,8 @@ void Menu::DrawSettings()
 				if (ImGui::Checkbox("Enable Disk Cache", &useDiskCache)) {
 					shaderCache.SetDiskCache(useDiskCache);
 				}
-				if (ImGui::IsItemHovered()) {
-					ImGui::BeginTooltip();
-					ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+				if (auto _tt = Util::HoverTooltipWrapper()) {
 					ImGui::Text("Disabling this stops shaders from being loaded from disk, as well as stops shaders from being saved to it.");
-					ImGui::PopTextWrapPos();
-					ImGui::EndTooltip();
 				}
 
 				bool useAsync = shaderCache.IsAsync();
@@ -247,12 +227,8 @@ void Menu::DrawSettings()
 				if (ImGui::Checkbox("Enable Async", &useAsync)) {
 					shaderCache.SetAsync(useAsync);
 				}
-				if (ImGui::IsItemHovered()) {
-					ImGui::BeginTooltip();
-					ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+				if (auto _tt = Util::HoverTooltipWrapper()) {
 					ImGui::Text("Skips a shader being replaced if it hasn't been compiled yet. Also makes compilation blazingly fast!");
-					ImGui::PopTextWrapPos();
-					ImGui::EndTooltip();
 				}
 
 				ImGui::EndTable();
@@ -321,12 +297,8 @@ void Menu::DrawSettings()
 			if (ImGui::Checkbox("Dump Shaders", &useDump)) {
 				shaderCache.SetDump(useDump);
 			}
-			if (ImGui::IsItemHovered()) {
-				ImGui::BeginTooltip();
-				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Dump shaders at startup. This should be used only when reversing shaders. Normal users don't need this.");
-				ImGui::PopTextWrapPos();
-				ImGui::EndTooltip();
 			}
 			spdlog::level::level_enum logLevel = State::GetSingleton()->GetLogLevel();
 			const char* items[] = {
@@ -343,46 +315,30 @@ void Menu::DrawSettings()
 				ImGui::SameLine();
 				State::GetSingleton()->SetLogLevel(static_cast<spdlog::level::level_enum>(item_current));
 			}
-			if (ImGui::IsItemHovered()) {
-				ImGui::BeginTooltip();
-				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Log level. Trace is most verbose. Default is info.");
-				ImGui::PopTextWrapPos();
-				ImGui::EndTooltip();
 			}
 
 			auto& shaderDefines = State::GetSingleton()->shaderDefinesString;
 			if (ImGui::InputText("Shader Defines", &shaderDefines)) {
 				State::GetSingleton()->SetDefines(shaderDefines);
 			}
-			if (ImGui::IsItemHovered()) {
-				ImGui::BeginTooltip();
-				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Defines for Shader Compiler. Semicolon \";\" separated. Clear with space. Rebuild shaders after making change. Compute Shaders require a restart to recompile.");
-				ImGui::PopTextWrapPos();
-				ImGui::EndTooltip();
 			}
 			ImGui::Spacing();
 			ImGui::SliderInt("Compiler Threads", &shaderCache.compilationThreadCount, 1, static_cast<int32_t>(std::thread::hardware_concurrency()));
-			if (ImGui::IsItemHovered()) {
-				ImGui::BeginTooltip();
-				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text(
 					"Number of threads to use to compile shaders. "
 					"The more threads the faster compilation will finish but may make the system unresponsive. ");
-				ImGui::PopTextWrapPos();
-				ImGui::EndTooltip();
 			}
 			ImGui::SliderInt("Background Compiler Threads", &shaderCache.backgroundCompilationThreadCount, 1, static_cast<int32_t>(std::thread::hardware_concurrency()));
-			if (ImGui::IsItemHovered()) {
-				ImGui::BeginTooltip();
-				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text(
 					"Number of threads to use to compile shaders while playing game. "
 					"This is activated if the startup compilation is skipped. "
 					"The more threads the faster compilation will finish but may make the system unresponsive. ");
-				ImGui::PopTextWrapPos();
-				ImGui::EndTooltip();
 			}
 
 			if (ImGui::SliderInt("Test Interval", (int*)&testInterval, 0, 10)) {
@@ -398,16 +354,12 @@ void Menu::DrawSettings()
 					logger::info("Setting new interval {}.", testInterval);
 				}
 			}
-			if (ImGui::IsItemHovered()) {
-				ImGui::BeginTooltip();
-				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text(
 					"Sets number of seconds before toggling between default USER and TEST config. "
 					"0 disables. Non-zero will enable testing mode. "
 					"Enabling will save current settings as TEST config. "
 					"This has no impact if no settings are changed. ");
-				ImGui::PopTextWrapPos();
-				ImGui::EndTooltip();
 			}
 			if (ImGui::Button("Dump Ini Settings", { -1, 0 })) {
 				Util::DumpSettingsOptions();
@@ -417,16 +369,12 @@ void Menu::DrawSettings()
 				if (ImGui::Button(blockingButtonString.c_str(), { -1, 0 })) {
 					shaderCache.DisableShaderBlocking();
 				}
-				if (ImGui::IsItemHovered()) {
-					ImGui::BeginTooltip();
-					ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+				if (auto _tt = Util::HoverTooltipWrapper()) {
 					ImGui::Text(
 						"Stop blocking Community Shaders shader. "
 						"Blocking is helpful when debugging shader errors in game to determine which shader has issues. "
 						"Blocking is enabled if in developer mode and pressing PAGEUP and PAGEDOWN. "
 						"Specific shader will be printed to logfile. ");
-					ImGui::PopTextWrapPos();
-					ImGui::EndTooltip();
 				}
 			}
 			if (ImGui::TreeNodeEx("Statistics", ImGuiTreeNodeFlags_DefaultOpen)) {
@@ -482,14 +430,10 @@ void Menu::DrawSettings()
 				if (ImGui::Button("Restore Defaults", { -1, 0 })) {
 					featureList[selectedFeature]->RestoreDefaultSettings();
 				}
-				if (ImGui::IsItemHovered()) {
-					ImGui::BeginTooltip();
-					ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+				if (auto _tt = Util::HoverTooltipWrapper()) {
 					ImGui::Text(
 						"Restores the feature's settings back to their default values. "
 						"You will still need to Save Settings to make these changes permanent. ");
-					ImGui::PopTextWrapPos();
-					ImGui::EndTooltip();
 				}
 			}
 

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -476,14 +476,27 @@ void Menu::DrawSettings()
 			}
 
 			ImGui::TableNextColumn();
+
+			bool shownFeature = selectedFeature < featureList.size();
+			if (shownFeature) {
+				if (ImGui::Button("Restore Defaults", { -1, 0 })) {
+					featureList[selectedFeature]->RestoreDefaultSettings();
+				}
+				if (ImGui::IsItemHovered()) {
+					ImGui::BeginTooltip();
+					ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+					ImGui::Text(
+						"Restores the feature's settings back to their default values. "
+						"You will still need to Save Settings to make these changes permanent. ");
+					ImGui::PopTextWrapPos();
+					ImGui::EndTooltip();
+				}
+			}
+
 			if (ImGui::BeginChild("##FeatureConfigFrame", { 0, 0 }, true)) {
-				bool shownFeature = false;
-				for (size_t i = 0; i < featureList.size(); i++)
-					if (i == selectedFeature) {
-						shownFeature = true;
-						featureList[i]->DrawSettings();
-					}
-				if (!shownFeature)
+				if (shownFeature)
+					featureList[selectedFeature]->DrawSettings();
+				else
 					ImGui::TextDisabled("Please select a feature on the left.");
 			}
 			ImGui::EndChild();

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -276,15 +276,13 @@ namespace Util
 		return cameraData;
 	}
 
-	HoverTooltipWrapper::operator bool()
-	{
-		hovered = ImGui::IsItemHovered();
+	HoverTooltipWrapper::HoverTooltipWrapper(){
+hovered = ImGui::IsItemHovered();
 		if (hovered) {
 			ImGui::BeginTooltip();
 			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
 		}
-		return hovered;
-	};
+	}
 
 	HoverTooltipWrapper::~HoverTooltipWrapper()
 	{

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -275,4 +275,22 @@ namespace Util
 		cameraData.w = accumulator->kCamera->GetRuntimeData2().viewFrustum.fFar * accumulator->kCamera->GetRuntimeData2().viewFrustum.fNear;
 		return cameraData;
 	}
+
+	HoverTooltipWrapper::operator bool()
+	{
+		hovered = ImGui::IsItemHovered();
+		if (hovered) {
+			ImGui::BeginTooltip();
+			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+		}
+		return hovered;
+	};
+
+	HoverTooltipWrapper::~HoverTooltipWrapper()
+	{
+		if (hovered) {
+			ImGui::PopTextWrapPos();
+			ImGui::EndTooltip();
+		}
+	}
 }

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -276,8 +276,9 @@ namespace Util
 		return cameraData;
 	}
 
-	HoverTooltipWrapper::HoverTooltipWrapper(){
-hovered = ImGui::IsItemHovered();
+	HoverTooltipWrapper::HoverTooltipWrapper()
+	{
+		hovered = ImGui::IsItemHovered();
 		if (hovered) {
 			ImGui::BeginTooltip();
 			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);

--- a/src/Util.h
+++ b/src/Util.h
@@ -27,7 +27,8 @@ namespace Util
 		bool hovered;
 
 	public:
+		HoverTooltipWrapper();
 		~HoverTooltipWrapper();
-		operator bool();
+		inline operator bool() { return hovered; }
 	};
 }

--- a/src/Util.h
+++ b/src/Util.h
@@ -15,6 +15,12 @@ namespace Util
 	void DumpSettingsOptions();
 	float4 GetCameraData();
 
+	/**
+	 * Usage:
+	 * if (auto _tt = Util::HoverTooltipWrapper()){
+	 *     ImGui::Text("What the tooltip says.");
+	 * }
+	*/
 	class HoverTooltipWrapper
 	{
 	private:

--- a/src/Util.h
+++ b/src/Util.h
@@ -14,4 +14,14 @@ namespace Util
 	float TryGetWaterHeight(float offsetX, float offsetY);
 	void DumpSettingsOptions();
 	float4 GetCameraData();
+
+	class HoverTooltipWrapper
+	{
+	private:
+		bool hovered;
+
+	public:
+		~HoverTooltipWrapper();
+		operator bool();
+	};
 }


### PR DESCRIPTION
Fixes https://github.com/doodlum/skyrim-community-shaders/issues/163

New tooltip usage:
```cpp
ImGui::SomeWidget();
if (auto _tt = Util::HoverTooltipWrapper()){
    ImGui::Text("What the tooltip says.");
}
```