### PR TITLE
fix: fix broken vr lights due to buffer alignment

### DIFF
--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -11,6 +11,7 @@ struct StructuredLight
 	float radius;
 	float4 positionWS[2];
 	float4 positionVS[2];
+	float pad0[4];
 };
 
 struct StrictLightData

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -37,6 +37,7 @@ public:
 		float radius;
 		PositionOpt positionWS[2];
 		PositionOpt positionVS[2];
+		float pad0[4];
 	};
 
 	struct ClusterAABB


### PR DESCRIPTION
Fixes issue introduced by c64421048a664ffdcc33d7b3666e8ef36ef6c440