### PR TITLE
chore: less hue preservation in tonemapping

### DIFF
--- a/package/Shaders/Common/DICETonemapper.hlsli
+++ b/package/Shaders/Common/DICETonemapper.hlsli
@@ -131,17 +131,8 @@ float3 ApplyHuePreservingShoulder(float3 col, float linearSegmentEnd = 0.25)
 	float saturationAmount = pow(smoothstep(1.0, 0.3, ictcp.x), 1.3);
 	col = ICtCpToRGB(ictcp * float3(1, saturationAmount.xx));
 
-	// Hue-preserving mapping
-	float maxCol = max(col.x, max(col.y, col.z));
-	float mappedMax = RangeCompress(maxCol, linearSegmentEnd);
-	float3 compressedHuePreserving = col * mappedMax / maxCol;
-
 	// Non-hue preserving mapping
-	float3 perChannelCompressed = RangeCompress(col, linearSegmentEnd);
-
-	// Combine hue-preserving and non-hue-preserving colors. Absolute hue preservation looks unnatural, as bright colors *appear* to have been hue shifted.
-	// Actually doing some amount of hue shifting looks more pleasing
-	col = lerp(perChannelCompressed, compressedHuePreserving, 0.6);
+	col = RangeCompress(col, linearSegmentEnd);
 
 	float3 ictcpMapped = RGBToICtCp(col);
 

--- a/package/Shaders/ISHDR.hlsl
+++ b/package/Shaders/ISHDR.hlsl
@@ -131,13 +131,15 @@ PS_OUTPUT main(PS_INPUT input)
 	ppColor = GammaToLinear(ppColor);
 
 	// HDR tonemapping
-	float3 linearColor = max(0, ApplyHuePreservingShoulder(ppColor, 1.0 - smoothstep(0.6, 1.4, FrameParams.x)));
+	float3 linearColor = ApplyHuePreservingShoulder(ppColor);
 
 	float3 srgbColor = LinearToGamma(linearColor);
 
 #		if defined(FADE)
 	srgbColor = lerp(srgbColor, Fade.xyz, Fade.w);
 #		endif
+
+	srgbColor = ToSRGBColor(srgbColor);
 
 	psout.Color = float4(srgbColor, 1.0);
 


### PR DESCRIPTION
Hue preservation shifted hues too much near Riften that it looked weird.

Also reverts the brightness slider to vanilla useage.