### PR TITLE
feat: Use parallax in landscape texture blending

### DIFF
--- a/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
+++ b/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
@@ -33,8 +33,8 @@ float GetMipLevel(float2 coords, Texture2D<float4> tex)
 }
 
 #if defined(LANDSCAPE)
-#define HEIGHT_POWER 4.0
-#define INV_HEIGHT_POWER 0.25
+#	define HEIGHT_POWER 4.0
+#	define INV_HEIGHT_POWER 0.25
 
 float GetTerrainHeight(PS_INPUT input, float2 coords, float mipLevels[6], float blendFactor, out float pixelOffset[6])
 {
@@ -60,16 +60,19 @@ float GetTerrainHeight(PS_INPUT input, float2 coords, float mipLevels[6], float 
 		pixelOffset[4] = 0;
 	if (input.LandBlendWeights2.y > 0.0)
 		pixelOffset[5] = pow(input.LandBlendWeights2.y, 1 + 1 * blendFactor) * (pow(TexLandColor6Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[5]).w, blendFactor * HEIGHT_POWER));
-	else pixelOffset[5] = 0;
+	else
+		pixelOffset[5] = 0;
 	float total = 0;
-	[unroll] for (int i = 0; i < 6; i++) {
+	[unroll] for (int i = 0; i < 6; i++)
+	{
 		total += pixelOffset[i];
 	}
 	float invtotal = rcp(total);
-	[unroll] for (int i = 0; i < 6; i++) {
+	[unroll] for (int i = 0; i < 6; i++)
+	{
 		pixelOffset[i] *= invtotal;
 	}
-	return pow(total, INV_HEIGHT_POWER*rcp(blendFactor));
+	return pow(total, INV_HEIGHT_POWER * rcp(blendFactor));
 }
 #endif
 
@@ -84,7 +87,7 @@ float2 GetParallaxCoords(float distance, float2 coords, float mipLevel, float3 v
 
 	float nearBlendToFar = saturate(distance / 2048.0);
 #if defined(LANDSCAPE)
-	// When CPM flag is disabled, will use linear blending as before. 
+	// When CPM flag is disabled, will use linear blending as before.
 	float blendFactor = extendedMaterialSettings.EnableComplexMaterial ? saturate(1 - nearBlendToFar) : INV_HEIGHT_POWER;
 #endif
 

--- a/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
+++ b/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
@@ -33,8 +33,8 @@ float GetMipLevel(float2 coords, Texture2D<float4> tex)
 }
 
 #if defined(LANDSCAPE)
-#define HEIGHT_POWER 4.0
-#define INV_HEIGHT_POWER 0.25
+#	define HEIGHT_POWER 4.0
+#	define INV_HEIGHT_POWER 0.25
 
 float GetTerrainHeight(PS_INPUT input, float2 coords, float mipLevels[6], float blendFactor, out float pixelOffset[6])
 {
@@ -42,7 +42,7 @@ float GetTerrainHeight(PS_INPUT input, float2 coords, float mipLevels[6], float 
 	float2 w2 = pow(input.LandBlendWeights2.xy, 1 + 1 * blendFactor);
 	float blendPower = blendFactor * HEIGHT_POWER;
 	// important to zero initialize, otherwise invalid/old values will be used here and as weights in Lighting.hlsl
-	pixelOffset[0] = 0; // can't init whole 'out' array by = {...}
+	pixelOffset[0] = 0;  // can't init whole 'out' array by = {...}
 	pixelOffset[1] = 0;
 	pixelOffset[2] = 0;
 	pixelOffset[3] = 0;
@@ -61,14 +61,16 @@ float GetTerrainHeight(PS_INPUT input, float2 coords, float mipLevels[6], float 
 	if (w2.y > 0.0)
 		pixelOffset[5] = w2.y * pow(TexLandColor6Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[5]).w, blendPower);
 	float total = 0;
-	[unroll] for (int i = 0; i < 6; i++) {
+	[unroll] for (int i = 0; i < 6; i++)
+	{
 		total += pixelOffset[i];
 	}
 	float invtotal = rcp(total);
-	[unroll] for (int i = 0; i < 6; i++) {
+	[unroll] for (int i = 0; i < 6; i++)
+	{
 		pixelOffset[i] *= invtotal;
 	}
-	return pow(total, INV_HEIGHT_POWER*rcp(blendFactor));
+	return pow(total, INV_HEIGHT_POWER * rcp(blendFactor));
 }
 #endif
 
@@ -83,7 +85,7 @@ float2 GetParallaxCoords(float distance, float2 coords, float mipLevel, float3 v
 
 	float nearBlendToFar = saturate(distance / 2048.0);
 #if defined(LANDSCAPE)
-	// When CPM flag is disabled, will use linear blending as before. 
+	// When CPM flag is disabled, will use linear blending as before.
 	float blendFactor = extendedMaterialSettings.EnableComplexMaterial ? saturate(1 - nearBlendToFar) : INV_HEIGHT_POWER;
 #endif
 

--- a/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
+++ b/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
@@ -58,13 +58,14 @@ float GetTerrainHeight(PS_INPUT input, float2 coords, float mipLevels[6], float 
 		pixelOffset[4] = 0;
 	if (input.LandBlendWeights2.y > 0.0)
 		pixelOffset[5] = TexLandColor6Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[5]).w;
-	else pixelOffset[5] = 0;
-	if(!extendedMaterialSettings.EnableComplexMaterial)
+	else
+		pixelOffset[5] = 0;
+	if (!extendedMaterialSettings.EnableComplexMaterial)
 		return (pixelOffset[0] * input.LandBlendWeights1.x + pixelOffset[1] * input.LandBlendWeights1.y + pixelOffset[2] * input.LandBlendWeights1.z + pixelOffset[3] * input.LandBlendWeights1.w + pixelOffset[4] * input.LandBlendWeights2.x + pixelOffset[5] * input.LandBlendWeights2.y);
 	float weights[6] = { input.LandBlendWeights1.x, input.LandBlendWeights1.y, input.LandBlendWeights1.z, input.LandBlendWeights1.w, input.LandBlendWeights2.x, input.LandBlendWeights2.y };
 	float total = 0;
 	for (int i = 0; i < 6; i++) {
-		pixelOffset[i] = pow(weights[i], 1+1 * blendFactor) * (pow(pixelOffset[i], blendFactor * 4));
+		pixelOffset[i] = pow(weights[i], 1 + 1 * blendFactor) * (pow(pixelOffset[i], blendFactor * 4));
 		total += pixelOffset[i];
 	}
 	for (int i = 0; i < 6; i++) {

--- a/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
+++ b/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
@@ -38,22 +38,28 @@ float GetTerrainHeight(PS_INPUT input, float2 coords, float mipLevels[6], out fl
 {
 	if (input.LandBlendWeights1.x > 0.0)
 		pixelOffset[0] = TexColorSampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[0]).w;
-	else pixelOffset[0] = 0;
+	else
+		pixelOffset[0] = 0;
 	if (input.LandBlendWeights1.y > 0.0)
 		pixelOffset[1] = TexLandColor2Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[1]).w;
-	else pixelOffset[1] = 0;
+	else
+		pixelOffset[1] = 0;
 	if (input.LandBlendWeights1.z > 0.0)
 		pixelOffset[2] = TexLandColor3Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[2]).w;
-	else pixelOffset[2] = 0;
+	else
+		pixelOffset[2] = 0;
 	if (input.LandBlendWeights1.w > 0.0)
 		pixelOffset[3] = TexLandColor4Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[3]).w;
-	else pixelOffset[3] = 0;
+	else
+		pixelOffset[3] = 0;
 	if (input.LandBlendWeights2.x > 0.0)
 		pixelOffset[4] = TexLandColor5Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[4]).w;
-	else pixelOffset[4] = 0;
+	else
+		pixelOffset[4] = 0;
 	if (input.LandBlendWeights2.y > 0.0)
 		pixelOffset[5] = TexLandColor6Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[5]).w;
-	else pixelOffset[5] = 0;
+	else
+		pixelOffset[5] = 0;
 	//float weights[6] = { input.LandBlendWeights1.x, input.LandBlendWeights1.y, input.LandBlendWeights1.z, input.LandBlendWeights1.w, input.LandBlendWeights2.x, input.LandBlendWeights2.y };
 	//float maxWeight = max(weights[0], max(weights[1], max(weights[2], max(weights[3], max(weights[4], weights[5])))));
 	//float maxOffset = max(pixelOffset[0], max(pixelOffset[1], max(pixelOffset[2], max(pixelOffset[3], max(pixelOffset[4], pixelOffset[5])))));
@@ -67,7 +73,7 @@ float GetTerrainHeight(PS_INPUT input, float2 coords, float mipLevels[6], out fl
 	//float height = (weights[0]+weights[1]+weights[2]+weights[3]+weights[4]+weights[5])/total;
 	//return height;
 	return max(max(pixelOffset[0], max(pixelOffset[1], max(pixelOffset[2], max(pixelOffset[3], max(pixelOffset[4], pixelOffset[5]))))), (pixelOffset[0] * input.LandBlendWeights1.x + pixelOffset[1] * input.LandBlendWeights1.y + pixelOffset[2] * input.LandBlendWeights1.z + pixelOffset[3] * input.LandBlendWeights1.w + pixelOffset[4] * input.LandBlendWeights2.x + pixelOffset[5] * input.LandBlendWeights2.y));
-	return  max(pixelOffset[0] * input.LandBlendWeights1.x, max(pixelOffset[1] * input.LandBlendWeights1.y, max(pixelOffset[2] * input.LandBlendWeights1.z, max(pixelOffset[3] * input.LandBlendWeights1.w, max(pixelOffset[4] * input.LandBlendWeights2.x,pixelOffset[5] * input.LandBlendWeights2.y)))));
+	return max(pixelOffset[0] * input.LandBlendWeights1.x, max(pixelOffset[1] * input.LandBlendWeights1.y, max(pixelOffset[2] * input.LandBlendWeights1.z, max(pixelOffset[3] * input.LandBlendWeights1.w, max(pixelOffset[4] * input.LandBlendWeights2.x, pixelOffset[5] * input.LandBlendWeights2.y)))));
 	return (pixelOffset[0] * input.LandBlendWeights1.x + pixelOffset[1] * input.LandBlendWeights1.y + pixelOffset[2] * input.LandBlendWeights1.z + pixelOffset[3] * input.LandBlendWeights1.w + pixelOffset[4] * input.LandBlendWeights2.x + pixelOffset[5] * input.LandBlendWeights2.y);
 }
 #endif
@@ -167,7 +173,6 @@ float2 GetParallaxCoords(float distance, float2 coords, float mipLevel, float3 v
 		{
 			parallaxAmount = (pt1.x * delta2 - pt2.x * delta1) / denominator;
 		}
-
 
 #if defined(LANDSCAPE)
 		float weights[6] = { input.LandBlendWeights1.x, input.LandBlendWeights1.y, input.LandBlendWeights1.z, input.LandBlendWeights1.w, input.LandBlendWeights2.x, input.LandBlendWeights2.y };

--- a/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
+++ b/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
@@ -34,21 +34,28 @@ float GetMipLevel(float2 coords, Texture2D<float4> tex)
 
 #if defined(LANDSCAPE)
 
-float GetTerrainHeight(PS_INPUT input, float2 coords, float mipLevels[6])
+float GetTerrainHeight(PS_INPUT input, float2 coords, float mipLevels[6], inout float pixelOffset[6])
 {
-	float height = 0.0;
+	// weights[i] = pow(weights[i] / maxWeight, 1 + 2 * blendFactor) * (pow(pixelOffset[i] + 1 - maxOffset, 1 + blendFactor * 100) + 0.1); 
 	if (input.LandBlendWeights1.x > 0.0)
-		height = TexColorSampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[0]).w * input.LandBlendWeights1.x;
+		pixelOffset[0] = TexColorSampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[0]).w;
+	else pixelOffset[0] = 0;
 	if (input.LandBlendWeights1.y > 0.0)
-		height += TexLandColor2Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[1]).w * input.LandBlendWeights1.y;
+		pixelOffset[1] = TexLandColor2Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[1]).w;
+	else pixelOffset[1] = 0;
 	if (input.LandBlendWeights1.z > 0.0)
-		height += TexLandColor3Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[2]).w * input.LandBlendWeights1.z;
+		pixelOffset[2] = TexLandColor3Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[2]).w;
+	else pixelOffset[2] = 0;
 	if (input.LandBlendWeights1.w > 0.0)
