### PR TITLE
perf: use `ankerl::unordered_dense::map` as Particle Lights maps, and minor optimsations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ find_package(directxtex CONFIG REQUIRED)
 find_path(CLIB_UTIL_INCLUDE_DIRS "ClibUtil/utils.hpp")
 find_package(pystring CONFIG REQUIRED)
 find_package(cppwinrt CONFIG REQUIRED)
+find_package(unordered_dense CONFIG REQUIRED)
 
 target_include_directories(
 	${PROJECT_NAME}
@@ -60,6 +61,7 @@ target_link_libraries(
 	Microsoft::DirectXTK
 	Microsoft::DirectXTex
 	pystring::pystring
+	unordered_dense::unordered_dense
 )
 
 # https://gitlab.kitware.com/cmake/cmake/-/issues/24922#note_1371990

--- a/include/PCH.h
+++ b/include/PCH.h
@@ -158,6 +158,19 @@ using json = nlohmann::json;
 #include <EASTL/unordered_map.h>
 #include <EASTL/vector.h>
 
+#include <ankerl/unordered_dense.h>
+template <>
+struct ankerl::unordered_dense::hash<std::string>
+{
+	using is_transparent = void;  // enable heterogeneous overloads
+	using is_avalanching = void;  // mark class as high quality avalanching hash
+
+	[[nodiscard]] auto operator()(std::string_view str) const noexcept -> uint64_t
+	{
+		return ankerl::unordered_dense::hash<std::string_view>{}(str);
+	}
+};
+
 #include "SimpleMath.h"
 
 using float2 = DirectX::SimpleMath::Vector2;

--- a/src/Features/LightLimitFIx/ParticleLights.h
+++ b/src/Features/LightLimitFIx/ParticleLights.h
@@ -32,8 +32,8 @@ public:
 		RE::NiColor color;
 	};
 
-	std::unordered_map<std::string, Config> particleLightConfigs;
-	std::unordered_map<std::string, GradientConfig> particleLightGradientConfigs;
+	ankerl::unordered_dense::map<std::string, Config> particleLightConfigs;
+	ankerl::unordered_dense::map<std::string, GradientConfig> particleLightGradientConfigs;
 
 	void GetConfigs();
 };

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -246,6 +246,13 @@ void LightLimitFix::Reset()
 	particleLights.clear();
 	std::swap(particleLights, queuedParticleLights);
 	boundViews = false;
