### PR TITLE
chore: convert to skyrim half gamma space

### DIFF
--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -25,7 +25,7 @@ float3 GetDynamicCubemapSpecularIrradiance(float2 uv, float3 N, float3 VN, float
 
 	float3 specularIrradiance = specularTexture.SampleLevel(SampColorSampler, R, level).xyz;
 	specularIrradiance *= horizon;
-	specularIrradiance = sRGB2Lin(specularIrradiance);
+	specularIrradiance = SkyrimGamma2Lin(specularIrradiance);
 
 	return specularIrradiance;
 }
@@ -53,7 +53,7 @@ float3 GetDynamicCubemap(float2 uv, float3 N, float3 VN, float3 V, float roughne
 	return horizon * ((F0 + S) * specularBRDF.x + specularBRDF.y);
 #	else
 	float3 specularIrradiance = specularTexture.SampleLevel(SampColorSampler, R, level).xyz;
-	specularIrradiance = sRGB2Lin(specularIrradiance);
+	specularIrradiance = SkyrimGamma2Lin(specularIrradiance);
 
 	return specularIrradiance * ((F0 + S) * specularBRDF.x + specularBRDF.y);
 #	endif

--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -24,8 +24,8 @@ float3 GetDynamicCubemapSpecularIrradiance(float2 uv, float3 N, float3 VN, float
 	horizon *= horizon * horizon;
 
 	float3 specularIrradiance = specularTexture.SampleLevel(SampColorSampler, R, level).xyz;
-	specularIrradiance *= horizon;
 	specularIrradiance = SkyrimGamma2Lin(specularIrradiance);
+	specularIrradiance *= horizon;
 
 	return specularIrradiance;
 }

--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/InferCubemapCS.hlsl
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/InferCubemapCS.hlsl
@@ -90,11 +90,11 @@ float3 GetSamplingVector(uint3 ThreadID, in RWTexture2DArray<float4> OutputTextu
 	}
 
 #if defined(REFLECTIONS)
-	color.rgb = lerp(color.rgb, sRGB2Lin(ReflectionsTexture.SampleLevel(LinearSampler, uv, 0)), saturate(mipLevel / 8.0));
+	color.rgb = lerp(color.rgb, SkyrimGamma2Lin(ReflectionsTexture.SampleLevel(LinearSampler, uv, 0)), saturate(mipLevel / 8.0));
 #else
-	color.rgb = lerp(color.rgb, color.rgb * sRGB2Lin(DefaultCubemap.SampleLevel(LinearSampler, uv, 0).x) * 2, saturate(mipLevel / 8.0));
+	color.rgb = lerp(color.rgb, color.rgb * SkyrimGamma2Lin(DefaultCubemap.SampleLevel(LinearSampler, uv, 0).x) * 2, saturate(mipLevel / 8.0));
 #endif
 
-	color.rgb = Lin2sRGB(color.rgb);
+	color.rgb = Lin2SkyrimGamma(color.rgb);
 	EnvInferredTexture[ThreadID] = max(0, color);
 }

--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/SpecularIrradianceCS.hlsl
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/SpecularIrradianceCS.hlsl
@@ -4,6 +4,8 @@
 // Pre-filters environment cube map using GGX NDF importance sampling.
 // Part of specular IBL split-sum approximation.
 
+#include "../Common/Color.hlsli"
+
 static const float PI = 3.141592;
 static const float TwoPI = 2 * PI;
 static const float Epsilon = 0.00001;
@@ -116,16 +118,6 @@ void computeBasisVectors(const float3 N, out float3 S, out float3 T)
 float3 tangentToWorld(const float3 v, const float3 N, const float3 S, const float3 T)
 {
 	return S * v.x + T * v.y + N * v.z;
-}
-
-float3 SkyrimGamma2Lin(float3 color)
-{
-	return color > 0.04045 ? pow(color / 1.055 + 0.055 / 1.055, 2.4) : color / 12.92;
-}
-
-float3 Lin2SkyrimGamma(float3 color)
-{
-	return color > 0.0031308 ? 1.055 * pow(color, 1.0 / 2.4) - 0.055 : 12.92 * color;
 }
 
 [numthreads(8, 8, 1)] void main(uint3 ThreadID

--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/SpecularIrradianceCS.hlsl
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/SpecularIrradianceCS.hlsl
@@ -118,12 +118,12 @@ float3 tangentToWorld(const float3 v, const float3 N, const float3 S, const floa
 	return S * v.x + T * v.y + N * v.z;
 }
 
-float3 sRGB2Lin(float3 color)
+float3 SkyrimGamma2Lin(float3 color)
 {
 	return color > 0.04045 ? pow(color / 1.055 + 0.055 / 1.055, 2.4) : color / 12.92;
 }
 
-float3 Lin2sRGB(float3 color)
+float3 Lin2SkyrimGamma(float3 color)
 {
 	return color > 0.0031308 ? 1.055 * pow(color, 1.0 / 2.4) - 0.055 : 12.92 * color;
 }
@@ -181,11 +181,11 @@ float3 Lin2sRGB(float3 color)
 			// Mip level to sample from.
 			float mipLevel = max(0.5 * log2(ws / wt) + 1.0, 0.0);
 
-			color += sRGB2Lin(inputTexture.SampleLevel(linear_wrap_sampler, Li, mipLevel).rgb) * cosLi;
+			color += SkyrimGamma2Lin(inputTexture.SampleLevel(linear_wrap_sampler, Li, mipLevel).rgb) * cosLi;
 			weight += cosLi;
 		}
 	}
 	color /= weight;
 
