### PR TITLE
chore: disable temporal denoiser on diffuse AO

### DIFF
--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
@@ -450,7 +450,7 @@ void CalculateGI(
 			lerpFactor = 0;
 #	endif
 
-		currGIAO = lerp(srcPrevGI[pxCoord], currGIAO, lerpFactor);
+		currGIAO = float4(lerp(srcPrevGI[pxCoord].rgb, currGIAO.rgb, lerpFactor), currGIAO.a);
 #	ifdef GI_SPECULAR
 		currGIAOSpecular = lerp(srcPrevGISpecular[pxCoord], currGIAOSpecular, lerpFactor);
 #	endif

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -298,8 +298,10 @@ void ScreenSpaceGI::DrawSettings()
 
 	if (ImGui::BeginTable("denoisers", 2)) {
 		ImGui::TableNextColumn();
-		recompileFlag |= ImGui::Checkbox("Temporal Denoiser", &settings.EnableTemporalDenoiser);
-
+		{
+			auto _ = DisableGuard(!settings.EnableGI);
+			recompileFlag |= ImGui::Checkbox("Temporal Denoiser", &settings.EnableTemporalDenoiser);
+		}
 		ImGui::TableNextColumn();
 		ImGui::Checkbox("Blur", &settings.EnableBlur);
 
@@ -578,7 +580,7 @@ void ScreenSpaceGI::CompileComputeShaders()
 			info.defines.push_back({ "HALF_RES", "" });
 		if (settings.HalfRate)
 			info.defines.push_back({ "HALF_RATE", "" });
-		if (settings.EnableTemporalDenoiser)
+		if (settings.EnableGI && settings.EnableTemporalDenoiser)
 			info.defines.push_back({ "TEMPORAL_DENOISER", "" });
 		if (settings.UseBitmask)
 			info.defines.push_back({ "BITMASK", "" });


### PR DESCRIPTION
it doesn't need it and only introduces ghosting