### PR TITLE
chore: add static-assert for GPU buffers

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -9,6 +9,9 @@
 #include <wrl\client.h>
 #include <wrl\wrappers\corewrappers.h>
 
+#define STATIC_ASSERT_ALIGNAS_16(structName) \
+	static_assert(sizeof(structName) % 16 == 0, #structName " is not a multiple of 16.");
+
 template <typename T>
 D3D11_BUFFER_DESC StructuredBufferDesc(uint64_t count, bool uav = true, bool dynamic = false)
 {

--- a/src/Deferred.h
+++ b/src/Deferred.h
@@ -62,7 +62,7 @@ public:
 		uint FrameCountAlwaysActive;
 		uint pad0[2];
 	};
-
+	STATIC_ASSERT_ALIGNAS_16(DeferredCB);
 	ConstantBuffer* deferredCB = nullptr;
 
 	ID3D11SamplerState* linearSampler = nullptr;
@@ -83,7 +83,7 @@ public:
 		DirectX::XMFLOAT4X3 ShadowMapProj[2][3];
 		DirectX::XMFLOAT4X3 CameraViewProjInverse[2];
 	};
-
+	STATIC_ASSERT_ALIGNAS_16(PerGeometry);
 	ID3D11ComputeShader* copyShadowCS = nullptr;
 	Buffer* perShadow = nullptr;
 	ID3D11ShaderResourceView* shadowView = nullptr;

--- a/src/Features/DynamicCubemaps.h
+++ b/src/Features/DynamicCubemaps.h
@@ -30,6 +30,7 @@ public:
 		float roughness;
 		float pad[3];
 	};
+	STATIC_ASSERT_ALIGNAS_16(SpecularMapFilterSettingsCB);
 
 	ID3D11ComputeShader* specularIrradianceCS = nullptr;
 	ConstantBuffer* spmapCB = nullptr;
@@ -45,7 +46,7 @@ public:
 		uint Reset;
 		float3 CameraPreviousPosAdjust;
 	};
-
+	STATIC_ASSERT_ALIGNAS_16(UpdateCubemapCB);
 	ID3D11ComputeShader* updateCubemapCS = nullptr;
 	ConstantBuffer* updateCubemapCB = nullptr;
 

--- a/src/Features/ExtendedMaterials.h
+++ b/src/Features/ExtendedMaterials.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Buffer.h"
 #include "Feature.h"
 
 struct ExtendedMaterials : Feature
@@ -29,7 +30,7 @@ struct ExtendedMaterials : Feature
 
 		float pad[2];
 	};
-
+	STATIC_ASSERT_ALIGNAS_16(Settings);
 	Settings settings;
 
 	virtual void DataLoaded() override;

--- a/src/Features/GrassCollision.h
+++ b/src/Features/GrassCollision.h
@@ -26,13 +26,14 @@ struct GrassCollision : Feature
 	{
 		float4 centre[2];
 	};
-
+	STATIC_ASSERT_ALIGNAS_16(CollisionData);
 	struct alignas(16) PerFrame
 	{
 		CollisionData collisionData[256];
 		uint numCollisions;
 		uint pad0[3];
 	};
+	STATIC_ASSERT_ALIGNAS_16(PerFrame);
 
 	std::uint32_t totalActorCount = 0;
 	std::uint32_t activeActorCount = 0;

--- a/src/Features/GrassLighting.h
+++ b/src/Features/GrassLighting.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Buffer.h"
 #include "Feature.h"
 
 struct GrassLighting : Feature
@@ -24,7 +25,7 @@ struct GrassLighting : Feature
 		float BasicGrassBrightness = 1.0f;
 		uint pad[3];
 	};
-
+	STATIC_ASSERT_ALIGNAS_16(Settings);
 	Settings settings;
 
 	virtual void DrawSettings() override;

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -38,7 +38,7 @@ public:
 		PositionOpt positionWS[2];
 		PositionOpt positionVS[2];
 	};
-
+	STATIC_ASSERT_ALIGNAS_16(LightData);
 	struct ClusterAABB
 	{
 		float4 minPoint;
@@ -51,6 +51,7 @@ public:
 		uint lightCount;
 		float pad0[2];
 	};