-	outputTexture[ThreadID] = float4(Lin2sRGB(color), 1.0);
+	outputTexture[ThreadID] = float4(Lin2SkyrimGamma(color), 1.0);
 }

--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/UpdateCubemapCS.hlsl
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/UpdateCubemapCS.hlsl
@@ -59,7 +59,7 @@ cbuffer UpdateData : register(b1)
 bool IsSaturated(float value) { return value == saturate(value); }
 bool IsSaturated(float2 value) { return IsSaturated(value.x) && IsSaturated(value.y); }
 
-float3 sRGB2Lin(float3 color)
+float3 SkyrimGamma2Lin(float3 color)
 {
 	return color > 0.04045 ? pow(color / 1.055 + 0.055 / 1.055, 2.4) : color / 12.92;
 }
@@ -172,7 +172,7 @@ float smoothbumpstep(float edge0, float edge1, float x)
 
 		if (linearDepth > 16.5) {  // Ignore objects which are too close
 			float3 color = ColorTexture.SampleLevel(LinearSampler, uv, 0);
-			float4 output = float4(sRGB2Lin(color), 1.0);
+			float4 output = float4(SkyrimGamma2Lin(color), 1.0);
 			float lerpFactor = 1.0 / 64.0;
 
 			half4 positionCS = half4(2 * half2(uv.x, -uv.y + 1) - 1, depth, 1);

--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/radianceDisocc.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/radianceDisocc.cs.hlsl
@@ -131,7 +131,7 @@ void readHistory(
 
 	half3 radiance = 0;
 #ifdef GI
-	radiance = sRGB2Lin(FULLRES_LOAD(srcDiffuse, pixCoord, uv * frameScale, samplerLinearClamp).rgb * GIStrength);
+	radiance = SkyrimGamma2Lin(FULLRES_LOAD(srcDiffuse, pixCoord, uv * frameScale, samplerLinearClamp).rgb * GIStrength);
 #	ifdef GI_BOUNCE
 	radiance += prev_ambient.rgb * GIBounceFade;
 #	endif

--- a/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSS.hlsli
+++ b/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSS.hlsli
@@ -100,7 +100,7 @@ float4 SSSSBlurCS(
 	float4 colorM = ColorTexture[DTid.xy];
 
 #if defined(HORIZONTAL)
-	colorM.rgb = sRGB2Lin(colorM.rgb);
+	colorM.rgb = SkyrimGamma2Lin(colorM.rgb);
 #endif
 
 	if (sssAmount == 0)
@@ -157,7 +157,7 @@ float4 SSSSBlurCS(
 		float3 color = ColorTexture[coords].rgb;
 
 #if defined(HORIZONTAL)
-		color.rgb = sRGB2Lin(color.rgb);
+		color.rgb = SkyrimGamma2Lin(color.rgb);
 #endif
 
 		float depth = DepthTexture[coords].r;

--- a/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSSCS.hlsl
+++ b/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSSCS.hlsl
@@ -39,7 +39,7 @@ cbuffer PerFrameSSS : register(b1)
 	bool humanProfile = MaskTexture[DTid.xy].y == sssAmount;
 
 	float4 color = SSSSBlurCS(DTid.xy, texCoord, float2(0.0, 1.0), sssAmount, humanProfile);
-	color.rgb = Lin2sRGB(color.rgb);
+	color.rgb = Lin2SkyrimGamma(color.rgb);
 	SSSRW[DTid.xy] = float4(color.rgb, 1.0);
 
 #endif

--- a/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
+++ b/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
@@ -144,7 +144,7 @@ float3 GetWetnessAmbientSpecular(float2 uv, float3 N, float3 VN, float3 V, float
 	float3 specularIrradiance = 1.0;
 #	else
 	float level = roughness * 7.0;
-	float3 specularIrradiance = sRGB2Lin(specularTexture.SampleLevel(SampColorSampler, R, level));
+	float3 specularIrradiance = SkyrimGamma2Lin(specularTexture.SampleLevel(SampColorSampler, R, level));
 #	endif
 #else
 	float3 specularIrradiance = 1.0;

--- a/package/Shaders/AmbientCompositeCS.hlsl
+++ b/package/Shaders/AmbientCompositeCS.hlsl
@@ -51,11 +51,11 @@ RWTexture2D<half3> DiffuseAmbientRW : register(u1);
 
 	half3 directionalAmbientColor = mul(DirectionalAmbient, half4(normalWS, 1.0));
 
-	half3 linAlbedo = sRGB2Lin(albedo);
-	half3 linDirectionalAmbientColor = sRGB2Lin(directionalAmbientColor);
-	half3 linDiffuseColor = sRGB2Lin(diffuseColor);
+	half3 linAlbedo = SkyrimGamma2Lin(albedo);
+	half3 linDirectionalAmbientColor = SkyrimGamma2Lin(directionalAmbientColor);
+	half3 linDiffuseColor = SkyrimGamma2Lin(diffuseColor);
 
-	half3 linAmbient = lerp(sRGB2Lin(albedo * directionalAmbientColor), linAlbedo * linDirectionalAmbientColor, pbrWeight);
+	half3 linAmbient = lerp(SkyrimGamma2Lin(albedo * directionalAmbientColor), linAlbedo * linDirectionalAmbientColor, pbrWeight);
 
 	half visibility = 1.0;
 #if defined(SKYLIGHTING)
@@ -90,10 +90,10 @@ RWTexture2D<half3> DiffuseAmbientRW : register(u1);
 #endif
 
 	linAmbient *= visibility;
-	diffuseColor = Lin2sRGB(linDiffuseColor);
-	directionalAmbientColor = Lin2sRGB(linDirectionalAmbientColor * visibility);
+	diffuseColor = Lin2SkyrimGamma(linDiffuseColor);
+	directionalAmbientColor = Lin2SkyrimGamma(linDirectionalAmbientColor * visibility);
 
-	diffuseColor = lerp(diffuseColor + directionalAmbientColor * albedo, Lin2sRGB(linDiffuseColor + linAmbient), pbrWeight);
+	diffuseColor = lerp(diffuseColor + directionalAmbientColor * albedo, Lin2SkyrimGamma(linDiffuseColor + linAmbient), pbrWeight);
 
 	MainRW[dispatchID.xy] = diffuseColor;
 };

--- a/package/Shaders/Common/Color.hlsli
+++ b/package/Shaders/Common/Color.hlsli
@@ -17,10 +17,10 @@ float RGBToLuminance2(float3 color)
 
 float3 SkyrimGamma2Lin(float3 color)
 {
-	return pow(abs(color), 1.5);
+	return pow(abs(color), 1.48);
 }
 
 float3 Lin2SkyrimGamma(float3 color)
 {
-	return pow(abs(color), 1.0 / 1.5);
+	return pow(abs(color), 1.0 / 1.48);
 }

--- a/package/Shaders/Common/Color.hlsli
+++ b/package/Shaders/Common/Color.hlsli
@@ -15,12 +15,12 @@ float RGBToLuminance2(float3 color)
 	return dot(color, float3(0.299, 0.587, 0.114));
 }
 
-float3 sRGB2Lin(float3 color)
+float3 SkyrimGamma2Lin(float3 color)
 {
-	return pow(abs(color), 2.2);
+	return pow(abs(color), 1.5);
 }
 
-float3 Lin2sRGB(float3 color)
+float3 Lin2SkyrimGamma(float3 color)
 {
-	return pow(abs(color), 1.0 / 2.2);
+	return pow(abs(color), 1.0 / 1.5);
 }

--- a/package/Shaders/Common/PBR.hlsli
+++ b/package/Shaders/Common/PBR.hlsli
@@ -87,17 +87,17 @@ namespace PBR
 
 	float3 AdjustDirectionalLightColor(float3 lightColor)
 	{
-		return pbrSettings.DirectionalLightColorMultiplier * sRGB2Lin(lightColor);
+		return pbrSettings.DirectionalLightColorMultiplier * lightColor;
 	}
 
 	float3 AdjustPointLightColor(float3 lightColor)
 	{
-		return pbrSettings.PointLightColorMultiplier * sRGB2Lin(lightColor);
+		return pbrSettings.PointLightColorMultiplier * lightColor;
 	}
 
 	float3 AdjustAmbientLightColor(float3 lightColor)
 	{
-		return pbrSettings.AmbientLightColorMultiplier * sRGB2Lin(lightColor);
+		return pbrSettings.AmbientLightColorMultiplier * lightColor;
 	}
 
 	// [Jimenez et al. 2016, "Practical Realtime Strategies for Accurate Indirect Occlusion"]

--- a/package/Shaders/Common/PBR.hlsli
+++ b/package/Shaders/Common/PBR.hlsli
@@ -87,17 +87,17 @@ namespace PBR
 
 	float3 AdjustDirectionalLightColor(float3 lightColor)
 	{
-		return pbrSettings.DirectionalLightColorMultiplier * lightColor;
+		return pbrSettings.DirectionalLightColorMultiplier * SkyrimGamma2Lin(lightColor);
 	}
 
 	float3 AdjustPointLightColor(float3 lightColor)
 	{
-		return pbrSettings.PointLightColorMultiplier * lightColor;
+		return pbrSettings.PointLightColorMultiplier * SkyrimGamma2Lin(lightColor);
 	}
 
 	float3 AdjustAmbientLightColor(float3 lightColor)
 	{
-		return pbrSettings.AmbientLightColorMultiplier * lightColor;
+		return pbrSettings.AmbientLightColorMultiplier * SkyrimGamma2Lin(lightColor);
 	}
 
 	// [Jimenez et al. 2016, "Practical Realtime Strategies for Accurate Indirect Occlusion"]

--- a/package/Shaders/DeferredCompositeCS.hlsl
+++ b/package/Shaders/DeferredCompositeCS.hlsl
@@ -60,7 +60,7 @@ Texture2D<half4> SpecularSSGITexture : register(t10);
 
 	half glossiness = normalGlossiness.z;
 
-	half3 color = lerp(diffuseColor + specularColor, Lin2sRGB(sRGB2Lin(diffuseColor) + sRGB2Lin(specularColor)), pbrWeight);
+	half3 color = lerp(diffuseColor + specularColor, Lin2SkyrimGamma(SkyrimGamma2Lin(diffuseColor) + SkyrimGamma2Lin(specularColor)), pbrWeight);
 
 #if defined(DYNAMIC_CUBEMAPS)
 
@@ -73,7 +73,7 @@ Texture2D<half4> SpecularSSGITexture : register(t10);
 
 		normalWS = lerp(normalWS, float3(0, 0, 1), wetnessMask);
 
-		color = sRGB2Lin(color);
+		color = SkyrimGamma2Lin(color);
 
 		half depth = DepthTexture[dispatchID.xy];
 
@@ -89,12 +89,12 @@ Texture2D<half4> SpecularSSGITexture : register(t10);
 		half roughness = 1.0 - glossiness;
 		half level = roughness * 7.0;
 
-		half3 directionalAmbientColor = sRGB2Lin(mul(DirectionalAmbient, half4(R, 1.0)));
+		half3 directionalAmbientColor = SkyrimGamma2Lin(mul(DirectionalAmbient, half4(R, 1.0)));
 		half3 finalIrradiance = 0;
 
 #	if defined(INTERIOR)
 		half3 specularIrradiance = EnvTexture.SampleLevel(LinearSampler, R, level).xyz;
-		specularIrradiance = sRGB2Lin(specularIrradiance);
+		specularIrradiance = SkyrimGamma2Lin(specularIrradiance);
 
 		finalIrradiance += specularIrradiance;
 #	elif defined(SKYLIGHTING)
@@ -114,19 +114,19 @@ Texture2D<half4> SpecularSSGITexture : register(t10);
 
 		if (skylightingSpecular < 1.0) {
 			specularIrradiance = EnvTexture.SampleLevel(LinearSampler, R, level).xyz;
-			specularIrradiance = sRGB2Lin(specularIrradiance);
+			specularIrradiance = SkyrimGamma2Lin(specularIrradiance);
 		}
 
 		half3 specularIrradianceReflections = 1.0;
 
 		if (skylightingSpecular > 0.0) {
 			specularIrradianceReflections = EnvReflectionsTexture.SampleLevel(LinearSampler, R, level).xyz;
-			specularIrradianceReflections = sRGB2Lin(specularIrradianceReflections);
+			specularIrradianceReflections = SkyrimGamma2Lin(specularIrradianceReflections);
 		}
 		finalIrradiance = finalIrradiance * skylightingSpecular + lerp(specularIrradiance, specularIrradianceReflections, skylightingSpecular);
 #	else
 		half3 specularIrradianceReflections = EnvReflectionsTexture.SampleLevel(LinearSampler, R, level).xyz;
-		specularIrradianceReflections = sRGB2Lin(specularIrradianceReflections);
+		specularIrradianceReflections = SkyrimGamma2Lin(specularIrradianceReflections);
 
 		finalIrradiance += specularIrradianceReflections;
 #	endif
@@ -138,7 +138,7 @@ Texture2D<half4> SpecularSSGITexture : register(t10);
 
 		color += reflectance * finalIrradiance;
 
-		color = Lin2sRGB(color);
+		color = Lin2SkyrimGamma(color);
 	}
 
 #endif

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2394,7 +2394,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 			directLightsDiffuseInput = lerp(directLightsDiffuseInput, pbrSurfaceProperties.CoatColor * coatLightsDiffuseColor, pbrSurfaceProperties.CoatStrength);
 		}
 
-		color.xyz += Lin2SkyrimGamma(directLightsDiffuseInput);
+		color.xyz += directLightsDiffuseInput;
 	}
 
 	float3 indirectDiffuseLobeWeight, indirectSpecularLobeWeight;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1614,6 +1614,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	float3 screenSpaceNormal = normalize(WorldToView(worldSpaceNormal, false, eyeIndex));
 
 #	if defined(TRUE_PBR)
