### PR TITLE
feat: linear water lighting and LOD lighting fixed

### DIFF
--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -672,7 +672,7 @@ float3 GetWaterDiffuseColor(PS_INPUT input, float3 normal, float3 viewDirection,
 	if (!(PixelShaderDescriptor & _Interior)) {
 		float vl = GetVL(input.WPosition.xyz, refractionWorldPosition.xyz, normal, screenPosition, shadow, a_eyeIndex);
 
-		float3 refractionDiffuseColorSunlight = 5 * refractionDiffuseColor * vl * sRGB2Lin(SunColor.xyz * SunDir.w);
+		float3 refractionDiffuseColorSunlight = 4 * refractionDiffuseColor * vl * sRGB2Lin(SunColor.xyz * SunDir.w);
 #				if defined(SKYLIGHTING)
 #					if defined(VR)
 		float3 skylightPosOffset = a_eyeIndex == 1 ? CameraPosAdjust[1] - CameraPosAdjust[0] : 0;

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -569,7 +569,7 @@ float3 GetWaterSpecularColor(PS_INPUT input, float3 normal, float3 viewDirection
 			float2 ssrReflectionUv = GetDynamicResolutionAdjustedScreenPosition((DynamicResolutionParams2.xy * input.HPosition.xy) * SSRParams.zw + SSRParams2.x * normal.xy);
 			float4 ssrReflectionColor1 = SSRReflectionTex.Sample(SSRReflectionSampler, ssrReflectionUv);
 			float4 ssrReflectionColor2 = RawSSRReflectionTex.Sample(RawSSRReflectionSampler, ssrReflectionUv);
-			
+
 			ssrReflectionColor1.xyz = sRGB2Lin(ssrReflectionColor1.xyz);
 			ssrReflectionColor2.xyz = sRGB2Lin(ssrReflectionColor2.xyz);
 
@@ -844,10 +844,10 @@ PS_OUTPUT main(PS_INPUT input)
 #				else
 	float3 sunColor = GetSunColor(normal, viewDirection);
 
-#	if defined(LOD)
+#					if defined(LOD)
 	if (length(sunColor) > 0.0)
 		shadow = GetWorldShadow(input.WPosition, length(input.WPosition.xyz), normal, eyeIndex);
-#	endif
+#					endif
 
 	if (!(PixelShaderDescriptor & _Interior)) {
 		if (shadow != 0.0) {


### PR DESCRIPTION
Water is made to use linear lighting so that it actually has correct reflections. This creates a significant change, but makes it match our other reflections, and looks like how enbs commonly make water look.

Shadows are added to LOD separately since the GetVL function does not run on LOD.

A multiplier is added to VL because otherwise it is too dim