+
+	static uint fc = 0;
+	if (++fc == 100) {
+		logger::debug("{} nanoseconds", benchTimer * 1e-2f);
+		benchTimer = 0;
+		fc = 0;
+	}
 }
 
 void LightLimitFix::Load(json& o_json)

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -518,7 +518,7 @@ std::optional<LightLimitFix::ConfigPair> LightLimitFix::GetConfigs(RE::BSEffectS
 
 std::optional<LightLimitFix::ConfigPair> LightLimitFix::CheckParticleLights(RE::BSRenderPass* a_pass, uint32_t)
 {
-	static ankerl::unordered_dense::map<RE::BSEffectShaderMaterial*, std::optional<LightLimitFix::ConfigPair>> cachedQuery{};
+	static ankerl::unordered_dense::map<RE::BSEffectShaderMaterial*, std::optional<ConfigPair>> cachedQuery{};
 
 	static auto func = [&](RE::BSRenderPass* a_pass) -> std::optional<ConfigPair> {
 		// see https://www.nexusmods.com/skyrimspecialedition/articles/1391
@@ -543,13 +543,7 @@ std::optional<LightLimitFix::ConfigPair> LightLimitFix::CheckParticleLights(RE::
 		return std::nullopt;
 	};
 
-	auto startTime = std::chrono::system_clock::now();
-	auto retval = func(a_pass);
-	auto endTime = std::chrono::system_clock::now();
-
-	benchTimer[0].add(std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count());
-
-	return retval;
+	return benchTimer[0].run<std::optional<ConfigPair>>(std::bind(func, a_pass));
 }
 
 void LightLimitFix::AddParticleLight(RE::BSRenderPass* a_pass, LightLimitFix::ConfigPair a_config)
@@ -626,11 +620,7 @@ void LightLimitFix::AddParticleLight(RE::BSRenderPass* a_pass, LightLimitFix::Co
 		queuedParticleLights.insert({ a_pass->geometry, { color, radius, *config } });
 	};
 
-	auto startTime = std::chrono::system_clock::now();
-	func(a_pass, a_config);
-	auto endTime = std::chrono::system_clock::now();
-
-	benchTimer[1].add(std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count());
+	benchTimer[1].run<void>(std::bind(func, a_pass, a_config));
 }
 
 enum class GrassShaderTechniques

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -198,6 +198,8 @@ public:
 	float CalculateLuminance(CachedParticleLight& light, RE::NiPoint3& point);
 	void AddParticleLightLuminance(RE::NiPoint3& targetPosition, int& numHits, float& lightLevel);
 
+	unsigned long long benchTimer = 0u;
+
 	struct Hooks
 	{
 		struct ValidLight1
@@ -231,8 +233,12 @@ public:
 		{
 			static void thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags)
 			{
+				auto startTime = std::chrono::system_clock::now();
 				if (!GetSingleton()->CheckParticleLights(Pass, Technique))
 					func(Pass, Technique, AlphaTest, RenderFlags);
+				auto endTime = std::chrono::system_clock::now();
+				if (auto shaderProperty = netimmerse_cast<RE::BSEffectShaderProperty*>(Pass->shaderProperty))
+					GetSingleton()->benchTimer += std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count();
 			}
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
@@ -241,8 +247,12 @@ public:
 		{
 			static void thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags)
 			{
+				auto startTime = std::chrono::system_clock::now();
 				if (!GetSingleton()->CheckParticleLights(Pass, Technique))
 					func(Pass, Technique, AlphaTest, RenderFlags);
+				auto endTime = std::chrono::system_clock::now();
+				if (auto shaderProperty = netimmerse_cast<RE::BSEffectShaderProperty*>(Pass->shaderProperty))
+					GetSingleton()->benchTimer += std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count();
 			}
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
@@ -251,8 +261,12 @@ public:
 		{
 			static void thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags)
 			{
+				auto startTime = std::chrono::system_clock::now();
 				if (!GetSingleton()->CheckParticleLights(Pass, Technique))
 					func(Pass, Technique, AlphaTest, RenderFlags);
+				auto endTime = std::chrono::system_clock::now();
+				if (auto shaderProperty = netimmerse_cast<RE::BSEffectShaderProperty*>(Pass->shaderProperty))
+					GetSingleton()->benchTimer += std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count();
 			}
 			static inline REL::Relocation<decltype(thunk)> func;
 		};

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -203,8 +203,6 @@ public:
 	float CalculateLuminance(CachedParticleLight& light, RE::NiPoint3& point);
 	void AddParticleLightLuminance(RE::NiPoint3& targetPosition, int& numHits, float& lightLevel);
 
-	Util::CountedTimer benchTimer[2];
-
 	struct Hooks
 	{
 		struct ValidLight1

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -180,8 +180,9 @@ public:
 
 	using ConfigPair = std::pair<ParticleLights::Config*, ParticleLights::GradientConfig*>;
 	std::optional<ConfigPair> GetConfigs(RE::BSEffectShaderMaterial* a_mat);
-	std::optional<ConfigPair> CheckParticleLights(RE::BSRenderPass* a_pass, uint32_t a_technique);
+	std::optional<ConfigPair> GetParticleLightConfigs(RE::BSRenderPass* a_pass);
 	void AddParticleLight(RE::BSRenderPass* a_pass, ConfigPair a_config);
+	bool CheckParticleLights(RE::BSRenderPass* a_pass, uint32_t a_technique);
 
 	void BSLightingShader_SetupGeometry_Before(RE::BSRenderPass* a_pass);
 
@@ -237,14 +238,7 @@ public:
 		{
 			static void thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags)
 			{
-				bool doFunc = true;
-				auto configs = GetSingleton()->CheckParticleLights(Pass, Technique);
-				if (configs.has_value()) {
-					GetSingleton()->AddParticleLight(Pass, configs.value());
-					doFunc = !(GetSingleton()->settings.EnableParticleLightsCulling && configs->first->cull);
-				}
-
-				if (doFunc)
+				if (GetSingleton()->CheckParticleLights(Pass, Technique))
 					func(Pass, Technique, AlphaTest, RenderFlags);
 			}
 			static inline REL::Relocation<decltype(thunk)> func;
@@ -254,14 +248,7 @@ public:
 		{
 			static void thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags)
 			{
-				bool doFunc = true;
-				auto configs = GetSingleton()->CheckParticleLights(Pass, Technique);
-				if (configs.has_value()) {
-					GetSingleton()->AddParticleLight(Pass, configs.value());
-					doFunc = !(GetSingleton()->settings.EnableParticleLightsCulling && configs->first->cull);
-				}
-
-				if (doFunc)
+				if (GetSingleton()->CheckParticleLights(Pass, Technique))
 					func(Pass, Technique, AlphaTest, RenderFlags);
 			}
 			static inline REL::Relocation<decltype(thunk)> func;
@@ -271,14 +258,7 @@ public:
 		{
 			static void thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags)
 			{
-				bool doFunc = true;
-				auto configs = GetSingleton()->CheckParticleLights(Pass, Technique);
-				if (configs.has_value()) {
-					GetSingleton()->AddParticleLight(Pass, configs.value());
-					doFunc = !(GetSingleton()->settings.EnableParticleLightsCulling && configs->first->cull);
-				}
-
-				if (doFunc)
+				if (GetSingleton()->CheckParticleLights(Pass, Technique))
 					func(Pass, Technique, AlphaTest, RenderFlags);
 			}
 			static inline REL::Relocation<decltype(thunk)> func;

--- a/src/Util.h
+++ b/src/Util.h
@@ -65,6 +65,19 @@ namespace Util
 		}
 		inline bool isNewFrame() { return isNewFrame(RE::BSGraphics::State::GetSingleton()->uiFrameCount); }
 	};
