### PR TITLE
feat: complete skylighting during loadscreen

### DIFF
--- a/features/Skylighting/Shaders/Skylighting/Skylighting.hlsli
+++ b/features/Skylighting/Shaders/Skylighting/Skylighting.hlsli
@@ -7,7 +7,7 @@ struct SkylightingSettings
 	row_major float4x4 OcclusionViewProj;
 	float4 OcclusionDir;
 
-	float3 PosOffset;   // xyz: cell origin in camera model space
+	float3 PosOffset;  // xyz: cell origin in camera model space
 	uint pad0;
 	uint3 ArrayOrigin;  // xyz: array origin, w: max accum frames
 	uint pad1;

--- a/features/Skylighting/Shaders/Skylighting/Skylighting.hlsli
+++ b/features/Skylighting/Shaders/Skylighting/Skylighting.hlsli
@@ -7,14 +7,16 @@ struct SkylightingSettings
 	row_major float4x4 OcclusionViewProj;
 	float4 OcclusionDir;
 
-	float4 PosOffset;   // xyz: cell origin in camera model space
-	uint4 ArrayOrigin;  // xyz: array origin, w: max accum frames
+	float3 PosOffset;   // xyz: cell origin in camera model space
+	uint pad0;
+	uint3 ArrayOrigin;  // xyz: array origin, w: max accum frames
+	uint pad1;
 	int4 ValidMargin;
 
 	float4 MixParams;  // x: min diffuse visibility, y: diffuse mult, z: min specular visibility, w: specular mult
 
 	uint DirectionalDiffuse;
-	float3 _pad1;
+	uint3 pad2;
 };
 
 #endif

--- a/features/Skylighting/Shaders/Skylighting/updateProbes.cs.hlsl
+++ b/features/Skylighting/Shaders/Skylighting/updateProbes.cs.hlsl
@@ -22,7 +22,7 @@ SamplerState samplerPointClamp : register(s0);
 
 [numthreads(8, 8, 1)] void main(uint3 dtid
 								: SV_DispatchThreadID) {
-	const float fadeInThreshold = settings.ArrayOrigin.w;
+	const float fadeInThreshold = 255;
 	const static sh2 unitSH = float4(sqrt(4.0 * shPI), 0, 0, 0);
 
 	uint3 cellID = (int3(dtid) - settings.ArrayOrigin.xyz) % ARRAY_DIM;

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -122,7 +122,7 @@ struct SkylightingSettings
 	row_major float4x4 OcclusionViewProj;
 	float4 OcclusionDir;
 
-	float3 PosOffset;   // xyz: cell origin in camera model space
+	float3 PosOffset;  // xyz: cell origin in camera model space
 	uint pad0;
 	uint3 ArrayOrigin;  // xyz: array origin, w: max accum frames
 	uint pad1;

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -122,14 +122,16 @@ struct SkylightingSettings
 	row_major float4x4 OcclusionViewProj;
 	float4 OcclusionDir;
 
-	float4 PosOffset;   // xyz: cell origin in camera model space
-	uint4 ArrayOrigin;  // xyz: array origin, w: max accum frames
+	float3 PosOffset;   // xyz: cell origin in camera model space
+	uint pad0;
+	uint3 ArrayOrigin;  // xyz: array origin, w: max accum frames
+	uint pad1;
 	int4 ValidMargin;
 
 	float4 MixParams;  // x: min diffuse visibility, y: diffuse mult, z: min specular visibility, w: specular mult
 
 	uint DirectionalDiffuse;
-	float3 pad0;
+	uint3 pad2;
 };
 
 struct PBRSettings

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -438,7 +438,7 @@ void Skylighting::Main_Precipitation_RenderOcclusion::thunk()
 			auto timePassed = std::chrono::duration_cast<std::chrono::milliseconds>(currentTimer - singleton->lastUpdateTimer).count();
 
 			if (singleton->forceFrames || timePassed >= (1000.0f / 30.0f)) {
-				singleton->forceFrames--;
+				singleton->forceFrames = (uint)std::max(0, (int)singleton->forceFrames - 1);
 				singleton->lastUpdateTimer = currentTimer;
 
 				auto renderer = RE::BSGraphics::Renderer::GetSingleton();

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -430,13 +430,13 @@ void Skylighting::Main_Precipitation_RenderOcclusion::thunk()
 				}
 			}
 
