### PR TITLE
refactor: clean up dynamic resolution utils

### DIFF
--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/ScreenSpaceShadows.hlsli
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/ScreenSpaceShadows.hlsli
@@ -20,16 +20,14 @@ float GetScreenSpaceShadow(float2 a_uv, float a_noise, float3 a_viewPosition, ui
 		float2 offset = mul(BlurOffsets[i], rotationMatrix) * 0.0025;
 
 		float2 sampleUV = a_uv + offset;
-		sampleUV = ConvertToStereoUV(sampleUV, a_eyeIndex);
-		sampleUV = GetDynamicResolutionAdjustedScreenPosition(sampleUV);
-		uint2 sampleCoord = sampleUV * BufferDim.xy;
+		int3 sampleCoord = ConvertUVToSampleCoord(sampleUV, a_eyeIndex);
 
-		float rawDepth = TexDepthSampler.Load(int3(sampleCoord, 0)).x;
+		float rawDepth = TexDepthSampler.Load(sampleCoord).x;
 		float linearDepth = GetScreenDepth(rawDepth);
 
 		float attenuation = 1.0 - saturate(100.0 * abs(linearDepth - a_viewPosition.z) / a_viewPosition.z);
 		if (attenuation > 0.0) {
-			shadow += ScreenSpaceShadowsTexture.Load(int3(sampleCoord, 0)).x * attenuation;
+			shadow += ScreenSpaceShadowsTexture.Load(sampleCoord).x * attenuation;
 			weight += attenuation;
 		}
 	}
@@ -37,7 +35,7 @@ float GetScreenSpaceShadow(float2 a_uv, float a_noise, float3 a_viewPosition, ui
 	if (weight > 0.0)
 		shadow /= weight;
 	else
-		shadow = ScreenSpaceShadowsTexture.Load(int3(GetDynamicResolutionAdjustedScreenPosition(ConvertToStereoUV(a_uv, a_eyeIndex)) * BufferDim.xy, 0)).x;
+		shadow = ScreenSpaceShadowsTexture.Load(ConvertUVToSampleCoord(a_uv, a_eyeIndex)).x;
 
 	return shadow;
 }

--- a/features/Terrain Blending/Shaders/TerrainBlending/TerrainBlending.hlsli
+++ b/features/Terrain Blending/Shaders/TerrainBlending/TerrainBlending.hlsli
@@ -10,7 +10,5 @@ float2 ShiftTerrain(float blendFactor, float2 coords, float3 viewDir, float3x3 t
 // Get a raw depth from the depth buffer. [0,1] in uv space
 float GetTerrainOffsetDepth(float2 uv, uint a_eyeIndex = 0)
 {
-	uv = ConvertToStereoUV(uv, a_eyeIndex);
-	uv = GetDynamicResolutionAdjustedScreenPosition(uv);
-	return TerrainBlendingMaskTexture.Load(int3(uv * BufferDim, 0));
+	return TerrainBlendingMaskTexture.Load(ConvertUVToSampleCoord(uv, a_eyeIndex));
 }

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -130,12 +130,18 @@ cbuffer FeatureData : register(b6)
 
 Texture2D<float4> TexDepthSampler : register(t20);
 
-// Get a raw depth from the depth buffer. [0,1] in uv space
-float GetDepth(float2 uv, uint a_eyeIndex = 0)
+// Get a int3 to be used as texture sample coord. [0,1] in uv space
+int3 ConvertUVToSampleCoord(float2 uv, uint a_eyeIndex)
 {
 	uv = ConvertToStereoUV(uv, a_eyeIndex);
 	uv = GetDynamicResolutionAdjustedScreenPosition(uv);
-	return TexDepthSampler.Load(int3(uv * BufferDim, 0)).x;
+	return int3(uv * BufferDim.xy, 0);
+}
+
+// Get a raw depth from the depth buffer. [0,1] in uv space
+float GetDepth(float2 uv, uint a_eyeIndex = 0)
+{
+	return TexDepthSampler.Load(ConvertUVToSampleCoord(uv, a_eyeIndex)).x;
 }
 
 float GetScreenDepth(float depth)

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -220,8 +220,8 @@ void Deferred::UpdateConstantBuffer()
 
 	auto state = State::GetSingleton();
 
-	data.BufferDim.x = state->screenWidth;
-	data.BufferDim.y = state->screenHeight;
+	data.BufferDim.x = state->screenSize.x;
+	data.BufferDim.y = state->screenSize.y;
 	data.BufferDim.z = 1.0f / data.BufferDim.x;
 	data.BufferDim.w = 1.0f / data.BufferDim.y;
 
@@ -234,7 +234,7 @@ void Deferred::UpdateConstantBuffer()
 	auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
 
 	auto useTAA = !REL::Module::IsVR() ? imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA->taaEnabled : imageSpaceManager->GetVRRuntimeData().BSImagespaceShaderISTemporalAA->taaEnabled;
-	data.FrameCount = useTAA ? RE::BSGraphics::State::GetSingleton()->uiFrameCount : 0;
+	data.FrameCount = useTAA ? RE::BSGraphics::State::GetSingleton()->frameCount : 0;
 
 	deferredCB->Update(data);
 }

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -584,7 +584,7 @@ void ScreenSpaceGI::UpdateSB()
 	auto viewport = RE::BSGraphics::State::GetSingleton();
 
 	float2 res = { (float)texRadiance->desc.Width, (float)texRadiance->desc.Height };
