### PR TITLE
perf: reduce default compilerThreads

### DIFF
--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -351,7 +351,7 @@ namespace SIE
 		void InsertModifiedShaderMap(std::string a_shader, std::chrono::time_point<std::chrono::system_clock> a_time);
 		std::chrono::time_point<std::chrono::system_clock> GetModifiedShaderMapTime(const std::string& a_shader);
 
-		int32_t compilationThreadCount = std::max(static_cast<int32_t>(std::thread::hardware_concurrency()) - 1, 1);
+		int32_t compilationThreadCount = std::max({ static_cast<int32_t>(std::thread::hardware_concurrency()) - 4, static_cast<int32_t>(std::thread::hardware_concurrency()) * 3 / 4, 1 });
 		int32_t backgroundCompilationThreadCount = std::max(static_cast<int32_t>(std::thread::hardware_concurrency()) / 2, 1);
 		BS::thread_pool compilationPool{};
 		bool backgroundCompilation = false;


### PR DESCRIPTION
Set the default to be the max of (maxCores - 4), (maxCores * 3/4), or 1