### PR TITLE
feat: add perfevent and marker flags

### DIFF
--- a/src/Features/SubsurfaceScattering.cpp
+++ b/src/Features/SubsurfaceScattering.cpp
@@ -160,6 +160,8 @@ void SubsurfaceScattering::DrawSSSWrapper(bool)
 	if (!SIE::ShaderCache::Instance().IsEnabled())
 		return;
 
+	State::GetSingleton()->BeginPerfEvent(std::format("DrawSSS: {}", GetShortName()));
+
 	auto& context = State::GetSingleton()->context;
 
 	ID3D11ShaderResourceView* srvs[8];
@@ -209,6 +211,7 @@ void SubsurfaceScattering::DrawSSSWrapper(bool)
 		dsv->Release();
 
 	validMaterial = false;
+	State::GetSingleton()->EndPerfEvent();
 }
 
 void SubsurfaceScattering::DrawSSS()

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1646,6 +1646,14 @@ namespace SIE
 		return nullptr;
 	}
 
+	std::string ShaderCache::GetDefinesString(RE::BSShader::Type enumType, uint32_t descriptor)
+	{
+		std::array<D3D_SHADER_MACRO, 64> defines{};
+		SIE::SShaderCache::GetShaderDefines(enumType, descriptor, &defines[0]);
+
+		return SIE::SShaderCache::MergeDefinesString(defines, true);
+	}
+
 	uint64_t ShaderCache::GetCachedHitTasks()
 	{
 		return compilationSet.cacheHitTasks;

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -173,6 +173,8 @@ namespace SIE
 		RE::BSGraphics::PixelShader* MakeAndAddPixelShader(const RE::BSShader& shader,
 			uint32_t descriptor);
 
+		static std::string GetDefinesString(RE::BSShader::Type enumType, uint32_t descriptor);
+
 		uint64_t GetCachedHitTasks();
 		uint64_t GetCompletedTasks();
 		uint64_t GetFailedTasks();

--- a/src/State.h
+++ b/src/State.h
@@ -83,6 +83,10 @@ public:
 	void SetupResources();
 	void ModifyShaderLookup(const RE::BSShader& a_shader, uint& a_vertexDescriptor, uint& a_pixelDescriptor);
 
+	void BeginPerfEvent(std::string_view title);
+	void EndPerfEvent();
+	void SetPerfMarker(std::string_view title);
+
 	struct PerShader
 	{
 		uint VertexShaderDescriptor;
@@ -118,4 +122,7 @@ public:
 	ID3D11DeviceContext* context = nullptr;
 	ID3D11Device* device = nullptr;
 	RE::BSGraphics::RendererShadowState* shadowState = nullptr;
+
+private:
+	std::shared_ptr<REX::W32::ID3DUserDefinedAnnotation> pPerf;
 };


### PR DESCRIPTION
Adds event around feature drawing (and explicitly added support for SSS)

Only adds the marker in development mode. Due to getting define will take a bit.

Also added marker for showing the DEFINES under the first event level

Examples in NSight.
![image](https://github.com/doodlum/skyrim-community-shaders/assets/964655/f366b4c9-afb1-4ba0-a722-85896b48884e)
![Screenshot 2024-04-01 193050](https://github.com/doodlum/skyrim-community-shaders/assets/964655/df6f8ee2-87c8-4ccb-936b-9ed597bfd99f)