-		{
-			std::chrono::time_point<std::chrono::system_clock> currentTimer = std::chrono::system_clock::now();
-			auto timePassed = std::chrono::duration_cast<std::chrono::milliseconds>(currentTimer - singleton->lastUpdateTimer).count();
+			{
+				std::chrono::time_point<std::chrono::system_clock> currentTimer = std::chrono::system_clock::now();
+				auto timePassed = std::chrono::duration_cast<std::chrono::milliseconds>(currentTimer - singleton->lastUpdateTimer).count();
 
-			if (singleton->forceFrames || timePassed >= (1000.0f / 30.0f)) {
-				singleton->forceFrames = (uint)std::max(0, (int)singleton->forceFrames - 1);
-				singleton->lastUpdateTimer = currentTimer;
+				if (singleton->forceFrames || timePassed >= (1000.0f / 30.0f)) {
+					singleton->forceFrames = (uint)std::max(0, (int)singleton->forceFrames - 1);
+					singleton->lastUpdateTimer = currentTimer;
 
 					auto renderer = RE::BSGraphics::Renderer::GetSingleton();
 					auto& precipitation = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kPRECIPITATION_OCCLUSION_MAP];

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -224,8 +224,7 @@ void Skylighting::Prepass()
 			.ArrayOrigin = {
 				((int)cellID.x - probeArrayDims[0] / 2) % probeArrayDims[0],
 				((int)cellID.y - probeArrayDims[1] / 2) % probeArrayDims[1],
-				((int)cellID.z - probeArrayDims[2] / 2) % probeArrayDims[2]
-			},
+				((int)cellID.z - probeArrayDims[2] / 2) % probeArrayDims[2] },
 			.ValidMargin = { (int)cellIDDiff.x, (int)cellIDDiff.y, (int)cellIDDiff.z },
 			.MixParams = { settings.MinDiffuseVisibility, settings.DiffusePower, settings.MinSpecularVisibility, settings.SpecularPower },
 			.DirectionalDiffuse = settings.DirectionalDiffuse,

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -225,7 +225,7 @@ void Skylighting::Prepass()
 				((int)cellID.x - probeArrayDims[0] / 2) % probeArrayDims[0],
 				((int)cellID.y - probeArrayDims[1] / 2) % probeArrayDims[1],
 				((int)cellID.z - probeArrayDims[2] / 2) % probeArrayDims[2],
-				255 },
+				64 },
 			.ValidMargin = { (int)cellIDDiff.x, (int)cellIDDiff.y, (int)cellIDDiff.z },
 			.MixParams = { settings.MinDiffuseVisibility, settings.DiffusePower, settings.MinSpecularVisibility, settings.SpecularPower },
 			.DirectionalDiffuse = settings.DirectionalDiffuse,