-		height += TexLandColor4Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[3]).w * input.LandBlendWeights1.w;
+		pixelOffset[3] = TexLandColor4Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[3]).w;
+	else pixelOffset[3] = 0;
 	if (input.LandBlendWeights2.x > 0.0)
-		height += TexLandColor5Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[4]).w * input.LandBlendWeights2.x;
+		pixelOffset[4] = TexLandColor5Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[4]).w;
+	else pixelOffset[4] = 0;
 	if (input.LandBlendWeights2.y > 0.0)
-		height += TexLandColor6Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[5]).w * input.LandBlendWeights2.y;
+		pixelOffset[5] = TexLandColor6Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[5]).w;
+	else pixelOffset[5] = 0;
+	float height = (pixelOffset[0]*input.LandBlendWeights1.x+pixelOffset[1]*input.LandBlendWeights1.y+pixelOffset[2]*input.LandBlendWeights1.z+pixelOffset[3]*input.LandBlendWeights1.w+pixelOffset[4]*input.LandBlendWeights2.x + pixelOffset[5]*input.LandBlendWeights2.y);
 	return height;
 }
 #endif
@@ -82,6 +89,10 @@ float2 GetParallaxCoords(float distance, float2 coords, float mipLevel, float3 v
 		float2 pt1 = 0;
 		float2 pt2 = 0;
 
+#if defined(LANDSCAPE)
+		float heights[6] = { 0, 0, 0, 0, 0, 0 };
+#endif
+
 		[loop] while (numSteps > 0)
 		{
 			float4 currentOffset[2];
@@ -91,10 +102,10 @@ float2 GetParallaxCoords(float distance, float2 coords, float mipLevel, float3 v
 
 #if defined(LANDSCAPE)
 			float4 currHeight;
-			currHeight.x = GetTerrainHeight(input, currentOffset[0].xy, mipLevels);
-			currHeight.y = GetTerrainHeight(input, currentOffset[0].zw, mipLevels);
-			currHeight.z = GetTerrainHeight(input, currentOffset[1].xy, mipLevels);
-			currHeight.w = GetTerrainHeight(input, currentOffset[1].zw, mipLevels);
+			currHeight.x = GetTerrainHeight(input, currentOffset[0].xy, mipLevels, heights);
+			currHeight.y = GetTerrainHeight(input, currentOffset[0].zw, mipLevels, heights);
+			currHeight.z = GetTerrainHeight(input, currentOffset[1].xy, mipLevels, heights);
+			currHeight.w = GetTerrainHeight(input, currentOffset[1].zw, mipLevels, heights);
 #else
 			float4 currHeight;
 			currHeight.x = tex.SampleLevel(texSampler, currentOffset[0].xy, mipLevel)[channel];
@@ -151,6 +162,24 @@ float2 GetParallaxCoords(float distance, float2 coords, float mipLevel, float3 v
 
 		nearBlendToFar *= nearBlendToFar;
 
+#if defined(LANDSCAPE)
+		float weights[6] = { input.LandBlendWeights1.x, input.LandBlendWeights1.y, input.LandBlendWeights1.z, input.LandBlendWeights1.w, input.LandBlendWeights2.x, input.LandBlendWeights2.y };
+		float maxOffset = max(heights[0], max(heights[1], max(heights[2], max(heights[3], max(heights[4], heights[5])))));
+		float maxWeight = max(weights[0], max(weights[1], max(weights[2], max(weights[3], max(weights[4], weights[5])))));
+		float blendFactor = saturate(1 - nearBlendToFar);
+		float total = 0;
+		for (int i = 0; i < 6; i++) {
+			weights[i] = pow(weights[i] / maxWeight, 1 + 2 * blendFactor) * (pow(heights[i] + 1 - maxOffset, blendFactor * 100) + 0.1);
+			total += weights[i];
+		}
+		input.LandBlendWeights1.x = weights[0] / total;
+		input.LandBlendWeights1.y = weights[1] / total;
+		input.LandBlendWeights1.z = weights[2] / total;
+		input.LandBlendWeights1.w = weights[3] / total;
+		input.LandBlendWeights2.x = weights[4] / total;
+		input.LandBlendWeights2.y = weights[5] / total;
+#endif
+
 		float offset = (1.0 - parallaxAmount) * -maxHeight + minHeight;
 		pixelOffset = lerp(parallaxAmount, 0.5, nearBlendToFar);
 		return lerp(viewDirTS.xy * offset + coords.xy, coords, nearBlendToFar);
@@ -186,10 +215,11 @@ float GetParallaxSoftShadowMultiplierTerrain(PS_INPUT input, float2 coords, floa
 		float2 rayDir = L.xy * 0.1;
 		float4 multipliers = rcp((float4(4, 3, 2, 1) + noise));
 		float4 sh;
-		sh.x = GetTerrainHeight(input, coords + rayDir * multipliers.x, mipLevel);
-		sh.y = GetTerrainHeight(input, coords + rayDir * multipliers.y, mipLevel);
-		sh.z = GetTerrainHeight(input, coords + rayDir * multipliers.z, mipLevel);
-		sh.w = GetTerrainHeight(input, coords + rayDir * multipliers.w, mipLevel);
+		float heights[6] = { 0, 0, 0, 0, 0, 0 };
+		sh.x = GetTerrainHeight(input, coords + rayDir * multipliers.x, mipLevel, heights);
+		sh.y = GetTerrainHeight(input, coords + rayDir * multipliers.y, mipLevel, heights);
+		sh.z = GetTerrainHeight(input, coords + rayDir * multipliers.z, mipLevel, heights);
+		sh.w = GetTerrainHeight(input, coords + rayDir * multipliers.w, mipLevel, heights);
 		return 1.0 - saturate(dot(max(0, sh - sh0), 1.0) * 2.0) * quality;
 	}
 	return 1.0;

--- a/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
+++ b/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
@@ -36,26 +36,32 @@ float GetMipLevel(float2 coords, Texture2D<float4> tex)
 
 float GetTerrainHeight(PS_INPUT input, float2 coords, float mipLevels[6], inout float pixelOffset[6])
 {
-	// weights[i] = pow(weights[i] / maxWeight, 1 + 2 * blendFactor) * (pow(pixelOffset[i] + 1 - maxOffset, 1 + blendFactor * 100) + 0.1); 
+	// weights[i] = pow(weights[i] / maxWeight, 1 + 2 * blendFactor) * (pow(pixelOffset[i] + 1 - maxOffset, 1 + blendFactor * 100) + 0.1);
 	if (input.LandBlendWeights1.x > 0.0)
 		pixelOffset[0] = TexColorSampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[0]).w;
-	else pixelOffset[0] = 0;
+	else
+		pixelOffset[0] = 0;
 	if (input.LandBlendWeights1.y > 0.0)
 		pixelOffset[1] = TexLandColor2Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[1]).w;
-	else pixelOffset[1] = 0;
+	else
+		pixelOffset[1] = 0;
 	if (input.LandBlendWeights1.z > 0.0)
 		pixelOffset[2] = TexLandColor3Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[2]).w;
-	else pixelOffset[2] = 0;
+	else
+		pixelOffset[2] = 0;
 	if (input.LandBlendWeights1.w > 0.0)
 		pixelOffset[3] = TexLandColor4Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[3]).w;
-	else pixelOffset[3] = 0;
+	else
+		pixelOffset[3] = 0;
 	if (input.LandBlendWeights2.x > 0.0)
 		pixelOffset[4] = TexLandColor5Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[4]).w;
