### PR TITLE
feat: pbr replacement for default land texture.

### DIFF
--- a/src/TruePBR.h
+++ b/src/TruePBR.h
@@ -37,6 +37,7 @@ public:
 	void SaveSettings(json& o_json);
 	void PrePass();
 	void PostPostLoad();
+	void DataLoaded();
 
 	void SetShaderResouces();
 	void GenerateShaderPermutations(RE::BSShader* shader);
@@ -97,6 +98,7 @@ public:
 	bool IsPBRTextureSet(const RE::TESForm* textureSet);
 
 	std::unordered_map<std::string, PBRTextureSetData> pbrTextureSets;
+	RE::BGSTextureSet* defaultPbrLandTextureSet = nullptr;
 	std::string selectedPbrTextureSetName;
 	PBRTextureSetData* selectedPbrTextureSet = nullptr;
 

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -4,6 +4,7 @@
 #include "Menu.h"
 #include "ShaderCache.h"
 #include "State.h"
+#include "TruePBR.h"
 
 #include "ENB/ENBSeriesAPI.h"
 #include "Features/ExtendedMaterials.h"
@@ -129,6 +130,7 @@ void MessageHandler(SKSE::MessagingInterface::Message* message)
 					shaderCache.WriteDiskCacheInfo();
 				}
 
+				TruePBR::GetSingleton()->DataLoaded();
 				for (auto* feature : Feature::GetFeatureList()) {
 					if (feature->loaded) {
 						feature->DataLoaded();


### PR DESCRIPTION
If texture set record named DefaultPBRLand is detected it will be used instead of ini-based vanilla default texture set.
Fix for https://github.com/doodlum/skyrim-community-shaders/issues/470