-	float2 dynres = res * viewport->GetRuntimeData().dynamicResolutionCurrentWidthScale;
+	float2 dynres = Util::ConvertToDynamic(res);
 	dynres = { floor(dynres.x), floor(dynres.y) };
 
 	static float4x4 prevInvView[2] = {};
@@ -607,7 +607,7 @@ void ScreenSpaceGI::UpdateSB()
 		data.RcpTexDim = float2(1.0f) / res;
 		data.FrameDim = dynres;
 		data.RcpFrameDim = float2(1.0f) / dynres;
-		data.FrameIndex = viewport->uiFrameCount;
+		data.FrameIndex = viewport->frameCount;
 
 		data.NumSlices = settings.NumSlices;
 		data.NumSteps = settings.NumSteps;
@@ -662,15 +662,12 @@ void ScreenSpaceGI::DrawSSGI(Texture2D* srcPrevAmbient)
 
 	//////////////////////////////////////////////////////
 
-	auto viewport = RE::BSGraphics::State::GetSingleton();
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
 	auto rts = renderer->GetRuntimeData().renderTargets;
 	auto deferred = Deferred::GetSingleton();
 
-	uint resolution[2] = {
-		(uint)(State::GetSingleton()->screenWidth * viewport->GetRuntimeData().dynamicResolutionCurrentWidthScale),
-		(uint)(State::GetSingleton()->screenHeight * viewport->GetRuntimeData().dynamicResolutionCurrentWidthScale)
-	};
+	float2 size = Util::ConvertToDynamic(State::GetSingleton()->screenSize);
+	uint resolution[2] = { (uint)size.x, (uint)size.y };
 
 	std::array<ID3D11ShaderResourceView*, 8> srvs = { nullptr };
 	std::array<ID3D11UnorderedAccessView*, 5> uavs = { nullptr };

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -90,8 +90,6 @@ void ScreenSpaceShadows::DrawShadows()
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
 	auto context = State::GetSingleton()->context;
 
-	auto viewport = RE::BSGraphics::State::GetSingleton();
-
 	auto accumulator = RE::BSGraphics::BSShaderAccumulator::GetCurrentAccumulator();
 	auto dirLight = skyrim_cast<RE::NiDirectionalLight*>(accumulator->GetRuntimeData().activeShadowSceneNode->GetRuntimeData().sunLight->light.get());
 
@@ -107,16 +105,15 @@ void ScreenSpaceShadows::DrawShadows()
 	lightProjection = DirectX::SimpleMath::Vector4::Transform(lightProjection, viewProjMat);
 	float lightProjectionF[4] = { lightProjection.x, lightProjection.y, lightProjection.z, lightProjection.w };
 
-	int viewportSize[2] = { (int)state->screenWidth, (int)state->screenHeight };
+	int viewportSize[2] = { (int)state->screenSize.x, (int)state->screenSize.y };
 
 	if (REL::Module::IsVR())
 		viewportSize[0] /= 2;
 