+	baseColor.xyz = Lin2SkyrimGamma(baseColor.xyz);
+
 	PBR::SurfaceProperties pbrSurfaceProperties = PBR::InitSurfaceProperties();
 
 	pbrSurfaceProperties.Roughness = saturate(rawRMAOS.x);
@@ -1996,7 +1998,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 #		if defined(WETNESS_EFFECTS)
 	if (waterRoughnessSpecular < 1.0)
-		wetnessSpecular += GetWetnessSpecular(wetnessNormal, normalizedDirLightDirectionWS, worldSpaceViewDirection, sRGB2Lin(dirLightColor * dirDetailShadow), waterRoughnessSpecular);
+		wetnessSpecular += GetWetnessSpecular(wetnessNormal, normalizedDirLightDirectionWS, worldSpaceViewDirection, SkyrimGamma2Lin(dirLightColor * dirDetailShadow), waterRoughnessSpecular);
 #		endif
 #	endif
 
@@ -2205,7 +2207,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 #			if defined(WETNESS_EFFECTS)
 		if (waterRoughnessSpecular < 1.0)
-			wetnessSpecular += GetWetnessSpecular(wetnessNormal, normalizedLightDirection, worldSpaceViewDirection, sRGB2Lin(lightColor), waterRoughnessSpecular);
+			wetnessSpecular += GetWetnessSpecular(wetnessNormal, normalizedLightDirection, worldSpaceViewDirection, SkyrimGamma2Lin(lightColor), waterRoughnessSpecular);
 #			endif
 	}
 #		endif
