### PR TITLE
feat: Add separate height slider for landscape parallax

### DIFF
--- a/features/Complex Parallax Materials/Shaders/ComplexParallaxMaterials/CRPM.hlsli
+++ b/features/Complex Parallax Materials/Shaders/ComplexParallaxMaterials/CRPM.hlsli
@@ -47,9 +47,9 @@ float2 GetParallaxCoords(float distance, float2 coords, float mipLevel, float3 v
 	float midBlendToFar = smoothstep(1.0 - perPassParallax[0].BlendRange, 1.0, distance);
 
 #if defined(LANDSCAPE)
-    float maxHeight = perPassParallax[0].LandscapeHeight;
+	float maxHeight = perPassParallax[0].LandscapeHeight;
 #else
-    float maxHeight = perPassParallax[0].Height;
+	float maxHeight = perPassParallax[0].Height;
 #endif
 	float minHeight = maxHeight * 0.5;
 
@@ -229,8 +229,7 @@ float2 GetParallaxCoords(float distance, float2 coords, float mipLevel, float3 v
 float GetParallaxSoftShadowMultiplier(float2 coords, float mipLevel, float3 L, float sh0, Texture2D<float4> tex, SamplerState texSampler, uint channel, float quality)
 {
 	if (quality > 0.0) {
-
-        const float height = 0.025;
+		const float height = 0.025;
 		const float2 rayDir = L.xy * height;
 
 		const float h0 = 1.0 - sh0;

--- a/features/Complex Parallax Materials/Shaders/ComplexParallaxMaterials/CRPM.hlsli
+++ b/features/Complex Parallax Materials/Shaders/ComplexParallaxMaterials/CRPM.hlsli
@@ -46,7 +46,11 @@ float2 GetParallaxCoords(float distance, float2 coords, float mipLevel, float3 v
 	float nearBlendToMid = smoothstep(perPassParallax[0].CRPMRange - perPassParallax[0].BlendRange, perPassParallax[0].CRPMRange, distance);
 	float midBlendToFar = smoothstep(1.0 - perPassParallax[0].BlendRange, 1.0, distance);
 
-	float maxHeight = perPassParallax[0].Height;
+#if defined(LANDSCAPE)
+    float maxHeight = perPassParallax[0].LandscapeHeight;
+#else
+    float maxHeight = perPassParallax[0].Height;
+#endif
 	float minHeight = maxHeight * 0.5;
 
 	float2 output;
@@ -225,7 +229,8 @@ float2 GetParallaxCoords(float distance, float2 coords, float mipLevel, float3 v
 float GetParallaxSoftShadowMultiplier(float2 coords, float mipLevel, float3 L, float sh0, Texture2D<float4> tex, SamplerState texSampler, uint channel, float quality)
 {
 	if (quality > 0.0) {
-		const float height = 0.025;
+
+        const float height = 0.025;
 		const float2 rayDir = L.xy * height;
 
 		const float h0 = 1.0 - sh0;

--- a/features/Complex Parallax Materials/Shaders/ComplexParallaxMaterials/ComplexParallaxMaterials.hlsli
+++ b/features/Complex Parallax Materials/Shaders/ComplexParallaxMaterials/ComplexParallaxMaterials.hlsli
@@ -11,7 +11,7 @@ struct PerPassParallax
 	float CRPMRange;
 	float BlendRange;
 	float Height;
-    float LandscapeHeight;
+	float LandscapeHeight;
 
 	bool EnableShadows;
 	uint ShadowsStartFade;

--- a/features/Complex Parallax Materials/Shaders/ComplexParallaxMaterials/ComplexParallaxMaterials.hlsli
+++ b/features/Complex Parallax Materials/Shaders/ComplexParallaxMaterials/ComplexParallaxMaterials.hlsli
@@ -11,6 +11,7 @@ struct PerPassParallax
 	float CRPMRange;
 	float BlendRange;
 	float Height;
+    float LandscapeHeight;
 
 	bool EnableShadows;
 	uint ShadowsStartFade;

--- a/src/Features/ExtendedMaterials.cpp
+++ b/src/Features/ExtendedMaterials.cpp
@@ -12,6 +12,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	CRPMRange,
 	BlendRange,
 	Height,
+	LandscapeHeight,
 	EnableShadows,
 	ShadowsStartFade,
 	ShadowsEndFade)
@@ -92,6 +93,10 @@ void ExtendedMaterials::DrawSettings()
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("The range between the highest and lowest point a surface can be offset by.");
 		}
+		ImGui::SliderFloat("Landscape Height", &settings.LandscapeHeight, 0, 0.2f);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("The range between the highest and lowest point a landscape surface can be offset by.");
+		}
 
 		ImGui::Spacing();
 		ImGui::Spacing();
@@ -118,7 +123,6 @@ void ExtendedMaterials::DrawSettings()
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Distance shadows finish fading.");
 		}
-
 		ImGui::TreePop();
 	}
 }

--- a/src/Features/ExtendedMaterials.h
+++ b/src/Features/ExtendedMaterials.h
@@ -29,6 +29,7 @@ struct ExtendedMaterials : Feature
 		float CRPMRange = 0.5f;
 		float BlendRange = 0.25f;
 		float Height = 0.1f;
+		float LandscapeHeight = 0.1f;
 
 		uint32_t EnableShadows = 1;
 		uint32_t ShadowsStartFade = 512;


### PR DESCRIPTION
Simply adds a separate slider for landscape parallax height scaling.  Why these lines look misaligned on github idk, they are formatted on my machine (angrysmiley).