@@ -411,7 +411,6 @@ void Skylighting::Main_Precipitation_RenderOcclusion::thunk()
 
 	if (singleton->doOcclusion) {
 		{
-
 			auto precipObject = precip->currentPrecip;
 			if (!precipObject) {
 				precipObject = precip->lastPrecip;

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -43,7 +43,7 @@ void Skylighting::DrawSettings()
 		auto& context = State::GetSingleton()->context;
 		UINT clr[1] = { 0 };
 		context->ClearUnorderedAccessViewUint(texAccumFramesArray->uav.get(), clr);
-		forceFrames = 255;
+		forceFrames = 255 * 4;
 	}
 	if (auto _tt = Util::HoverTooltipWrapper())
 		ImGui::Text("Changes below require rebuilding, a loading screen, or moving away from the current location to apply.");
@@ -224,8 +224,8 @@ void Skylighting::Prepass()
 			.ArrayOrigin = {
 				((int)cellID.x - probeArrayDims[0] / 2) % probeArrayDims[0],
 				((int)cellID.y - probeArrayDims[1] / 2) % probeArrayDims[1],
-				((int)cellID.z - probeArrayDims[2] / 2) % probeArrayDims[2],
-				64 },
+				((int)cellID.z - probeArrayDims[2] / 2) % probeArrayDims[2]
+			},
 			.ValidMargin = { (int)cellIDDiff.x, (int)cellIDDiff.y, (int)cellIDDiff.z },
 			.MixParams = { settings.MinDiffuseVisibility, settings.DiffusePower, settings.MinSpecularVisibility, settings.SpecularPower },
 			.DirectionalDiffuse = settings.DirectionalDiffuse,

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -404,8 +404,6 @@ void Skylighting::Main_Precipitation_RenderOcclusion::thunk()
 	State::GetSingleton()->BeginPerfEvent("PRECIPITATION MASK");
 	State::GetSingleton()->SetPerfMarker("PRECIPITATION MASK");
 
-	static bool doPrecip = false;
-
 	auto sky = RE::Sky::GetSingleton();
 	auto precip = sky->precip;
 
@@ -413,7 +411,6 @@ void Skylighting::Main_Precipitation_RenderOcclusion::thunk()
 
 	if (singleton->doOcclusion) {
 		{
-			doPrecip = false;
 
 			auto precipObject = precip->currentPrecip;
 			if (!precipObject) {
@@ -432,8 +429,6 @@ void Skylighting::Main_Precipitation_RenderOcclusion::thunk()
 		}
 
 		{
-			doPrecip = true;
-
 			std::chrono::time_point<std::chrono::system_clock> currentTimer = std::chrono::system_clock::now();
 			auto timePassed = std::chrono::duration_cast<std::chrono::milliseconds>(currentTimer - singleton->lastUpdateTimer).count();
 

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -4,7 +4,6 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	Skylighting::Settings,
 	DirectionalDiffuse,
 	MaxZenith,
-	MaxFrames,
 	MinDiffuseVisibility,
 	DiffusePower,
 	MinSpecularVisibility,
@@ -44,13 +43,10 @@ void Skylighting::DrawSettings()
 		auto& context = State::GetSingleton()->context;
 		UINT clr[1] = { 0 };
 		context->ClearUnorderedAccessViewUint(texAccumFramesArray->uav.get(), clr);
+		forceFrames = 255;
 	}
 	if (auto _tt = Util::HoverTooltipWrapper())
 		ImGui::Text("Changes below require rebuilding, a loading screen, or moving away from the current location to apply.");
-
-	ImGui::SliderInt("Update Frames", &settings.MaxFrames, 0, 255, "%d", ImGuiSliderFlags_AlwaysClamp);
-	if (auto _tt = Util::HoverTooltipWrapper())
-		ImGui::Text("Aggregating over how many frames to build up skylighting.");
 
 	ImGui::SliderAngle("Max Zenith Angle", &settings.MaxZenith, 0, 90);
 	if (auto _tt = Util::HoverTooltipWrapper())
@@ -229,7 +225,7 @@ void Skylighting::Prepass()
 				((int)cellID.x - probeArrayDims[0] / 2) % probeArrayDims[0],
 				((int)cellID.y - probeArrayDims[1] / 2) % probeArrayDims[1],
 				((int)cellID.z - probeArrayDims[2] / 2) % probeArrayDims[2],
-				(uint)settings.MaxFrames },
+				255 },
 			.ValidMargin = { (int)cellIDDiff.x, (int)cellIDDiff.y, (int)cellIDDiff.z },
 			.MixParams = { settings.MinDiffuseVisibility, settings.DiffusePower, settings.MinSpecularVisibility, settings.SpecularPower },
 			.DirectionalDiffuse = settings.DirectionalDiffuse,
@@ -283,6 +279,7 @@ void Skylighting::PostPostLoad()
 	stl::write_thunk_call<Main_Precipitation_RenderOcclusion>(REL::RelocationID(35560, 36559).address() + REL::Relocate(0x3A1, 0x3A1, 0x2FA));
 	stl::write_thunk_call<SetViewFrustum>(REL::RelocationID(25643, 26185).address() + REL::Relocate(0x5D9, 0x59D, 0x5DC));
 	stl::write_vfunc<0x6, BSUtilityShader_SetupGeometry>(RE::VTABLE_BSUtilityShader[0]);
+	MenuOpenCloseEventHandler::Register();
 }
 
 //////////////////////////////////////////////////////////////