-	else pixelOffset[4] = 0;
+	else
+		pixelOffset[4] = 0;
 	if (input.LandBlendWeights2.y > 0.0)
 		pixelOffset[5] = TexLandColor6Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[5]).w;
-	else pixelOffset[5] = 0;
-	float height = (pixelOffset[0]*input.LandBlendWeights1.x+pixelOffset[1]*input.LandBlendWeights1.y+pixelOffset[2]*input.LandBlendWeights1.z+pixelOffset[3]*input.LandBlendWeights1.w+pixelOffset[4]*input.LandBlendWeights2.x + pixelOffset[5]*input.LandBlendWeights2.y);
+	else
+		pixelOffset[5] = 0;
+	float height = (pixelOffset[0] * input.LandBlendWeights1.x + pixelOffset[1] * input.LandBlendWeights1.y + pixelOffset[2] * input.LandBlendWeights1.z + pixelOffset[3] * input.LandBlendWeights1.w + pixelOffset[4] * input.LandBlendWeights2.x + pixelOffset[5] * input.LandBlendWeights2.y);
 	return height;
 }
 #endif

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1087,10 +1087,19 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		mipLevels[3] = GetMipLevel(uv, TexLandColor4Sampler);
 		mipLevels[4] = GetMipLevel(uv, TexLandColor5Sampler);
 		mipLevels[5] = GetMipLevel(uv, TexLandColor6Sampler);
