### PR TITLE
feat: hdr tonemapping

### DIFF
--- a/package/Shaders/Common/DICETonemapper.hlsli
+++ b/package/Shaders/Common/DICETonemapper.hlsli
@@ -3,22 +3,22 @@
 // Applies exponential ("Photographic") luma compression
 float RangeCompress(float x)
 {
-    return 1.0 - exp(-x);
+	return 1.0 - exp(-x);
 }
 
 float RangeCompress(float val, float threshold)
 {
-    float v1 = val;
-    float v2 = threshold + (1 - threshold) * RangeCompress((val - threshold) / (1 - threshold));
-    return val < threshold ? v1 : v2;
+	float v1 = val;
+	float v2 = threshold + (1 - threshold) * RangeCompress((val - threshold) / (1 - threshold));
+	return val < threshold ? v1 : v2;
 }
 
 float3 RangeCompress(float3 val, float threshold)
 {
-    return float3(
-        RangeCompress(val.x, threshold),
-        RangeCompress(val.y, threshold),
-        RangeCompress(val.z, threshold));
+	return float3(
+		RangeCompress(val.x, threshold),
+		RangeCompress(val.y, threshold),
+		RangeCompress(val.z, threshold));
 }
 
 static const float PQ_constant_N = (2610.0 / 4096.0 / 4.0);
@@ -30,138 +30,130 @@ static const float PQ_constant_C3 = (2392.0 / 4096.0 * 32.0);
 // PQ (Perceptual Quantiser; ST.2084) encode/decode used for HDR TV and grading
 float3 LinearToPQ(float3 linearCol, const float maxPqValue)
 {
-    linearCol /= maxPqValue;
+	linearCol /= maxPqValue;
 
-    float3 colToPow = pow(linearCol, PQ_constant_N);
-    float3 numerator = PQ_constant_C1 + PQ_constant_C2*colToPow;
-    float3 denominator = 1.0 + PQ_constant_C3*colToPow;
-    float3 pq = pow(numerator / denominator, PQ_constant_M);
+	float3 colToPow = pow(linearCol, PQ_constant_N);
+	float3 numerator = PQ_constant_C1 + PQ_constant_C2 * colToPow;
+	float3 denominator = 1.0 + PQ_constant_C3 * colToPow;
+	float3 pq = pow(numerator / denominator, PQ_constant_M);
 
-    return pq;
+	return pq;
 }
 
 float3 PQtoLinear(float3 linearCol, const float maxPqValue)
 {
-    float3 colToPow = pow(linearCol, 1.0 / PQ_constant_M);
-    float3 numerator = max(colToPow - PQ_constant_C1, 0.0);
-    float3 denominator = PQ_constant_C2 - (PQ_constant_C3 * colToPow);
-    float3 linearColor = pow(numerator / denominator, 1.0 / PQ_constant_N);
+	float3 colToPow = pow(linearCol, 1.0 / PQ_constant_M);
+	float3 numerator = max(colToPow - PQ_constant_C1, 0.0);
+	float3 denominator = PQ_constant_C2 - (PQ_constant_C3 * colToPow);
+	float3 linearColor = pow(numerator / denominator, 1.0 / PQ_constant_N);
 
-    linearColor *= maxPqValue;
+	linearColor *= maxPqValue;
 
-    return linearColor;
+	return linearColor;
 }
