### PR TITLE
fix: specular gi affecting diffuse gi, revert disable temporal denoiser on diffuse AO

### DIFF
--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
@@ -450,7 +450,8 @@ void CalculateGI(
 			lerpFactor = 0;
 #	endif
 
-		currGIAO = float4(lerp(srcPrevGI[pxCoord].rgb, currGIAO.rgb, lerpFactor), currGIAO.a);
+		float4 lerpGIAO = lerp(srcPrevGI[pxCoord], currGIAO, lerpFactor);
+		currGIAO = useHistory ? lerpGIAO : float4(lerpGIAO.rgb, currGIAO.a);
 #	ifdef GI_SPECULAR
 		currGIAOSpecular = lerp(srcPrevGISpecular[pxCoord], currGIAOSpecular, lerpFactor);
 #	endif

--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
@@ -244,9 +244,11 @@ void CalculateGI(
 				uint2 bitsRangeGI = uint2(round(angleRangeGI.x * 32u), round((angleRangeGI.y - angleRangeGI.x) * 32u));
 				uint maskedBitsGI = ((1 << bitsRangeGI.y) - 1) << bitsRangeGI.x;
 
-				uint checkGI = maskedBitsGI & ~bitmaskGI;
+				uint overlappedBits = maskedBitsGI & ~bitmaskGI;
+				bool checkGI = overlappedBits;
 #		ifdef GI_SPECULAR
-				checkGI = checkGI || (maskedBitsGISpecular & ~bitsRangeGISpecular);
+				uint overlappedBitsSpecular = maskedBitsGISpecular & ~bitsRangeGISpecular;
+				checkGI = checkGI || overlappedBitsSpecular;
 #		endif
 #	else
 				bool checkGI = shc > horizonCos;
@@ -268,14 +270,14 @@ void CalculateGI(
 
 						float nov = dot(viewspaceNormal, sampleHorizonVec);
 
-						float3 diffuseRadiance = sampleRadiance * countbits(checkGI) * 0.03125;  // 1/32
+						float3 diffuseRadiance = sampleRadiance * countbits(overlappedBits) * 0.03125;  // 1/32
 						diffuseRadiance *= nov;
 						diffuseRadiance = max(0, diffuseRadiance);
 
 						radiance += diffuseRadiance;
 
 #		ifdef GI_SPECULAR
-						float3 specularRadiance = sampleRadiance * countbits(maskedBitsGISpecular & ~bitmaskGISpecular) * 0.03125;  // 1/32
+						float3 specularRadiance = sampleRadiance * countbits(overlappedBitsSpecular) * 0.03125;  // 1/32
 						specularRadiance *= nov;
 						specularRadiance = max(0, specularRadiance);
 

--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
@@ -452,8 +452,7 @@ void CalculateGI(
 			lerpFactor = 0;
 #	endif
 
-		float4 lerpGIAO = lerp(srcPrevGI[pxCoord], currGIAO, lerpFactor);
-		currGIAO = useHistory ? lerpGIAO : float4(lerpGIAO.rgb, currGIAO.a);
+		currGIAO = float4(lerp(srcPrevGI[pxCoord].rgb, currGIAO.rgb, lerpFactor), currGIAO.a);
 #	ifdef GI_SPECULAR
 		currGIAOSpecular = lerp(srcPrevGISpecular[pxCoord], currGIAOSpecular, lerpFactor);
 #	endif

--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
@@ -452,7 +452,7 @@ void CalculateGI(
 			lerpFactor = 0;
 #	endif
 
-		currGIAO = float4(lerp(srcPrevGI[pxCoord].rgb, currGIAO.rgb, lerpFactor), currGIAO.a);
+		currGIAO = lerp(srcPrevGI[pxCoord], currGIAO, lerpFactor);
 #	ifdef GI_SPECULAR
 		currGIAOSpecular = lerp(srcPrevGISpecular[pxCoord], currGIAOSpecular, lerpFactor);
 #	endif

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -298,10 +298,8 @@ void ScreenSpaceGI::DrawSettings()
 
 	if (ImGui::BeginTable("denoisers", 2)) {
 		ImGui::TableNextColumn();
-		{
-			auto _ = DisableGuard(!settings.EnableGI);
-			recompileFlag |= ImGui::Checkbox("Temporal Denoiser", &settings.EnableTemporalDenoiser);
-		}
+		recompileFlag |= ImGui::Checkbox("Temporal Denoiser", &settings.EnableTemporalDenoiser);
+
 		ImGui::TableNextColumn();
 		ImGui::Checkbox("Blur", &settings.EnableBlur);
 
@@ -580,7 +578,7 @@ void ScreenSpaceGI::CompileComputeShaders()
 			info.defines.push_back({ "HALF_RES", "" });
 		if (settings.HalfRate)
 			info.defines.push_back({ "HALF_RATE", "" });
-		if (settings.EnableGI && settings.EnableTemporalDenoiser)
+		if (settings.EnableTemporalDenoiser)
 			info.defines.push_back({ "TEMPORAL_DENOISER", "" });
 		if (settings.UseBitmask)
 			info.defines.push_back({ "BITMASK", "" });

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -580,7 +580,7 @@ void ScreenSpaceGI::CompileComputeShaders()
 			info.defines.push_back({ "HALF_RES", "" });
 		if (settings.HalfRate)
 			info.defines.push_back({ "HALF_RATE", "" });
-		if (settings.EnableGI && settings.EnableTemporalDenoiser)
+		if ((settings.EnableGI && settings.EnableTemporalDenoiser) || settings.HalfRate)
 			info.defines.push_back({ "TEMPORAL_DENOISER", "" });
 		if (settings.UseBitmask)
 			info.defines.push_back({ "BITMASK", "" });

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -580,7 +580,7 @@ void ScreenSpaceGI::CompileComputeShaders()
 			info.defines.push_back({ "HALF_RES", "" });
 		if (settings.HalfRate)
 			info.defines.push_back({ "HALF_RATE", "" });
-		if ((settings.EnableGI && settings.EnableTemporalDenoiser) || settings.HalfRate)
+		if (settings.EnableGI && settings.EnableTemporalDenoiser)
 			info.defines.push_back({ "TEMPORAL_DENOISER", "" });
 		if (settings.UseBitmask)
 			info.defines.push_back({ "BITMASK", "" });


### PR DESCRIPTION
turns out AO still needs temporal in some cases, welp