@@ -440,7 +437,8 @@ void Skylighting::Main_Precipitation_RenderOcclusion::thunk()
 			std::chrono::time_point<std::chrono::system_clock> currentTimer = std::chrono::system_clock::now();
 			auto timePassed = std::chrono::duration_cast<std::chrono::milliseconds>(currentTimer - singleton->lastUpdateTimer).count();
 
-			if (timePassed >= (1000.0f / 30.0f)) {
+			if (singleton->forceFrames || timePassed >= (1000.0f / 30.0f)) {
+				singleton->forceFrames--;
 				singleton->lastUpdateTimer = currentTimer;
 
 				auto renderer = RE::BSGraphics::Renderer::GetSingleton();

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -411,7 +411,6 @@ void Skylighting::Main_Precipitation_RenderOcclusion::thunk()
 
 	if (singleton->doOcclusion) {
 		{
-
 			auto precipObject = precip->currentPrecip;
 			if (!precipObject) {
 				precipObject = precip->lastPrecip;

--- a/src/Features/Skylighting.h
+++ b/src/Features/Skylighting.h
@@ -55,14 +55,15 @@ struct Skylighting : Feature
 		float4 OcclusionDir;
 
 		float3 PosOffset;  // cell origin in camera model space
-		float _pad0;
-		uint ArrayOrigin[4];  // xyz: array origin, w: max accum frames
+		uint _pad0;
+		uint ArrayOrigin[3];  // xyz: array origin, w: max accum frames
+		uint _pad1;
 		int ValidMargin[4];
 
 		float4 MixParams;  // x: min diffuse visibility, y: diffuse mult, z: min specular visibility, w: specular mult
 
 		uint DirectionalDiffuse;
-		float3 _pad1;
+		uint _pad2[3];
 	} cbData;
 	static_assert(sizeof(SkylightingCB) % 16 == 0);
 	eastl::unique_ptr<ConstantBuffer> skylightingCB = nullptr;
@@ -89,7 +90,7 @@ struct Skylighting : Feature
 	bool foliage = false;
 	REX::W32::XMFLOAT4X4 OcclusionTransform;
 	float4 OcclusionDir;
-	uint forceFrames = 255;
+	uint forceFrames = 255 * 4;
 
 	std::chrono::time_point<std::chrono::system_clock> lastUpdateTimer = std::chrono::system_clock::now();
 
@@ -129,7 +130,7 @@ struct Skylighting : Feature
 			// When entering a new cell through a loadscreen, update every frame until completion
 			if (a_event->menuName == RE::LoadingMenu::MENU_NAME) {
 				if (!a_event->opening)
-					Skylighting::GetSingleton()->forceFrames = 255;
+					Skylighting::GetSingleton()->forceFrames = 255 * 4;
 			}
 
 			return RE::BSEventNotifyControl::kContinue;

--- a/src/Features/Skylighting.h
+++ b/src/Features/Skylighting.h
@@ -152,6 +152,4 @@ struct Skylighting : Feature
 			return true;
 		}
 	};
-	
 };
-

--- a/src/Features/Skylighting.h
+++ b/src/Features/Skylighting.h
@@ -42,7 +42,7 @@ struct Skylighting : Feature
 	struct Settings
 	{
 		bool DirectionalDiffuse = false;
-		float MaxZenith = 3.1415926f / 3.f;  // 60 deg
+		float MaxZenith = 3.1415926f / 4.f;  // 45 deg
 		float MinDiffuseVisibility = 0.1f;
 		float DiffusePower = 1.f;
 		float MinSpecularVisibility = 0.f;


### PR DESCRIPTION
Skylighting is now always set to 255 frames because it minimises potential issues in more complex environments, e.g. in Solitude.

Whenever there is a loadscreen, skylighting will render once every frame until 255 frames have past.

The rebuild skylighting button also makes use of this, so is much faster.