### PR TITLE
chore: separate raindrop splash and ripple intervals

### DIFF
--- a/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
+++ b/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
@@ -32,7 +32,7 @@ struct PerPassWetnessEffects
 	float RaindropGridSizeRcp;
 	float RaindropIntervalRcp;
 	float RaindropChance;
-    float SplashesLifetime;
+	float SplashesLifetime;
 	float SplashesStrength;
 	float SplashesMinRadius;
 	float SplashesMaxRadius;
@@ -166,64 +166,63 @@ float4 GetRainDrops(float3 worldPos, float t, float3 normal)
 	float3 rippleNormal = float3(0, 0, 1);
 	float wetness = 0;
 
-    if (perPassWetnessEffects[0].EnableSplashes || perPassWetnessEffects[0].EnableRipples)
-        for (int i = -1; i <= 1; i++)
-            for (int j = -1; j <= 1; j++) {
-                int2 gridCurr = grid + int2(i, j);
-                float tOffset = float(iqint3(gridCurr)) * uintToFloat;
+	if (perPassWetnessEffects[0].EnableSplashes || perPassWetnessEffects[0].EnableRipples)
+		for (int i = -1; i <= 1; i++)
+			for (int j = -1; j <= 1; j++) {
+				int2 gridCurr = grid + int2(i, j);
+				float tOffset = float(iqint3(gridCurr)) * uintToFloat;
 
 				// splashes
-                if (perPassWetnessEffects[0].EnableSplashes)
-                {
-                    float residual = t * perPassWetnessEffects[0].RaindropIntervalRcp / perPassWetnessEffects[0].SplashesLifetime + tOffset + worldPos.z * 0.001;
-                    uint timestep = residual;
-                    residual = residual - timestep;
+				if (perPassWetnessEffects[0].EnableSplashes) {
+					float residual = t * perPassWetnessEffects[0].RaindropIntervalRcp / perPassWetnessEffects[0].SplashesLifetime + tOffset + worldPos.z * 0.001;
+					uint timestep = residual;
+					residual = residual - timestep;
 
-                    uint3 hash = pcg3d(uint3(gridCurr, timestep));
-                    float3 floatHash = float3(hash) * uintToFloat;
+					uint3 hash = pcg3d(uint3(gridCurr, timestep));
+					float3 floatHash = float3(hash) * uintToFloat;
 
-                    if (floatHash.z < (perPassWetnessEffects[0].RaindropChance)) {
-                        float2 vec2Centre = int2(i, j) + floatHash.xy - gridUV;
-                        float distSqr = dot(vec2Centre, vec2Centre);
-                        float drop_radius = lerp(perPassWetnessEffects[0].SplashesMinRadius, perPassWetnessEffects[0].SplashesMaxRadius,
+					if (floatHash.z < (perPassWetnessEffects[0].RaindropChance)) {
+						float2 vec2Centre = int2(i, j) + floatHash.xy - gridUV;
+						float distSqr = dot(vec2Centre, vec2Centre);
+						float drop_radius = lerp(perPassWetnessEffects[0].SplashesMinRadius, perPassWetnessEffects[0].SplashesMaxRadius,
 							float(iqint3(hash.yz)) * uintToFloat);
-                        if (distSqr < drop_radius * drop_radius)
-                            wetness = max(wetness, RainFade(residual));
-                    }
-                }
+						if (distSqr < drop_radius * drop_radius)
+							wetness = max(wetness, RainFade(residual));
+					}
+				}
 
 				// ripples
-                if (perPassWetnessEffects[0].EnableRipples) {
-                    float residual = t * perPassWetnessEffects[0].RaindropIntervalRcp + tOffset + worldPos.z * 0.001;
-                    uint timestep = residual;
-                    residual = residual - timestep;
+				if (perPassWetnessEffects[0].EnableRipples) {
+					float residual = t * perPassWetnessEffects[0].RaindropIntervalRcp + tOffset + worldPos.z * 0.001;
+					uint timestep = residual;
+					residual = residual - timestep;
 
-                    uint3 hash = pcg3d(uint3(gridCurr, timestep));
-                    float3 floatHash = float3(hash) * uintToFloat;
+					uint3 hash = pcg3d(uint3(gridCurr, timestep));
+					float3 floatHash = float3(hash) * uintToFloat;
 
-                    if (floatHash.z < (perPassWetnessEffects[0].RaindropChance)) {
-                        float2 vec2Centre = int2(i, j) + floatHash.xy - gridUV;
-                        float distSqr = dot(vec2Centre, vec2Centre);
-                        float rippleT = residual * perPassWetnessEffects[0].RippleLifetimeRcp;
-                        if (rippleT < 1.) {
-                            float ripple_r = lerp(0., perPassWetnessEffects[0].RippleRadius, rippleT);
-                            float ripple_inner_radius = ripple_r - perPassWetnessEffects[0].RippleBreadth;
+					if (floatHash.z < (perPassWetnessEffects[0].RaindropChance)) {
+						float2 vec2Centre = int2(i, j) + floatHash.xy - gridUV;
+						float distSqr = dot(vec2Centre, vec2Centre);
+						float rippleT = residual * perPassWetnessEffects[0].RippleLifetimeRcp;
+						if (rippleT < 1.) {
+							float ripple_r = lerp(0., perPassWetnessEffects[0].RippleRadius, rippleT);
+							float ripple_inner_radius = ripple_r - perPassWetnessEffects[0].RippleBreadth;
 
-                            float band_lerp = (sqrt(distSqr) - ripple_inner_radius) * rippleBreadthRcp;
-                            if (band_lerp > 0. && band_lerp < 1.) {
-                                float deriv = (band_lerp < .5 ? SmoothstepDeriv(band_lerp * 2.) : -SmoothstepDeriv(2. - band_lerp * 2.)) *
+							float band_lerp = (sqrt(distSqr) - ripple_inner_radius) * rippleBreadthRcp;
+							if (band_lerp > 0. && band_lerp < 1.) {
+								float deriv = (band_lerp < .5 ? SmoothstepDeriv(band_lerp * 2.) : -SmoothstepDeriv(2. - band_lerp * 2.)) *
 								              lerp(perPassWetnessEffects[0].RippleStrength, 0, rippleT * rippleT);
 
-                                float3 grad = float3(normalize(vec2Centre), -deriv);
-                                float3 bitangent = float3(-grad.y, grad.x, 0);
-                                float3 normal = normalize(cross(grad, bitangent));
+								float3 grad = float3(normalize(vec2Centre), -deriv);
+								float3 bitangent = float3(-grad.y, grad.x, 0);
+								float3 normal = normalize(cross(grad, bitangent));
 
-                                rippleNormal = ReorientNormal(normal, rippleNormal);
-                            }
-                        }
-                    }
-                }				
-            }
+								rippleNormal = ReorientNormal(normal, rippleNormal);
+							}
+						}
+					}
+				}
+			}
 
 	if (perPassWetnessEffects[0].EnableChaoticRipples) {
 		float3 turbulenceNormal = noise(float3(worldPos.xy * perPassWetnessEffects[0].ChaoticRippleScaleRcp, t * perPassWetnessEffects[0].ChaoticRippleSpeed));

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -49,6 +49,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	RaindropGridSize,
 	RaindropInterval,
 	RaindropChance,
+	SplashesLifetime,
 	SplashesStrength,
 	SplashesMinRadius,
 	SplashesMaxRadius,
@@ -101,7 +102,7 @@ void WetnessEffects::DrawSettings()
 				"Chaotic ripples are not affected by raindrop settings.");
 
 			ImGui::SliderFloat("Grid Size", &settings.RaindropGridSize, 1.f, 10.f, "%.1f game unit(s)");
-			ImGui::SliderFloat("Interval", &settings.RaindropInterval, 0.0f, 2.f, "%.1f sec");
+			ImGui::SliderFloat("Interval", &settings.RaindropInterval, 0.1f, 2.f, "%.1f sec");
 			ImGui::SliderFloat("Chance", &settings.RaindropChance, 0.0f, 1.f, "%.2f", ImGuiSliderFlags_AlwaysClamp);
 			if (auto _tt = Util::HoverTooltipWrapper())
 				ImGui::Text("Portion of raindrops that will actually cause splashes and ripples.");
@@ -116,6 +117,7 @@ void WetnessEffects::DrawSettings()
 			ImGui::SliderFloat("Max Radius", &settings.SplashesMaxRadius, 0.f, 1.f, "%.2f", ImGuiSliderFlags_AlwaysClamp);
 			if (auto _tt = Util::HoverTooltipWrapper())
 				ImGui::Text("As portion of grid size.");
+			ImGui::SliderFloat("Lifetime", &settings.SplashesLifetime, 0.1f, 20.f, "%.1f");
 			ImGui::TreePop();
 		}
 