-
 
 // RGB with sRGB/Rec.709 primaries to CIE XYZ
 float3 RGBToXYZ(float3 c)
 {
-    float3x3 mat = float3x3(
-        0.4124564,  0.3575761,  0.1804375,
-        0.2126729,  0.7151522,  0.0721750,
-        0.0193339,  0.1191920,  0.9503041
-    );
-    return mul(mat, c);
+	float3x3 mat = float3x3(
+		0.4124564, 0.3575761, 0.1804375,
+		0.2126729, 0.7151522, 0.0721750,
+		0.0193339, 0.1191920, 0.9503041);
+	return mul(mat, c);
 }
 float3 XYZToRGB(float3 c)
 {
-    float3x3 mat = float3x3(
-         3.24045483602140870, -1.53713885010257510, -0.49853154686848090,
-        -0.96926638987565370,  1.87601092884249100,  0.04155608234667354,
-         0.05564341960421366, -0.20402585426769815,  1.05722516245792870
-    );
-    return mul(mat, c);
+	float3x3 mat = float3x3(
+		3.24045483602140870, -1.53713885010257510, -0.49853154686848090,
+		-0.96926638987565370, 1.87601092884249100, 0.04155608234667354,
+		0.05564341960421366, -0.20402585426769815, 1.05722516245792870);
+	return mul(mat, c);
 }
 // Converts XYZ tristimulus values into cone responses for the three types of cones in the human visual system, matching long, medium, and short wavelengths.
 // Note that there are many LMS color spaces; this one follows the ICtCp color space specification.
 float3 XYZToLMS(float3 c)
 {
-    float3x3 mat = float3x3(
-        0.3592,  0.6976, -0.0358,
-        -0.1922, 1.1004,  0.0755,
-        0.0070,  0.0749,  0.8434
-    ); 
-    return mul(mat, c);
+	float3x3 mat = float3x3(
+		0.3592, 0.6976, -0.0358,
+		-0.1922, 1.1004, 0.0755,
+		0.0070, 0.0749, 0.8434);
+	return mul(mat, c);
 }
 float3 LMSToXYZ(float3 c)
 {
-    float3x3 mat = float3x3(
-         2.07018005669561320, -1.32645687610302100,  0.206616006847855170,
-         0.36498825003265756,  0.68046736285223520, -0.045421753075853236,
-        -0.04959554223893212, -0.04942116118675749,  1.187995941732803400
-    );
-    return mul(mat, c);
+	float3x3 mat = float3x3(
+		2.07018005669561320, -1.32645687610302100, 0.206616006847855170,
+		0.36498825003265756, 0.68046736285223520, -0.045421753075853236,
+		-0.04959554223893212, -0.04942116118675749, 1.187995941732803400);
+	return mul(mat, c);
 }
