### PR TITLE
build: introduces a windows based build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2022 AS base
+SHELL ["cmd", "/S", "/C"]
+
+RUN powershell -NoProfile -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; \
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; \
+    iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')); \
+    choco install curl git 7zip -y; \
+    choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y"
+
+RUN \
+    curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtools.exe \
+    && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache \
+        --installPath "%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\BuildTools" \
+        --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
+        --add Microsoft.VisualStudio.Component.Windows11SDK.26100 \
+        --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 \
+        --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 \
+        --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 \
+        --remove Microsoft.VisualStudio.Component.Windows81SDK \
+        || IF "%ERRORLEVEL%"=="3010" EXIT 0) \
+    && del /q vs_buildtools.exe
+ 
+RUN git clone https://github.com/microsoft/vcpkg.git C:/vcpkg && \
+    cd C:/vcpkg && \
+    bootstrap-vcpkg.bat
+   
+RUN setx /M VCPKG_ROOT "C:/vcpkg" && mkdir C:\skyrim-community-shaders
+
+WORKDIR C:/skyrim-community-shaders
+
+ENTRYPOINT ["powershell", "-File", "C:/skyrim-community-shaders/containerbuild.ps1"]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For those who prefer to not install Visual Studio or other build dependencies on
 1. Install [Docker](https://www.docker.com/products/docker-desktop/) first if not already there. 
 2. In a shell of your choice run to switch to Windows containers and create the build container:
 ```pwsh
-docker context use desktop-windows; `
+& 'C:\Program Files\Docker\Docker\DockerCli.exe' -SwitchWindowsEngine; `
 docker build -t skyrim-community-shaders .
 ```
 3. Then run the build: 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For those who prefer to not install Visual Studio or other build dependencies on
 1. Install [Docker](https://www.docker.com/products/docker-desktop/) first if not already there. 
 2. In a shell of your choice run to switch to Windows containers and create the build container:
 ```pwsh
-docker context use windows; `
+docker context use desktop-windows; `
 docker build -t skyrim-community-shaders .
 ```
 3. Then run the build: 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,17 @@ When switching between different presets you might need to remove the build fold
 ### Build with Docker
 For those who prefer to not install Visual Studio or other build dependencies on their machine, this encapsulates it. This uses Windows Containers, so no WSL for now.  
 1. Install [Docker](https://www.docker.com/products/docker-desktop/) first if not already there. 
-2. In a shell of your choice run:
+2. In a shell of your choice run to switch to Windows containers and create the build container:
 ```pwsh
 docker context use windows; `
-docker build -t skyrim-community-shaders .; `
+docker build -t skyrim-community-shaders .
+```
+3. Then run the build: 
+```pwsh
 docker run -it --rm -v .:C:/skyrim-community-shaders skyrim-community-shaders:latest
 ```
-3. Retrieve the generated build files from the `build/aio` folder.
+4. Retrieve the generated build files from the `build/aio` folder.
+5. In subsequent builds only run the build step (3.)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ When using custom preset you can call BuildRelease.bat with an parameter to spec
 
 When switching between different presets you might need to remove the build folder
 
+### Build with Docker
+For those who prefer to not install Visual Studio or other build dependencies on their machine, this encapsulates it. This uses Windows Containers, so no WSL for now.  
+1. Install [Docker](https://www.docker.com/products/docker-desktop/) first if not already there. 
+2. In a shell of your choice run:
+```pwsh
+docker context use windows; `
+docker build -t skyrim-community-shaders .; `
+docker run -it --rm -v .:C:/skyrim-community-shaders skyrim-community-shaders:latest
+```
+3. Retrieve the generated build files from the `build/aio` folder.
+
 ## License
 
 ### Default

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ SKSE core plugin for community-driven advanced graphics modifications.
 - Run `cmake`
 - Close the cmd window
 
+Or, in powershell run:
+```pwsh
+& "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" amd64
+```
+
 ## Clone and Build
 Open terminal (e.g., PowerShell) and run the following commands:
 

--- a/containerbuild.ps1
+++ b/containerbuild.ps1
@@ -5,19 +5,18 @@ param (
 Write-Host "Starting build..."
 
 # Setup
-ls "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build"
 & "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" amd64
 
 if (-Not (Test-Path -Path "CMakeUserPresets.json")) {
     Copy-Item -Path "CMakeUserPresets.json.template" -Destination "CMakeUserPresets.json"
-    (Get-Content -Path "CMakeUserPresets.json") -replace 'F:/MySkyrimModpack/mods/CommunityShaders;F:/SteamLibrary/steamapps/common/SkyrimVR/Data;F:/SteamLibrary/steamapps/common/Skyrim Special Edition/Data', 'C:/skyrim-community-shaders/build-output' | Set-Content -Path "CMakeUserPresets.json"
+    (Get-Content -Path "CMakeUserPresets.json") -replace 'F:/MySkyrimModpack/mods/CommunityShaders;F:/SteamLibrary/steamapps/common/SkyrimVR/Data;F:/SteamLibrary/steamapps/common/Skyrim Special Edition/Data', 'C:/skyrim-community-shaders/build' | Set-Content -Path "CMakeUserPresets.json"
     Write-Host "CMakeUserPresets.json created and modified."
 } else {
     Write-Host "CMakeUserPresets.json already exists. No action taken."
 }
 
 # Generate
-cmake -S . --preset=$preset --check-stamp-file build/ALL/CMakeFiles/generate.stamp
+cmake -S . --preset=$preset --check-stamp-file build/$preset/CMakeFiles/generate.stamp
 if ($LASTEXITCODE -ne 0) {
     Write-Host "CMake configuration failed."
     exit 1

--- a/containerbuild.ps1
+++ b/containerbuild.ps1
@@ -1,0 +1,33 @@
+param (
+    [string]$preset = "ALL"  # Default value for preset is "ALL"
+)
+
+Write-Host "Starting build..."
+
+# Setup
+ls "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build"
+& "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" amd64
+
+if (-Not (Test-Path -Path "CMakeUserPresets.json")) {
+    Copy-Item -Path "CMakeUserPresets.json.template" -Destination "CMakeUserPresets.json"
+    (Get-Content -Path "CMakeUserPresets.json") -replace 'F:/MySkyrimModpack/mods/CommunityShaders;F:/SteamLibrary/steamapps/common/SkyrimVR/Data;F:/SteamLibrary/steamapps/common/Skyrim Special Edition/Data', 'C:/skyrim-community-shaders/build-output' | Set-Content -Path "CMakeUserPresets.json"
+    Write-Host "CMakeUserPresets.json created and modified."
+} else {
+    Write-Host "CMakeUserPresets.json already exists. No action taken."
+}
+
+# Generate
+cmake -S . --preset=$preset --check-stamp-file build/ALL/CMakeFiles/generate.stamp
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "CMake configuration failed."
+    exit 1
+}
+
+# Build
+cmake --build build/$preset --config Release
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Build failed."
+    exit 1
+}
+
+Write-Host "Build completed successfully."


### PR DESCRIPTION
For those preferring to build in containers, based on a windows container. Might do Linux in the future to avoid the cursed windows containers and their size, even when taking core images. This could be the first step towards some form of CI setup.. or stay just another, quicker way to build.

Not perfect, had ideas to reuse the BuildRelease.bat more by putting the user preset check and generation plus directory replacement in there.
Or extend it with another parameter and pass the output directory overwrite required for the container directly to cmake (maybe -DCommunityShadersOutputDir=C:\skyrim-community-shaders).
CMD limitations make that ugly without extra dependency so it stays in the container specific script for now.

Any suggestions welcome. 


