### PR TITLE
feat: unlocked HDR range of game buffers

### DIFF
--- a/package/Shaders/DeferredCompositeCS.hlsl
+++ b/package/Shaders/DeferredCompositeCS.hlsl
@@ -161,7 +161,7 @@ Texture2D<half4> SpecularSSGITexture : register(t10);
 
 #endif
 
-	MainRW[dispatchID.xy] = min(color, 128);  // Vanilla bloom fix
+	MainRW[dispatchID.xy] = min(color, 250);  // Vanilla bloom fix
 	NormalTAAMaskSpecularMaskRW[dispatchID.xy] = half4(EncodeNormalVanilla(normalVS), 0.0, 0.0);
 	SnowParametersRW[dispatchID.xy] = snowParameters;
 }

--- a/package/Shaders/ISLightingComposite.hlsl
+++ b/package/Shaders/ISLightingComposite.hlsl
@@ -62,8 +62,7 @@ PS_OUTPUT main(PS_INPUT input)
 	float4 fog = FogTex.Sample(FogSampler, input.TexCoord);
 
 	if (fog.x + fog.y + fog.z + fog.w != 0) {
-		psout.Color =
-			float4(saturate(FogNearColor.w * lerp(preFog.xyz, fog.xyz, fog.w)), saturate(preFog.w));
+		psout.Color = float4(FogNearColor.w * lerp(preFog.xyz, fog.xyz, fog.w), saturate(preFog.w));
 	} else {
 		psout.Color = preFog;
 	}

--- a/package/Shaders/ISSAOComposite.hlsl
+++ b/package/Shaders/ISSAOComposite.hlsl
@@ -198,7 +198,7 @@ PS_OUTPUT main(PS_INPUT input)
 	composedColor *= 1 - SparklesParameters2.w;
 	composedColor += sparklesColor;
 
-	psout.Color = saturate(composedColor);
+	psout.Color = composedColor;
 
 	return psout;
 }


### PR DESCRIPTION
Uncaps buffers from being limited to a range of 0-1, to properly support HDR tonemapping and HDR outputs.