-
 
 // RGB with sRGB/Rec.709 primaries to ICtCp
 float3 RGBToICtCp(float3 col)
 {
-    col = RGBToXYZ(col);
-    col = XYZToLMS(col);
-    // 1.0f = 100 nits, 100.0f = 10k nits
-    col = LinearToPQ(max(0.0.xxx, col), 100.0);
+	col = RGBToXYZ(col);
+	col = XYZToLMS(col);
+	// 1.0f = 100 nits, 100.0f = 10k nits
+	col = LinearToPQ(max(0.0.xxx, col), 100.0);
 
-    // Convert PQ-LMS into ICtCp. Note that the "S" channel is not used,
-    // but overlap between the cone responses for long, medium, and short wavelengths
-    // ensures that the corresponding part of the spectrum contributes to luminance.
+	// Convert PQ-LMS into ICtCp. Note that the "S" channel is not used,
+	// but overlap between the cone responses for long, medium, and short wavelengths
+	// ensures that the corresponding part of the spectrum contributes to luminance.
 
-    float3x3 mat = float3x3(
-        0.5000,  0.5000,  0.0000,
-        1.6137, -3.3234,  1.7097,
-        4.3780, -4.2455, -0.1325
-    );
+	float3x3 mat = float3x3(
+		0.5000, 0.5000, 0.0000,
+		1.6137, -3.3234, 1.7097,
+		4.3780, -4.2455, -0.1325);
 
-    return mul(mat, col);
+	return mul(mat, col);
 }
 
 float3 ICtCpToRGB(float3 col)
 {
-    float3x3 mat = float3x3(
-        1.0,  0.00860514569398152,  0.11103560447547328,
-        1.0, -0.00860514569398152, -0.11103560447547328,
-        1.0,  0.56004885956263900, -0.32063747023212210
-    );
-    col = mul(mat, col);
+	float3x3 mat = float3x3(
+		1.0, 0.00860514569398152, 0.11103560447547328,
+		1.0, -0.00860514569398152, -0.11103560447547328,
+		1.0, 0.56004885956263900, -0.32063747023212210);
+	col = mul(mat, col);
 
-    // 1.0f = 100 nits, 100.0f = 10k nits
-    col = PQtoLinear(col, 100.0);
-    col = LMSToXYZ(col);
-    return XYZToRGB(col);
+	// 1.0f = 100 nits, 100.0f = 10k nits
+	col = PQtoLinear(col, 100.0);
+	col = LMSToXYZ(col);
+	return XYZToRGB(col);
 }
 
 // Only compress luminance starting at a certain point. Dimmer inputs are passed through without modification.
 float3 ApplyHuePreservingShoulder(float3 col, float linearSegmentEnd = 0.25)
 {
-    float3 ictcp = RGBToICtCp(col);
+	float3 ictcp = RGBToICtCp(col);
 
-    // Hue-preserving range compression requires desaturation in order to achieve a natural look. We adaptively desaturate the input based on its luminance.
-    float saturationAmount = pow(smoothstep(1.0, 0.3, ictcp.x), 1.3);
-    col = ICtCpToRGB(ictcp * float3(1, saturationAmount.xx));
+	// Hue-preserving range compression requires desaturation in order to achieve a natural look. We adaptively desaturate the input based on its luminance.
+	float saturationAmount = pow(smoothstep(1.0, 0.3, ictcp.x), 1.3);
+	col = ICtCpToRGB(ictcp * float3(1, saturationAmount.xx));
 
-    // Hue-preserving mapping
-    float maxCol = max(col.x, max(col.y, col.z));
-    float mappedMax = RangeCompress(maxCol, linearSegmentEnd);
-    float3 compressedHuePreserving = col * mappedMax / maxCol;
+	// Hue-preserving mapping
+	float maxCol = max(col.x, max(col.y, col.z));
+	float mappedMax = RangeCompress(maxCol, linearSegmentEnd);
+	float3 compressedHuePreserving = col * mappedMax / maxCol;
 
-    // Non-hue preserving mapping
-    float3 perChannelCompressed = RangeCompress(col, linearSegmentEnd);
+	// Non-hue preserving mapping
+	float3 perChannelCompressed = RangeCompress(col, linearSegmentEnd);
 
-    // Combine hue-preserving and non-hue-preserving colors. Absolute hue preservation looks unnatural, as bright colors *appear* to have been hue shifted.
-    // Actually doing some amount of hue shifting looks more pleasing
-    col = lerp(perChannelCompressed, compressedHuePreserving, 0.6);
+	// Combine hue-preserving and non-hue-preserving colors. Absolute hue preservation looks unnatural, as bright colors *appear* to have been hue shifted.
+	// Actually doing some amount of hue shifting looks more pleasing
+	col = lerp(perChannelCompressed, compressedHuePreserving, 0.6);
 
-    float3 ictcpMapped = RGBToICtCp(col);
+	float3 ictcpMapped = RGBToICtCp(col);
 
-    // Smoothly ramp off saturation as brightness increases, but keep some even for very bright input
-    float postCompressionSaturationBoost = 0.3 * smoothstep(1.0, 0.5, ictcp.x);
+	// Smoothly ramp off saturation as brightness increases, but keep some even for very bright input
+	float postCompressionSaturationBoost = 0.3 * smoothstep(1.0, 0.5, ictcp.x);
 
-    // Re-introduce some hue from the pre-compression color. Something similar could be accomplished by delaying the luma-dependent desaturation before range compression.
-    // Doing it here however does a better job of preserving perceptual luminance of highly saturated colors. Because in the hue-preserving path we only range-compress the max channel,
-    // saturated colors lose luminance. By desaturating them more aggressively first, compressing, and then re-adding some saturation, we can preserve their brightness to a greater extent.
-    ictcpMapped.yz = lerp(ictcpMapped.yz, ictcp.yz * ictcpMapped.x / max(1e-3, ictcp.x), postCompressionSaturationBoost);
+	// Re-introduce some hue from the pre-compression color. Something similar could be accomplished by delaying the luma-dependent desaturation before range compression.
+	// Doing it here however does a better job of preserving perceptual luminance of highly saturated colors. Because in the hue-preserving path we only range-compress the max channel,
+	// saturated colors lose luminance. By desaturating them more aggressively first, compressing, and then re-adding some saturation, we can preserve their brightness to a greater extent.
+	ictcpMapped.yz = lerp(ictcpMapped.yz, ictcp.yz * ictcpMapped.x / max(1e-3, ictcp.x), postCompressionSaturationBoost);
 
-    col = ICtCpToRGB(ictcpMapped);
+	col = ICtCpToRGB(ictcpMapped);
 
-    return col;
+	return col;
 }

