### PR TITLE
fix(VR): fix flickering of non-PBR assets

### DIFF
--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -656,7 +656,7 @@ void LightLimitFix::UpdateLights()
 
 	// Process point lights
 
-	for (auto& e : shadowSceneNode->GetRuntimeData().activePointLights) {
+	for (auto& e : shadowSceneNode->GetRuntimeData().activeLights) {
 		if (auto bsLight = e.get()) {
 			if (auto niLight = bsLight->light.get()) {
 				if (IsValidLight(bsLight) && IsGlobalLight(bsLight)) {


### PR DESCRIPTION
Fix flickering of nonPBR assets when PBR assets are used.

Co-authored-by: @Jonahex 
