### PR TITLE
fix: use GET_INSTANCE_MEMBER macro to get proper state runtime

### DIFF
--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -92,7 +92,9 @@ void CloudShadows::ModifySky(const RE::BSShader*, const uint32_t descriptor)
 		return;
 
 	auto& shadowState = State::GetSingleton()->shadowState;
-	auto cubeMapRenderTarget = !REL::Module::IsVR() ? shadowState->GetRuntimeData().cubeMapRenderTarget : shadowState->GetVRRuntimeData().cubeMapRenderTarget;
+
+	GET_INSTANCE_MEMBER(cubeMapRenderTarget, shadowState);
+
 	if (cubeMapRenderTarget != RE::RENDER_TARGETS_CUBEMAP::kREFLECTIONS)
 		return;
 
@@ -177,7 +179,8 @@ void CloudShadows::DrawShadows()
 		return;
 
 	auto& shadowState = State::GetSingleton()->shadowState;
-	auto cubeMapRenderTarget = !REL::Module::IsVR() ? shadowState->GetRuntimeData().cubeMapRenderTarget : shadowState->GetVRRuntimeData().cubeMapRenderTarget;
+
+	GET_INSTANCE_MEMBER(cubeMapRenderTarget, shadowState);
 
 	if (cubeMapRenderTarget != RE::RENDER_TARGETS_CUBEMAP::kREFLECTIONS) {
 		static Util::FrameChecker frame_checker;

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -397,7 +397,9 @@ void DynamicCubemaps::Draw(const RE::BSShader* shader, const uint32_t)
 	if (shader->shaderType.get() == RE::BSShader::Type::Lighting || shader->shaderType.get() == RE::BSShader::Type::Water) {
 		// During world cubemap generation we cannot use the cubemap
 		auto& shadowState = State::GetSingleton()->shadowState;
-		auto cubeMapRenderTarget = !REL::Module::IsVR() ? shadowState->GetRuntimeData().cubeMapRenderTarget : shadowState->GetVRRuntimeData().cubeMapRenderTarget;
+
+		GET_INSTANCE_MEMBER(cubeMapRenderTarget, shadowState);
+
 		if (cubeMapRenderTarget != RE::RENDER_TARGETS_CUBEMAP::kREFLECTIONS && !renderedScreenCamera) {
 			UpdateCubemap();
 			renderedScreenCamera = true;

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -97,7 +97,12 @@ void ScreenSpaceShadows::DrawShadows()
 	float3 light = { directionNi.x, directionNi.y, directionNi.z };
 	light.Normalize();
 	float4 lightProjection = float4(-light.x, -light.y, -light.z, 0.0f);
-	lightProjection = DirectX::SimpleMath::Vector4::Transform(lightProjection, shadowState->GetRuntimeData().cameraData.getEye().viewProjMat);
+
+	Matrix viewProjMat = !REL::Module::IsVR() ?
+	                         shadowState->GetRuntimeData().cameraData.getEye().viewProjMat :
+	                         shadowState->GetVRRuntimeData().cameraData.getEye().viewProjMat;
+
+	lightProjection = DirectX::SimpleMath::Vector4::Transform(lightProjection, viewProjMat);
 	float lightProjectionF[4] = { lightProjection.x, lightProjection.y, lightProjection.z, lightProjection.w };
 
 	int viewportSize[2] = { (int)state->screenWidth, (int)state->screenHeight };

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -590,9 +590,9 @@ void State::UpdateSharedData(const RE::BSShader* a_shader, const uint32_t)
 	if (a_shader->shaderType.get() == RE::BSShader::Type::Lighting) {
 		bool updateBuffer = false;
 
-		bool currentReflections = (!REL::Module::IsVR() ?
-										  shadowState->GetRuntimeData().cubeMapRenderTarget :
-										  shadowState->GetVRRuntimeData().cubeMapRenderTarget) == RE::RENDER_TARGETS_CUBEMAP::kREFLECTIONS;
+		GET_INSTANCE_MEMBER(cubeMapRenderTarget, shadowState);
+
+		bool currentReflections = cubeMapRenderTarget == RE::RENDER_TARGETS_CUBEMAP::kREFLECTIONS;
 
 		if (lightingData.Reflections != (uint)currentReflections) {
 			updateBuffer = true;

--- a/src/VariableRateShading.cpp
+++ b/src/VariableRateShading.cpp
@@ -278,9 +278,12 @@ void VariableRateShading::UpdateViews(bool a_enable)
 
 	auto state = RE::BSGraphics::RendererShadowState::GetSingleton();
 
-	vrsPass = screenTargets.contains(state->GetRuntimeData().renderTargets[0]);
+	GET_INSTANCE_MEMBER(renderTargets, state);
+	GET_INSTANCE_MEMBER(depthStencil, state);
 
-	if (state->GetRuntimeData().depthStencil == RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN || state->GetRuntimeData().depthStencil == RE::RENDER_TARGETS_DEPTHSTENCIL::kPOST_ZPREPASS_COPY) {
+	vrsPass = screenTargets.contains(renderTargets[0]);
+
+	if (depthStencil == RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN || depthStencil == RE::RENDER_TARGETS_DEPTHSTENCIL::kPOST_ZPREPASS_COPY) {
 		vrsPass = true;
 	}
 


### PR DESCRIPTION
VR is still not working properly, but at least accessing the correct state runtime now