+	float2 size = Util::ConvertToDynamic({ (float)viewportSize[0], (float)viewportSize[1] });
+
 	int minRenderBounds[2] = { 0, 0 };
-	int maxRenderBounds[2] = {
-		(int)((float)viewportSize[0] * viewport->GetRuntimeData().dynamicResolutionCurrentWidthScale),
-		(int)((float)viewportSize[1] * viewport->GetRuntimeData().dynamicResolutionCurrentHeightScale)
-	};
+	int maxRenderBounds[2] = { (int)size.x, (int)size.y };
 
 	auto depth = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kPOST_ZPREPASS_COPY];
 	context->CSSetShaderResources(0, 1, &depth.depthSRV);

--- a/src/Features/SubsurfaceScattering.cpp
+++ b/src/Features/SubsurfaceScattering.cpp
@@ -163,10 +163,7 @@ void SubsurfaceScattering::DrawSSS()
 
 	validMaterials = false;
 
-	auto viewport = RE::BSGraphics::State::GetSingleton();
-
-	float resolutionX = blurHorizontalTemp->desc.Width * viewport->GetRuntimeData().dynamicResolutionCurrentWidthScale;
-	float resolutionY = blurHorizontalTemp->desc.Height * viewport->GetRuntimeData().dynamicResolutionCurrentHeightScale;
+	auto dispatchCount = Util::GetScreenDispatchCount();
 
 	{
 		auto cameraData = Util::GetCameraData(0);
@@ -205,7 +202,7 @@ void SubsurfaceScattering::DrawSSS()
 			auto shader = GetComputeShaderHorizontalBlur();
 			context->CSSetShader(shader, nullptr, 0);
 
-			context->Dispatch((uint32_t)std::ceil(resolutionX / 8.0f), (uint32_t)std::ceil(resolutionY / 8.0f), 1);
+			context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
 		}
 
 		uav = nullptr;
@@ -222,7 +219,7 @@ void SubsurfaceScattering::DrawSSS()
 			auto shader = GetComputeShaderVerticalBlur();
 			context->CSSetShader(shader, nullptr, 0);
 
-			context->Dispatch((uint32_t)std::ceil(resolutionX / 8.0f), (uint32_t)std::ceil(resolutionY / 8.0f), 1);
+			context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
 		}
 	}
 

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -343,8 +343,7 @@ void State::SetupResources()
 	renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN].texture->GetDesc(&texDesc);
 
 	isVR = REL::Module::IsVR();
-	screenWidth = (float)texDesc.Width;
-	screenHeight = (float)texDesc.Height;
+	screenSize = { (float)texDesc.Width, (float)texDesc.Height };
 	context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
 	device = reinterpret_cast<ID3D11Device*>(renderer->GetRuntimeData().forwarder);
 	context->QueryInterface(__uuidof(pPerf), reinterpret_cast<void**>(&pPerf));
@@ -483,7 +482,7 @@ void State::UpdateSharedData()
 		data.DirLightDirection.Normalize();
 
 		data.CameraData = Util::GetCameraData();
-		data.BufferDim = { screenWidth, screenHeight };
+		data.BufferDim = { screenSize.x, screenSize.y, 1.0f / screenSize.x, 1.0f / screenSize.y };
 		data.Timer = timer;
 
 		auto viewport = RE::BSGraphics::State::GetSingleton();
@@ -491,7 +490,7 @@ void State::UpdateSharedData()
 		auto bTAA = !REL::Module::IsVR() ? imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA->taaEnabled :
 		                                   imageSpaceManager->GetVRRuntimeData().BSImagespaceShaderISTemporalAA->taaEnabled;
 
