### PR TITLE
ci: run clang-format on all pushes

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -2,9 +2,6 @@ name: Run clang-format Linter
 
 on:
   push:
-    branches:
-      - main
-      - dev
   pull_request_target:
     branches:
       - main


### PR DESCRIPTION
To address when doodles doesn't clang-format locally and pushes a new branch.