### PR TITLE
docs: provide gpl exception for hardware sdks

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ When switching between different presets you might need to remove the build fold
 ### Default
 
 [GPL-3.0-or-later](COPYING) WITH [Modding Exception AND GPL-3.0 Linking Exception (with Corresponding Source)](EXCEPTIONS.md).  
-Specifically, the Modded Code is Skyrim (and its variants) and Modding Libraries include [SKSE](https://skse.silverlock.org/) and Commonlib (and variants).
+Specifically, the Modded Code includes: 
+* Skyrim (and its variants) 
+* Hardware drivers to enable additional functionality provided via proprietary SDKs, such as [Nvidia DLSS](https://developer.nvidia.com/rtx/dlss/get-started), [AMD FidelityFX FSR3](https://gpuopen.com/fidelityfx-super-resolution-3/), and [Intel XeSS](https://github.com/intel/xess)
+
+The Modding Libraries include: 
+* [SKSE](https://skse.silverlock.org/) 
+* Commonlib (and variants).
 
 ### Shaders
 


### PR DESCRIPTION
Given #504, we need to approve an expanded exception for our use of GPL3. Essentially, if CS incorporates any hardware vendor SDKS, (e.g., Nvidia DLSS), those are generally not compatible with GPL since they are proprietary and do not allow sharing of source code. This exception excludes those SDKS from the GPL3 requirements.

You are tagged as a contributor of code to CS, please Approve.
**Approved:**
@doodlum @alandtse @Pentalimbed  @ThePagi @TKCen @CiMaWi @FlayaN @Andersw88 @thorwin99 @H4vC @langfod @AceAmir @Jonahex @TheRiverwoodModder
**Pending:**
@ffarrell17 - [imgui work/refactoring](https://github.com/doodlum/skyrim-community-shaders/pulls?q=sort%3Aupdated-desc+is%3Apr+author%3Affarrell17)
@jeanluciano - Ok without; pr reverted #38
@rjwignar - Ok without; CI work; refactoring
@LaoBro  - Ok without; minor changes #44
@ceejbot - Ok without; contribution wasn't cpp #47


Please note, while I tagged everyone who has added code, we may proceed without your Approval if we determine we do not need your approval. But it's nice to have everyone on board.