### PR TITLE
chore: show which feature is selected in the CS menu

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -437,7 +437,7 @@ void Menu::DrawSettings()
 
 			ImGui::TableNextColumn();
 			if (ImGui::BeginListBox("##FeatureList", { -FLT_MIN, -FLT_MIN })) {
-				ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0.15f, 0.15f, 0.15f, 1.0f)); // Selected feature header color
+				ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));  // Selected feature header color
 				for (size_t i = 0; i < sortedList.size(); i++)
 					if (sortedList[i]->loaded) {
 						if (ImGui::Selectable(fmt::format(" {} ", sortedList[i]->GetName()).c_str(), selectedFeature == i, ImGuiSelectableFlags_SpanAllColumns))

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -437,18 +437,20 @@ void Menu::DrawSettings()
 
 			ImGui::TableNextColumn();
 			if (ImGui::BeginListBox("##FeatureList", { -FLT_MIN, -FLT_MIN })) {
+				ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0.15f, 0.15f, 0.15f, 1.0f)); // Selected feature header color
 				for (size_t i = 0; i < sortedList.size(); i++)
 					if (sortedList[i]->loaded) {
-						if (ImGui::Selectable(fmt::format("{} ", sortedList[i]->GetName()).c_str(), selectedFeature == i, ImGuiSelectableFlags_SpanAllColumns))
+						if (ImGui::Selectable(fmt::format(" {} ", sortedList[i]->GetName()).c_str(), selectedFeature == i, ImGuiSelectableFlags_SpanAllColumns))
 							selectedFeature = i;
 						ImGui::SameLine();
 						ImGui::TextDisabled(fmt::format("({})", sortedList[i]->version).c_str());
 					} else if (!sortedList[i]->version.empty()) {
-						ImGui::TextDisabled(fmt::format("{} ({})", sortedList[i]->GetName(), sortedList[i]->version).c_str());
+						ImGui::TextDisabled(fmt::format(" {} ({})", sortedList[i]->GetName(), sortedList[i]->version).c_str());
 						if (auto _tt = Util::HoverTooltipWrapper()) {
 							ImGui::Text(sortedList[i]->failedLoadedMessage.c_str());
 						}
 					}
+				ImGui::PopStyleColor();
 				ImGui::EndListBox();
 			}
 


### PR DESCRIPTION
- When a feature is selected in the CS menu features list it will now show the same color as ImGuiCol_HeaderActive.
- Note: The way that ImGui works is that the `ImGuiCol_Header` style is only applied to a Selectable when it is selected.
- Confirmed it works in both in normal and Debug mode.