### PR TITLE
fix: fix VR Water Caustics edge cases

### DIFF
--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -482,7 +482,7 @@ float3 GetWaterNormal(PS_INPUT input, float distanceFactor, float normalsDepthFa
 #			else
 	float3 flowmapNormal0 = GetFlowmapNormal(input, uvShift.xx, 9.92, 0, a_eyeIndex);
 	float3 flowmapNormal1 = GetFlowmapNormal(input, float2(0, uvShift), 10.64, 0.27, a_eyeIndex);
-	float3 flowmapNormal2 = GetFlowmapNormal(input, 0.0.xx, 8, 0);
+	float3 flowmapNormal2 = GetFlowmapNormal(input, 0.0.xx, 8, 0, a_eyeIndex);
 	float3 flowmapNormal3 = GetFlowmapNormal(input, float2(uvShift, 0), 8.48, 0.62, a_eyeIndex);
 #			endif
 
@@ -540,7 +540,7 @@ float3 GetWaterNormal(PS_INPUT input, float distanceFactor, float normalsDepthFa
 		normalMul.y * ((1 - normalMul.x) * flowmapNormal3.z + normalMul.x * flowmapNormal2.z) +
 		(1 - normalMul.y) * (normalMul.x * flowmapNormal1.z + (1 - normalMul.x) * flowmapNormal0.z);
 	finalNormal = normalize(lerp(normals1 + float3(0, 0, 1), normalize(lerp(finalNormal, flowmapNormal, normalBlendFactor)), distanceFactor));
-#				if defined(WATER_CAUSTICS)
+#				if defined(WATER_CAUSTICS) && !defined(VR)
 	caustics = lerp(blendedCaustics, flowmapCausticsWeighted, normalBlendFactor);
 #				endif
 #			endif


### PR DESCRIPTION
Fixed a few shader compilation errors in some edge cases:
- When using Flow Maps, avoid BlendedCaustics from being used since it is currently undefined in VR
- When WATER_CAUSTICS is undefined / not installed, added eyeIndex to GetFlowmapNormal for flowmapNormal2 