### PR TITLE
fix: PBR directional light specular fix and llf compile fixes

### DIFF
--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -16,7 +16,7 @@ cbuffer SharedData : register(b5)
 	float4 BufferDim;
 	float Timer;
 	uint FrameCount;
-	bool Interior;
+	bool Interior; 	// If the area lacks a directional shadow light e.g. the sun or moon
 	uint pad0b4[1];
 };
 

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -16,7 +16,7 @@ cbuffer SharedData : register(b5)
 	float4 BufferDim;
 	float Timer;
 	uint FrameCount;
-	bool Interior; 	// If the area lacks a directional shadow light e.g. the sun or moon
+	bool Interior;  // If the area lacks a directional shadow light e.g. the sun or moon
 	uint pad0b4[1];
 };
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -913,12 +913,6 @@ float GetSnowParameterY(float texProjTmp, float alpha)
 #	endif
 }
 
-float3 ApplyFogAndClampColor(float3 srcColor, float4 fogParam, float3 clampColor, out float3 preClampColor)
-{
-	preClampColor = (srcColor - lerp(srcColor, fogParam.xyz, fogParam.w) * FogColor.w) * FrameParams.y;
-	return min(preClampColor + clampColor, srcColor);
-}
-
 #	if defined(LOD)
 #		undef EXTENDED_MATERIALS
 #		undef WATER_BLENDING
@@ -1930,7 +1924,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		lightsDiffuseColor += dirDiffuseColor;
 		coatLightsDiffuseColor += coatDirDiffuseColor;
 		transmissionColor += dirTransmissionColor;
-		specularColorPBR += dirSpecularColor;
+		specularColorPBR += dirSpecularColor * !Interior;
 #		if defined(LOD_LAND_BLEND)
 		lodLandDiffuseColor += dirLightColor * saturate(dirLightAngle) * dirDetailShadow;
 #		endif
@@ -2560,15 +2554,15 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #	if defined(LIGHT_LIMIT_FIX) && defined(LLFDEBUG)
 	if (lightLimitFixSettings.EnableLightsVisualisation) {
 		if (lightLimitFixSettings.LightsVisualisationMode == 0) {
-			psout.Diffuse.xyz = TurboColormap(NumStrictLights >= 7.0);
+			psout.Diffuse.xyz = TurboColormap(strictLights[0].NumStrictLights >= 7.0);
 		} else if (lightLimitFixSettings.LightsVisualisationMode == 1) {
-			psout.Diffuse.xyz = TurboColormap((float)NumStrictLights / 15.0);
+			psout.Diffuse.xyz = TurboColormap((float)strictLights[0].NumStrictLights / 15.0);
 		} else {
 			psout.Diffuse.xyz = TurboColormap((float)numClusteredLights / 128.0);
 		}
 		baseColor.xyz = 0.0;
 	} else {
-		psout.Diffuse.xyz = color.xyz - preClampColor * FrameParams.z;
+		psout.Diffuse.xyz = color.xyz;
 	}
 #	else
 	psout.Diffuse.xyz = color.xyz;


### PR DESCRIPTION

![ScreenShot3950](https://github.com/user-attachments/assets/29340813-61f9-4a2e-a695-ccfd599be225)
![ScreenShot3951](https://github.com/user-attachments/assets/b048c1a8-1d0b-4e35-9759-a3448d32b5e1)

Fixes directional lights applying to the specular in interiors. This doesn't make sense for the specular since we already include ambient light like that in the dynamic cubemap. 

Also fixes the light limit fix debug visualisations compile errors, and removes unneeded color clamping. 