### PR TITLE
feat: rebuild shaders when editing shader defines

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -332,6 +332,19 @@ void Menu::DrawSettings()
 			if (ImGui::InputText("Shader Defines", &shaderDefines)) {
 				State::GetSingleton()->SetDefines(shaderDefines);
 			}
+			if (ImGui::IsItemDeactivatedAfterEdit() || (ImGui::IsItemActive() &&
+														   (ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Enter)) ||
+															   ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_KeypadEnter))))) {
+				State::GetSingleton()->SetDefines(shaderDefines);
+				shaderCache.Clear();
+				Deferred::GetSingleton()->ClearShaderCache();
+				VariableRateShading::GetSingleton()->ClearShaderCache();
+				for (auto* feature : Feature::GetFeatureList()) {
+					if (feature->loaded) {
+						feature->ClearShaderCache();
+					}
+				}
+			}
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Defines for Shader Compiler. Semicolon \";\" separated. Clear with space. Rebuild shaders after making change. Compute Shaders require a restart to recompile.");
 			}


### PR DESCRIPTION
Improves the behavior when modifying the Advanced -> Shader Defines. Shaders will be rebuilt on any change in the field when focus is lost or if enter is pressed.