@@ -2259,11 +2261,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	float skylightingDiffuse = shFuncProductIntegral(skylightingSH, shEvaluateCosineLobe(skylightingSettings.DirectionalDiffuse ? worldSpaceNormal : float3(0, 0, 1))) / shPI;
 	skylightingDiffuse = Skylighting::mixDiffuse(skylightingSettings, skylightingDiffuse);
 #		if !defined(TRUE_PBR)
-	directionalAmbientColor = sRGB2Lin(directionalAmbientColor);
+	directionalAmbientColor = SkyrimGamma2Lin(directionalAmbientColor);
 #		endif
 	directionalAmbientColor *= skylightingDiffuse;
 #		if !defined(TRUE_PBR)
-	directionalAmbientColor = Lin2sRGB(directionalAmbientColor);
+	directionalAmbientColor = Lin2SkyrimGamma(directionalAmbientColor);
 #		endif
 #	endif
 
@@ -2294,7 +2296,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		dynamicCubemap = true;
 		envColorBase = TexEnvSampler.SampleLevel(SampEnvSampler, float3(1.0, 0.0, 0.0), 0);
 		if (envColorBase.a < 1.0) {
-			F0 = sRGB2Lin(envColorBase.rgb) + sRGB2Lin(baseColor.rgb);
+			F0 = SkyrimGamma2Lin(envColorBase.rgb) + SkyrimGamma2Lin(baseColor.rgb);
 			envRoughness = envColorBase.a;
 		} else {
 			F0 = 1.0;
@@ -2305,7 +2307,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #			if defined(CREATOR)
 	if (cubemapCreatorSettings.Enabled) {
 		dynamicCubemap = true;
-		F0 = sRGB2Lin(cubemapCreatorSettings.CubemapColor.rgb) + sRGB2Lin(baseColor.xyz);
+		F0 = SkyrimGamma2Lin(cubemapCreatorSettings.CubemapColor.rgb) + SkyrimGamma2Lin(baseColor.xyz);
 		envRoughness = cubemapCreatorSettings.CubemapColor.a;
 	}
 #			endif
@@ -2314,7 +2316,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #			if defined(EMAT)
 		envRoughness = lerp(envRoughness, 1.0 - complexMaterialColor.y, (float)complexMaterial);
 		envRoughness *= envRoughness;
-		F0 = lerp(F0, sRGB2Lin(complexSpecular), (float)complexMaterial);
+		F0 = lerp(F0, SkyrimGamma2Lin(complexSpecular), (float)complexMaterial);
 #			endif
 
 		envColor = GetDynamicCubemap(screenUV, worldSpaceNormal, worldSpaceVertexNormal, worldSpaceViewDirection, envRoughness, F0, diffuseColor, viewPosition.z) * envMask;
@@ -2443,7 +2445,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #			else
 		diffuseColor = 1.0;
 #			endif
-		specularColor = sRGB2Lin(specularColor);
+		specularColor = SkyrimGamma2Lin(specularColor);
 	}
 #		endif
 
