### PR TITLE
refactor(WetnessEffects): flatten logic for clarity and maintainability

### DIFF
--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -268,7 +268,7 @@ void WetnessEffects::CalculateWetness(RE::TESWeather* weather, RE::Sky* sky, flo
 
 void WetnessEffects::Draw(const RE::BSShader* shader, const uint32_t)
 {
-	if (!shader->shaderType.any(RE::BSShader::Type::Lighting, RE::BSShader::Type::Grass)) 
+	if (!shader->shaderType.any(RE::BSShader::Type::Lighting, RE::BSShader::Type::Grass))
 		return;
 
 	auto& context = State::GetSingleton()->context;


### PR DESCRIPTION
Flatten deeply nested if-statements in the Draw function. This refactor does not introduce any new functionality or performance improvements. Makes code more redable.

Details:
I disliked the deeply nested code which made it hard to read, so I have de-nested it somewhat. I did not make any new functions to de-nest it even further, as I do not know if that would be too much of a change. I can separate the logic into sub-functions to de-nest this even further.

Edit: I have a 1080 card, and there is a problem with the 1000 series and below, so I have not tested the code to see if it messes anything up. It really shouldn't as I have have just de-nested the logic here.