### PR TITLE
fix: Specify magic-enum port version in vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -40,7 +40,12 @@
     {
       "name": "tracy",
       "version": "0.11.0"
-    }
+    },
+    {
+      "name": "magic-enum",
+      "version": "0.9.6",
+      "port-version": 1
+  }
   ],
   "builtin-baseline": "1dc5ee30eb1032221d29f281f4a94b73f06b4284"
 }


### PR DESCRIPTION
Magic-enum got two versions with the same version number, breaking the build process. This selects the correct one. Or something, I have no idea. It just works.