### PR TITLE
chore: updated feature settings for correct color space

### DIFF
--- a/src/Features/ScreenSpaceGI.h
+++ b/src/Features/ScreenSpaceGI.h
@@ -66,8 +66,8 @@ struct ScreenSpaceGI : Feature
 		float GIBounceFade = 1.f;
 		float GIDistanceCompensation = 0.f;
 		// mix
-		float AOPower = 2.f;
-		float GIStrength = 3.f;
+		float AOPower = 1.f;
+		float GIStrength = 6.f;
 		// denoise
 		bool EnableTemporalDenoiser = true;
 		bool EnableBlur = true;

--- a/src/Features/Skylighting.h
+++ b/src/Features/Skylighting.h
@@ -44,7 +44,7 @@ struct Skylighting : Feature
 		bool DirectionalDiffuse = false;
 		float MaxZenith = 3.1415926f / 3.f;  // 60 deg
 		int MaxFrames = 64;
-		float MinDiffuseVisibility = 0.1f;
+		float MinDiffuseVisibility = 0.25f;
 		float DiffusePower = 1.f;
 		float MinSpecularVisibility = 0.f;
 		float SpecularPower = 1.f;


### PR DESCRIPTION
Increases the brightness of skylightng to the typically lowest ENB value.

Halves AO power and doubles IL power to look similar to the previous look.

All default settings can be tweaked further later.