-		data.FrameCount = viewport->uiFrameCount * (bTAA || State::GetSingleton()->upscalerLoaded);
+		data.FrameCount = viewport->frameCount * (bTAA || State::GetSingleton()->upscalerLoaded);
 
 		for (int i = -2; i <= 2; i++) {
 			for (int k = -2; k <= 2; k++) {

--- a/src/State.h
+++ b/src/State.h
@@ -134,8 +134,7 @@ public:
 
 	// Skyrim constants
 	bool isVR = false;
-	float screenWidth = 0;
-	float screenHeight = 0;
+	float2 screenSize = {};
 	ID3D11DeviceContext* context = nullptr;
 	ID3D11Device* device = nullptr;
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -334,16 +334,20 @@ namespace Util
 		return cameraData;
 	}
 
-	DispatchCount GetScreenDispatchCount()
+	float2 ConvertToDynamic(float2 size)
 	{
-		auto state = State::GetSingleton();
 		auto viewport = RE::BSGraphics::State::GetSingleton();
 
-		float resolutionX = state->screenWidth * viewport->GetRuntimeData().dynamicResolutionCurrentWidthScale;
-		float resolutionY = state->screenHeight * viewport->GetRuntimeData().dynamicResolutionCurrentHeightScale;
+		return float2(
+			size.x * viewport->GetRuntimeData().dynamicResolutionWidthRatio,
+			size.y * viewport->GetRuntimeData().dynamicResolutionHeightRatio);
+	}
 
-		uint dispatchX = (uint)std::ceil(resolutionX / 8.0f);
-		uint dispatchY = (uint)std::ceil(resolutionY / 8.0f);
+	DispatchCount GetScreenDispatchCount()
+	{
+		float2 resolution = ConvertToDynamic(State::GetSingleton()->screenSize);
+		uint dispatchX = (uint)std::ceil(resolution.x / 8.0f);
+		uint dispatchY = (uint)std::ceil(resolution.y / 8.0f);
 
 		return { dispatchX, dispatchY };
 	}

--- a/src/Util.h
+++ b/src/Util.h
@@ -53,6 +53,8 @@ namespace Util
 		return shadowState->GetVRRuntimeData().cameraData.getEye(eyeIndex);
 	}
 
+	float2 ConvertToDynamic(float2 size);
+
 	struct DispatchCount
 	{
 		uint x;
@@ -96,7 +98,7 @@ namespace Util
 			last_frame = frame;
 			return retval;
 		}
-		inline bool isNewFrame() { return isNewFrame(RE::BSGraphics::State::GetSingleton()->uiFrameCount); }
+		inline bool isNewFrame() { return isNewFrame(RE::BSGraphics::State::GetSingleton()->frameCount); }
 	};
 
 	// for simple benchmarking

--- a/src/VariableRateShading.cpp
+++ b/src/VariableRateShading.cpp
@@ -190,9 +190,8 @@ void VariableRateShading::Setup()
 	vrsActive = true;
 	logger::info("Successfully initialized NVAPI; Variable Rate Shading is available.");
 
-	auto width = State::GetSingleton()->screenWidth;
-	auto height = State::GetSingleton()->screenHeight;
-	SetupSingleEyeVRS(0, (int)width, (int)height);
+	auto screenSize = State::GetSingleton()->screenSize;
+	SetupSingleEyeVRS(0, (int)screenSize.x, (int)screenSize.y);
 
 	{
 		auto& main = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];
@@ -224,7 +223,7 @@ void VariableRateShading::Setup()
 				D3D11_TEXTURE2D_DESC texDesc{};
 				target.texture->GetDesc(&texDesc);
 
-				if (texDesc.Width == width && texDesc.Height == height) {
+				if (texDesc.Width == screenSize.x && texDesc.Height == screenSize.y) {
 					screenTargets.insert(i);
 				}
 			}


### PR DESCRIPTION
Updated to latest CommonLibSSE-NG and updated related dynamic resolution names

HLSL: 
- Added a `ConvertUVToSampleCoord` method to make it easier to load from a stereo texture with dynamic resolution
	- Usage: `Texture.Load(ConvertUVToSampleCoord(uv, eyeIndex))` instead of having to convert uv to stereo and multiply with BufferDim and dynamic scaling

CPP:
- Added a `ConvertToDynamic` method to Util to convert a size to support dynamic resolution
- Use `GetScreenDispatchCount` for SubsurfaceScattering due to it having the same resolution as the main texture anyway. So same resolution, so cleaner to use GetScreenDispatchCount Util
- Converted `float screenWidth` and `float screenHeight` to `float2 screenSize` in State to use it with utils easier