### PR TITLE
fix: black reflections + InWorld flag

### DIFF
--- a/package/Shaders/Common/Permutation.hlsli
+++ b/package/Shaders/Common/Permutation.hlsli
@@ -40,6 +40,8 @@
 #define _GrayscaleToAlpha (1 << 20)
 #define _IgnoreTexAlpha (1 << 21)
 
+#define _InWorld (1 << 24)
+
 cbuffer PerShader : register(b4)
 {
 	uint VertexShaderDescriptor;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1023,7 +1023,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	float3 viewPosition = mul(CameraView[eyeIndex], float4(input.WorldPosition.xyz, 1)).xyz;
 	float2 screenUV = ViewToUV(viewPosition, true, eyeIndex);
 	float screenNoise = InterleavedGradientNoise(screenUV * BufferDim * DynamicResolutionParams1.xy, FrameCount);
-	
+
 	// If InWorld or first-person
 	bool mainPass = (PixelShaderDescriptor & _InWorld) || !FrameParams.y;
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1732,7 +1732,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	float wetnessOcclusion = mainPass ? pow(saturate(shUnproject(skylightingSH, float3(0, 0, 1))), 2) : 0;
 #		else
 	float wetnessOcclusion = mainPass;
-#	endif
+#		endif
 
 	float4 raindropInfo = float4(0, 0, 1, 0);
 	if (worldSpaceNormal.z > 0 && wetnessEffects.Raining > 0.0f && wetnessEffects.EnableRaindropFx &&
@@ -1741,9 +1741,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #		if defined(SKINNED)
 			raindropInfo = GetRainDrops(input.ModelPosition, wetnessEffects.Time, worldSpaceNormal);
 #		elif defined(DEFERRED)
-		raindropInfo = GetRainDrops(input.WorldPosition + CameraPosAdjust[eyeIndex], wetnessEffects.Time, worldSpaceNormal);
+			raindropInfo = GetRainDrops(input.WorldPosition + CameraPosAdjust[eyeIndex], wetnessEffects.Time, worldSpaceNormal);
 #		else
-		raindropInfo = GetRainDrops(!FrameParams.y ? input.ModelPosition : input.WorldPosition + CameraPosAdjust[eyeIndex], wetnessEffects.Time, worldSpaceNormal);
+			raindropInfo = GetRainDrops(!FrameParams.y ? input.ModelPosition : input.WorldPosition + CameraPosAdjust[eyeIndex], wetnessEffects.Time, worldSpaceNormal);
 #		endif
 	}
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1840,13 +1840,13 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #		if defined(SOFT_LIGHTING) || defined(BACK_LIGHTING) || defined(RIM_LIGHTING)
 	if (!inDirShadow && dirLightAngle > 0.0) {
 #		else
-	if (!inDirShadow && PixelShaderDescriptor){
+	if (!inDirShadow && PixelShaderDescriptor) {
 #		endif
 #	else
 #		if defined(SOFT_LIGHTING) || defined(BACK_LIGHTING) || defined(RIM_LIGHTING)
 	if (!inDirShadow && dirLightAngle > 0.0 && (PixelShaderDescriptor & _InWorld || !FrameParams.y)) {
 #		else
-	if (!inDirShadow && PixelShaderDescriptor & (PixelShaderDescriptor & _InWorld || !FrameParams.y)){
+	if (!inDirShadow && PixelShaderDescriptor & (PixelShaderDescriptor & _InWorld || !FrameParams.y)) {
 #		endif
 #	endif
 #	if defined(DEFERRED) && defined(SCREEN_SPACE_SHADOWS)
@@ -1864,11 +1864,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 			[branch] if (extendedMaterialSettings.EnableParallax && extendedMaterialSettings.EnableShadows)
 				parallaxShadow = GetParallaxSoftShadowMultiplier(uv, mipLevel, dirLightDirectionTS, sh0, TexParallaxSampler, SampParallaxSampler, 0, parallaxShadowQuality, screenNoise, displacementParams);
 #		elif defined(ENVMAP)
-			[branch] if (complexMaterialParallax && extendedMaterialSettings.EnableShadows)
-				parallaxShadow = GetParallaxSoftShadowMultiplier(uv, mipLevel, dirLightDirectionTS, sh0, TexEnvMaskSampler, SampEnvMaskSampler, 3, parallaxShadowQuality, screenNoise, displacementParams);
+		[branch] if (complexMaterialParallax && extendedMaterialSettings.EnableShadows)
+			parallaxShadow = GetParallaxSoftShadowMultiplier(uv, mipLevel, dirLightDirectionTS, sh0, TexEnvMaskSampler, SampEnvMaskSampler, 3, parallaxShadowQuality, screenNoise, displacementParams);
 #		elif defined(TRUE_PBR) && !defined(LODLANDSCAPE)
-			[branch] if (PBRParallax && extendedMaterialSettings.EnableShadows)
-				parallaxShadow = GetParallaxSoftShadowMultiplier(uv, mipLevel, dirLightDirectionTS, sh0, TexParallaxSampler, SampParallaxSampler, 0, parallaxShadowQuality, screenNoise, displacementParams);
+		[branch] if (PBRParallax && extendedMaterialSettings.EnableShadows)
+			parallaxShadow = GetParallaxSoftShadowMultiplier(uv, mipLevel, dirLightDirectionTS, sh0, TexParallaxSampler, SampParallaxSampler, 0, parallaxShadowQuality, screenNoise, displacementParams);
 #		endif  // LANDSCAPE
 		}
 #	endif  // defined(EMAT) && (defined (SKINNED) || !defined \
@@ -2629,8 +2629,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	psout.Reflectance = float4(wetnessReflectance, psout.Diffuse.w);
 	psout.NormalGlossiness = float4(EncodeNormal(screenSpaceNormal), lerp(outGlossiness, 1.0, wetnessGlossinessSpecular), psout.Diffuse.w);
 #		else
-	psout.Reflectance = float4(0.0.xxx, psout.Diffuse.w);
-	psout.NormalGlossiness = float4(EncodeNormal(screenSpaceNormal), outGlossiness, psout.Diffuse.w);
+psout.Reflectance = float4(0.0.xxx, psout.Diffuse.w);
+psout.NormalGlossiness = float4(EncodeNormal(screenSpaceNormal), outGlossiness, psout.Diffuse.w);
 #		endif
 
 	psout.Parameters.w = psout.Diffuse.w;
@@ -2655,7 +2655,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	float wetnessNormalAmount = saturate(dot(float3(0, 0, 1), wetnessNormal) * saturate(flatnessAmount));
 	psout.Masks = float4(0, 0, wetnessNormalAmount, psout.Diffuse.w);
 #		else
-	psout.Masks = float4(0, 0, 0, psout.Diffuse.w);
+psout.Masks = float4(0, 0, 0, psout.Diffuse.w);
 #		endif
 #	endif
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1853,13 +1853,12 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #		endif
 #	endif
 
-	if (extraDirShadows){
-
+	if (extraDirShadows) {
 #	if defined(DEFERRED) && defined(SCREEN_SPACE_SHADOWS)
 #		if defined(SOFT_LIGHTING) || defined(BACK_LIGHTING) || defined(RIM_LIGHTING)
-	if (dirLightAngle > 0.0)
+		if (dirLightAngle > 0.0)
 #		endif
-		dirDetailShadow = GetScreenSpaceShadow(screenUV, screenNoise, viewPosition, eyeIndex);
+			dirDetailShadow = GetScreenSpaceShadow(screenUV, screenNoise, viewPosition, eyeIndex);
 #	endif
 
 #	if defined(EMAT) && (defined(SKINNED) || !defined(MODELSPACENORMALS))
@@ -1873,11 +1872,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 			[branch] if (extendedMaterialSettings.EnableParallax && extendedMaterialSettings.EnableShadows)
 				parallaxShadow = GetParallaxSoftShadowMultiplier(uv, mipLevel, dirLightDirectionTS, sh0, TexParallaxSampler, SampParallaxSampler, 0, parallaxShadowQuality, screenNoise, displacementParams);
 #		elif defined(ENVMAP)
-		[branch] if (complexMaterialParallax && extendedMaterialSettings.EnableShadows)
-			parallaxShadow = GetParallaxSoftShadowMultiplier(uv, mipLevel, dirLightDirectionTS, sh0, TexEnvMaskSampler, SampEnvMaskSampler, 3, parallaxShadowQuality, screenNoise, displacementParams);
+			[branch] if (complexMaterialParallax && extendedMaterialSettings.EnableShadows)
+				parallaxShadow = GetParallaxSoftShadowMultiplier(uv, mipLevel, dirLightDirectionTS, sh0, TexEnvMaskSampler, SampEnvMaskSampler, 3, parallaxShadowQuality, screenNoise, displacementParams);
 #		elif defined(TRUE_PBR) && !defined(LODLANDSCAPE)
-		[branch] if (PBRParallax && extendedMaterialSettings.EnableShadows)
-			parallaxShadow = GetParallaxSoftShadowMultiplier(uv, mipLevel, dirLightDirectionTS, sh0, TexParallaxSampler, SampParallaxSampler, 0, parallaxShadowQuality, screenNoise, displacementParams);
+			[branch] if (PBRParallax && extendedMaterialSettings.EnableShadows)
+				parallaxShadow = GetParallaxSoftShadowMultiplier(uv, mipLevel, dirLightDirectionTS, sh0, TexParallaxSampler, SampParallaxSampler, 0, parallaxShadowQuality, screenNoise, displacementParams);
 #		endif  // LANDSCAPE
 		}
 #	endif  // defined(EMAT) && (defined (SKINNED) || !defined \
@@ -2638,8 +2637,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	psout.Reflectance = float4(wetnessReflectance, psout.Diffuse.w);
 	psout.NormalGlossiness = float4(EncodeNormal(screenSpaceNormal), lerp(outGlossiness, 1.0, wetnessGlossinessSpecular), psout.Diffuse.w);
 #		else
-psout.Reflectance = float4(0.0.xxx, psout.Diffuse.w);
-psout.NormalGlossiness = float4(EncodeNormal(screenSpaceNormal), outGlossiness, psout.Diffuse.w);
+	psout.Reflectance = float4(0.0.xxx, psout.Diffuse.w);
+	psout.NormalGlossiness = float4(EncodeNormal(screenSpaceNormal), outGlossiness, psout.Diffuse.w);
 #		endif
 
 	psout.Parameters.w = psout.Diffuse.w;
@@ -2664,7 +2663,7 @@ psout.NormalGlossiness = float4(EncodeNormal(screenSpaceNormal), outGlossiness, 
 	float wetnessNormalAmount = saturate(dot(float3(0, 0, 1), wetnessNormal) * saturate(flatnessAmount));
 	psout.Masks = float4(0, 0, wetnessNormalAmount, psout.Diffuse.w);
 #		else
-psout.Masks = float4(0, 0, 0, psout.Diffuse.w);
+	psout.Masks = float4(0, 0, 0, psout.Diffuse.w);
 #		endif
 #	endif
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1837,23 +1837,28 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	float dirDetailShadow = 1.0;
 	float dirShadow = 1.0;
 	float parallaxShadow = 1;
-#	if defined(DEFERRED)
 
+#	if defined(DEFERRED)
 #		if defined(SOFT_LIGHTING) || defined(BACK_LIGHTING) || defined(RIM_LIGHTING)
-	if (!inDirShadow && mainPass) {
+	bool extraDirShadows = !inDirShadow && mainPass;
 #		else
 	// If lighting cannot hit the backface of the object, do not render shadows
-	if (!inDirShadow && dirLightAngle > 0.0 && mainPass) {
+	bool extraDirShadows = !inDirShadow && dirLightAngle > 0.0 && mainPass;
 #		endif
 #	else
 #		if defined(SOFT_LIGHTING) || defined(BACK_LIGHTING) || defined(RIM_LIGHTING)
-	if (!inDirShadow && mainPass) {
+	bool extraDirShadows = !inDirShadow && mainPass;
 #		else
-	// If lighting cannot hit the backface of the object, do not render shadows
-	if (!inDirShadow && dirLightAngle > 0.0 && mainPass) {
+	bool extraDirShadows = !inDirShadow && dirLightAngle > 0.0 && mainPass;
 #		endif
 #	endif
+
+	if (extraDirShadows){
+
 #	if defined(DEFERRED) && defined(SCREEN_SPACE_SHADOWS)
+#		if defined(SOFT_LIGHTING) || defined(BACK_LIGHTING) || defined(RIM_LIGHTING)
+	if (dirLightAngle > 0.0)
+#		endif
 		dirDetailShadow = GetScreenSpaceShadow(screenUV, screenNoise, viewPosition, eyeIndex);
 #	endif
 

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -49,6 +49,7 @@ void State::Draw()
 					// Only check against non-shader bits
 					currentPixelDescriptor &= ~modifiedPixelDescriptor;
 
+					// Set an unused bit to indicate if we are rendering an object in the main rendering pass
 					if (Deferred::GetSingleton()->inWorld) {
 						currentPixelDescriptor |= (uint32_t)PermutationFlags::InWorld;
 					}

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -49,8 +49,7 @@ void State::Draw()
 					// Only check against non-shader bits
 					currentPixelDescriptor &= ~modifiedPixelDescriptor;
 
-					if (Deferred::GetSingleton()->inWorld)
-					{
+					if (Deferred::GetSingleton()->inWorld) {
 						currentPixelDescriptor |= (uint32_t)PermutationFlags::InWorld;
 					}
 
@@ -69,7 +68,7 @@ void State::Draw()
 					if (frameChecker.isNewFrame()) {
 						ID3D11Buffer* buffers[3] = { permutationCB->CB(), sharedDataCB->CB(), featureDataCB->CB() };
 						context->PSSetConstantBuffers(4, 3, buffers);
-					}			
+					}
 
 					if (IsDeveloperMode()) {
 						BeginPerfEvent(std::format("Draw: CS {}::{:x}", magic_enum::enum_name(currentShader->shaderType.get()), currentPixelDescriptor));


### PR DESCRIPTION
InWorld flag does not include first-person models currently. The game already supplies a flag for that.

Black reflections are due to trying to use data which is not yet bound in reflections. This just disables using such features for now.