### PR TITLE
fix: fix VR in skylighting-sh branch

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1825,7 +1825,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 	// This also applies fresnel
 	float3 wetnessReflectance = GetWetnessAmbientSpecular(screenUV, wetnessNormal, worldSpaceVertexNormal, worldSpaceViewDirection, 1.0 - wetnessGlossinessSpecular);
-	;
 
 #		if !defined(DEFERRED)
 	wetnessSpecular += wetnessReflectance;

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -1,7 +1,6 @@
 #include "Skylighting.h"
 #include <DDSTextureLoader.h>
 #include <Deferred.h>
-#include <Util.h>
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	Skylighting::Settings,

--- a/src/Features/Skylighting.h
+++ b/src/Features/Skylighting.h
@@ -3,6 +3,7 @@
 #include "Buffer.h"
 #include "Feature.h"
 #include "State.h"
+#include "Util.h"
 
 struct Skylighting : Feature
 {
@@ -389,8 +390,7 @@ public:
 				} else {
 					doPrecip = true;
 
-					auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
-					GetSingleton()->eyePosition = shadowState->GetRuntimeData().posAdjust.getEye();
+					GetSingleton()->eyePosition = Util::GetEyePosition(0);
 
 					auto renderer = RE::BSGraphics::Renderer::GetSingleton();
 					auto& precipitation = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kPRECIPITATION_OCCLUSION_MAP];

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -493,6 +493,6 @@ namespace Hooks
 		if (!REL::Module::IsVR())
 			stl::write_thunk_call<CreateRenderTarget_Snow>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0x406, 0x409));
 		stl::write_thunk_call<CreateDepthStencil_PrecipitationMask>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0x1245, 0x554, 0x1917));
-		stl::write_thunk_call<CreateCubemapRenderTarget_Reflections>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0xA25, 0x554, 0x6b9));
+		stl::write_thunk_call<CreateCubemapRenderTarget_Reflections>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0xA25, 0x554, 0xCD2));
 	}
 }


### PR DESCRIPTION
fix runtime crashes for VR

Wetness doesn't work if I don't revert this change https://github.com/doodlum/skyrim-community-shaders/blob/skylighting-sh/package/Shaders/Lighting.hlsl#L1504-L1510
Not sure if still issue in flatrim or not