### PR TITLE
chore: add helper functions and classes

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -77,6 +77,20 @@ private:
 	D3D11_BUFFER_DESC desc;
 };
 
+template <typename T>
+D3D11_BUFFER_DESC StructuredBufferDesc()
+{
+	D3D11_BUFFER_DESC desc{};
+	ZeroMemory(&desc, sizeof(desc));
+	desc.Usage = D3D11_USAGE_DYNAMIC;
+	desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+	desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+	desc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
+	desc.StructureByteStride = sizeof(T);
+	desc.ByteWidth = sizeof(T);
+	return desc;
+}
+
 class StructuredBuffer
 {
 public:
@@ -168,6 +182,40 @@ public:
 	winrt::com_ptr<ID3D11UnorderedAccessView> uav;
 };
 
+class Texture1D
+{
+public:
+	Texture1D(D3D11_TEXTURE1D_DESC const& a_desc)
+	{
+		desc = a_desc;
+		auto device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		DX::ThrowIfFailed(device->CreateTexture1D(&desc, nullptr, resource.put()));
+	}
+
+	void CreateSRV(D3D11_SHADER_RESOURCE_VIEW_DESC const& a_desc)
+	{
+		ID3D11Device* device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		DX::ThrowIfFailed(device->CreateShaderResourceView(resource.get(), &a_desc, srv.put()));
+	}
+	void CreateUAV(D3D11_UNORDERED_ACCESS_VIEW_DESC const& a_desc)
+	{
+		ID3D11Device* device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		DX::ThrowIfFailed(device->CreateUnorderedAccessView(resource.get(), &a_desc, uav.put()));
+	}
+
+	void CreateRTV(D3D11_RENDER_TARGET_VIEW_DESC const& a_desc)
+	{
+		ID3D11Device* device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		DX::ThrowIfFailed(device->CreateRenderTargetView(resource.get(), &a_desc, rtv.put()));
+	}
+
+	D3D11_TEXTURE1D_DESC desc;
+	winrt::com_ptr<ID3D11Texture1D> resource;
+	winrt::com_ptr<ID3D11ShaderResourceView> srv;
+	winrt::com_ptr<ID3D11UnorderedAccessView> uav;
+	winrt::com_ptr<ID3D11RenderTargetView> rtv;
+};
+
 class Texture2D
 {
 public:
@@ -176,6 +224,12 @@ public:
 		desc = a_desc;
 		auto device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
 		DX::ThrowIfFailed(device->CreateTexture2D(&desc, nullptr, resource.put()));
+	}
+
+	Texture2D(ID3D11Texture2D* a_resource)
+	{
+		a_resource->GetDesc(&desc);
+		resource.attach(a_resource);
 	}
 
 	void CreateSRV(D3D11_SHADER_RESOURCE_VIEW_DESC const& a_desc)

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -78,7 +78,7 @@ private:
 };
 
 template <typename T>
-D3D11_BUFFER_DESC StructuredBufferDesc()
+D3D11_BUFFER_DESC StructuredBufferDesc(UINT a_count = 1)
 {
 	D3D11_BUFFER_DESC desc{};
 	ZeroMemory(&desc, sizeof(desc));
@@ -87,7 +87,7 @@ D3D11_BUFFER_DESC StructuredBufferDesc()
 	desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
 	desc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
 	desc.StructureByteStride = sizeof(T);
-	desc.ByteWidth = sizeof(T);
+	desc.ByteWidth = sizeof(T) * a_count;
 	return desc;
 }
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -295,3 +295,39 @@ namespace Util
 		}
 	}
 }
+
+namespace nlohmann
+{
+	void to_json(json& j, const float2& v)
+	{
+		j = json{ v.x, v.y };
+	}
+
+	void from_json(const json& j, float2& v)
+	{
+		std::array<float, 2> temp = j;
+		v = { temp[0], temp[1] };
+	}
+
+	void to_json(json& j, const float3& v)
+	{
+		j = json{ v.x, v.y, v.z };
+	}
+
+	void from_json(const json& j, float3& v)
+	{
+		std::array<float, 3> temp = j;
+		v = { temp[0], temp[1], temp[2] };
+	}
+
+	void to_json(json& j, const float4& v)
+	{
+		j = json{ v.x, v.y, v.z, v.w };
+	}
+
+	void from_json(const json& j, float4& v)
+	{
+		std::array<float, 4> temp = j;
+		v = { temp[0], temp[1], temp[2], temp[3] };
+	}
+}

--- a/src/Util.h
+++ b/src/Util.h
@@ -31,4 +31,35 @@ namespace Util
 		~HoverTooltipWrapper();
 		inline operator bool() { return hovered; }
 	};
+
+	/**
+	 * Usage:
+	 * static FrameChecker frame_checker;
+	 * if(frame_checker.isNewFrame())
+	 *     ...
+	*/
+	class FrameChecker
+	{
+	private:
+		uint32_t last_frame = UINT32_MAX;
+
+	public:
+		inline bool isNewFrame(uint32_t frame)
+		{
+			bool retval = last_frame != frame;
+			last_frame = frame;
+			return retval;
+		}
+		inline bool isNewFrame() { return isNewFrame(RE::BSGraphics::State::GetSingleton()->uiFrameCount); }
+	};
 }
+
+namespace nlohmann
+{
+	void to_json(json& j, const float2& v);
+	void from_json(const json& j, float2& v);
+	void to_json(json& j, const float3& v);
+	void from_json(const json& j, float3& v);
+	void to_json(json& j, const float4& v);
+	void from_json(const json& j, float4& v);
+};


### PR DESCRIPTION
A few edits I made on my own demo branches.
- `StructuredBufferDesc` like `ConstantBufferDesc` for generic feature setting buffers (partially https://github.com/doodlum/skyrim-community-shaders/issues/185)
- `Texture1D` class
- `Texture2D` initialiser that takes an existing resource loaded by DirectXTex
- `FrameChecker` helper class for checking new frames when `Reset()` is not enough
- `floatx` vectors are now json-ifiable as fixed length arrays