### PR TITLE
feat: effect lighting

### DIFF
--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -499,10 +499,6 @@ cbuffer PerGeometry : register(b2)
 #	endif
 };
 
-#	if !defined(LIGHTING)
-#		undef LIGHT_LIMIT_FIX
-#	endif
-
 #	if defined(LIGHT_LIMIT_FIX)
 #		include "LightLimitFix/LightLimitFix.hlsli"
 #	endif

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -513,11 +513,6 @@ cbuffer PerGeometry : register(b2)
 #		include "TerrainOcclusion/TerrainOcclusion.hlsli"
 #	endif
 
-#	if defined(SKYLIGHTING)
-#		define SL_INCL_METHODS
-#		include "Skylighting/Skylighting.hlsli"
-#	endif
-
 #	if defined(CLOUD_SHADOWS)
 #		include "CloudShadows/CloudShadows.hlsli"
 #	endif

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -507,20 +507,20 @@ cbuffer PerGeometry : register(b2)
 #		include "LightLimitFix/LightLimitFix.hlsli"
 #	endif
 
-#define LinearSampler SampBaseSampler
+#	define LinearSampler SampBaseSampler
 
-#		if defined(TERRA_OCC)
-#			include "TerrainOcclusion/TerrainOcclusion.hlsli"
-#		endif
+#	if defined(TERRA_OCC)
+#		include "TerrainOcclusion/TerrainOcclusion.hlsli"
+#	endif
 
-#		if defined(SKYLIGHTING)
-#			define SL_INCL_METHODS
-#			include "Skylighting/Skylighting.hlsli"
-#		endif
+#	if defined(SKYLIGHTING)
+#		define SL_INCL_METHODS
+#		include "Skylighting/Skylighting.hlsli"
+#	endif
 
-#		if defined(CLOUD_SHADOWS)
-#			include "CloudShadows/CloudShadows.hlsli"
-#		endif
+#	if defined(CLOUD_SHADOWS)
+#		include "CloudShadows/CloudShadows.hlsli"
+#	endif
 
 #	include "Common/ShadowSampling.hlsli"
 
@@ -531,14 +531,13 @@ float3 GetLightingColor(float3 msPosition, float3 worldPosition, float4 screenPo
 	float4 lightFadeMul = 1.0.xxxx - saturate(PLightingRadiusInverseSquared * lightDistanceSquared);
 
 	float3 color = DLightColor.xyz;
-	if (!Interior && (PixelShaderDescriptor & _InWorld)) 
-	{
-		float3 viewDirection = normalize(worldPosition);	
+	if (!Interior && (PixelShaderDescriptor & _InWorld)) {
+		float3 viewDirection = normalize(worldPosition);
 		color = DirLightColorShared * GetEffectShadow(worldPosition, viewDirection, screenPosition, eyeIndex);
 
 		float3 directionalAmbientColor = DirectionalAmbientShared._14_24_34;
 		color += directionalAmbientColor;
-    } else {
+	} else {
 		color = DirLightColorShared;
 
 		float3 directionalAmbientColor = DirectionalAmbientShared._14_24_34;

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -499,7 +499,7 @@ cbuffer PerGeometry : register(b2)
 #	endif
 };
 
-#	if defined(MEMBRANE) || !defined(LIGHTING)
+#	if !defined(LIGHTING)
 #		undef LIGHT_LIMIT_FIX
 #	endif
 

--- a/src/Features/TerrainOcclusion.h
+++ b/src/Features/TerrainOcclusion.h
@@ -14,13 +14,7 @@ struct TerrainOcclusion : public Feature
 	virtual inline std::string GetName() override { return "Terrain Occlusion"; }
 	virtual inline std::string GetShortName() override { return "TerrainOcclusion"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "TERRA_OCC"; }
-	inline bool HasShaderDefine(RE::BSShader::Type type) override
-	{
-		return type == RE::BSShader::Type::Lighting ||
-		       type == RE::BSShader::Type::DistantTree ||
-		       type == RE::BSShader::Type::Grass ||
-		       type == RE::BSShader::Type::Water;
-	};
+	virtual inline bool HasShaderDefine(RE::BSShader::Type) override { return true; }
 
 	struct Settings
 	{


### PR DESCRIPTION
![ScreenShot4124](https://github.com/user-attachments/assets/ebda576f-1adb-42a4-9118-df09eb0a1118)
![ScreenShot4123](https://github.com/user-attachments/assets/fed93b2e-73de-4f00-ad06-2425e7c6fe7b)

Replaces the "effect lighting" colours with ones based on the weather/lighting template, and in exteriors it adds shadows from the directional light. This has a minimal performance impact in tested scenarios.

This only applies to effects with the Lighting flag. It does not affect things like external emittance.