### PR TITLE
build: allow multiple presets in build folder

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,9 +9,6 @@ on:
 permissions:
   contents: write
 
-env:
-  VCPKG_COMMIT_ID: 34742e119fb2aae42f10c03a98e475eb1934f7c9
-
 jobs:
   compile:
     name: build plugin and addons
@@ -19,19 +16,19 @@ jobs:
     steps:
         - uses: actions/checkout@v3
           with:
-            submodules: 'true'
+            submodules: recursive
 
         - uses: ilammy/msvc-dev-cmd@v1.10.0
 
-        - uses: lukka/run-vcpkg@v11
+        - uses: lukka/run-vcpkg@v11.5
           with:
-              vcpkgGitCommitId: ${{ env.VCPKG_COMMIT_ID }}
+            vcpkgJsonGlob: vcpkg.json
 
         - name: cmake configure
           run: cmake -S . --preset=ALL --check-stamp-file "build\CMakeFiles\generate.stamp"
 
         - name: cmake build
-          run: cmake --build build --config Release
+          run: cmake --build build/ALL --config Release
 
         - name: create a tagged release and upload the archive
           uses: ncipollo/release-action@v1

--- a/BuildRelease.bat
+++ b/BuildRelease.bat
@@ -7,9 +7,9 @@ if NOT "%1" == "" (
 
 echo Running preset %preset%
 
-cmake -S . --preset=%preset% --check-stamp-file "build\CMakeFiles\generate.stamp"
+cmake -S . --preset=%preset% --check-stamp-file "build\%preset%\CMakeFiles\generate.stamp"
 if %ERRORLEVEL% NEQ 0 exit 1
-cmake --build build --config Release
+cmake --build build/%preset% --config Release
 if %ERRORLEVEL% NEQ 0 exit 1
 
 pause

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_libraries(
 	pystring::pystring
 	unordered_dense::unordered_dense
 	efsw::efsw
-	 ${NVAPI_LIBRARY} 
+	${NVAPI_LIBRARY} 
 )
 
 # https://gitlab.kitware.com/cmake/cmake/-/issues/24922#note_1371990

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,20 +12,14 @@
 			"cacheVariables": {
 				"SKSE_SUPPORT_XBYAK": "ON"
 			},
-			"binaryDir": "${sourceDir}/build"
+			"binaryDir": "${sourceDir}/build/${presetName}"
 		},
 		{
 			"name": "vcpkg",
 			"hidden": true,
 			"cacheVariables": {
-				"CMAKE_TOOLCHAIN_FILE": {
-					"type": "STRING",
-					"value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-				},
-				"VCPKG_OVERLAY_PORTS": {
-					"type": "STRING",
-					"value": "${sourceDir}/cmake/ports/"
-				  },
+				"CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+				"VCPKG_OVERLAY_PORTS": "${sourceDir}/cmake/ports/",
 				"VCPKG_TARGET_TRIPLET": "x64-windows-static-md"
 			}
 		},
@@ -53,12 +47,11 @@
 			}
 		},
 		{
-			"name": "AE",
+			"name": "skyrim",
+			"hidden": true,
 			"cacheVariables": {
 				"BUILD_SKYRIM": true,
-				"ENABLE_SKYRIM_AE": "ON",
-				"ENABLE_SKYRIM_SE": "OFF",
-				"ENABLE_SKYRIM_VR": "OFF"
+				"BUILD_TESTS": "OFF"
 			},
 			"inherits": [
 				"common",
@@ -66,82 +59,60 @@
 				"win64",
 				"msvc"
 			]
+		},
+		{
+			"name": "AE",
+			"cacheVariables": {
+				"ENABLE_SKYRIM_AE": "ON",
+				"ENABLE_SKYRIM_SE": "OFF",
+				"ENABLE_SKYRIM_VR": "OFF"
+			},
+			"inherits": "skyrim"
 		},
 		{
 			"name": "SE",
 			"cacheVariables": {
-				"BUILD_SKYRIM": true,
 				"ENABLE_SKYRIM_AE": "OFF",
 				"ENABLE_SKYRIM_SE": "ON",
 				"ENABLE_SKYRIM_VR": "OFF"
 			},
-			"inherits": [
-				"common",
-				"vcpkg",
-				"win64",
-				"msvc"
-			]
+			"inherits": "skyrim"
 		},
 		{
 			"name": "VR",
 			"cacheVariables": {
-				"BUILD_SKYRIM": true,
 				"ENABLE_SKYRIM_AE": "OFF",
 				"ENABLE_SKYRIM_SE": "OFF",
 				"ENABLE_SKYRIM_VR": "ON"
 			},
-			"inherits": [
-				"common",
-				"vcpkg",
-				"win64",
-				"msvc"
-			]
+			"inherits": "skyrim"
 		},
 		{
 			"name": "ALL",
 			"cacheVariables": {
-				"BUILD_SKYRIM": true,
 				"ENABLE_SKYRIM_AE": "ON",
 				"ENABLE_SKYRIM_SE": "ON",
 				"ENABLE_SKYRIM_VR": "ON"
 			},
-			"inherits": [
-				"common",
-				"vcpkg",
-				"win64",
-				"msvc"
-			]
+			"inherits": "skyrim"
 		},
 		{
 			"name": "PRE-AE",
 			"cacheVariables": {
-				"BUILD_SKYRIM": true,
 				"ENABLE_SKYRIM_AE": "OFF",
 				"ENABLE_SKYRIM_SE": "ON",
 				"ENABLE_SKYRIM_VR": "ON"
 			},
-			"inherits": [
-				"common",
-				"vcpkg",
-				"win64",
-				"msvc"
-			]
+			"inherits": "skyrim"
 		},
 		{
 			"name": "FLATRIM",
 			"cacheVariables": {
-				"BUILD_SKYRIM": true,
 				"ENABLE_SKYRIM_AE": "ON",
 				"ENABLE_SKYRIM_SE": "ON",
-				"ENABLE_SKYRIM_VR": "OFF",
-				"Build Tests": "OFF"
+				"ENABLE_SKYRIM_VR": "OFF"
 			},
-			"inherits": [
-				"common",
-				"vcpkg",
-				"win64",
-				"msvc"
-			]
+			"inherits": "skyrim"
 		}
 	]
 }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If you want an example CMakeUserPreset to start off with you can copy the `CMake
 * Make sure `"AUTO_PLUGIN_DEPLOYMENT"` is set to `"ON"` in `CMakeUserPresets.json`
 * Change the `"CommunityShadersOutputDir"` value to match your desired outputs, if you want multiple folders you can separate them by `;` is shown in the template example
 #### AIO_ZIP_TO_DIST
-* This option is default `"OFF"`
+* This option is default `"ON"`
 * Make sure `"AIO_ZIP_TO_DIST"` is set to `"ON"` in `CMakeUserPresets.json`
 * This will create a `CommunityShaders_AIO.7z` archive in /dist containing all features and base mod
 #### ZIP_TO_DIST

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,37 +1,41 @@
 {
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "communityshaders",
-  "version-semver": "0.7.4",
-  "description": "",
   "license": "GPL-3.0",
+  "features": {
+    "commonlibsse-ng": {
+      "description": "Dependencies of clib-ng",
+      "dependencies": ["fmt", "directxtk", "rapidcsv", "spdlog"]
+    }
+  },
+  "default-features": ["commonlibsse-ng"],
   "dependencies": [
     "bshoshany-thread-pool",
+    "clib-util",
     "cppwinrt",
-    "fmt",
-    "directxtk",
-    "rapidcsv",
-    "spdlog",
+    "directxtex",
+    "eastl",
+    "efsw",
+    {
+      "name": "imgui",
+      "features": ["dx11-binding", "win32-binding", "docking-experimental"]
+    },
     "magic-enum",
-    "xbyak",
-    "catch2",
     "magic-enum",
     "nlohmann-json",
     "pystring",
-    "directxtex",
-    {
-      "name": "imgui",
-      "features": ["dx11-binding", "win32-binding", "docking-experimental"],
-      "version>=": "1.88"
-    },
-    "eastl",
-    "clib-util",
     "unordered-dense",
-    "efsw"
+    "xbyak"
   ],
   "overrides": [
     {
       "name": "bshoshany-thread-pool",
-      "version-string": "3.5.0"
+      "version": "3.5.0"
+    },
+    {
+      "name": "imgui",
+      "version": "1.90"
     }
   ],
-  "builtin-baseline": "83972272512ce4ede5fc3b2ba98f6468b179f192"
+  "builtin-baseline": "1dc5ee30eb1032221d29f281f4a94b73f06b4284"
 }


### PR DESCRIPTION
- Creates a subfolder in build for each preset which allows to switch between different presets and not getting into issues for caches. One example is a bug for https://github.com/doodlum/skyrim-community-shaders/pull/365 using the msvc generator not updating when toggling the `TRACY_SUPPORT` cmake option causing the define not to update in vs without removing the build folder.
<img width="166" alt="image" src="https://github.com/user-attachments/assets/8777f163-6a70-40d9-a5b1-fcb91124c4a0">

- ~Run `build` action on pull-request if cpp changes were found~ Will do in another PR
- Cleanup `vcpkg.json` config
- Cleanup `CmakePresets.json`