### PR TITLE
fix: fix missing directory ctd with DynamicCubeMap Creator

### DIFF
--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -86,22 +86,16 @@ void DynamicCubemaps::DrawSettings()
 					}
 
 					ID3D11Texture2D* tempTexture;
-					DX::ThrowIfFailed(device->CreateTexture2D(&texDesc, subresourceData, &tempTexture));
-
 					DirectX::ScratchImage image;
-					DX::ThrowIfFailed(CaptureTexture(device, context, tempTexture, image));
 
-					bool defaultDynamicCubeMapSavePathSafe = true;
 					try {
+						DX::ThrowIfFailed(device->CreateTexture2D(&texDesc, subresourceData, &tempTexture));
+						DX::ThrowIfFailed(CaptureTexture(device, context, tempTexture, image));
+
 						if (std::filesystem::create_directories(defaultDynamicCubeMapSavePath)) {
 							logger::info("Missing DynamicCubeMap Creator directory created: {}", defaultDynamicCubeMapSavePath);
 						}
-					} catch (const std::exception) {
-						logger::error("Failed to create missing DynamicCubeMap Creator directory: {}", defaultDynamicCubeMapSavePath);
-						defaultDynamicCubeMapSavePathSafe = false;
-					}
 
-					if (defaultDynamicCubeMapSavePathSafe) {
 						std::filesystem::path DynamicCubeMapSavePath = defaultDynamicCubeMapSavePath;
 						std::filesystem::path filename(std::format("R{:03d}G{:03d}B{:03d}A{:03d}.dds", colorPixel.r, colorPixel.g, colorPixel.b, colorPixel.a));
 						DynamicCubeMapSavePath /= filename;
@@ -112,7 +106,11 @@ void DynamicCubemaps::DrawSettings()
 							DX::ThrowIfFailed(SaveToDDSFile(image.GetImages(), image.GetImageCount(), image.GetMetadata(), DirectX::DDS_FLAGS::DDS_FLAGS_NONE, DynamicCubeMapSavePath.c_str()));
 							logger::info("DynamicCubeMap Creator file for {} written", filename.string());
 						}
+
+					} catch (const std::exception& e) {
+						logger::error("Failed in DynamicCubeMap Creator file: {} {}", defaultDynamicCubeMapSavePath, e.what());
 					}
+
 					image.Release();
 					tempTexture->Release();
 				}

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -102,7 +102,6 @@ void DynamicCubemaps::DrawSettings()
 					}
 
 					if (defaultDynamicCubeMapSavePathSafe) {
-
 						std::filesystem::path DynamicCubeMapSavePath = defaultDynamicCubeMapSavePath;
 						std::filesystem::path filename(std::format("R{:03d}G{:03d}B{:03d}A{:03d}.dds", colorPixel.r, colorPixel.g, colorPixel.b, colorPixel.a));
 						DynamicCubeMapSavePath /= filename;

--- a/src/Features/DynamicCubemaps.h
+++ b/src/Features/DynamicCubemaps.h
@@ -20,7 +20,7 @@ public:
 	}
 
 	const std::string defaultDynamicCubeMapSavePath = "Data\\textures\\DynamicCubemaps";
-	
+
 	// Specular irradiance
 
 	ID3D11SamplerState* computeSampler = nullptr;

--- a/src/Features/DynamicCubemaps.h
+++ b/src/Features/DynamicCubemaps.h
@@ -19,6 +19,8 @@ public:
 		return &singleton;
 	}
 
+	const std::string defaultDynamicCubeMapSavePath = "Data\\textures\\DynamicCubemaps";
+	
 	// Specular irradiance
 
 	ID3D11SamplerState* computeSampler = nullptr;


### PR DESCRIPTION
When a destination folder for the DynamicCubeMap Creator export does not exist then CS should not crash.

Now:
Create Folder if destination folder does not exist. Unable to create missing folder: log error
File Object with same name exists: skips