### PR TITLE
build: update clib-ng to latest and remove old RE

### DIFF
--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -17,31 +17,6 @@ void CloudShadows::CheckResourcesSide(int side)
 	context->ClearRenderTargetView(cubemapCloudOccRTVs[side], black);
 }
 
-class BSSkyShaderProperty : public RE::BSShaderProperty
-{
-public:
-	enum SkyObject
-	{
-		SO_SUN = 0x0,
-		SO_SUN_GLARE = 0x1,
-		SO_ATMOSPHERE = 0x2,
-		SO_CLOUDS = 0x3,
-		SO_SKYQUAD = 0x4,
-		SO_STARS = 0x5,
-		SO_MOON = 0x6,
-		SO_MOON_SHADOW = 0x7,
-	};
-
-	RE::NiColorA kBlendColor;
-	RE::NiSourceTexture* pBaseTexture;
-	RE::NiSourceTexture* pBlendTexture;
-	char _pad0[0x10];
-	float fBlendValue;
-	uint16_t usCloudLayer;
-	bool bFadeSecondTexture;
-	uint32_t uiSkyObjectType;
-};
-
 void CloudShadows::ModifySky(RE::BSRenderPass* Pass)
 {
 	auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
@@ -51,9 +26,9 @@ void CloudShadows::ModifySky(RE::BSRenderPass* Pass)
 	if (cubeMapRenderTarget != RE::RENDER_TARGETS_CUBEMAP::kREFLECTIONS)
 		return;
 
-	auto skyProperty = static_cast<const BSSkyShaderProperty*>(Pass->shaderProperty);
+	auto skyProperty = static_cast<const RE::BSSkyShaderProperty*>(Pass->shaderProperty);
 
-	if (skyProperty->uiSkyObjectType == BSSkyShaderProperty::SkyObject::SO_CLOUDS) {
+	if (skyProperty->uiSkyObjectType == RE::BSSkyShaderProperty::SkyObject::SO_CLOUDS) {
 		auto renderer = RE::BSGraphics::Renderer::GetSingleton();
 		auto& context = State::GetSingleton()->context;
 

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -358,177 +358,21 @@ enum class ShaderTechnique
 	BloodSplaterSplatter = 0x5C006074,
 };
 
-class BSUtilityShader : public RE::BSShader
-{
-public:
-	enum class Flags
-	{
-		None = 0,
-		Vc = 1 << 0,
-		Texture = 1 << 1,
-		Skinned = 1 << 2,
-		Normals = 1 << 3,
-		BinormalTangent = 1 << 4,
-		AlphaTest = 1 << 7,
-		LodLandscape = 1 << 8,
-		RenderNormal = 1 << 9,
-		RenderNormalFalloff = 1 << 10,
-		RenderNormalClamp = 1 << 11,
-		RenderNormalClear = 1 << 12,
-		RenderDepth = 1 << 13,
-		RenderShadowmap = 1 << 14,
-		RenderShadowmapClamped = 1 << 15,
-		GrayscaleToAlpha = 1 << 15,
-		RenderShadowmapPb = 1 << 16,
-		AdditionalAlphaMask = 1 << 16,
-		DepthWriteDecals = 1 << 17,
-		DebugShadowSplit = 1 << 18,
-		DebugColor = 1 << 19,
-		GrayscaleMask = 1 << 20,
-		RenderShadowmask = 1 << 21,
-		RenderShadowmaskSpot = 1 << 22,
-		RenderShadowmaskPb = 1 << 23,
-		RenderShadowmaskDpb = 1 << 24,
-		RenderBaseTexture = 1 << 25,
-		TreeAnim = 1 << 26,
-		LodObject = 1 << 27,
-		LocalMapFogOfWar = 1 << 28,
-		OpaqueEffect = 1 << 29,
-	};
-
-	static BSUtilityShader* GetSingleton()
-	{
-		static REL::Relocation<BSUtilityShader**> singleton{ RELOCATION_ID(528354, 415300) };
-		return *singleton;
-	}
-	~BSUtilityShader() override;  // 00
-
-	// override (BSShader)
-	bool SetupTechnique(std::uint32_t globalTechnique) override;            // 02
-	void RestoreTechnique(std::uint32_t globalTechnique) override;          // 03
-	void SetupGeometry(RE::BSRenderPass* pass, uint32_t flags) override;    // 06
-	void RestoreGeometry(RE::BSRenderPass* pass, uint32_t flags) override;  // 07
-};
-
-struct RenderPassArray
-{
-	static RE::BSRenderPass* MakeRenderPass(RE::BSShader* shader, RE::BSShaderProperty* property, RE::BSGeometry* geometry,
-		uint32_t technique, uint8_t numLights, RE::BSLight** lights)
-	{
-		using func_t = decltype(&RenderPassArray::MakeRenderPass);
-		static REL::Relocation<func_t> func{ RELOCATION_ID(100717, 107497) };
-		return func(shader, property, geometry, technique, numLights, lights);
-	}
-
-	static void ClearRenderPass(RE::BSRenderPass* pass)
-	{
-		using func_t = decltype(&RenderPassArray::ClearRenderPass);
-		static REL::Relocation<func_t> func{ RELOCATION_ID(100718, 107498) };
-		func(pass);
-	}
-
-	void Clear()
-	{
-		while (head != nullptr) {
-			RE::BSRenderPass* next = head->next;
-			ClearRenderPass(head);
-			head = next;
-		}
-		head = nullptr;
-	}
-
-	RE::BSRenderPass* EmplacePass(RE::BSShader* shader, RE::BSShaderProperty* property, RE::BSGeometry* geometry,
-		uint32_t technique, uint8_t numLights = 0, RE::BSLight* light0 = nullptr, RE::BSLight* light1 = nullptr,
-		RE::BSLight* light2 = nullptr, RE::BSLight* light3 = nullptr)
-	{
-		RE::BSLight* lights[4];
-		lights[0] = light0;
-		lights[1] = light1;
-		lights[2] = light2;
-		lights[3] = light3;
-		auto* newPass = MakeRenderPass(shader, property, geometry, technique, numLights, lights);
-		if (head != nullptr) {
-			RE::BSRenderPass* lastPass = head;
-			while (lastPass->next != nullptr) {
-				lastPass = lastPass->next;
-			}
-			lastPass->next = newPass;
-		} else {
-			head = newPass;
-		}
-		return newPass;
-	}
-
-	RE::BSRenderPass* head;  // 00
-	uint64_t unk08;          // 08
-};
-
-class BSBatchRenderer
-{
-public:
-	struct PersistentPassList
-	{
-		RE::BSRenderPass* m_Head;
-		RE::BSRenderPass* m_Tail;
-	};
-
-	struct GeometryGroup
-	{
-		BSBatchRenderer* m_BatchRenderer;
-		PersistentPassList m_PassList;
-		uintptr_t UnkPtr4;
-		float m_Depth;  // Distance from geometry to camera location
-		uint16_t m_Count;
-		uint8_t m_Flags;  // Flags
-	};
-
-	struct PassGroup
-	{
-		RE::BSRenderPass* m_Passes[5];
-		uint32_t m_ValidPassBits;  // OR'd with (1 << PassIndex)
-	};
-
-	RE::BSTArray<void*> unk008;                       // 008
-	RE::BSTHashMap<RE::UnkKey, RE::UnkValue> unk020;  // 020
-	std::uint64_t unk050;                             // 050
-	std::uint64_t unk058;                             // 058
-	std::uint64_t unk060;                             // 060
-	std::uint64_t unk068;                             // 068
-	GeometryGroup* m_GeometryGroups[16];
-	GeometryGroup* m_AlphaGroup;
-	void* unk1;
-	void* unk2;
-};
-
 //////////////////////////////////////////////////////////////
 
-static void Precipitation_SetupMask(RE::Precipitation* a_This)
-{
-	using func_t = decltype(&Precipitation_SetupMask);
-	static REL::Relocation<func_t> func{ REL::RelocationID(25641, 26183) };
-	func(a_This);
-}
-
-static void Precipitation_RenderMask(RE::Precipitation* a_This, BSParticleShaderRainEmitter* a_emitter)
-{
-	using func_t = decltype(&Precipitation_RenderMask);
-	static REL::Relocation<func_t> func{ REL::RelocationID(25642, 26184) };
-	func(a_This, a_emitter);
-}
-
-void* Skylighting::BSLightingShaderProperty_GetPrecipitationOcclusionMapRenderPassesImpl::thunk(
+RE::BSLightingShaderProperty::Data* Skylighting::BSLightingShaderProperty_GetPrecipitationOcclusionMapRenderPassesImpl::thunk(
 	RE::BSLightingShaderProperty* property,
 	RE::BSGeometry* geometry,
 	[[maybe_unused]] uint32_t renderMode,
 	[[maybe_unused]] RE::BSGraphics::BSShaderAccumulator* accumulator)
 {
-	auto batch = (BSBatchRenderer*)accumulator->GetRuntimeData().batchRenderer;
-	batch->m_GeometryGroups[14]->m_Flags &= ~1;
+	auto batch = accumulator->GetRuntimeData().batchRenderer;
+	batch->geometryGroups[14]->flags &= ~1;
 
 	using enum RE::BSShaderProperty::EShaderPropertyFlag;
-	using enum BSUtilityShader::Flags;
+	using enum RE::BSUtilityShader::Flags;
 
-	auto* precipitationOcclusionMapRenderPassList = reinterpret_cast<RenderPassArray*>(&property->unk0C8);
+	auto* precipitationOcclusionMapRenderPassList = &property->unk0C8;
 
 	precipitationOcclusionMapRenderPassList->Clear();
 	if (GetSingleton()->inOcclusion && !GetSingleton()->renderTrees) {
@@ -541,11 +385,11 @@ void* Skylighting::BSLightingShaderProperty_GetPrecipitationOcclusionMapRenderPa
 
 	if (property->flags.any(kZBufferWrite) && property->flags.none(kRefraction, kTempRefraction, kMultiTextureLandscape, kNoLODLandBlend, kLODLandscape, kEyeReflect, kDecal, kDynamicDecal, kAnisotropicLighting) && !(property->flags.any(kSkinned) && property->flags.none(kTreeAnim))) {
 		if (geometry->worldBound.radius > GetSingleton()->boundSize) {
-			stl::enumeration<BSUtilityShader::Flags> technique;
+			stl::enumeration<RE::BSUtilityShader::Flags> technique;
 			technique.set(RenderDepth);
 
 			auto pass = precipitationOcclusionMapRenderPassList->EmplacePass(
-				BSUtilityShader::GetSingleton(),
+				RE::BSUtilityShader::GetSingleton(),
 				property,
 				geometry,
 				technique.underlying() + static_cast<uint32_t>(ShaderTechnique::UtilityGeneralStart));
@@ -577,14 +421,14 @@ void Skylighting::Main_Precipitation_RenderOcclusion::thunk()
 				precipObject = precip->lastPrecip;
 			}
 			if (precipObject) {
-				Precipitation_SetupMask(precip);
-				Precipitation_SetupMask(precip);  // Calling setup twice fixes an issue when it is raining
+				precip->SetupMask();
+				precip->SetupMask();  // Calling setup twice fixes an issue when it is raining
 				auto effect = precipObject->GetGeometryRuntimeData().properties[RE::BSGeometry::States::kEffect];
 				auto shaderProp = netimmerse_cast<RE::BSShaderProperty*>(effect.get());
 				auto particleShaderProperty = netimmerse_cast<RE::BSParticleShaderProperty*>(shaderProp);
-				auto rain = (BSParticleShaderRainEmitter*)(particleShaderProperty->particleEmitter);
+				auto rain = (RE::BSParticleShaderRainEmitter*)(particleShaderProperty->particleEmitter);
 
-				Precipitation_RenderMask(precip, rain);
+				precip->RenderMask(rain);
 			}
 		}
 
@@ -646,18 +490,16 @@ void Skylighting::Main_Precipitation_RenderOcclusion::thunk()
 
 				PrecipitationShaderDirection = { PrecipitationShaderDirectionF.x, PrecipitationShaderDirectionF.y, PrecipitationShaderDirectionF.z };
 
-				Precipitation_SetupMask(precip);
-				Precipitation_SetupMask(precip);  // Calling setup twice fixes an issue when it is raining
+				precip->SetupMask();
+				precip->SetupMask();  // Calling setup twice fixes an issue when it is raining
 
 				BSParticleShaderRainEmitter* rain = new BSParticleShaderRainEmitter;
-				Precipitation_RenderMask(precip, rain);
+				precip->RenderMask((RE::BSParticleShaderRainEmitter*)rain);
 				singleton->inOcclusion = false;
-				RE::BSParticleShaderCubeEmitter* cube = (RE::BSParticleShaderCubeEmitter*)rain;
 
 				singleton->OcclusionDir = -float4{ PrecipitationShaderDirectionF.x, PrecipitationShaderDirectionF.y, PrecipitationShaderDirectionF.z, 0 };
-				singleton->OcclusionTransform = cube->occlusionProjection;
+				singleton->OcclusionTransform = ((RE::BSParticleShaderRainEmitter*)rain)->occlusionProjection;
 
-				cube = nullptr;
 				delete rain;
 
 				PrecipitationShaderCubeSize = originalPrecipitationShaderCubeSize;

--- a/src/Features/Skylighting.h
+++ b/src/Features/Skylighting.h
@@ -98,7 +98,7 @@ struct Skylighting : Feature
 	// Hooks
 	struct BSLightingShaderProperty_GetPrecipitationOcclusionMapRenderPassesImpl
 	{
-		static void* thunk(RE::BSLightingShaderProperty* property, RE::BSGeometry* geometry, uint32_t renderMode, RE::BSGraphics::BSShaderAccumulator* accumulator);
+		static RE::BSLightingShaderProperty::Data* thunk(RE::BSLightingShaderProperty* property, RE::BSGeometry* geometry, uint32_t renderMode, RE::BSGraphics::BSShaderAccumulator* accumulator);
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 


### PR DESCRIPTION
Update clib-ng to latest and remove old RE of Skylighting and CloudShadows.
Temp update to point to my fork of clib-ng with this fix. It's currently one commit ahead of clib-ng

Have all been verified that it works in runtime (below clib update was needed)