+
+	// for simple benchmarking
+	struct CountedTimer
+	{
+		unsigned long long count = 0u;
+		unsigned long long timer = 0u;
+		inline float avgTime() const { return timer / (float)count; }
+		inline void add(unsigned long long t)
+		{
+			timer += t;
+			count++;
+		}
+	};
 }
 
 namespace nlohmann

--- a/src/Util.h
+++ b/src/Util.h
@@ -69,13 +69,34 @@ namespace Util
 	// for simple benchmarking
 	struct CountedTimer
 	{
+		std::chrono::system_clock::time_point start_time;
+
 		unsigned long long count = 0u;
 		unsigned long long timer = 0u;
+
 		inline float avgTime() const { return timer / (float)count; }
 		inline void add(unsigned long long t)
 		{
 			timer += t;
 			count++;
+		}
+
+		inline void start() { start_time = std::chrono::system_clock::now(); }
+		inline void end() { add(std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now() - start_time).count()); }
+
+		template <typename T>
+		T run(std::function<T()> func)
+		{
+			if constexpr (std::is_same_v<T, void>) {
+				start();
+				func();
+				end();
+			} else {
+				start();
+				T retval = func();
+				end();
+				return retval;
+			}
 		}
 	};
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -23,7 +23,8 @@
       "version>=": "1.88"
     },
     "eastl",
-    "clib-util"
+    "clib-util",
+    "unordered-dense"
   ],
   "overrides": [
     {


### PR DESCRIPTION
[`ankerl::unordered_dense::map`](https://github.com/martinus/unordered_dense) is [the fastest hash map](https://martin.ankerl.com/2022/08/27/hashmap-bench-01/) on the market. Using it with heterogenous lookup gives 8% improvement on `CheckParticleLights`.

Also come with minor changes that makes `CheckParticleLights` code more readable and modulised, and maybe infinitesimally faster.

Also come with a simple timer class in `Util`.