### PR TITLE
build: bump commonlibng to 3.7.0

### DIFF
--- a/include/PCH.h
+++ b/include/PCH.h
@@ -83,7 +83,6 @@ namespace stl
 }
 
 namespace logger = SKSE::log;
-namespace WinAPI = SKSE::WinAPI;
 
 namespace util
 {

--- a/src/Bindings.cpp
+++ b/src/Bindings.cpp
@@ -1,9 +1,10 @@
 #include "Bindings.h"
+#include "State.h"
 #include "Util.h"
 
 void Bindings::DepthStencilStateSetDepthMode(RE::BSGraphics::DepthStencilDepthMode a_mode)
 {
-	auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
+	auto& state = State::GetSingleton()->shadowState;
 	GET_INSTANCE_MEMBER(depthStencilDepthMode, state)
 	GET_INSTANCE_MEMBER(depthStencilDepthModePrevious, state)
 	GET_INSTANCE_MEMBER(stateUpdateFlags, state)
@@ -19,7 +20,7 @@ void Bindings::DepthStencilStateSetDepthMode(RE::BSGraphics::DepthStencilDepthMo
 
 void Bindings::AlphaBlendStateSetMode(uint32_t a_mode)
 {
-	auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
+	auto& state = State::GetSingleton()->shadowState;
 	GET_INSTANCE_MEMBER(alphaBlendMode, state)
 	GET_INSTANCE_MEMBER(stateUpdateFlags, state)
 
@@ -31,7 +32,7 @@ void Bindings::AlphaBlendStateSetMode(uint32_t a_mode)
 
 void Bindings::AlphaBlendStateSetAlphaToCoverage(uint32_t a_value)
 {
-	auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
+	auto& state = State::GetSingleton()->shadowState;
 	GET_INSTANCE_MEMBER(alphaBlendAlphaToCoverage, state)
 	GET_INSTANCE_MEMBER(stateUpdateFlags, state)
 
@@ -43,7 +44,7 @@ void Bindings::AlphaBlendStateSetAlphaToCoverage(uint32_t a_value)
 
 void Bindings::AlphaBlendStateSetWriteMode(uint32_t a_value)
 {
-	auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
+	auto& state = State::GetSingleton()->shadowState;
 	GET_INSTANCE_MEMBER(alphaBlendWriteMode, state)
 	GET_INSTANCE_MEMBER(stateUpdateFlags, state)
 
@@ -57,7 +58,7 @@ void Bindings::SetOverwriteTerrainMode(bool a_enable)
 {
 	if (overrideTerrain != a_enable) {
 		overrideTerrain = a_enable;
-		auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
+		auto& state = State::GetSingleton()->shadowState;
 		GET_INSTANCE_MEMBER(stateUpdateFlags, state)
 		stateUpdateFlags.set(RE::BSGraphics::ShaderFlags::DIRTY_DEPTH_MODE);
 		stateUpdateFlags.set(RE::BSGraphics::ShaderFlags::DIRTY_ALPHA_BLEND);
@@ -68,7 +69,7 @@ void Bindings::SetOverwriteTerrainMaskingMode(TerrainMaskMode a_mode)
 {
 	if (terrainMask != a_mode) {
 		terrainMask = a_mode;
-		auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
+		auto& state = State::GetSingleton()->shadowState;
 		GET_INSTANCE_MEMBER(stateUpdateFlags, state)
 		stateUpdateFlags.set(RE::BSGraphics::ShaderFlags::DIRTY_RENDERTARGET);
 	}
@@ -88,8 +89,8 @@ struct BlendStates
 
 void Bindings::SetDirtyStates(bool)
 {
-	auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
-	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+	auto& state = State::GetSingleton()->shadowState;
+	auto& context = State::GetSingleton()->context;
 	GET_INSTANCE_MEMBER(depthStencilStencilMode, state)
 	GET_INSTANCE_MEMBER(depthStencilDepthMode, state)
 	GET_INSTANCE_MEMBER(alphaBlendAlphaToCoverage, state)
@@ -261,7 +262,7 @@ void Bindings::Reset()
 	//SetOverwriteTerrainMode(false);
 	//SetOverwriteTerrainMaskingMode(TerrainMaskMode::kNone);
 
-	//auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+	//auto& context = State::GetSingleton()->context;
 	//FLOAT clear[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 	//context->ClearRenderTargetView(terrainBlendingMask->rtv.get(), clear);
 }

--- a/src/Bindings.cpp
+++ b/src/Bindings.cpp
@@ -89,7 +89,7 @@ struct BlendStates
 void Bindings::SetDirtyStates(bool)
 {
 	auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
-	auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 	GET_INSTANCE_MEMBER(depthStencilStencilMode, state)
 	GET_INSTANCE_MEMBER(depthStencilDepthMode, state)
 	GET_INSTANCE_MEMBER(alphaBlendAlphaToCoverage, state)
@@ -261,7 +261,7 @@ void Bindings::Reset()
 	//SetOverwriteTerrainMode(false);
 	//SetOverwriteTerrainMaskingMode(TerrainMaskMode::kNone);
 
-	//auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+	//auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 	//FLOAT clear[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 	//context->ClearRenderTargetView(terrainBlendingMask->rtv.get(), clear);
 }

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -47,7 +47,7 @@ public:
 	ConstantBuffer(D3D11_BUFFER_DESC const& a_desc)
 	{
 		desc = a_desc;
-		auto device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		auto device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		DX::ThrowIfFailed(device->CreateBuffer(&desc, nullptr, resource.ReleaseAndGetAddressOf()));
 	}
 
@@ -55,7 +55,7 @@ public:
 
 	void Update(void const* src_data, size_t data_size)
 	{
-		ID3D11DeviceContext* ctx = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+		ID3D11DeviceContext* ctx = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 		if (desc.Usage & D3D11_USAGE_DYNAMIC) {
 			D3D11_MAPPED_SUBRESOURCE mapped_buffer{};
 			ZeroMemory(&mapped_buffer, sizeof(D3D11_MAPPED_SUBRESOURCE));
@@ -98,7 +98,7 @@ public:
 	{
 		desc = a_desc;
 		count = a_count;
-		auto device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		auto device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		DX::ThrowIfFailed(device->CreateBuffer(&desc, nullptr, resource.ReleaseAndGetAddressOf()));
 	}
 
@@ -107,7 +107,7 @@ public:
 
 	virtual void CreateSRV()
 	{
-		ID3D11Device* device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		ID3D11Device* device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc{};
 		srv_desc.Format = DXGI_FORMAT_UNKNOWN;
 		srv_desc.ViewDimension = D3D11_SRV_DIMENSION_BUFFEREX;
@@ -120,7 +120,7 @@ public:
 
 	virtual void CreateUAV()
 	{
-		ID3D11Device* device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		ID3D11Device* device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		D3D11_UNORDERED_ACCESS_VIEW_DESC uav_desc{};
 		uav_desc.Format = DXGI_FORMAT_UNKNOWN;
 		uav_desc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
@@ -134,7 +134,7 @@ public:
 
 	void Update(void const* src_data, [[maybe_unused]] size_t data_size)
 	{
-		ID3D11DeviceContext* ctx = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+		ID3D11DeviceContext* ctx = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 		D3D11_MAPPED_SUBRESOURCE mapped_buffer{};
 		ZeroMemory(&mapped_buffer, sizeof(D3D11_MAPPED_SUBRESOURCE));
 		DX::ThrowIfFailed(ctx->Map(resource.Get(), 0u, D3D11_MAP_WRITE_DISCARD, 0u, &mapped_buffer));
@@ -161,18 +161,18 @@ public:
 	Buffer(D3D11_BUFFER_DESC const& a_desc, D3D11_SUBRESOURCE_DATA* a_init = nullptr)
 	{
 		desc = a_desc;
-		auto device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		auto device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		DX::ThrowIfFailed(device->CreateBuffer(&desc, a_init, resource.put()));
 	}
 
 	void CreateSRV(D3D11_SHADER_RESOURCE_VIEW_DESC const& a_desc)
 	{
-		ID3D11Device* device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		ID3D11Device* device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		DX::ThrowIfFailed(device->CreateShaderResourceView(resource.get(), &a_desc, srv.put()));
 	}
 	void CreateUAV(D3D11_UNORDERED_ACCESS_VIEW_DESC const& a_desc)
 	{
-		ID3D11Device* device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		ID3D11Device* device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		DX::ThrowIfFailed(device->CreateUnorderedAccessView(resource.get(), &a_desc, uav.put()));
 	}
 
@@ -188,24 +188,24 @@ public:
 	Texture1D(D3D11_TEXTURE1D_DESC const& a_desc)
 	{
 		desc = a_desc;
-		auto device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		auto device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		DX::ThrowIfFailed(device->CreateTexture1D(&desc, nullptr, resource.put()));
 	}
 
 	void CreateSRV(D3D11_SHADER_RESOURCE_VIEW_DESC const& a_desc)
 	{
-		ID3D11Device* device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		ID3D11Device* device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		DX::ThrowIfFailed(device->CreateShaderResourceView(resource.get(), &a_desc, srv.put()));
 	}
 	void CreateUAV(D3D11_UNORDERED_ACCESS_VIEW_DESC const& a_desc)
 	{
-		ID3D11Device* device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		ID3D11Device* device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		DX::ThrowIfFailed(device->CreateUnorderedAccessView(resource.get(), &a_desc, uav.put()));
 	}
 
 	void CreateRTV(D3D11_RENDER_TARGET_VIEW_DESC const& a_desc)
 	{
-		ID3D11Device* device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		ID3D11Device* device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		DX::ThrowIfFailed(device->CreateRenderTargetView(resource.get(), &a_desc, rtv.put()));
 	}
 
@@ -222,7 +222,7 @@ public:
 	Texture2D(D3D11_TEXTURE2D_DESC const& a_desc)
 	{
 		desc = a_desc;
-		auto device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		auto device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		DX::ThrowIfFailed(device->CreateTexture2D(&desc, nullptr, resource.put()));
 	}
 
@@ -234,18 +234,18 @@ public:
 
 	void CreateSRV(D3D11_SHADER_RESOURCE_VIEW_DESC const& a_desc)
 	{
-		ID3D11Device* device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		ID3D11Device* device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		DX::ThrowIfFailed(device->CreateShaderResourceView(resource.get(), &a_desc, srv.put()));
 	}
 	void CreateUAV(D3D11_UNORDERED_ACCESS_VIEW_DESC const& a_desc)
 	{
-		ID3D11Device* device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		ID3D11Device* device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		DX::ThrowIfFailed(device->CreateUnorderedAccessView(resource.get(), &a_desc, uav.put()));
 	}
 
 	void CreateRTV(D3D11_RENDER_TARGET_VIEW_DESC const& a_desc)
 	{
-		ID3D11Device* device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		ID3D11Device* device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		DX::ThrowIfFailed(device->CreateRenderTargetView(resource.get(), &a_desc, rtv.put()));
 	}
 
@@ -262,18 +262,18 @@ public:
 	Texture3D(D3D11_TEXTURE3D_DESC const& a_desc)
 	{
 		desc = a_desc;
-		auto device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		auto device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		DX::ThrowIfFailed(device->CreateTexture3D(&desc, nullptr, resource.put()));
 	}
 
 	void CreateSRV(D3D11_SHADER_RESOURCE_VIEW_DESC const& a_desc)
 	{
-		ID3D11Device* device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		ID3D11Device* device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		DX::ThrowIfFailed(device->CreateShaderResourceView(resource.get(), &a_desc, srv.put()));
 	}
 	void CreateUAV(D3D11_UNORDERED_ACCESS_VIEW_DESC const& a_desc)
 	{
-		ID3D11Device* device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		ID3D11Device* device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 		DX::ThrowIfFailed(device->CreateUnorderedAccessView(resource.get(), &a_desc, uav.put()));
 	}
 

--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -74,7 +74,7 @@ void CloudShadows::CheckResourcesSide(int side)
 	if (!frame_checker[side].isNewFrame())
 		return;
 
-	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+	auto& context = State::GetSingleton()->context;
 
 	float black[4] = { 0, 0, 0, 0 };
 	context->ClearRenderTargetView(cubemapCloudOccRTVs[side], black);
@@ -85,7 +85,7 @@ void CloudShadows::ModifySky(const RE::BSShader*, const uint32_t descriptor)
 	if (!settings.EnableCloudShadows)
 		return;
 
-	auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
+	auto& shadowState = State::GetSingleton()->shadowState;
 	auto cubeMapRenderTarget = !REL::Module::IsVR() ? shadowState->GetRuntimeData().cubeMapRenderTarget : shadowState->GetVRRuntimeData().cubeMapRenderTarget;
 	if (cubeMapRenderTarget != RE::RENDER_TARGETS_CUBEMAP::kREFLECTIONS)
 		return;
@@ -106,8 +106,8 @@ void CloudShadows::ModifySky(const RE::BSShader*, const uint32_t descriptor)
 	auto tech_enum = static_cast<SkyShaderTechniques>(descriptor);
 	if (tech_enum == SkyShaderTechniques::Clouds || tech_enum == SkyShaderTechniques::CloudsLerp || tech_enum == SkyShaderTechniques::CloudsFade) {
 		auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-		auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
-		auto device = reinterpret_cast<ID3D11Device*>(renderer->GetRuntimeData().forwarder);
+		auto& context = State::GetSingleton()->context;
+		auto& device = State::GetSingleton()->device;
 
 		{
 			ID3D11ShaderResourceView* srv = nullptr;
@@ -165,9 +165,9 @@ void CloudShadows::ModifySky(const RE::BSShader*, const uint32_t descriptor)
 
 void CloudShadows::ModifyLighting()
 {
-	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+	auto& context = State::GetSingleton()->context;
 
-	auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
+	auto& shadowState = State::GetSingleton()->shadowState;
 	auto cubeMapRenderTarget = !REL::Module::IsVR() ? shadowState->GetRuntimeData().cubeMapRenderTarget : shadowState->GetVRRuntimeData().cubeMapRenderTarget;
 	if (cubeMapRenderTarget != RE::RENDER_TARGETS_CUBEMAP::kREFLECTIONS) {
 		static Util::FrameChecker frame_checker;
@@ -191,7 +191,7 @@ void CloudShadows::Draw(const RE::BSShader* shader, const uint32_t descriptor)
 	static Util::FrameChecker frame_checker;
 	if (frame_checker.isNewFrame()) {
 		// update settings buffer
-		auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+		auto& context = State::GetSingleton()->context;
 
 		PerPass perPassData{};
 
@@ -237,7 +237,7 @@ void CloudShadows::Save(json& o_json)
 void CloudShadows::SetupResources()
 {
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto device = reinterpret_cast<ID3D11Device*>(renderer->GetRuntimeData().forwarder);
+	auto& device = State::GetSingleton()->device;
 
 	{
 		auto reflections = renderer->GetRendererData().cubemapRenderTargets[RE::RENDER_TARGET_CUBEMAP::kREFLECTIONS];
@@ -290,7 +290,7 @@ void CloudShadows::RestoreDefaultSettings()
 void CloudShadows::Hooks::BSBatchRenderer__RenderPassImmediately::thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags)
 {
 	auto feat = GetSingleton();
-	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+	auto& context = State::GetSingleton()->context;
 
 	func(Pass, Technique, AlphaTest, RenderFlags);
 

--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -74,7 +74,7 @@ void CloudShadows::CheckResourcesSide(int side)
 	if (!frame_checker[side].isNewFrame())
 		return;
 
-	auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 	float black[4] = { 0, 0, 0, 0 };
 	context->ClearRenderTargetView(cubemapCloudOccRTVs[side], black);
@@ -106,8 +106,8 @@ void CloudShadows::ModifySky(const RE::BSShader*, const uint32_t descriptor)
 	auto tech_enum = static_cast<SkyShaderTechniques>(descriptor);
 	if (tech_enum == SkyShaderTechniques::Clouds || tech_enum == SkyShaderTechniques::CloudsLerp || tech_enum == SkyShaderTechniques::CloudsFade) {
 		auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-		auto context = renderer->GetRuntimeData().context;
-		auto device = renderer->GetRuntimeData().forwarder;
+		auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
+		auto device = reinterpret_cast<ID3D11Device*>(renderer->GetRuntimeData().forwarder);
 
 		{
 			ID3D11ShaderResourceView* srv = nullptr;
@@ -165,7 +165,7 @@ void CloudShadows::ModifySky(const RE::BSShader*, const uint32_t descriptor)
 
 void CloudShadows::ModifyLighting()
 {
-	auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 	auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
 	auto cubeMapRenderTarget = !REL::Module::IsVR() ? shadowState->GetRuntimeData().cubeMapRenderTarget : shadowState->GetVRRuntimeData().cubeMapRenderTarget;
@@ -191,7 +191,7 @@ void CloudShadows::Draw(const RE::BSShader* shader, const uint32_t descriptor)
 	static Util::FrameChecker frame_checker;
 	if (frame_checker.isNewFrame()) {
 		// update settings buffer
-		auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+		auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 		PerPass perPassData{};
 
@@ -237,7 +237,7 @@ void CloudShadows::Save(json& o_json)
 void CloudShadows::SetupResources()
 {
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto device = renderer->GetRuntimeData().forwarder;
+	auto device = reinterpret_cast<ID3D11Device*>(renderer->GetRuntimeData().forwarder);
 
 	{
 		auto reflections = renderer->GetRendererData().cubemapRenderTargets[RE::RENDER_TARGET_CUBEMAP::kREFLECTIONS];
@@ -290,7 +290,7 @@ void CloudShadows::RestoreDefaultSettings()
 void CloudShadows::Hooks::BSBatchRenderer__RenderPassImmediately::thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags)
 {
 	auto feat = GetSingleton();
-	auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 	func(Pass, Technique, AlphaTest, RenderFlags);
 

--- a/src/Features/DistantTreeLighting.cpp
+++ b/src/Features/DistantTreeLighting.cpp
@@ -113,7 +113,7 @@ void DistantTreeLighting::ModifyDistantTree(const RE::BSShader*, const uint32_t 
 
 		perPass->Update(perPassData);
 
-		auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+		auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 		ID3D11Buffer* buffers[2];
 		context->VSGetConstantBuffers(2, 1, buffers);  // buffers[0]

--- a/src/Features/DistantTreeLighting.cpp
+++ b/src/Features/DistantTreeLighting.cpp
@@ -113,7 +113,7 @@ void DistantTreeLighting::ModifyDistantTree(const RE::BSShader*, const uint32_t 
 
 		perPass->Update(perPassData);
 
-		auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+		auto& context = State::GetSingleton()->context;
 
 		ID3D11Buffer* buffers[2];
 		context->VSGetConstantBuffers(2, 1, buffers);  // buffers[0]

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -44,9 +44,8 @@ void DynamicCubemaps::DrawSettings()
 				ImGui::ColorEdit3("Color", (float*)&cubemapColor);
 				ImGui::SliderFloat("Roughness", &cubemapColor.w, 0.0f, 1.0f, "%.2f");
 				if (ImGui::Button("Export")) {
-					auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-					auto device = reinterpret_cast<ID3D11Device*>(renderer->GetRuntimeData().forwarder);
-					auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
+					auto& device = State::GetSingleton()->device;
+					auto& context = State::GetSingleton()->context;
 
 					D3D11_TEXTURE2D_DESC texDesc{};
 					texDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
@@ -222,7 +221,7 @@ void DynamicCubemaps::UpdateCubemapCapture()
 {
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
 
-	auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
+	auto& context = State::GetSingleton()->context;
 
 	auto& depth = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kPOST_ZPREPASS_COPY];
 	auto& snowSwap = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kSNOW_SWAP];
@@ -243,7 +242,7 @@ void DynamicCubemaps::UpdateCubemapCapture()
 	static float3 cameraPreviousPosAdjust = { 0, 0, 0 };
 	updateData.CameraPreviousPosAdjust = cameraPreviousPosAdjust;
 
-	auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
+	auto& state = State::GetSingleton()->shadowState;
 	auto eyePosition = !REL::Module::IsVR() ?
 	                       state->GetRuntimeData().posAdjust.getEye(0) :
 	                       state->GetVRRuntimeData().posAdjust.getEye(0);
@@ -297,7 +296,7 @@ void DynamicCubemaps::DrawDeferred()
 void DynamicCubemaps::UpdateCubemap()
 {
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
+	auto& context = State::GetSingleton()->context;
 
 	//if (!REL::Module::IsVR()) {
 	//	auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
@@ -397,14 +396,13 @@ void DynamicCubemaps::Draw(const RE::BSShader* shader, const uint32_t)
 {
 	if (shader->shaderType.get() == RE::BSShader::Type::Lighting || shader->shaderType.get() == RE::BSShader::Type::Water) {
 		// During world cubemap generation we cannot use the cubemap
-		auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
+		auto& shadowState = State::GetSingleton()->shadowState;
 		auto cubeMapRenderTarget = !REL::Module::IsVR() ? shadowState->GetRuntimeData().cubeMapRenderTarget : shadowState->GetVRRuntimeData().cubeMapRenderTarget;
 		if (cubeMapRenderTarget != RE::RENDER_TARGETS_CUBEMAP::kREFLECTIONS && !renderedScreenCamera) {
 			UpdateCubemap();
 			renderedScreenCamera = true;
 
-			auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-			auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
+			auto& context = State::GetSingleton()->context;
 
 			if (enableCreator) {
 				CreatorSettingsCB data{};
@@ -434,7 +432,7 @@ void DynamicCubemaps::SetupResources()
 	GetComputeShaderSpecularIrradiance();
 
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto device = reinterpret_cast<ID3D11Device*>(renderer->GetRuntimeData().forwarder);
+	auto& device = State::GetSingleton()->device;
 
 	{
 		D3D11_SAMPLER_DESC samplerDesc = {};

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -45,8 +45,8 @@ void DynamicCubemaps::DrawSettings()
 				ImGui::SliderFloat("Roughness", &cubemapColor.w, 0.0f, 1.0f, "%.2f");
 				if (ImGui::Button("Export")) {
 					auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-					auto device = renderer->GetRuntimeData().forwarder;
-					auto context = renderer->GetRuntimeData().context;
+					auto device = reinterpret_cast<ID3D11Device*>(renderer->GetRuntimeData().forwarder);
+					auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
 
 					D3D11_TEXTURE2D_DESC texDesc{};
 					texDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
@@ -222,7 +222,7 @@ void DynamicCubemaps::UpdateCubemapCapture()
 {
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
 
-	auto context = renderer->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
 
 	auto& depth = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kPOST_ZPREPASS_COPY];
 	auto& snowSwap = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kSNOW_SWAP];
@@ -297,7 +297,7 @@ void DynamicCubemaps::DrawDeferred()
 void DynamicCubemaps::UpdateCubemap()
 {
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto context = renderer->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
 
 	//if (!REL::Module::IsVR()) {
 	//	auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
@@ -404,7 +404,7 @@ void DynamicCubemaps::Draw(const RE::BSShader* shader, const uint32_t)
 			renderedScreenCamera = true;
 
 			auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-			auto context = renderer->GetRuntimeData().context;
+			auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
 
 			if (enableCreator) {
 				CreatorSettingsCB data{};
@@ -434,7 +434,7 @@ void DynamicCubemaps::SetupResources()
 	GetComputeShaderSpecularIrradiance();
 
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto device = renderer->GetRuntimeData().forwarder;
+	auto device = reinterpret_cast<ID3D11Device*>(renderer->GetRuntimeData().forwarder);
 
 	{
 		D3D11_SAMPLER_DESC samplerDesc = {};

--- a/src/Features/DynamicCubemaps.h
+++ b/src/Features/DynamicCubemaps.h
@@ -2,6 +2,7 @@
 
 #include "Buffer.h"
 #include "Feature.h"
+#include "State.h"
 
 class MenuOpenCloseEventHandler : public RE::BSTEventSink<RE::MenuOpenCloseEvent>
 {

--- a/src/Features/ExtendedMaterials.cpp
+++ b/src/Features/ExtendedMaterials.cpp
@@ -125,7 +125,7 @@ void ExtendedMaterials::DrawSettings()
 
 void ExtendedMaterials::ModifyLighting(const RE::BSShader*, const uint32_t)
 {
-	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+	auto& context = State::GetSingleton()->context;
 
 	{
 		PerPass data{};
@@ -174,8 +174,7 @@ void ExtendedMaterials::SetupResources()
 
 	logger::info("Creating terrain parallax sampler state");
 
-	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto device = reinterpret_cast<ID3D11Device*>(renderer->GetRuntimeData().forwarder);
+	auto& device = State::GetSingleton()->device;
 
 	D3D11_SAMPLER_DESC samplerDesc = {};
 	samplerDesc.Filter = D3D11_FILTER_ANISOTROPIC;

--- a/src/Features/ExtendedMaterials.cpp
+++ b/src/Features/ExtendedMaterials.cpp
@@ -125,7 +125,7 @@ void ExtendedMaterials::DrawSettings()
 
 void ExtendedMaterials::ModifyLighting(const RE::BSShader*, const uint32_t)
 {
-	auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 	{
 		PerPass data{};
@@ -175,7 +175,7 @@ void ExtendedMaterials::SetupResources()
 	logger::info("Creating terrain parallax sampler state");
 
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto device = renderer->GetRuntimeData().forwarder;
+	auto device = reinterpret_cast<ID3D11Device*>(renderer->GetRuntimeData().forwarder);
 
 	D3D11_SAMPLER_DESC samplerDesc = {};
 	samplerDesc.Filter = D3D11_FILTER_ANISOTROPIC;

--- a/src/Features/ExtendedMaterials.h
+++ b/src/Features/ExtendedMaterials.h
@@ -2,6 +2,7 @@
 
 #include "Buffer.h"
 #include "Feature.h"
+#include "State.h"
 
 struct ExtendedMaterials : Feature
 {

--- a/src/Features/GrassCollision.cpp
+++ b/src/Features/GrassCollision.cpp
@@ -227,7 +227,7 @@ void GrassCollision::UpdateCollisions()
 		collisions->CreateSRV(srvDesc);
 	}
 
-	auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 	D3D11_MAPPED_SUBRESOURCE mapped;
 	DX::ThrowIfFailed(context->Map(collisions->resource.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));
 	size_t bytes = sizeof(CollisionSData) * colllisionCount;
@@ -273,7 +273,7 @@ void GrassCollision::ModifyGrass(const RE::BSShader*, const uint32_t)
 	}
 
 	if (settings.EnableGrassCollision) {
-		auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+		auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 		ID3D11ShaderResourceView* views[1]{};
 		views[0] = collisions->srv.get();

--- a/src/Features/GrassCollision.cpp
+++ b/src/Features/GrassCollision.cpp
@@ -135,7 +135,7 @@ static bool GetShapeBound(RE::bhkNiCollisionObject* Colliedobj, RE::NiPoint3& ce
 
 void GrassCollision::UpdateCollisions()
 {
-	auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
+	auto& state = State::GetSingleton()->shadowState;
 
 	auto frameCount = RE::BSGraphics::State::GetSingleton()->uiFrameCount;
 
@@ -227,7 +227,7 @@ void GrassCollision::UpdateCollisions()
 		collisions->CreateSRV(srvDesc);
 	}
 
-	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+	auto& context = State::GetSingleton()->context;
 	D3D11_MAPPED_SUBRESOURCE mapped;
 	DX::ThrowIfFailed(context->Map(collisions->resource.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));
 	size_t bytes = sizeof(CollisionSData) * colllisionCount;
@@ -248,7 +248,7 @@ void GrassCollision::ModifyGrass(const RE::BSShader*, const uint32_t)
 		PerFrame perFrameData{};
 		ZeroMemory(&perFrameData, sizeof(perFrameData));
 
-		auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
+		auto& state = State::GetSingleton()->shadowState;
 		auto& shaderState = RE::BSShaderManager::State::GetSingleton();
 
 		auto bound = shaderState.cachedPlayerBound;
@@ -273,7 +273,7 @@ void GrassCollision::ModifyGrass(const RE::BSShader*, const uint32_t)
 	}
 
 	if (settings.EnableGrassCollision) {
-		auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+		auto& context = State::GetSingleton()->context;
 
 		ID3D11ShaderResourceView* views[1]{};
 		views[0] = collisions->srv.get();

--- a/src/Features/GrassLighting.cpp
+++ b/src/Features/GrassLighting.cpp
@@ -100,7 +100,7 @@ void GrassLighting::ModifyGrass(const RE::BSShader*, const uint32_t descriptor)
 			updatePerFrame = false;
 		}
 
-		auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+		auto& context = State::GetSingleton()->context;
 
 		ID3D11Buffer* buffers[2];
 		context->VSGetConstantBuffers(2, 1, buffers);  // buffers[0]

--- a/src/Features/GrassLighting.cpp
+++ b/src/Features/GrassLighting.cpp
@@ -100,7 +100,7 @@ void GrassLighting::ModifyGrass(const RE::BSShader*, const uint32_t descriptor)
 			updatePerFrame = false;
 		}
 
-		auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+		auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 		ID3D11Buffer* buffers[2];
 		context->VSGetConstantBuffers(2, 1, buffers);  // buffers[0]

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -310,7 +310,7 @@ void LightLimitFix::BSLightingShader_SetupGeometry_After(RE::BSRenderPass*)
 	static bool wasEmpty = false;
 	bool isEmpty = strictLightDataTemp.NumLights == 0;
 	if (!isEmpty || (isEmpty && !wasEmpty)) {
-		auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+		auto& context = State::GetSingleton()->context;
 		D3D11_MAPPED_SUBRESOURCE mapped;
 		DX::ThrowIfFailed(context->Map(strictLightData->resource.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));
 		size_t bytes = sizeof(StrictLightData);
@@ -322,7 +322,7 @@ void LightLimitFix::BSLightingShader_SetupGeometry_After(RE::BSRenderPass*)
 
 void LightLimitFix::SetLightPosition(LightLimitFix::LightData& a_light, RE::NiPoint3 a_initialPosition, bool a_cached)
 {
-	auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
+	auto& state = State::GetSingleton()->shadowState;
 	for (int eyeIndex = 0; eyeIndex < eyeCount; eyeIndex++) {
 		RE::NiPoint3 eyePosition;
 		Matrix viewMatrix;
@@ -377,7 +377,7 @@ void LightLimitFix::AddParticleLightLuminance(RE::NiPoint3& targetPosition, int&
 
 void LightLimitFix::Bind()
 {
-	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+	auto& context = State::GetSingleton()->context;
 	auto accumulator = RE::BSGraphics::BSShaderAccumulator::GetCurrentAccumulator();
 
 	auto reflections = (!REL::Module::IsVR() ?
@@ -732,7 +732,7 @@ void LightLimitFix::UpdateLights()
 	lightsFar = std::min(16384.0f, accumulator->kCamera->GetRuntimeData2().viewFrustum.fFar);
 
 	auto shadowSceneNode = RE::BSShaderManager::State::GetSingleton().shadowSceneNode[0];
-	auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
+	auto& state = State::GetSingleton()->shadowState;
 
 	// Cache data since cameraData can become invalid in first-person
 
@@ -922,7 +922,7 @@ void LightLimitFix::UpdateLights()
 		}
 	}
 
-	static auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+	static auto& context = State::GetSingleton()->context;
 
 	{
 		auto projMatrixUnjittered = eyeCount == 1 ? state->GetRuntimeData().cameraData.getEye().projMatrixUnjittered : state->GetVRRuntimeData().cameraData.getEye().projMatrixUnjittered;

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -310,7 +310,7 @@ void LightLimitFix::BSLightingShader_SetupGeometry_After(RE::BSRenderPass*)
 	static bool wasEmpty = false;
 	bool isEmpty = strictLightDataTemp.NumLights == 0;
 	if (!isEmpty || (isEmpty && !wasEmpty)) {
-		auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+		auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 		D3D11_MAPPED_SUBRESOURCE mapped;
 		DX::ThrowIfFailed(context->Map(strictLightData->resource.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));
 		size_t bytes = sizeof(StrictLightData);
@@ -377,7 +377,7 @@ void LightLimitFix::AddParticleLightLuminance(RE::NiPoint3& targetPosition, int&
 
 void LightLimitFix::Bind()
 {
-	auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 	auto accumulator = RE::BSGraphics::BSShaderAccumulator::GetCurrentAccumulator();
 
 	auto reflections = (!REL::Module::IsVR() ?
@@ -922,7 +922,7 @@ void LightLimitFix::UpdateLights()
 		}
 	}
 
-	static auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+	static auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 	{
 		auto projMatrixUnjittered = eyeCount == 1 ? state->GetRuntimeData().cameraData.getEye().projMatrixUnjittered : state->GetVRRuntimeData().cameraData.getEye().projMatrixUnjittered;

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -195,7 +195,7 @@ void ScreenSpaceShadows::ModifyLighting(const RE::BSShader*, const uint32_t)
 	if (!loaded)
 		return;
 
-	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+	auto& context = State::GetSingleton()->context;
 
 	auto accumulator = RE::BSGraphics::BSShaderAccumulator::GetCurrentAccumulator();
 	auto dirLight = skyrim_cast<RE::NiDirectionalLight*>(accumulator->GetRuntimeData().activeShadowSceneNode->GetRuntimeData().sunLight->light.get());
@@ -211,7 +211,7 @@ void ScreenSpaceShadows::ModifyLighting(const RE::BSShader*, const uint32_t)
 			{
 				logger::debug("Creating screenSpaceShadowsTexture");
 
-				auto device = reinterpret_cast<ID3D11Device*>(renderer->GetRuntimeData().forwarder);
+				auto& device = State::GetSingleton()->device;
 
 				D3D11_SAMPLER_DESC samplerDesc = {};
 				samplerDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
@@ -252,7 +252,7 @@ void ScreenSpaceShadows::ModifyLighting(const RE::BSShader*, const uint32_t)
 			}
 		}
 
-		auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
+		auto& shadowState = State::GetSingleton()->shadowState;
 
 		bool enableSSS = true;
 

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -195,7 +195,7 @@ void ScreenSpaceShadows::ModifyLighting(const RE::BSShader*, const uint32_t)
 	if (!loaded)
 		return;
 
-	auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 	auto accumulator = RE::BSGraphics::BSShaderAccumulator::GetCurrentAccumulator();
 	auto dirLight = skyrim_cast<RE::NiDirectionalLight*>(accumulator->GetRuntimeData().activeShadowSceneNode->GetRuntimeData().sunLight->light.get());
@@ -211,7 +211,7 @@ void ScreenSpaceShadows::ModifyLighting(const RE::BSShader*, const uint32_t)
 			{
 				logger::debug("Creating screenSpaceShadowsTexture");
 
-				auto device = renderer->GetRuntimeData().forwarder;
+				auto device = reinterpret_cast<ID3D11Device*>(renderer->GetRuntimeData().forwarder);
 
 				D3D11_SAMPLER_DESC samplerDesc = {};
 				samplerDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;

--- a/src/Features/SubsurfaceScattering.cpp
+++ b/src/Features/SubsurfaceScattering.cpp
@@ -160,7 +160,7 @@ void SubsurfaceScattering::DrawSSSWrapper(bool)
 	if (!SIE::ShaderCache::Instance().IsEnabled())
 		return;
 
-	auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 	ID3D11ShaderResourceView* srvs[8];
 	context->PSGetShaderResources(0, 8, srvs);
@@ -244,7 +244,7 @@ void SubsurfaceScattering::DrawSSS()
 	}
 
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto context = renderer->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
 
 	{
 		ID3D11Buffer* buffer[1] = { blurCB->CB() };
@@ -452,7 +452,7 @@ void SubsurfaceScattering::OverrideFirstPersonRenderTargets()
 	renderTargets[2] = normalsMode;
 
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto context = renderer->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
 
 	{
 		auto& target = renderer->GetRuntimeData().renderTargets[renderTargets[2]];
@@ -507,7 +507,7 @@ void SubsurfaceScattering::BSLightingShader_SetupSkin(RE::BSRenderPass* a_pass)
 			perPassData.IsBeastRace = isBeastRace;
 
 			auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-			auto context = renderer->GetRuntimeData().context;
+			auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
 
 			D3D11_MAPPED_SUBRESOURCE mapped;
 			DX::ThrowIfFailed(context->Map(perPass->resource.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));
@@ -521,7 +521,7 @@ void SubsurfaceScattering::BSLightingShader_SetupSkin(RE::BSRenderPass* a_pass)
 void SubsurfaceScattering::Bind()
 {
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto context = renderer->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
 	ID3D11ShaderResourceView* view = perPass->srv.get();
 	context->PSSetShaderResources(36, 1, &view);
 	validMaterial = true;

--- a/src/Features/SubsurfaceScattering.cpp
+++ b/src/Features/SubsurfaceScattering.cpp
@@ -160,7 +160,7 @@ void SubsurfaceScattering::DrawSSSWrapper(bool)
 	if (!SIE::ShaderCache::Instance().IsEnabled())
 		return;
 
-	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+	auto& context = State::GetSingleton()->context;
 
 	ID3D11ShaderResourceView* srvs[8];
 	context->PSGetShaderResources(0, 8, srvs);
@@ -229,7 +229,7 @@ void SubsurfaceScattering::DrawSSS()
 		                                   imageSpaceManager->GetVRRuntimeData().BSImagespaceShaderISTemporalAA->taaEnabled;
 		blurCBData.FrameCount = viewport->uiFrameCount * (bTAA || State::GetSingleton()->upscalerLoaded);
 
-		auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
+		auto& shadowState = State::GetSingleton()->shadowState;
 		auto cameraData = !REL::Module::IsVR() ? shadowState->GetRuntimeData().cameraData.getEye() :
 		                                         shadowState->GetVRRuntimeData().cameraData.getEye();
 
@@ -244,7 +244,7 @@ void SubsurfaceScattering::DrawSSS()
 	}
 
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
+	auto& context = State::GetSingleton()->context;
 
 	{
 		ID3D11Buffer* buffer[1] = { blurCB->CB() };
@@ -311,7 +311,7 @@ void SubsurfaceScattering::Draw(const RE::BSShader* a_shader, const uint32_t)
 {
 	if (a_shader->shaderType.get() == RE::BSShader::Type::Lighting) {
 		if (normalsMode == RE::RENDER_TARGET::kNONE) {
-			auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
+			auto& state = State::GetSingleton()->shadowState;
 			GET_INSTANCE_MEMBER(renderTargets, state)
 			normalsMode = renderTargets[2];
 		}
@@ -441,7 +441,7 @@ void SubsurfaceScattering::PostPostLoad()
 
 void SubsurfaceScattering::OverrideFirstPersonRenderTargets()
 {
-	auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
+	auto& state = State::GetSingleton()->shadowState;
 	GET_INSTANCE_MEMBER(renderTargets, state)
 	GET_INSTANCE_MEMBER(setRenderTargetMode, state)
 	GET_INSTANCE_MEMBER(stateUpdateFlags, state)
@@ -452,7 +452,7 @@ void SubsurfaceScattering::OverrideFirstPersonRenderTargets()
 	renderTargets[2] = normalsMode;
 
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
+	auto& context = State::GetSingleton()->context;
 
 	{
 		auto& target = renderer->GetRuntimeData().renderTargets[renderTargets[2]];
@@ -506,8 +506,7 @@ void SubsurfaceScattering::BSLightingShader_SetupSkin(RE::BSRenderPass* a_pass)
 			perPassData.ValidMaterial = validMaterial;
 			perPassData.IsBeastRace = isBeastRace;
 
-			auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-			auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
+			auto& context = State::GetSingleton()->context;
 
 			D3D11_MAPPED_SUBRESOURCE mapped;
 			DX::ThrowIfFailed(context->Map(perPass->resource.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));
@@ -520,8 +519,7 @@ void SubsurfaceScattering::BSLightingShader_SetupSkin(RE::BSRenderPass* a_pass)
 
 void SubsurfaceScattering::Bind()
 {
-	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
+	auto& context = State::GetSingleton()->context;
 	ID3D11ShaderResourceView* view = perPass->srv.get();
 	context->PSSetShaderResources(36, 1, &view);
 	validMaterial = true;

--- a/src/Features/TerrainBlending.cpp
+++ b/src/Features/TerrainBlending.cpp
@@ -72,7 +72,7 @@ void TerrainBlending::SetupGeometry(RE::BSRenderPass* a_pass)
 			Bindings::GetSingleton()->SetOverwriteTerrainMode(true);
 			Bindings::GetSingleton()->SetOverwriteTerrainMaskingMode(Bindings::TerrainMaskMode::kRead);
 
-			auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+			auto& context = State::GetSingleton()->context;
 			auto view = Bindings::GetSingleton()->terrainBlendingMask ? Bindings::GetSingleton()->terrainBlendingMask->srv.get() : nullptr;
 			if (view)
 				context->PSSetShaderResources(35, 1, &view);

--- a/src/Features/TerrainBlending.cpp
+++ b/src/Features/TerrainBlending.cpp
@@ -72,7 +72,7 @@ void TerrainBlending::SetupGeometry(RE::BSRenderPass* a_pass)
 			Bindings::GetSingleton()->SetOverwriteTerrainMode(true);
 			Bindings::GetSingleton()->SetOverwriteTerrainMaskingMode(Bindings::TerrainMaskMode::kRead);
 
-			auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+			auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 			auto view = Bindings::GetSingleton()->terrainBlendingMask ? Bindings::GetSingleton()->terrainBlendingMask->srv.get() : nullptr;
 			if (view)
 				context->PSSetShaderResources(35, 1, &view);

--- a/src/Features/WaterBlending.cpp
+++ b/src/Features/WaterBlending.cpp
@@ -40,7 +40,7 @@ void WaterBlending::DrawSettings()
 void WaterBlending::Draw(const RE::BSShader* shader, const uint32_t)
 {
 	if (shader->shaderType.any(RE::BSShader::Type::Water, RE::BSShader::Type::Lighting)) {
-		auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+		auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 		PerPass data{};
 		data.settings = settings;

--- a/src/Features/WaterBlending.cpp
+++ b/src/Features/WaterBlending.cpp
@@ -40,7 +40,7 @@ void WaterBlending::DrawSettings()
 void WaterBlending::Draw(const RE::BSShader* shader, const uint32_t)
 {
 	if (shader->shaderType.any(RE::BSShader::Type::Water, RE::BSShader::Type::Lighting)) {
-		auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+		auto& context = State::GetSingleton()->context;
 
 		PerPass data{};
 		data.settings = settings;

--- a/src/Features/WaterBlending.h
+++ b/src/Features/WaterBlending.h
@@ -2,6 +2,7 @@
 
 #include "Buffer.h"
 #include "Feature.h"
+#include "State.h"
 
 struct WaterBlending : Feature
 {

--- a/src/Features/WaterCaustics.cpp
+++ b/src/Features/WaterCaustics.cpp
@@ -8,14 +8,14 @@ void WaterCaustics::DrawSettings()
 
 void WaterCaustics::Draw(const RE::BSShader*, const uint32_t)
 {
-	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+	auto& context = State::GetSingleton()->context;
 	context->PSSetShaderResources(70, 1, &causticsView);
 }
 
 void WaterCaustics::SetupResources()
 {
-	auto device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
-	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+	auto& device = State::GetSingleton()->device;
+	auto& context = State::GetSingleton()->context;
 
 	DirectX::CreateDDSTextureFromFile(device, context, L"Data\\Shaders\\WaterCaustics\\watercaustics.dds", nullptr, &causticsView);
 }

--- a/src/Features/WaterCaustics.cpp
+++ b/src/Features/WaterCaustics.cpp
@@ -14,7 +14,7 @@ void WaterCaustics::Draw(const RE::BSShader*, const uint32_t)
 
 void WaterCaustics::SetupResources()
 {
-	auto device =reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
+	auto device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 	DirectX::CreateDDSTextureFromFile(device, context, L"Data\\Shaders\\WaterCaustics\\watercaustics.dds", nullptr, &causticsView);

--- a/src/Features/WaterCaustics.cpp
+++ b/src/Features/WaterCaustics.cpp
@@ -8,14 +8,14 @@ void WaterCaustics::DrawSettings()
 
 void WaterCaustics::Draw(const RE::BSShader*, const uint32_t)
 {
-	auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 	context->PSSetShaderResources(70, 1, &causticsView);
 }
 
 void WaterCaustics::SetupResources()
 {
-	auto device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
-	auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+	auto device =reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 	DirectX::CreateDDSTextureFromFile(device, context, L"Data\\Shaders\\WaterCaustics\\watercaustics.dds", nullptr, &causticsView);
 }

--- a/src/Features/WaterCaustics.h
+++ b/src/Features/WaterCaustics.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Feature.h"
-
+#include "State.h"
 struct WaterCaustics : Feature
 {
 public:

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -269,7 +269,7 @@ void WetnessEffects::CalculateWetness(RE::TESWeather* weather, RE::Sky* sky, flo
 void WetnessEffects::Draw(const RE::BSShader* shader, const uint32_t)
 {
 	if (shader->shaderType.any(RE::BSShader::Type::Lighting, RE::BSShader::Type::Grass)) {
-		auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+		auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 		if (requiresUpdate) {
 			requiresUpdate = false;
@@ -458,7 +458,7 @@ void WetnessEffects::Hooks::BSParticleShader_SetupGeometry::thunk(RE::BSShader* 
 	static Util::FrameChecker frameChecker;
 	if (frameChecker.isNewFrame()) {
 		auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-		auto context = renderer->GetRuntimeData().context;
+		auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
 		auto precipation = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kPRECIPITATION_OCCLUSION_MAP];
 		context->CopyResource(GetSingleton()->precipOcclusionTex->resource.get(), precipation.texture);
 	}

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -269,7 +269,7 @@ void WetnessEffects::CalculateWetness(RE::TESWeather* weather, RE::Sky* sky, flo
 void WetnessEffects::Draw(const RE::BSShader* shader, const uint32_t)
 {
 	if (shader->shaderType.any(RE::BSShader::Type::Lighting, RE::BSShader::Type::Grass)) {
-		auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
+		auto& context = State::GetSingleton()->context;
 
 		if (requiresUpdate) {
 			requiresUpdate = false;
@@ -458,7 +458,7 @@ void WetnessEffects::Hooks::BSParticleShader_SetupGeometry::thunk(RE::BSShader* 
 	static Util::FrameChecker frameChecker;
 	if (frameChecker.isNewFrame()) {
 		auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-		auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
+		auto& context = State::GetSingleton()->context;
 		auto precipation = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kPRECIPITATION_OCCLUSION_MAP];
 		context->CopyResource(GetSingleton()->precipOcclusionTex->resource.get(), precipation.texture);
 	}

--- a/src/Features/WetnessEffects.h
+++ b/src/Features/WetnessEffects.h
@@ -64,7 +64,7 @@ public:
 		float Wetness;
 		float PuddleWetness;
 		DirectX::XMFLOAT3X4 DirectionalAmbientWS;
-		RE::DirectX::XMFLOAT4X4 PrecipProj;
+		REX::W32::XMFLOAT4X4 PrecipProj;
 		Settings settings;
 
 		float pad[4 - (sizeof(Settings) / 4 + 16) % 4];
@@ -83,7 +83,7 @@ public:
 	uint32_t currentWeatherID = 0;
 	uint32_t lastWeatherID = 0;
 	float previousWeatherTransitionPercentage = 0.0f;
-	RE::DirectX::XMFLOAT4X4 precipProj;
+	REX::W32::XMFLOAT4X4 precipProj;
 
 	virtual void SetupResources();
 	virtual void Reset();

--- a/src/Features/WetnessEffects.h
+++ b/src/Features/WetnessEffects.h
@@ -2,6 +2,7 @@
 
 #include "Buffer.h"
 #include "Feature.h"
+#include "State.h"
 
 struct WetnessEffects : Feature
 {

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -275,9 +275,9 @@ namespace Hooks
 
 			auto manager = RE::BSGraphics::Renderer::GetSingleton();
 
-			auto context = manager->GetRuntimeData().context;
-			auto swapchain = manager->GetRuntimeData().renderWindows->swapChain;
-			auto device = manager->GetRuntimeData().forwarder;
+			auto context = reinterpret_cast<ID3D11DeviceContext*>(manager->GetRuntimeData().context);
+			auto swapchain = reinterpret_cast<IDXGISwapChain*>(manager->GetRuntimeData().renderWindows->swapChain);
+			auto device = reinterpret_cast<ID3D11Device*>(manager->GetRuntimeData().forwarder);
 
 			logger::info("Detouring virtual function tables");
 

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1144,21 +1144,21 @@ namespace SIE
 					ShaderClass::Vertex, type, descriptor);
 				if (bufferSizes[0] != 0) {
 					newShader->constantBuffers[0].buffer =
-						(RE::ID3D11Buffer*)perTechniqueBuffersArray.get()[bufferSizes[0]];
+						(REX::W32::ID3D11Buffer*)perTechniqueBuffersArray.get()[bufferSizes[0]];
 				} else {
 					newShader->constantBuffers[0].buffer = nullptr;
 					newShader->constantBuffers[0].data = bufferData.get();
 				}
 				if (bufferSizes[1] != 0) {
 					newShader->constantBuffers[1].buffer =
-						(RE::ID3D11Buffer*)perMaterialBuffersArray.get()[bufferSizes[1]];
+						(REX::W32::ID3D11Buffer*)perMaterialBuffersArray.get()[bufferSizes[1]];
 				} else {
 					newShader->constantBuffers[1].buffer = nullptr;
 					newShader->constantBuffers[1].data = bufferData.get();
 				}
 				if (bufferSizes[2] != 0) {
 					newShader->constantBuffers[2].buffer =
-						(RE::ID3D11Buffer*)perGeometryBuffersArray.get()[bufferSizes[2]];
+						(REX::W32::ID3D11Buffer*)perGeometryBuffersArray.get()[bufferSizes[2]];
 				} else {
 					newShader->constantBuffers[2].buffer = nullptr;
 					newShader->constantBuffers[2].data = bufferData.get();
@@ -1201,21 +1201,21 @@ namespace SIE
 					ShaderClass::Pixel, type, descriptor);
 				if (bufferSizes[0] != 0) {
 					newShader->constantBuffers[0].buffer =
-						(RE::ID3D11Buffer*)perTechniqueBuffersArray.get()[bufferSizes[0]];
+						(REX::W32::ID3D11Buffer*)perTechniqueBuffersArray.get()[bufferSizes[0]];
 				} else {
 					newShader->constantBuffers[0].buffer = nullptr;
 					newShader->constantBuffers[0].data = bufferData.get();
 				}
 				if (bufferSizes[1] != 0) {
 					newShader->constantBuffers[1].buffer =
-						(RE::ID3D11Buffer*)perMaterialBuffersArray.get()[bufferSizes[1]];
+						(REX::W32::ID3D11Buffer*)perMaterialBuffersArray.get()[bufferSizes[1]];
 				} else {
 					newShader->constantBuffers[1].buffer = nullptr;
 					newShader->constantBuffers[1].data = bufferData.get();
 				}
 				if (bufferSizes[2] != 0) {
 					newShader->constantBuffers[2].buffer =
-						(RE::ID3D11Buffer*)perGeometryBuffersArray.get()[bufferSizes[2]];
+						(REX::W32::ID3D11Buffer*)perGeometryBuffersArray.get()[bufferSizes[2]];
 				} else {
 					newShader->constantBuffers[2].buffer = nullptr;
 					newShader->constantBuffers[2].data = bufferData.get();
@@ -1601,7 +1601,7 @@ namespace SIE
 			std::lock_guard lockGuard(vertexShadersMutex);
 
 			const auto result = (*device)->CreateVertexShader(shaderBlob->GetBufferPointer(),
-				newShader->byteCodeSize, nullptr, &newShader->shader);
+				newShader->byteCodeSize, nullptr, reinterpret_cast<ID3D11VertexShader**>(&newShader->shader));
 			if (FAILED(result)) {
 				logger::error("Failed to create vertex shader {}::{}",
 					magic_enum::enum_name(shader.shaderType.get()), descriptor);
@@ -1629,7 +1629,7 @@ namespace SIE
 
 			std::lock_guard lockGuard(pixelShadersMutex);
 			const auto result = (*device)->CreatePixelShader(shaderBlob->GetBufferPointer(),
-				shaderBlob->GetBufferSize(), nullptr, &newShader->shader);
+				shaderBlob->GetBufferSize(), nullptr, reinterpret_cast<ID3D11PixelShader**>(&newShader->shader));
 			if (FAILED(result)) {
 				logger::error("Failed to create pixel shader {}::{}",
 					magic_enum::enum_name(shader.shaderType.get()),

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -21,7 +21,7 @@ void State::Draw()
 				ModifyShaderLookup(*currentShader, currentVertexDescriptor, currentPixelDescriptor);
 				UpdateSharedData(currentShader, currentPixelDescriptor);
 
-				auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+				auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 				static RE::BSGraphics::VertexShader* vertexShader = nullptr;
 				static RE::BSGraphics::PixelShader* pixelShader = nullptr;
@@ -30,8 +30,8 @@ void State::Draw()
 				pixelShader = shaderCache.GetPixelShader(*currentShader, currentPixelDescriptor);
 
 				if (vertexShader && pixelShader) {
-					context->VSSetShader(vertexShader->shader, NULL, NULL);
-					context->PSSetShader(pixelShader->shader, NULL, NULL);
+					context->VSSetShader(reinterpret_cast<ID3D11VertexShader*>(vertexShader->shader), NULL, NULL);
+					context->PSSetShader(reinterpret_cast<ID3D11PixelShader*>(pixelShader->shader), NULL, NULL);
 				}
 
 				if (vertexShader && pixelShader) {
@@ -50,7 +50,7 @@ void State::Draw()
 void State::DrawDeferred()
 {
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto context = renderer->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
 
 	ID3D11ShaderResourceView* srvs[8];
 	context->PSGetShaderResources(0, 8, srvs);
@@ -106,7 +106,7 @@ void State::DrawDeferred()
 void State::DrawPreProcess()
 {
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto context = renderer->GetRuntimeData().context;
+	auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
 
 	ID3D11ShaderResourceView* srvs[8];
 	context->PSGetShaderResources(0, 8, srvs);
@@ -427,7 +427,7 @@ void State::SetupResources()
 void State::ModifyShaderLookup(const RE::BSShader& a_shader, uint& a_vertexDescriptor, uint& a_pixelDescriptor)
 {
 	if (a_shader.shaderType.get() == RE::BSShader::Type::Lighting || a_shader.shaderType.get() == RE::BSShader::Type::Water || a_shader.shaderType.get() == RE::BSShader::Type::Effect) {
-		auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+		auto context = reinterpret_cast<ID3D11DeviceContext*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context);
 
 		if (a_vertexDescriptor != lastVertexDescriptor || a_pixelDescriptor != lastPixelDescriptor) {
 			PerShader data{};
@@ -568,7 +568,7 @@ void State::UpdateSharedData(const RE::BSShader* a_shader, const uint32_t)
 
 		lightingData.Timer = timer;
 
-		auto context = renderer->GetRuntimeData().context;
+		auto context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
 
 		if (updateBuffer) {
 			D3D11_MAPPED_SUBRESOURCE mapped;

--- a/src/State.h
+++ b/src/State.h
@@ -111,6 +111,11 @@ public:
 
 	std::unique_ptr<Buffer> lightingDataBuffer = nullptr;
 
+	// Skyrim constants
+	bool isVR = false;
 	float screenWidth = 0;
 	float screenHeight = 0;
+	ID3D11DeviceContext* context = nullptr;
+	ID3D11Device* device = nullptr;
+	RE::BSGraphics::RendererShadowState* shadowState = nullptr;
 };

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -111,7 +111,7 @@ namespace Util
 
 	ID3D11DeviceChild* CompileShader(const wchar_t* FilePath, const std::vector<std::pair<const char*, const char*>>& Defines, const char* ProgramType, const char* Program)
 	{
-		auto device = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder;
+		auto device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
 
 		// Build defines (aka convert vector->D3DCONSTANT array)
 		std::vector<D3D_SHADER_MACRO> macros;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -111,7 +111,7 @@ namespace Util
 
 	ID3D11DeviceChild* CompileShader(const wchar_t* FilePath, const std::vector<std::pair<const char*, const char*>>& Defines, const char* ProgramType, const char* Program)
 	{
-		auto device = reinterpret_cast<ID3D11Device*>(RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().forwarder);
+		auto& device = State::GetSingleton()->device;
 
 		// Build defines (aka convert vector->D3DCONSTANT array)
 		std::vector<D3D_SHADER_MACRO> macros;
@@ -235,7 +235,7 @@ namespace Util
 
 	float TryGetWaterHeight(float offsetX, float offsetY)
 	{
-		if (auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton()) {
+		if (auto& shadowState = State::GetSingleton()->shadowState) {
 			if (auto tes = RE::TES::GetSingleton()) {
 				auto position = !REL::Module::IsVR() ? shadowState->GetRuntimeData().posAdjust.getEye() : shadowState->GetVRRuntimeData().posAdjust.getEye();
 				position.x += offsetX;


### PR DESCRIPTION
Due to an upstream breaking change, any access to winapi namespace is now under the REX::D3D namespace. This means that accessing various D3D objects will need a cast.

closes #237