--- a/package/Shaders/Common/DICETonemapper.hlsli
+++ b/package/Shaders/Common/DICETonemapper.hlsli
@@ -1,0 +1,167 @@
+// https://www.ea.com/frostbite/news/high-dynamic-range-color-grading-and-display-in-frostbite
+
+// Applies exponential ("Photographic") luma compression
+float RangeCompress(float x)
+{
+    return 1.0 - exp(-x);
+}
+
+float RangeCompress(float val, float threshold)
+{
+    float v1 = val;
+    float v2 = threshold + (1 - threshold) * RangeCompress((val - threshold) / (1 - threshold));
+    return val < threshold ? v1 : v2;
+}
+
+float3 RangeCompress(float3 val, float threshold)
+{
+    return float3(
+        RangeCompress(val.x, threshold),
+        RangeCompress(val.y, threshold),
+        RangeCompress(val.z, threshold));
+}
+
+static const float PQ_constant_N = (2610.0 / 4096.0 / 4.0);
+static const float PQ_constant_M = (2523.0 / 4096.0 * 128.0);
+static const float PQ_constant_C1 = (3424.0 / 4096.0);
+static const float PQ_constant_C2 = (2413.0 / 4096.0 * 32.0);
+static const float PQ_constant_C3 = (2392.0 / 4096.0 * 32.0);
+
+// PQ (Perceptual Quantiser; ST.2084) encode/decode used for HDR TV and grading
+float3 LinearToPQ(float3 linearCol, const float maxPqValue)
+{
+    linearCol /= maxPqValue;
+
+    float3 colToPow = pow(linearCol, PQ_constant_N);
+    float3 numerator = PQ_constant_C1 + PQ_constant_C2*colToPow;
+    float3 denominator = 1.0 + PQ_constant_C3*colToPow;
+    float3 pq = pow(numerator / denominator, PQ_constant_M);
+
+    return pq;
+}
+
+float3 PQtoLinear(float3 linearCol, const float maxPqValue)
+{
+    float3 colToPow = pow(linearCol, 1.0 / PQ_constant_M);
+    float3 numerator = max(colToPow - PQ_constant_C1, 0.0);
+    float3 denominator = PQ_constant_C2 - (PQ_constant_C3 * colToPow);
+    float3 linearColor = pow(numerator / denominator, 1.0 / PQ_constant_N);
+
+    linearColor *= maxPqValue;
+
+    return linearColor;
+}
+
+
+// RGB with sRGB/Rec.709 primaries to CIE XYZ
+float3 RGBToXYZ(float3 c)
+{
+    float3x3 mat = float3x3(
+        0.4124564,  0.3575761,  0.1804375,
+        0.2126729,  0.7151522,  0.0721750,
+        0.0193339,  0.1191920,  0.9503041
+    );
+    return mul(mat, c);
+}
+float3 XYZToRGB(float3 c)
+{
+    float3x3 mat = float3x3(
+         3.24045483602140870, -1.53713885010257510, -0.49853154686848090,
+        -0.96926638987565370,  1.87601092884249100,  0.04155608234667354,
+         0.05564341960421366, -0.20402585426769815,  1.05722516245792870
+    );
+    return mul(mat, c);
+}
+// Converts XYZ tristimulus values into cone responses for the three types of cones in the human visual system, matching long, medium, and short wavelengths.
+// Note that there are many LMS color spaces; this one follows the ICtCp color space specification.
+float3 XYZToLMS(float3 c)
+{
+    float3x3 mat = float3x3(
+        0.3592,  0.6976, -0.0358,
+        -0.1922, 1.1004,  0.0755,
+        0.0070,  0.0749,  0.8434
+    ); 
+    return mul(mat, c);
+}
+float3 LMSToXYZ(float3 c)
+{
+    float3x3 mat = float3x3(
+         2.07018005669561320, -1.32645687610302100,  0.206616006847855170,
+         0.36498825003265756,  0.68046736285223520, -0.045421753075853236,
+        -0.04959554223893212, -0.04942116118675749,  1.187995941732803400
+    );
+    return mul(mat, c);
+}
+
+
+// RGB with sRGB/Rec.709 primaries to ICtCp
+float3 RGBToICtCp(float3 col)
+{
+    col = RGBToXYZ(col);
+    col = XYZToLMS(col);
+    // 1.0f = 100 nits, 100.0f = 10k nits
+    col = LinearToPQ(max(0.0.xxx, col), 100.0);
+
+    // Convert PQ-LMS into ICtCp. Note that the "S" channel is not used,
+    // but overlap between the cone responses for long, medium, and short wavelengths
+    // ensures that the corresponding part of the spectrum contributes to luminance.
+
+    float3x3 mat = float3x3(
+        0.5000,  0.5000,  0.0000,
+        1.6137, -3.3234,  1.7097,
+        4.3780, -4.2455, -0.1325
+    );
+
+    return mul(mat, col);
+}
+
+float3 ICtCpToRGB(float3 col)
+{
+    float3x3 mat = float3x3(
+        1.0,  0.00860514569398152,  0.11103560447547328,
+        1.0, -0.00860514569398152, -0.11103560447547328,
+        1.0,  0.56004885956263900, -0.32063747023212210
+    );
+    col = mul(mat, col);
+
+    // 1.0f = 100 nits, 100.0f = 10k nits
+    col = PQtoLinear(col, 100.0);
+    col = LMSToXYZ(col);
+    return XYZToRGB(col);
+}
+
+// Only compress luminance starting at a certain point. Dimmer inputs are passed through without modification.
+float3 ApplyHuePreservingShoulder(float3 col, float linearSegmentEnd = 0.25)
+{
+    float3 ictcp = RGBToICtCp(col);
+
+    // Hue-preserving range compression requires desaturation in order to achieve a natural look. We adaptively desaturate the input based on its luminance.
+    float saturationAmount = pow(smoothstep(1.0, 0.3, ictcp.x), 1.3);
+    col = ICtCpToRGB(ictcp * float3(1, saturationAmount.xx));
+
+    // Hue-preserving mapping
+    float maxCol = max(col.x, max(col.y, col.z));
+    float mappedMax = RangeCompress(maxCol, linearSegmentEnd);
+    float3 compressedHuePreserving = col * mappedMax / maxCol;
+
+    // Non-hue preserving mapping
+    float3 perChannelCompressed = RangeCompress(col, linearSegmentEnd);
+
+    // Combine hue-preserving and non-hue-preserving colors. Absolute hue preservation looks unnatural, as bright colors *appear* to have been hue shifted.
+    // Actually doing some amount of hue shifting looks more pleasing
+    col = lerp(perChannelCompressed, compressedHuePreserving, 0.6);
+
+    float3 ictcpMapped = RGBToICtCp(col);
+
+    // Smoothly ramp off saturation as brightness increases, but keep some even for very bright input
+    float postCompressionSaturationBoost = 0.3 * smoothstep(1.0, 0.5, ictcp.x);
+
+    // Re-introduce some hue from the pre-compression color. Something similar could be accomplished by delaying the luma-dependent desaturation before range compression.
+    // Doing it here however does a better job of preserving perceptual luminance of highly saturated colors. Because in the hue-preserving path we only range-compress the max channel,
+    // saturated colors lose luminance. By desaturating them more aggressively first, compressing, and then re-adding some saturation, we can preserve their brightness to a greater extent.
+    ictcpMapped.yz = lerp(ictcpMapped.yz, ictcp.yz * ictcpMapped.x / max(1e-3, ictcp.x), postCompressionSaturationBoost);
+
+    col = ICtCpToRGB(ictcpMapped);
+
+    return col;
+}