-		uv = GetParallaxCoords(input, viewPosition.z, uv, mipLevels, viewDirection, tbnTr, screenNoise, pixelOffset);
-		if (extendedMaterialSettings.EnableShadows && parallaxShadowQuality > 0.0f) {
-			float heights[6] = { 0, 0, 0, 0, 0, 0 };
-			sh0 = GetTerrainHeight(input, uv, mipLevels, heights);
+		float weights[6];
+		uv = GetParallaxCoords(input, viewPosition.z, uv, mipLevels, viewDirection, tbnTr, screenNoise, pixelOffset, weights);
+		if(extendedMaterialSettings.EnableComplexMaterial){
+			input.LandBlendWeights1.x = weights[0];
+			input.LandBlendWeights1.y = weights[1];
+			input.LandBlendWeights1.z = weights[2];
+			input.LandBlendWeights1.w = weights[3];
+			input.LandBlendWeights2.x = weights[4];
+			input.LandBlendWeights2.y = weights[5];
+		}
+		if (extendedMaterialSettings.EnableShadows && parallaxShadowQuality > 0.0f){
+
+			sh0 = GetTerrainHeight(input, uv, mipLevels, weights);
 		}
 	}
 #		endif  // EMAT

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1097,7 +1097,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 			input.LandBlendWeights2.x = weights[4];
 			input.LandBlendWeights2.y = weights[5];
 		}
