### PR TITLE
feat: LLF config extension for particle light billboards

### DIFF
--- a/src/Features/LightLimitFIx/ParticleLights.cpp
+++ b/src/Features/LightLimitFIx/ParticleLights.cpp
@@ -35,8 +35,11 @@ void ParticleLights::GetConfigs()
 			data.colorMult.red = (float)ini.GetDoubleValue("Light", "ColorMultRed", 1.0);
 			data.colorMult.green = (float)ini.GetDoubleValue("Light", "ColorMultGreen", 1.0);
 			data.colorMult.blue = (float)ini.GetDoubleValue("Light", "ColorMultBlue", 1.0);
+      data.brightnessMult = (float)ini.GetDoubleValue("Light", "BrightnessMult", 1.0);
 			data.radiusMult = (float)ini.GetDoubleValue("Light", "RadiusMult", 1.0);
-			data.saturationMult = (float)ini.GetDoubleValue("Light", "SaturationMult", 1.0);
+      data.billboardBrightnessMult = (float)ini.GetDoubleValue("Light", "BillboardBrightnessMult", 1.0);
+      data.billboardRadiusMult = (float)ini.GetDoubleValue("Light", "BillboardRadiusMult", 1.0);
+      data.saturationMult = (float)ini.GetDoubleValue("Light", "SaturationMult", 1.0);
 			data.flicker = ini.GetBoolValue("Light", "Flicker", false);
 			data.flickerSpeed = (float)ini.GetDoubleValue("Light", "FlickerSpeed", 1.0);
 			data.flickerIntensity = (float)ini.GetDoubleValue("Light", "FlickerIntensity", 0.0);

--- a/src/Features/LightLimitFIx/ParticleLights.cpp
+++ b/src/Features/LightLimitFIx/ParticleLights.cpp
@@ -35,11 +35,11 @@ void ParticleLights::GetConfigs()
 			data.colorMult.red = (float)ini.GetDoubleValue("Light", "ColorMultRed", 1.0);
 			data.colorMult.green = (float)ini.GetDoubleValue("Light", "ColorMultGreen", 1.0);
 			data.colorMult.blue = (float)ini.GetDoubleValue("Light", "ColorMultBlue", 1.0);
-      data.brightnessMult = (float)ini.GetDoubleValue("Light", "BrightnessMult", 1.0);
+			data.brightnessMult = (float)ini.GetDoubleValue("Light", "BrightnessMult", 1.0);
 			data.radiusMult = (float)ini.GetDoubleValue("Light", "RadiusMult", 1.0);
-      data.billboardBrightnessMult = (float)ini.GetDoubleValue("Light", "BillboardBrightnessMult", 1.0);
-      data.billboardRadiusMult = (float)ini.GetDoubleValue("Light", "BillboardRadiusMult", 1.0);
-      data.saturationMult = (float)ini.GetDoubleValue("Light", "SaturationMult", 1.0);
+			data.billboardBrightnessMult = (float)ini.GetDoubleValue("Light", "BillboardBrightnessMult", 1.0);
+			data.billboardRadiusMult = (float)ini.GetDoubleValue("Light", "BillboardRadiusMult", 1.0);
+			data.saturationMult = (float)ini.GetDoubleValue("Light", "SaturationMult", 1.0);
 			data.flicker = ini.GetBoolValue("Light", "Flicker", false);
 			data.flickerSpeed = (float)ini.GetDoubleValue("Light", "FlickerSpeed", 1.0);
 			data.flickerIntensity = (float)ini.GetDoubleValue("Light", "FlickerIntensity", 0.0);

--- a/src/Features/LightLimitFIx/ParticleLights.h
+++ b/src/Features/LightLimitFIx/ParticleLights.h
@@ -19,7 +19,10 @@ public:
 	{
 		bool cull = false;
 		RE::NiColor colorMult{ 1.0f, 1.0f, 1.0f };
-		float radiusMult = 1.0f;
+    float brightnessMult = 1.0f;
+    float radiusMult = 1.0f;
+    float billboardBrightnessMult = 1.0f;
+    float billboardRadiusMult = 1.0f;
 		float saturationMult = 1.0f;
 		bool flicker = false;
 		float flickerSpeed = 0.0f;

--- a/src/Features/LightLimitFIx/ParticleLights.h
+++ b/src/Features/LightLimitFIx/ParticleLights.h
@@ -19,10 +19,10 @@ public:
 	{
 		bool cull = false;
 		RE::NiColor colorMult{ 1.0f, 1.0f, 1.0f };
-    float brightnessMult = 1.0f;
-    float radiusMult = 1.0f;
-    float billboardBrightnessMult = 1.0f;
-    float billboardRadiusMult = 1.0f;
+		float brightnessMult = 1.0f;
+		float radiusMult = 1.0f;
+		float billboardBrightnessMult = 1.0f;
+		float billboardRadiusMult = 1.0f;
 		float saturationMult = 1.0f;
 		bool flicker = false;
 		float flickerSpeed = 0.0f;

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -878,7 +878,7 @@ void LightLimitFix::UpdateLights()
 					color.x = particleLight.second.color.red * particleData->GetParticlesRuntimeData().color[p].red;
 					color.y = particleLight.second.color.green * particleData->GetParticlesRuntimeData().color[p].green;
 					color.z = particleLight.second.color.blue * particleData->GetParticlesRuntimeData().color[p].blue;
-					clusteredLight.color += Saturation(color, settings.ParticleLightsSaturation) * alpha * settings.ParticleBrightness;
+					clusteredLight.color += Saturation(color, settings.ParticleLightsSaturation) * alpha * settings.ParticleBrightness * particleLight.second.config.brightnessMult;
 
 					clusteredLight.radius += radius * settings.ParticleRadius * particleLight.second.config.radiusMult;
 					clusteredLight.positionWS[0].data.x += positionWS.x;
@@ -898,8 +898,8 @@ void LightLimitFix::UpdateLights()
 
 				light.color = Saturation(light.color, settings.ParticleLightsSaturation);
 
-				light.color *= particleLight.second.color.alpha * settings.BillboardBrightness;
-				light.radius = particleLight.first->worldBound.radius * settings.BillboardRadius * particleLight.second.config.radiusMult;
+				light.color *= particleLight.second.color.alpha * settings.BillboardBrightness * particleLight.second.config.billboardBrightnessMult;
+				light.radius = particleLight.first->worldBound.radius * settings.BillboardRadius * particleLight.second.config.billboardRadiusMult;
 
 				auto position = particleLight.first->world.translate;
 


### PR DESCRIPTION
This is a small change has the goal to allow for separated, ini-based and file-specific control over particle lights and their billboards. 
This is to alleviate users with different lighting mods (say lux vs luminous) where, for example, tweaking LLF billboard settings for lit plants can look good but the lit windows of the temple of kynareth next to it are overblown. 

Three parameters are added to the ParticleLights config struct and the subsequent ParticleLight logic in LightLimitFix. The BrightnessMult was added for completions sake. 

In the ini/config it should be used like this:
[Light]
BrightnessMult = 0.5
RadiusMult = 0.5
BillboardBrightnessMult = 0.5
BillboardRadiusMult = 0.5

TODO: 
* Check if hlsl stuff needs to be touched (think not?)
* Setup windows compile chain, wrote it on Linux so could not test, should compile fine as the change is small, better safe than sorry though
* Update sample inis and wiki