### PR TITLE
ci: clang_format.yml lints only modified source files

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -30,8 +30,8 @@ jobs:
         uses: tj-actions/changed-files@v42.0.5
         with:
           files: |
-            src/Features/*.cpp
-            src/Features/*.h
+            src/**/*.{cpp,h}
+            include/**/*.{h,hpp}
             **/*.hlsl
             **/*.hlsli
           separator: ","

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -42,7 +42,9 @@ jobs:
           CHANGED_FILES="${CHANGED_FILES// /\\ }"
           CHANGED_FILES=$(echo "$CHANGED_FILES" | tr ',' ' ')
           echo "::set-output name=changed_files::${CHANGED_FILES}"
-      - uses: DoozyX/clang-format-lint-action@v0.17
+      - name: Format changed files
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: DoozyX/clang-format-lint-action@v0.17
         with:
           source: "."
           exclude: "extern include"

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -24,7 +24,7 @@ jobs:
           # make sure the parent commit is grabbed as well, because
           # that's what will get formatted (i.e. the most recent commit)
           fetch-depth: 2
-      # format the latest commit
+      # retrieve comma-separated list of modified files
       - name: Retrieve changed files
         id: changed-files
         uses: tj-actions/changed-files@v42.0.5
@@ -35,6 +35,7 @@ jobs:
             **/*.hlsl
             **/*.hlsli
           separator: ","
+        # process modified files list before passing to clang-format-lint-action
       - name: Process changed files list
         id: process-list
         run: |
@@ -42,6 +43,7 @@ jobs:
           CHANGED_FILES="${CHANGED_FILES// /\\ }"
           CHANGED_FILES=$(echo "$CHANGED_FILES" | tr ',' ' ')
           echo "::set-output name=changed_files::${CHANGED_FILES}"
+      # format the latest commit
       - name: Format changed files
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: DoozyX/clang-format-lint-action@v0.17

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -46,7 +46,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: DoozyX/clang-format-lint-action@v0.17
         with:
-          source: "."
+          source: "${{ steps.process-list.outputs.changed_files }}"
           exclude: "extern include"
           extensions: "h,cpp,c,hlsl,hlsli"
           clangFormatVersion: 16

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -32,6 +32,9 @@ jobs:
           files: |
             src/Features/*.cpp
             src/Features/*.h
+            **/*.hlsl
+            **/*.hlsli
+          separator: ","
       - uses: DoozyX/clang-format-lint-action@v0.17
         with:
           source: "."

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -25,6 +25,13 @@ jobs:
           # that's what will get formatted (i.e. the most recent commit)
           fetch-depth: 2
       # format the latest commit
+      - name: Changed Files
+        id: changed-files
+        uses: tj-actions/changed-files@v42.0.5
+        with:
+          files: |
+            src/Features/*.cpp
+            src/Features/*.h
       - uses: DoozyX/clang-format-lint-action@v0.17
         with:
           source: "."

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -25,7 +25,7 @@ jobs:
           # that's what will get formatted (i.e. the most recent commit)
           fetch-depth: 2
       # format the latest commit
-      - name: Changed Files
+      - name: Retrieve changed files
         id: changed-files
         uses: tj-actions/changed-files@v42.0.5
         with:
@@ -35,6 +35,13 @@ jobs:
             **/*.hlsl
             **/*.hlsli
           separator: ","
+      - name: Process changed files list
+        id: process-list
+        run: |
+          CHANGED_FILES="${{ steps.changed-files.outputs.all_changed_files }}"
+          CHANGED_FILES="${CHANGED_FILES// /\\ }"
+          CHANGED_FILES=$(echo "$CHANGED_FILES" | tr ',' ' ')
+          echo "::set-output name=changed_files::${CHANGED_FILES}"
       - uses: DoozyX/clang-format-lint-action@v0.17
         with:
           source: "."

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -25,7 +25,7 @@ jobs:
           # that's what will get formatted (i.e. the most recent commit)
           fetch-depth: 2
       # format the latest commit
-      - uses: DoozyX/clang-format-lint-action@v0.16.2
+      - uses: DoozyX/clang-format-lint-action@v0.17
         with:
           source: "."
           exclude: "extern include"


### PR DESCRIPTION
This fixes #128 

Summary
---
Added two steps to `.github/workflows/clang_format.yml` to lint only modified C++ source files and shader files (.hlsli, .hlsl)
### `changed-files`
The `changed-files` step uses [tj-actions/changed-files](https://github.com/tj-actions/changed-files) to retrieve a comma-separated list of changed C++ and shader files. The comma-separated list is then processed and passed to the `Format changed files` step

### `process-list`
The `process-list` step processes the filelist to be properly passed to [DoozyX/clang-format-lint-action](https://github.com/DoozyX/clang-format-lint-action)

filepaths with whitespaces are made unix-friendly 
(e.g., `Complex Parallax Materials/file.hlsl` --> `Complex\ Parallax\ Materials/file.hlsl`)

commas replaced with whitespaces to separate multiple filepaths
(e.g., `file.hlsl,src/Features/DistantTreeLighting.cpp` --> `file.hlsl src/Features/DistantTreeLighting.cpp`)

### Changes to `Format changed files` step
Upgraded DoozyX/clang-format-lint-action from v0.16.2 to [v0.17](https://github.com/DoozyX/clang-format-lint-action/releases/tag/v0.17) to [allow filepaths containing whitespaces](https://github.com/DoozyX/clang-format-lint-action/pull/63)

This step now only executes if the `changed-files` step retrieves any modified files.


Test runs
---
A test version of this workflow is available at [rjwignar/issue-128-test](https://github.com/rjwignar/skyrim-community-shaders/tree/rjwignar/issue-128-test), where rjwignar/issue-128-test was added as a triggering branch.
Here are some example runs:
- [no source/shader files (.cpp, .h, .hlsl, .hlsli) modified](https://github.com/rjwignar/skyrim-community-shaders/commit/65180dc420a5740d225521446034589130741600): https://github.com/rjwignar/skyrim-community-shaders/actions/runs/8090549201
- [source and shader files modified](https://github.com/rjwignar/skyrim-community-shaders/commit/de0d9a729ffe61b005f974d193d8467d1e8551a2): https://github.com/rjwignar/skyrim-community-shaders/actions/runs/8090570952
- [one CPP file modified](https://github.com/rjwignar/skyrim-community-shaders/commit/cd5feb9cf5b7ea9ed51c475312a5802ca88ccc9f): https://github.com/rjwignar/skyrim-community-shaders/actions/runs/8099605920
- two CPP files modified: https://github.com/rjwignar/skyrim-community-shaders/actions/runs/8099468721/job/22135271181
- one shader file modified: https://github.com/rjwignar/skyrim-community-shaders/actions/runs/8099587212/job/22135680525
- [two shader files modified](https://github.com/rjwignar/skyrim-community-shaders/commit/a6d33c411fef60af843986c2bb358c7ec7365ca2): https://github.com/rjwignar/skyrim-community-shaders/actions/runs/8099493456/job/22135358324