--- a/package/Shaders/ISHDR.hlsl
+++ b/package/Shaders/ISHDR.hlsl
@@ -1,6 +1,7 @@
 #include "Common/Color.hlsli"
 #include "Common/DummyVSTexCoord.hlsl"
 #include "Common/FrameBuffer.hlsli"
+#include "Common/DICETonemapper.hlsli"
 
 typedef VS_OUTPUT PS_INPUT;
 
@@ -50,6 +51,43 @@ float GetTonemapFactorHejlBurgessDawson(float luminance)
 	       pow(((tmp * 6.2 + 0.5) * tmp) / (tmp * (tmp * 6.2 + 1.7) + 0.06), GammaCorrectionValue);
 }
 
+// SafeDivision and RestorePostProcess by Pumbo https://github.com/Filoppi
+
+// Returns 0, 1 or FLT_MAX if "dividend" is 0
+float SafeDivision(float quotient, float dividend, int fallbackMode = 0)
+{
+	if (dividend == 0.0) {
+        if (fallbackMode == 0)
+          return 0;
+        if (fallbackMode == 1)
+          return sign(quotient);
+        return asfloat(0x7F7FFFFF) * sign(quotient);
+    }
+    return quotient / dividend;
+}
+
+// Returns 0, 1 or FLT_MAX if "dividend" is 0
+float3 SafeDivision(float3 quotient, float3 dividend, int fallbackMode = 0)
+{
+    return float3(SafeDivision(quotient.x, dividend.x, fallbackMode), SafeDivision(quotient.y, dividend.y, fallbackMode), SafeDivision(quotient.z, dividend.z, fallbackMode));
+}
+
+// Takes any original color (before some post process is applied to it) and re-applies the same transformation the post process had applied to it on a different (but similar) color.
+// The images are expected to have roughly the same mid gray.
+// It can be used for example to apply any SDR LUT or SDR Color Correction on an HDR color.
+float3 RestorePostProcess(float3 NonPostProcessedTargetColor, float3 NonPostProcessedSourceColor, float3 PostProcessedSourceColor)
+{
+    static const float MaxShadowsColor = pow(1.0 / 3.0, 2.2);
+    const float3 PostProcessColorRatio = SafeDivision(PostProcessedSourceColor, NonPostProcessedSourceColor);
+    const float3 PostProcessColorOffset = PostProcessedSourceColor - NonPostProcessedSourceColor;
+    const float3 PostProcessedRatioColor = NonPostProcessedTargetColor * PostProcessColorRatio;
+    const float3 PostProcessedOffsetColor = NonPostProcessedTargetColor + PostProcessColorOffset;
+    // Near black, we prefer using the "offset" (sum) pp restoration method, as otherwise any raised black from post processing would not work to apply,
+    // for example if any zero was shifted to a more raised color, "PostProcessColorRatio" would not be able to replicate that shift due to a division by zero.
+    const float3 PostProcessedTargetColor = lerp(PostProcessedOffsetColor, PostProcessedRatioColor, max(saturate(abs(NonPostProcessedTargetColor) / MaxShadowsColor), saturate(abs(NonPostProcessedSourceColor) / MaxShadowsColor)));
+    return PostProcessedTargetColor;
+}
+
 PS_OUTPUT main(PS_INPUT input)
 {
 	PS_OUTPUT psout;
@@ -83,39 +121,78 @@ PS_OUTPUT main(PS_INPUT input)
 	psout.Color = float4(downsampledColor, BlurScale.z);
 
 #	elif defined(BLEND)
-	float2 adjustedTexCoord = GetDynamicResolutionAdjustedScreenPosition(input.TexCoord);
-	float3 blendColor = BlendTex.Sample(BlendSampler, adjustedTexCoord).xyz;
-	float3 imageColor = 0;
+	float2 uv = GetDynamicResolutionAdjustedScreenPosition(input.TexCoord);
+
+	float3 inputColor = BlendTex.Sample(BlendSampler, uv).xyz;
+
+	float3 bloomColor = 0;
 	if (Flags.x > 0.5) {
-		imageColor = ImageTex.Sample(ImageSampler, adjustedTexCoord).xyz;
+		bloomColor = ImageTex.Sample(ImageSampler, uv).xyz;
 	} else {
-		imageColor = ImageTex.Sample(ImageSampler, input.TexCoord).xyz;
-	}
-	float2 avgValue = AvgTex.Sample(AvgSampler, input.TexCoord).xy;
-
-	float luminance = max(1e-5, RGBToLuminance(blendColor));
-	float exposureAdjustedLuminance = (avgValue.y / avgValue.x) * luminance;
-	float blendFactor;
-	if (Param.z > 0.5) {
-		blendFactor = GetTonemapFactorHejlBurgessDawson(exposureAdjustedLuminance);
-	} else {
-		blendFactor = GetTonemapFactorReinhard(exposureAdjustedLuminance);
+		bloomColor = ImageTex.Sample(ImageSampler, input.TexCoord.xy).xyz;
 	}
 
-	float3 blendedColor =
-		blendColor * (blendFactor / luminance) + saturate(Param.x - blendFactor) * imageColor;
-	float blendedLuminance = RGBToLuminance(blendedColor);
+	float2 avgValue = AvgTex.Sample(AvgSampler, input.TexCoord.xy).xy;
 
-	float4 linearColor = lerp(avgValue.x,
-		Cinematic.w * lerp(lerp(blendedLuminance, float4(blendedColor, 1), Cinematic.x),
-						  blendedLuminance * Tint, Tint.w),
-		Cinematic.z);
-	float4 srgbColor = float4(ToSRGBColor(saturate(linearColor.xyz)), linearColor.w);
+	// Vanilla tonemapping and post-processing
+	float3 gameSdrColor = 0.0;
+	float3 ppColor = 0.0;
+	{
+		float luminance = max(1e-5, RGBToLuminance(inputColor));
+		float exposureAdjustedLuminance = (avgValue.y / avgValue.x) * luminance;
+		float blendFactor;
+		if (Param.z > 0.5) {
+			blendFactor = GetTonemapFactorHejlBurgessDawson(exposureAdjustedLuminance);
+		} else {
+			blendFactor = GetTonemapFactorReinhard(exposureAdjustedLuminance);
+		}
+
+		float3 blendedColor = inputColor * (blendFactor / luminance);
+		blendedColor += saturate(Param.x - blendFactor) * bloomColor;
+		
+		gameSdrColor = blendedColor;
+
+		float blendedLuminance = RGBToLuminance(blendedColor);
+
+		float4 linearColor = lerp(avgValue.x,
+			Cinematic.w * lerp(lerp(blendedLuminance, float4(blendedColor, 1), Cinematic.x),
+							blendedLuminance * Tint, Tint.w),
+			Cinematic.z);
+
+		gameSdrColor = max(0, gameSdrColor);
+		ppColor = max(0, linearColor);
+	}
+
+	// Apply bloom directly to the HDR input
+	inputColor += saturate(Param.x - inputColor) * bloomColor;
+	
+	// Eye adaptation
+	inputColor *= avgValue.y / avgValue.x;
+
+	// Gamma to linear
+	inputColor = pow(inputColor, 2.2);
+	gameSdrColor = pow(gameSdrColor, 2.2);
+	ppColor = pow(ppColor, 2.2);
+	bloomColor = pow(bloomColor, 2.2);
+
+	// Map SDR post-processing data to HDR
+	inputColor = max(0, RestorePostProcess(inputColor, gameSdrColor, ppColor));
+	
+	// Tonemap HDR input which contains post-processing
+	float3 linearColor = max(0, ApplyHuePreservingShoulder(inputColor, lerp(0.25, 0.5, Param.z)));
+	
+	// Linear to gamma
+	float3 srgbColor = pow(linearColor, 1.0 / 2.2);
+
 #		if defined(FADE)
-	srgbColor = lerp(srgbColor, Fade, Fade.w);
+	srgbColor = lerp(srgbColor, Fade.xyz, Fade.w);
 #		endif
-	psout.Color = srgbColor;
 
+	// Game brightness slider
+	srgbColor = ToSRGBColor(srgbColor);
+
+	psout.Color = float4(srgbColor, 1.0);
+	
 #	endif
 
 	return psout;

--- a/package/Shaders/ISHDR.hlsl
+++ b/package/Shaders/ISHDR.hlsl
@@ -173,7 +173,6 @@ PS_OUTPUT main(PS_INPUT input)
 	inputColor = pow(inputColor, 2.2);
 	gameSdrColor = pow(gameSdrColor, 2.2);
 	ppColor = pow(ppColor, 2.2);
-	bloomColor = pow(bloomColor, 2.2);
 
 	// Map SDR post-processing data to HDR
 	inputColor = max(0, RestorePostProcess(inputColor, gameSdrColor, ppColor));

--- a/package/Shaders/ISHDR.hlsl
+++ b/package/Shaders/ISHDR.hlsl
@@ -179,17 +179,14 @@ PS_OUTPUT main(PS_INPUT input)
 	inputColor = max(0, RestorePostProcess(inputColor, gameSdrColor, ppColor));
 
 	// Tonemap HDR input which contains post-processing
-	float3 linearColor = max(0, ApplyHuePreservingShoulder(inputColor, lerp(0.25, 0.5, Param.z)));
 
+	float3 linearColor = max(0, ApplyHuePreservingShoulder(inputColor, 1.0 - smoothstep(0.6, 1.4, FrameParams.x)));
 	// Linear to gamma
 	float3 srgbColor = pow(linearColor, 1.0 / 2.2);
 
 #		if defined(FADE)
 	srgbColor = lerp(srgbColor, Fade.xyz, Fade.w);
 #		endif
-
-	// Game brightness slider
-	srgbColor = ToSRGBColor(srgbColor);
 
 	psout.Color = float4(srgbColor, 1.0);
 


### PR DESCRIPTION
Implements a neutral tonemapper as seen in some Frostbyte games: https://www.ea.com/frostbite/news/high-dynamic-range-color-grading-and-display-in-frostbite 

This fixes overly bright areas of the screen, particularly when using PBR, without modifying the look of the game to a significant degree, nor does it shift hues.