-		if (extendedMaterialSettings.EnableShadows && parallaxShadowQuality > 0.0f){
+		if (extendedMaterialSettings.EnableShadows && parallaxShadowQuality > 0.0f) {
 			sh0 = GetTerrainHeight(input, uv, mipLevels, parallaxShadowQuality, weights);
 		}
 	}

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1089,7 +1089,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		mipLevels[5] = GetMipLevel(uv, TexLandColor6Sampler);
 		float weights[6];
 		uv = GetParallaxCoords(input, viewPosition.z, uv, mipLevels, viewDirection, tbnTr, screenNoise, pixelOffset, weights);
-		if(extendedMaterialSettings.EnableComplexMaterial){
+		if (extendedMaterialSettings.EnableComplexMaterial) {
 			input.LandBlendWeights1.x = weights[0];
 			input.LandBlendWeights1.y = weights[1];
 			input.LandBlendWeights1.z = weights[2];
@@ -1097,8 +1097,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 			input.LandBlendWeights2.x = weights[4];
 			input.LandBlendWeights2.y = weights[5];
 		}
-		if (extendedMaterialSettings.EnableShadows && parallaxShadowQuality > 0.0f){
-
+		if (extendedMaterialSettings.EnableShadows && parallaxShadowQuality > 0.0f) {
 			sh0 = GetTerrainHeight(input, uv, mipLevels, weights);
 		}
 	}

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1099,7 +1099,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		}
 		if (extendedMaterialSettings.EnableShadows && parallaxShadowQuality > 0.0f){
 
-			sh0 = GetTerrainHeight(input, uv, mipLevels, weights);
+			sh0 = GetTerrainHeight(input, uv, mipLevels, parallaxShadowQuality, weights);
 		}
 	}
 #		endif  // EMAT

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1088,8 +1088,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		mipLevels[4] = GetMipLevel(uv, TexLandColor5Sampler);
 		mipLevels[5] = GetMipLevel(uv, TexLandColor6Sampler);
 		uv = GetParallaxCoords(input, viewPosition.z, uv, mipLevels, viewDirection, tbnTr, screenNoise, pixelOffset);