@@ -2460,7 +2462,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #		endif
 #		if defined(DYNAMIC_CUBEMAPS)
 	if (dynamicCubemap)
-		specularColor = Lin2sRGB(specularColor);
+		specularColor = Lin2SkyrimGamma(specularColor);
 #		endif
 #	endif
 
@@ -2473,7 +2475,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	color.xyz += specularColor;
 #		endif
 
-	color.xyz = sRGB2Lin(color.xyz);
+	color.xyz = SkyrimGamma2Lin(color.xyz);
 #	endif
 
 #	if defined(WETNESS_EFFECTS) && !defined(TRUE_PBR)
@@ -2484,7 +2486,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	color.xyz += specularColorPBR;
 #	endif
 
-	color.xyz = Lin2sRGB(color.xyz);
+	color.xyz = Lin2SkyrimGamma(color.xyz);
 
 #	if defined(LOD_LAND_BLEND) && defined(TRUE_PBR)
 	{
@@ -2495,7 +2497,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 #		if defined(DEFERRED)
 		specularColorPBR = lerp(specularColorPBR, 0, lodLandBlendFactor);
-		indirectDiffuseLobeWeight = lerp(indirectDiffuseLobeWeight, sRGB2Lin(input.Color.xyz * lodLandColor * lodLandFadeFactor), lodLandBlendFactor);
+		indirectDiffuseLobeWeight = lerp(indirectDiffuseLobeWeight, SkyrimGamma2Lin(input.Color.xyz * lodLandColor * lodLandFadeFactor), lodLandBlendFactor);
 		indirectSpecularLobeWeight = lerp(indirectSpecularLobeWeight, 0, lodLandBlendFactor);
 		pbrGlossiness = lerp(pbrGlossiness, 0, lodLandBlendFactor);
 #		endif
@@ -2636,13 +2638,13 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 	float3 outputSpecular = specularColor.xyz;
 #		if defined(TRUE_PBR)
-	outputSpecular = Lin2sRGB(specularColorPBR.xyz);
+	outputSpecular = Lin2SkyrimGamma(specularColorPBR.xyz);
 #		endif
 	psout.Specular = float4(outputSpecular, psout.Diffuse.w);
 
 	float3 outputAlbedo = baseColor.xyz * vertexColor;
 #		if defined(TRUE_PBR)
-	outputAlbedo = Lin2sRGB(indirectDiffuseLobeWeight);
+	outputAlbedo = Lin2SkyrimGamma(indirectDiffuseLobeWeight);
 #		endif
 	psout.Albedo = float4(outputAlbedo, psout.Diffuse.w);
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1253,6 +1253,12 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #	endif  // LANDSCAPE
 
 		float4 rawBaseColor = TexColorSampler.Sample(SampColorSampler, diffuseUv);
+#	if defined(TRUE_PBR)
+#		if defined(LANDSCAPE)
+		if ((PBRFlags & TruePBR_LandTile0PBR) != 0)
+#		endif
+			rawBaseColor.rgb = Lin2SkyrimGamma(rawBaseColor.rgb);
+#	endif
 		baseColor = rawBaseColor;
 
 		float landSnowMask1 = GetLandSnowMaskValue(baseColor.w);
@@ -1341,6 +1347,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 	if (input.LandBlendWeights1.y > 0.0) {
 		float4 landColor2 = TexLandColor2Sampler.Sample(SampLandColor2Sampler, uv);
+#		if defined(TRUE_PBR)
+		[branch] if ((PBRFlags & TruePBR_LandTile1PBR) != 0)
+			landColor2.rgb = Lin2SkyrimGamma(landColor2.rgb);
+#		endif
 		float landSnowMask2 = GetLandSnowMaskValue(landColor2.w);
 		baseColor += input.LandBlendWeights1.yyyy * landColor2;
 		float4 landNormal2 = TexLandNormal2Sampler.Sample(SampLandNormal2Sampler, uv);
@@ -1368,6 +1378,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 	if (input.LandBlendWeights1.z > 0.0) {
 		float4 landColor3 = TexLandColor3Sampler.Sample(SampLandColor3Sampler, uv);
+#		if defined(TRUE_PBR)
+		[branch] if ((PBRFlags & TruePBR_LandTile2PBR) != 0)
+			landColor3.rgb = Lin2SkyrimGamma(landColor3.rgb);
+#		endif
 		float landSnowMask3 = GetLandSnowMaskValue(landColor3.w);
 		baseColor += input.LandBlendWeights1.zzzz * landColor3;
 		float4 landNormal3 = TexLandNormal3Sampler.Sample(SampLandNormal3Sampler, uv);
@@ -1395,6 +1409,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 	if (input.LandBlendWeights1.w > 0.0) {
 		float4 landColor4 = TexLandColor4Sampler.Sample(SampLandColor4Sampler, uv);
+#		if defined(TRUE_PBR)
+		[branch] if ((PBRFlags & TruePBR_LandTile3PBR) != 0)
+			landColor4.rgb = Lin2SkyrimGamma(landColor4.rgb);
+#		endif
 		float landSnowMask4 = GetLandSnowMaskValue(landColor4.w);
 		baseColor += input.LandBlendWeights1.wwww * landColor4;
 		float4 landNormal4 = TexLandNormal4Sampler.Sample(SampLandNormal4Sampler, uv);
@@ -1422,6 +1440,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 	if (input.LandBlendWeights2.x > 0.0) {
 		float4 landColor5 = TexLandColor5Sampler.Sample(SampLandColor5Sampler, uv);
+#		if defined(TRUE_PBR)
+		[branch] if ((PBRFlags & TruePBR_LandTile4PBR) != 0)
+			landColor5.rgb = Lin2SkyrimGamma(landColor5.rgb);
+#		endif
 		float landSnowMask5 = GetLandSnowMaskValue(landColor5.w);
 		baseColor += input.LandBlendWeights2.xxxx * landColor5;
 		float4 landNormal5 = TexLandNormal5Sampler.Sample(SampLandNormal5Sampler, uv);
@@ -1449,6 +1471,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 	if (input.LandBlendWeights2.y > 0.0) {
 		float4 landColor6 = TexLandColor6Sampler.Sample(SampLandColor6Sampler, uv);
+#		if defined(TRUE_PBR)
+		[branch] if ((PBRFlags & TruePBR_LandTile5PBR) != 0)
+			landColor6.rgb = Lin2SkyrimGamma(landColor6.rgb);
+#		endif
 		float landSnowMask6 = GetLandSnowMaskValue(landColor6.w);
 		baseColor += input.LandBlendWeights2.yyyy * landColor6;
 		float4 landNormal6 = TexLandNormal6Sampler.Sample(SampLandNormal6Sampler, uv);
@@ -1563,7 +1589,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		float3 projBaseColor = TexProjDiffuseSampler.Sample(SampProjDiffuseSampler, projNormalDiffuseUv).xyz * ProjectedUVParams2.xyz;
 		float projBlendWeight = smoothstep(0, 1, 5 * (0.1 + projWeight));
 #			if defined(TRUE_PBR)
-		projBaseColor = saturate(EnvmapData.xyz * projBaseColor);
+		projBaseColor = saturate(EnvmapData.xyz * Lin2SkyrimGamma(projBaseColor));
 		rawRMAOS.xyw = lerp(rawRMAOS.xyw, float3(ParallaxOccData.x, 0, ParallaxOccData.y), projBlendWeight);
 #			endif
 		normal.xyz = lerp(normal.xyz, finalProjNormal, projBlendWeight);
@@ -1614,8 +1640,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	float3 screenSpaceNormal = normalize(WorldToView(worldSpaceNormal, false, eyeIndex));
 
 #	if defined(TRUE_PBR)
-	baseColor.xyz = Lin2SkyrimGamma(baseColor.xyz);
-
 	PBR::SurfaceProperties pbrSurfaceProperties = PBR::InitSurfaceProperties();
 
 	pbrSurfaceProperties.Roughness = saturate(rawRMAOS.x);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1640,6 +1640,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	float3 screenSpaceNormal = normalize(WorldToView(worldSpaceNormal, false, eyeIndex));
 
 #	if defined(TRUE_PBR)
+	baseColor.xyz = SkyrimGamma2Lin(baseColor.xyz);
+
 	PBR::SurfaceProperties pbrSurfaceProperties = PBR::InitSurfaceProperties();
 
 	pbrSurfaceProperties.Roughness = saturate(rawRMAOS.x);
@@ -2392,7 +2394,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 			directLightsDiffuseInput = lerp(directLightsDiffuseInput, pbrSurfaceProperties.CoatColor * coatLightsDiffuseColor, pbrSurfaceProperties.CoatStrength);
 		}
 
-		color.xyz += directLightsDiffuseInput;
+		color.xyz += Lin2SkyrimGamma(directLightsDiffuseInput);
 	}
 
 	float3 indirectDiffuseLobeWeight, indirectSpecularLobeWeight;

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -630,8 +630,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 	diffuseColor.xyz += transmissionColor;
 	specularColor.xyz += specularColorPBR;
-	specularColor.xyz = Lin2sRGB(specularColor.xyz);
-	diffuseColor.xyz = Lin2sRGB(diffuseColor.xyz);
+	specularColor.xyz = Lin2SkyrimGamma(specularColor.xyz);
+	diffuseColor.xyz = Lin2SkyrimGamma(diffuseColor.xyz);
 #			else
 
 #				if !defined(SSGI)
@@ -648,9 +648,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	float skylighting = shFuncProductIntegral(skylightingSH, shEvaluateCosineLobe(skylightingSettings.DirectionalDiffuse ? normal : float3(0, 0, 1))) / shPI;
 	skylighting = Skylighting::mixDiffuse(skylightingSettings, skylighting);
 
-	directionalAmbientColor = sRGB2Lin(directionalAmbientColor);
+	directionalAmbientColor = SkyrimGamma2Lin(directionalAmbientColor);
 	directionalAmbientColor *= skylighting;
-	directionalAmbientColor = Lin2sRGB(directionalAmbientColor);
+	directionalAmbientColor = Lin2SkyrimGamma(directionalAmbientColor);
 #					endif  // SKYLIGHTING
 
 	diffuseColor += directionalAmbientColor;
@@ -681,7 +681,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 	float3 normalVS = normalize(WorldToView(normal, false, eyeIndex));
 #			if defined(TRUE_PBR)
-	psout.Albedo = float4(Lin2sRGB(indirectDiffuseLobeWeight), 1);
+	psout.Albedo = float4(Lin2SkyrimGamma(indirectDiffuseLobeWeight), 1);
 	psout.NormalGlossiness = float4(EncodeNormal(normalVS), 1 - pbrSurfaceProperties.Roughness, 1);
 	psout.Reflectance = float4(indirectSpecularLobeWeight, 1);
 	psout.Parameters = float4(0, 0, 1, 1);


### PR DESCRIPTION
From Exist, empirically we have:
- `vanilla_albedo = pow(equivalent_pbr_albedo, 1.5)`

Then consider the equations:
1. `vanilla_pixel_value = vanilla_albedo * vanilla_light`
2. `pbr_pixel_value = pbr_albedo * pbr_light`
If we assume `pbr_light = pow(vanilla_light, 1.5)`, then

> `vanilla_pixel_value = pow(pbr_pixel_value, 1.5)`

Also, `vanilla_pixel_value` is directly outputed as if it is srgb
which is equivalent to **tonemapping with a 2.2 gamma curve**

Therefore, we can say the final presented pixels are equivalent to pbr values tonemapped with a gamma curve of `2.2/1.5 = 1.44`, and true physically based light luminance is the 1.5 power of vanilla light.

PP is not edited in this commit in order to preserve vanilla visual, but pbr integration has been altered:
1. Light colour conversion using 1.5 gamma
2. Landscape albedo are blended in vanilla space to preserve visuals, then converted to linear for PBR, finally back to gamma for saving

EDIT: using sqrt(2.2) = 1.48 gamma now.