### PR TITLE
fix: ctd when files were deleted from shaders path

### DIFF
--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1808,7 +1808,7 @@ namespace SIE
 	{
 		auto& cache = SIE::ShaderCache::Instance();
 		const std::filesystem::path filePath = std::filesystem::path(std::format("{}\\{}", dir, filename));
-		auto modifiedTime = std::chrono::clock_cast<std::chrono::system_clock>(std::filesystem::last_write_time(filePath));
+		std::chrono::time_point<std::chrono::system_clock> modifiedTime{};
 		std::string extension = filePath.extension().string();
 		std::string parentDir = filePath.parent_path().string();
 		std::string shaderTypeString = filePath.stem().string();
@@ -1819,12 +1819,16 @@ namespace SIE
 		case efsw::Actions::Delete:
 			break;
 		case efsw::Actions::Modified:
-			logger::info("Detected changed file {}", filePath.string());
-			if (extension.starts_with(".hlsl") && parentDir.ends_with("Shaders") && shaderType.has_value()) {  // TODO: Case insensitive checks
+			logger::debug("Detected changed path {}", filePath.string());
+			if (std::filesystem::exists(filePath))
+				modifiedTime = std::chrono::clock_cast<std::chrono::system_clock>(std::filesystem::last_write_time(filePath));
+			else // if file doesn't exist, don't do anything
+				return;
+			if (!std::filesystem::is_directory(filePath) && extension.starts_with(".hlsl") && parentDir.ends_with("Shaders") && shaderType.has_value()) {  // TODO: Case insensitive checks
 				// Shader types, so only invalidate specific shader type (e.g,. Lighting)
 				cache.modifiedShaderMap.insert_or_assign(shaderTypeString, modifiedTime);
 				cache.Clear(shaderType.value());
-			} else if (extension.starts_with(".hlsl")) {  // TODO: Case insensitive checks
+			} else if (!std::filesystem::is_directory(filePath) && extension.starts_with(".hlsl")) {  // TODO: Case insensitive checks
 				// all other shaders, since we don't know what is using it, clear everything
 				cache.DeleteDiskCache();
 				cache.Clear();


### PR DESCRIPTION
Root cause was attempt to access deleted file's
timestamp.