### PR TITLE
feat: disable fileWatcher by default

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -361,6 +361,17 @@ void Menu::DrawSettings()
 					"Enabling will save current settings as TEST config. "
 					"This has no impact if no settings are changed. ");
 			}
+			bool useFileWatcher = shaderCache.UseFileWatcher();
+			ImGui::TableNextColumn();
+			if (ImGui::Checkbox("Enable File Watcher", &useFileWatcher)) {
+				shaderCache.SetFileWatcher(useFileWatcher);
+			}
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text(
+					"Automatically recompile shaders on file change. "
+					"Intended for developing.");
+			}
+
 			if (ImGui::Button("Dump Ini Settings", { -1, 0 })) {
 				Util::DumpSettingsOptions();
 			}

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -136,7 +136,11 @@ namespace SIE
 		void DeleteDiskCache();
 		void ValidateDiskCache();
 		void WriteDiskCacheInfo();
+		bool UseFileWatcher() const;
+		void SetFileWatcher(bool value);
+
 		void StartFileWatcher();
+		void StopFileWatcher();
 
 		/** @brief Update the RE::BSShader::Type timestamp based on timestamp.
 		@param  a_type Case insensitive string for the type of shader. E.g., Lighting
@@ -312,6 +316,7 @@ namespace SIE
 		bool isAsync = true;
 		bool isDump = false;
 		bool hideError = false;
+		bool useFileWatcher = false;
 
 		std::stop_source ssource;
 		std::mutex vertexShadersMutex;
@@ -323,9 +328,9 @@ namespace SIE
 		std::mutex modifiedMapMutex;
 
 		// efsw file watcher
-		efsw::FileWatcher* fileWatcher;
+		efsw::FileWatcher* fileWatcher = nullptr;
 		efsw::WatchID watchID;
-		UpdateListener* listener;
+		UpdateListener* listener = nullptr;
 	};
 
 	// Inherits from the abstract listener class, and implements the the file action handler
@@ -345,7 +350,7 @@ namespace SIE
 			std::string oldFilename;
 		};
 		std::mutex actionMutex;
-		std::vector<fileAction> queue{}; 
+		std::vector<fileAction> queue{};
 		size_t lastQueueSize = queue.size();
 	};
 }

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -137,6 +137,12 @@ namespace SIE
 		void ValidateDiskCache();
 		void WriteDiskCacheInfo();
 		void StartFileWatcher();
+
+		/** @brief Update the RE::BSShader::Type timestamp based on timestamp.
+		@param  a_type Case insensitive string for the type of shader. E.g., Lighting
+		@return True if the shader for the type (i.e., Lighting.hlsl) timestamp was updated
+		*/
+		bool UpdateShaderModifiedTime(std::string a_type);
 		/** @brief Whether the ShaderFile for RE::BSShader::Type has been modified since the timestamp.
 		@param  a_type Case insensitive string for the type of shader. E.g., Lighting
 		@param  a_current The current time in system_clock::time_point.

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -332,6 +332,20 @@ namespace SIE
 	class UpdateListener : public efsw::FileWatchListener
 	{
 	public:
+		void processQueue();
 		void handleFileAction(efsw::WatchID, const std::string& dir, const std::string& filename, efsw::Action action, std::string) override;
+
+	private:
+		struct fileAction
+		{
+			efsw::WatchID watchID;
+			std::string dir;
+			std::string filename;
+			efsw::Action action;
+			std::string oldFilename;
+		};
+		std::mutex actionMutex;
+		std::vector<fileAction> queue{}; 
+		size_t lastQueueSize = queue.size();
 	};
 }

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -222,6 +222,8 @@ void State::Load(bool a_test)
 			shaderCache.compilationThreadCount = std::clamp(advanced["Compiler Threads"].get<int32_t>(), 1, static_cast<int32_t>(std::thread::hardware_concurrency()));
 		if (advanced["Background Compiler Threads"].is_number_integer())
 			shaderCache.backgroundCompilationThreadCount = std::clamp(advanced["Background Compiler Threads"].get<int32_t>(), 1, static_cast<int32_t>(std::thread::hardware_concurrency()));
+		if (advanced["Use FileWatcher"].is_boolean())
+			shaderCache.SetFileWatcher(advanced["Use FileWatcher"]);
 	}
 
 	if (settings["General"].is_object()) {
@@ -270,6 +272,7 @@ void State::Save(bool a_test)
 	advanced["Shader Defines"] = shaderDefinesString;
 	advanced["Compiler Threads"] = shaderCache.compilationThreadCount;
 	advanced["Background Compiler Threads"] = shaderCache.backgroundCompilationThreadCount;
+	advanced["Use FileWatcher"] = shaderCache.UseFileWatcher();
 	settings["Advanced"] = advanced;
 
 	json general;

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -96,7 +96,8 @@ void MessageHandler(SKSE::MessagingInterface::Message* message)
 				auto& shaderCache = SIE::ShaderCache::Instance();
 
 				shaderCache.ValidateDiskCache();
-				shaderCache.StartFileWatcher();
+				if (shaderCache.UseFileWatcher())
+					shaderCache.StartFileWatcher();
 				for (auto* feature : Feature::GetFeatureList()) {
 					if (feature->loaded) {
 						feature->PostPostLoad();


### PR DESCRIPTION
FileWatcher is now under the Advanced Menu as a setting. This should
disable the code that may be killing bad Linux installs by gating the
use of `std::filesystem::last_write_time` and `esfw` behind a setting.