+	STATIC_ASSERT_ALIGNAS_16(LightGrid);
 
 	struct alignas(16) LightBuildingCB
 	{
@@ -58,13 +59,13 @@ public:
 		float LightsFar;
 		uint pad0[2];
 	};
-
+	STATIC_ASSERT_ALIGNAS_16(LightBuildingCB);
 	struct alignas(16) LightCullingCB
 	{
 		uint LightCount;
 		float pad[3];
 	};
-
+	STATIC_ASSERT_ALIGNAS_16(LightCullingCB);
 	struct alignas(16) PerFrame
 	{
 		uint EnableContactShadows;
@@ -74,7 +75,7 @@ public:
 
 		uint ClusterSize[4];
 	};
-
+	STATIC_ASSERT_ALIGNAS_16(PerFrame);
 	PerFrame GetCommonBufferData();
 
 	struct alignas(16) StrictLightData
@@ -85,7 +86,7 @@ public:
 		float LightsFar;
 		uint pad0;
 	};
-
+	STATIC_ASSERT_ALIGNAS_16(StrictLightData);
 	StrictLightData strictLightDataTemp;
 
 	struct CachedParticleLight

--- a/src/Features/ScreenSpaceGI.h
+++ b/src/Features/ScreenSpaceGI.h
@@ -117,6 +117,7 @@ struct ScreenSpaceGI : Feature
 
 		float pad[2];
 	};
+	STATIC_ASSERT_ALIGNAS_16(SSGICB);
 	eastl::unique_ptr<ConstantBuffer> ssgiCB;
 
 	eastl::unique_ptr<Texture2D> texNoise = nullptr;

--- a/src/Features/ScreenSpaceShadows.h
+++ b/src/Features/ScreenSpaceShadows.h
@@ -47,6 +47,7 @@ struct ScreenSpaceShadows : Feature
 
 		BendSettings settings;
 	};
+	STATIC_ASSERT_ALIGNAS_16(RaymarchCB);
 
 	ID3D11SamplerState* pointBorderSampler = nullptr;
 

--- a/src/Features/SubsurfaceScattering.h
+++ b/src/Features/SubsurfaceScattering.h
@@ -35,7 +35,7 @@ public:
 	{
 		float4 Sample[SSSS_N_SAMPLES];
 	};
-
+	STATIC_ASSERT_ALIGNAS_16(Kernel);
 	struct alignas(16) BlurCB
 	{
 		Kernel BaseKernel;
@@ -45,6 +45,7 @@ public:
 		float SSSS_FOVY;
 		uint pad[3];
 	};
+	STATIC_ASSERT_ALIGNAS_16(BlurCB);
 
 	ConstantBuffer* blurCB = nullptr;
 	BlurCB blurCBData{};

--- a/src/Features/TerrainShadows.h
+++ b/src/Features/TerrainShadows.h
@@ -55,6 +55,7 @@ struct TerrainShadows : public Feature
 		float2 ZRange;
 		float2 Offset;
 	};
+	STATIC_ASSERT_ALIGNAS_16(PerFrame);
 
 	PerFrame GetCommonBufferData();
 

--- a/src/Features/WetnessEffects.h
+++ b/src/Features/WetnessEffects.h
@@ -64,6 +64,7 @@ public:
 		Settings settings;
 		uint pad0[2];
 	};
+	STATIC_ASSERT_ALIGNAS_16(PerFrame);
 
 	Settings settings;
 

--- a/src/State.h
+++ b/src/State.h
@@ -128,7 +128,7 @@ public:
 		uint ExtraShaderDescriptor;
 		uint pad0[1];
 	};
-
+	STATIC_ASSERT_ALIGNAS_16(PermutationCB);
 	ConstantBuffer* permutationCB = nullptr;
 
 	struct alignas(16) SharedDataCB
@@ -144,7 +144,7 @@ public:
 		uint InInterior;
 		uint InMapMenu;
 	};
-
+	STATIC_ASSERT_ALIGNAS_16(SharedDataCB);
 	ConstantBuffer* sharedDataCB = nullptr;
 	ConstantBuffer* featureDataCB = nullptr;
 


### PR DESCRIPTION
This requires all buffers that will be sent to the GPU will be aligned to size 16.