--- a/src/Features/WetnessEffects.h
+++ b/src/Features/WetnessEffects.h
@@ -32,7 +32,7 @@ public:
 		float PuddleMaxAngle = 0.95f;
 		float PuddleMinWetness = 0.85f;
 		float MinRainWetness = 0.65f;
-		float SkinWetness = 0.825f;
+		float SkinWetness = 0.95f;
 		float WeatherTransitionSpeed = 3.0f;
 
 		// Raindrop fx settings
@@ -44,13 +44,14 @@ public:
 		float RaindropGridSize = 4.f;
 		float RaindropInterval = .5f;
 		float RaindropChance = .3f;
+		float SplashesLifetime = 10.0f;
 		float SplashesStrength = 1.2f;
 		float SplashesMinRadius = .3f;
 		float SplashesMaxRadius = .5f;
 		float RippleStrength = 1.f;
 		float RippleRadius = 1.f;
 		float RippleBreadth = .5f;
-		float RippleLifetime = .1f;
+		float RippleLifetime = .15f;
 		float ChaoticRippleStrength = .1f;
 		float ChaoticRippleScale = 1.f;
 		float ChaoticRippleSpeed = 20.f;


### PR DESCRIPTION
- Added a user setting to allow raindrop splashes and ripples to occur at different speeds and set splashes to occur 10x slower than ripples by default.
- Adjusted the default setting for Skin Wetness to make it more visible