### PR TITLE
feat: add feature version detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,42 @@ if(MSVC_VERSION GREATER_EQUAL 1936 AND MSVC_IDE) # 17.6+
 endif()
 
 # #######################################################################################################################
+# # Feature version detection
+# #######################################################################################################################
+
+file(GLOB_RECURSE FEATURE_CONFIG_FILES
+	LIST_DIRECTORIES false
+	CONFIGURE_DEPENDS
+	"features/*/Shaders/Features/*.ini"
+)
+
+foreach(FEATURE_PATH ${FEATURE_CONFIG_FILES})
+	get_filename_component(FEATURE ${FEATURE_PATH} NAME_WE)
+	file(READ "${FEATURE_PATH}" CONFIG_VALUE)
+	string(REGEX MATCH "Version = ([0-9]*)-([0-9]*)-([0-9]*)" _ ${CONFIG_VALUE})
+	set(ver_major ${CMAKE_MATCH_1})
+	set(ver_minor ${CMAKE_MATCH_2})
+	set(ver_patch ${CMAKE_MATCH_3})
+	list(APPEND FEATURE_VERSIONS \t\t{\ \"${FEATURE}\"sv,\ {${ver_major},${ver_minor},${ver_patch}}\ })
+endforeach()
+
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${FEATURE_CONFIG_FILES}")
+
+string (REPLACE ";" ",\n" FEATURE_VERSIONS "${FEATURE_VERSIONS}")
+
+configure_file(
+	${CMAKE_CURRENT_SOURCE_DIR}/cmake/FeatureVersions.h.in
+	${CMAKE_CURRENT_BINARY_DIR}/cmake/FeatureVersions.h
+	@ONLY
+)
+
+target_sources(
+	"${PROJECT_NAME}"
+	PRIVATE
+	${CMAKE_CURRENT_BINARY_DIR}/cmake/FeatureVersions.h
+)
+
+# #######################################################################################################################
 # # Automatic deployment
 # #######################################################################################################################
 file(GLOB FEATURE_PATHS LIST_DIRECTORIES true ${CMAKE_SOURCE_DIR}/features/*)

--- a/cmake/FeatureVersions.h.in
+++ b/cmake/FeatureVersions.h.in
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace FeatureVersions
+{
+	using namespace std::literals::string_view_literals;
+
+	static const std::map<std::string_view, REL::Version> FEATURE_MINIMAL_VERSIONS
+	{
+@FEATURE_VERSIONS@
+	};
+}

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -4,6 +4,7 @@ struct Feature
 {
 	bool loaded = false;
 	std::string version;
+	std::string failedLoadedMessage;
 
 	virtual std::string GetName() = 0;
 	virtual std::string GetShortName() = 0;

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -419,6 +419,11 @@ void Menu::DrawSettings()
 							selectedFeature = i;
 						ImGui::SameLine();
 						ImGui::TextDisabled(fmt::format("({})", featureList[i]->version).c_str());
+					} else {
+						ImGui::TextDisabled(fmt::format("{} ({})", featureList[i]->GetName(), featureList[i]->version).c_str());
+						if (auto _tt = Util::HoverTooltipWrapper()) {
+							ImGui::Text(featureList[i]->failedLoadedMessage.c_str());
+						}
 					}
 				ImGui::EndListBox();
 			}

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -419,7 +419,7 @@ void Menu::DrawSettings()
 							selectedFeature = i;
 						ImGui::SameLine();
 						ImGui::TextDisabled(fmt::format("({})", featureList[i]->version).c_str());
-					} else {
+					} else if (!featureList[i]->version.empty()) {
 						ImGui::TextDisabled(fmt::format("{} ({})", featureList[i]->GetName(), featureList[i]->version).c_str());
 						if (auto _tt = Util::HoverTooltipWrapper()) {
 							ImGui::Text(featureList[i]->failedLoadedMessage.c_str());


### PR DESCRIPTION
fix #145

This is how the cmake generated header file will look like:
![featureversions](https://github.com/doodlum/skyrim-community-shaders/assets/964655/11345718-27df-4b31-b153-7d74c8e4d899)

I tested this by going into the manually editing some versions in skyrim data folder after compiling and changed some versions around. It will set loaded to false for the feature, add a log and show this in the UI:
![old-feat](https://github.com/doodlum/skyrim-community-shaders/assets/964655/d29c11de-b9dc-47da-9cd3-2c87f1c8a32a)
![new-major](https://github.com/doodlum/skyrim-community-shaders/assets/964655/f6b2374e-b589-4119-a7ba-9247c6844606)