-		if (extendedMaterialSettings.EnableShadows && parallaxShadowQuality > 0.0f)
-			sh0 = GetTerrainHeight(input, uv, mipLevels);
+		if (extendedMaterialSettings.EnableShadows && parallaxShadowQuality > 0.0f){
+			float heights[6] = { 0, 0, 0, 0, 0, 0 };
+			sh0 = GetTerrainHeight(input, uv, mipLevels, heights);
+		}
 	}
 #		endif  // EMAT
 #	endif      // LANDSCAPE

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1088,7 +1088,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		mipLevels[4] = GetMipLevel(uv, TexLandColor5Sampler);
 		mipLevels[5] = GetMipLevel(uv, TexLandColor6Sampler);
 		uv = GetParallaxCoords(input, viewPosition.z, uv, mipLevels, viewDirection, tbnTr, screenNoise, pixelOffset);
-		if (extendedMaterialSettings.EnableShadows && parallaxShadowQuality > 0.0f){
+		if (extendedMaterialSettings.EnableShadows && parallaxShadowQuality > 0.0f) {
 			float heights[6] = { 0, 0, 0, 0, 0, 0 };
 			sh0 = GetTerrainHeight(input, uv, mipLevels, heights);
 		}


### PR DESCRIPTION
Just a small change in the blending weights of landscape textures, makes details pop out more and make it feel more like distinct materials than a linear blend. Performance impact should be minimal.