### PR TITLE
feat: add hlsl-specific clear

### DIFF
--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1439,7 +1439,7 @@ namespace SIE
 					logger::debug("Saved shader to {}", Util::WStringToString(diskPath));
 				}
 			}
-			cache.AddCompletedShader(shaderClass, shader, descriptor, shaderBlob);
+			cache.AddCompletedShader(shaderClass, shader, descriptor, shaderBlob, pathString);
 			return shaderBlob;
 		}
 
@@ -1891,6 +1891,85 @@ namespace SIE
 		compilationSet.Clear();
 		std::unique_lock lock{ mapMutex };
 		shaderMap.clear();
+		hlslToShaderMap.clear();
+	}
+
+	template <typename ShaderType, typename MutexType>
+	void ReleaseShader(ShaderType& shaders,
+		MutexType& mutex, RE::BSShader::Type type, uint32_t descriptor)
+	{
+		std::lock_guard<MutexType> lockGuard(mutex);
+
+		if (static_cast<size_t>(type) < shaders.size()) {
+			auto& shaderMap = shaders[static_cast<size_t>(type)];
+			auto shaderIt = shaderMap.find(descriptor);
+			if (shaderIt != shaderMap.end()) {
+				auto& shaderPtr = shaderIt->second;
+				if (shaderPtr && shaderPtr->shader) {
+					shaderPtr->shader->Release();
+				}
+				shaderMap.erase(shaderIt);
+			}
+		}
+	}
+	bool ShaderCache::Clear(const std::string& a_path)
+	{
+		std::string lowerFilePath = Util::FixFilePath(a_path);
+
+		std::unique_lock lock{ mapMutex };
+		auto it = hlslToShaderMap.find(lowerFilePath);
+
+		if (it != hlslToShaderMap.end()) {
+			auto& entries = it->second;
+
+			for (auto& entry : entries) {
+				// Remove shader key from the map
+				shaderMap.erase(entry.key);
+
+				// Handle vertex, pixel, and compute shaders using the templated function
+				switch (entry.shaderClass) {
+				case SIE::ShaderClass::Vertex:
+					ReleaseShader(vertexShaders, vertexShadersMutex, entry.type, entry.descriptor);
+					break;
+				case SIE::ShaderClass::Pixel:
+					ReleaseShader(pixelShaders, pixelShadersMutex, entry.type, entry.descriptor);
+					break;
+				case SIE::ShaderClass::Compute:
+					ReleaseShader(computeShaders, computeShadersMutex, entry.type, entry.descriptor);
+					break;
+				default:
+					// Handle unexpected shader classes if necessary
+					logger::warn("Unexpected shader class: {}", static_cast<int>(entry.shaderClass));
+					break;
+				}
+				const auto& filePath = entry.diskPath;
+				const auto& filePathString = Util::WStringToString(filePath);
+				try {
+					if (std::filesystem::exists(filePath)) {
+						std::filesystem::remove(filePath);
+						logger::debug("Deleted {}", filePathString);
+					}
+				} catch (const std::exception& e) {
+					logger::warn("Failed to delete file {}: {}", filePathString, e.what());
+				} catch (...) {
+					logger::warn("An unknown error occurred while trying to delete file '{}'", filePathString);
+				}
+				compilationSet.Clear();
+				// Log that the shader is marked for recompile
+				logger::debug("Marking recompile for shader: {}", entry.key);
+			}
+
+			if (!entries.empty()) {
+				logger::debug("Marked {} entries for recompile due to change to {}", entries.size(), a_path);
+			}
+
+			// Clear the entries after marking them for recompile
+			entries.clear();
+
+			return true;
+		}
+
+		return false;
 	}
 
 	void ShaderCache::Clear(RE::BSShader::Type a_type)
@@ -1920,24 +1999,51 @@ namespace SIE
 		compilationSet.Clear();
 	}
 
-	bool ShaderCache::AddCompletedShader(ShaderClass shaderClass, const RE::BSShader& shader, uint32_t descriptor, ID3DBlob* a_blob)
+	bool ShaderCache::AddCompletedShader(ShaderClass shaderClass, const RE::BSShader& shader, uint32_t descriptor, ID3DBlob* a_blob, const std::string& a_path)
 	{
 		auto key = SIE::SShaderCache::GetShaderString(shaderClass, shader, descriptor, true);
 		auto status = a_blob ? ShaderCompilationTask::Status::Completed : ShaderCompilationTask::Status::Failed;
 		std::unique_lock lock{ mapMutex };
 		logger::debug("Adding {} shader to map: {}", magic_enum ::enum_name(status), key);
 		shaderMap.insert_or_assign(key, ShaderCacheResult{ a_blob, status, system_clock::now() });
-		return (bool)a_blob;
+		if (!a_path.empty()) {
+			std::string lowerFilePath = Util::FixFilePath(a_path);
+			auto it = hlslToShaderMap.find(lowerFilePath);
+			hlslRecord newRecord{ key, shader.shaderType.get(), descriptor, shaderClass, SIE::SShaderCache::GetDiskPath(shader.fxpFilename, descriptor, shaderClass) };
+
+			if (it != hlslToShaderMap.end()) {
+				auto& entries = it->second;
+
+				// Find and remove existing record with the same key
+				auto existingRecord = std::find_if(entries.begin(), entries.end(),
+					[&](const hlslRecord& r) { return r.key == key; });
+
+				if (existingRecord != entries.end()) {
+					entries.erase(existingRecord);  // Remove the old record
+				}
+
+				// Insert the new or updated record
+				entries.insert(newRecord);
+			} else {
+				// Create a new entry in hlslToShaderMap for this file path
+				hlslToShaderMap.emplace(lowerFilePath, std::set<hlslRecord>{ newRecord });
+			}
+		}
+
+		return a_blob != nullptr;
 	}
 
 	ID3DBlob* ShaderCache::GetCompletedShader(const std::string& a_key)
 	{
 		std::string type = SIE::SShaderCache::GetTypeFromShaderString(a_key);
-		UpdateShaderModifiedTime(a_key);
+		UpdateShaderModifiedTime(type);
 		std::scoped_lock lock{ mapMutex };
 		if (!shaderMap.empty() && shaderMap.contains(a_key)) {
 			if (ShaderModifiedSince(type, shaderMap.at(a_key).compileTime)) {
-				logger::debug("Shader {} compiled {} before changes at {}", a_key, std::format("{:%Y%m%d%H%M}", shaderMap.at(a_key).compileTime), std::format("{:%Y%m%d%H%M}", GetModifiedShaderMapTime(type)));
+				logger::debug("Shader {} compiled {} before changes at {}",
+					a_key,
+					std::format("{:%H:%M:%S}", shaderMap.at(a_key).compileTime),
+					std::format("{:%H:%M:%S}", GetModifiedShaderMapTime(type)));
 				return nullptr;
 			}
 			auto status = shaderMap.at(a_key).status;
@@ -2135,17 +2241,32 @@ namespace SIE
 		}
 	}
 
-	bool ShaderCache::UpdateShaderModifiedTime(std::string a_type)
+	bool ShaderCache::UpdateShaderModifiedTime(const std::string& a_type, boolean a_forceUpdate)
 	{
 		if (!UseFileWatcher())
 			return false;
-		if (a_type.empty() || !magic_enum::enum_cast<RE::BSShader::Type>(a_type, magic_enum::case_insensitive).has_value())  // type is invalid
-			return false;
-		std::filesystem::path filePath{ SIE::SShaderCache::GetShaderPath(a_type) };
+		// Validate the shader type
+		if (a_type.empty() || !magic_enum::enum_cast<RE::BSShader::Type>(a_type, magic_enum::case_insensitive).has_value()) {
+			return false;  // Invalid type
+		}
+
 		std::lock_guard lockGuard(modifiedMapMutex);
+
+		// Check for force update
+		if (a_forceUpdate) {
+			// Set an artificial timestamp far in the future (100 years)
+			auto futureTime = std::chrono::system_clock::now() + std::chrono::hours(24 * 365 * 100);
+			modifiedShaderMap.insert_or_assign(a_type, futureTime);
+			return true;
+		}
+
+		// Otherwise, update with the actual file time
+		std::filesystem::path filePath{ SIE::SShaderCache::GetShaderPath(a_type) };
 		if (std::filesystem::exists(filePath)) {
 			auto fileTime = std::chrono::clock_cast<std::chrono::system_clock>(std::filesystem::last_write_time(filePath));
-			if (!modifiedShaderMap.contains(a_type) || modifiedShaderMap.at(a_type) != fileTime) {  // insert if new or timestamp changed
+
+			// Update only if timestamp has changed
+			if (!modifiedShaderMap.contains(a_type) || modifiedShaderMap.at(a_type) != fileTime) {
 				modifiedShaderMap.insert_or_assign(a_type, fileTime);
 				return true;
 			}
@@ -2153,15 +2274,19 @@ namespace SIE
 		return false;
 	}
 
-	bool ShaderCache::ShaderModifiedSince(std::string a_type, system_clock::time_point a_current)
+	bool ShaderCache::ShaderModifiedSince(const std::string& a_type, std::chrono::system_clock::time_point a_current)
 	{
 		if (!UseFileWatcher())
 			return false;
-		if (a_type.empty() || !magic_enum::enum_cast<RE::BSShader::Type>(a_type, magic_enum::case_insensitive).has_value())  // type is invalid
-			return false;
+		// Validate the shader type
+		if (a_type.empty() || !magic_enum::enum_cast<RE::BSShader::Type>(a_type, magic_enum::case_insensitive).has_value()) {
+			return false;  // Invalid type
+		}
+
 		std::lock_guard lockGuard(modifiedMapMutex);
-		return !modifiedShaderMap.empty() && modifiedShaderMap.contains(a_type)  // map has Type
-		       && modifiedShaderMap.at(a_type) > a_current;                      //modification time is newer than a_current
+
+		// Check if the shader type exists in the map and if its modification time is newer than a_current
+		return !modifiedShaderMap.empty() && modifiedShaderMap.contains(a_type) && modifiedShaderMap.at(a_type) > a_current;
 	}
 
 	RE::BSGraphics::VertexShader* ShaderCache::MakeAndAddVertexShader(const RE::BSShader& shader,
@@ -2286,7 +2411,7 @@ namespace SIE
 		return hideError;
 	}
 
-	void ShaderCache::InsertModifiedShaderMap(std::string a_shader, std::chrono::time_point<std::chrono::system_clock> a_time)
+	void ShaderCache::InsertModifiedShaderMap(const std::string& a_shader, std::chrono::time_point<std::chrono::system_clock> a_time)
 	{
 		std::lock_guard lockGuard(modifiedMapMutex);
 		modifiedShaderMap.insert_or_assign(a_shader, a_time);
@@ -2493,24 +2618,47 @@ namespace SIE
 
 	void UpdateListener::UpdateCache(const std::filesystem::path& filePath, SIE::ShaderCache& cache, bool& clearCache, bool& fileDone)
 	{
-		std::string extension = filePath.extension().string();
-		std::string parentDir = filePath.parent_path().string();
-		std::string shaderTypeString = filePath.stem().string();
+		// Extract file components
+		const std::string extension = filePath.extension().string();
+		const std::string shaderTypeString = filePath.stem().string();
 		std::chrono::time_point<std::chrono::system_clock> modifiedTime{};
 		auto shaderType = magic_enum::enum_cast<RE::BSShader::Type>(shaderTypeString, magic_enum::case_insensitive);
 		fileDone = true;
-		if (std::filesystem::exists(filePath))
+		// Check if the file exists and get its modified time
+		if (std::filesystem::exists(filePath)) {
 			modifiedTime = std::chrono::clock_cast<std::chrono::system_clock>(std::filesystem::last_write_time(filePath));
-		else  // if file doesn't exist, don't do anything
+		} else {
+			fileDone = true;
 			return;
-		if (!std::filesystem::is_directory(filePath) && extension.starts_with(".hlsl") && parentDir.ends_with("Shaders") && shaderType.has_value()) {  // TODO: Case insensitive checks
-			// Shader types, so only invalidate specific shader type (e.g,. Lighting)
-			cache.InsertModifiedShaderMap(shaderTypeString, modifiedTime);
-			cache.Clear(shaderType.value());
-		} else if (!std::filesystem::is_directory(filePath) && extension.starts_with(".hlsl")) {  // TODO: Case insensitive checks
-			// all other shaders, since we don't know what is using it, clear everything
-			clearCache = true;
 		}
+
+		// Ensure the file is not a directory and is a valid shader file (.hlsl)
+		std::string lowerExtension = extension;
+		std::transform(lowerExtension.begin(), lowerExtension.end(), lowerExtension.begin(),
+			[](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+		if (!std::filesystem::is_directory(filePath) && lowerExtension == ".hlsl") {
+			// Update cache with the modified shader
+			cache.InsertModifiedShaderMap(shaderTypeString, modifiedTime);
+
+			// Attempt to mark the shader for recompilation
+			bool foundPath = cache.Clear(filePath.string());
+
+			if (!foundPath) {
+				// File was not found in the the map so check its shader type
+				std::string parentDirName = filePath.parent_path().filename().string();
+				std::transform(parentDirName.begin(), parentDirName.end(), parentDirName.begin(),
+					[](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+				// Check if the parent directory name matches "shaders" in a case-insensitive way
+				if (lowerExtension == ".hlsl" && parentDirName == "shaders" && shaderType.has_value()) {
+					cache.Clear(shaderType.value());
+				} else {
+					// If it's not specifically handled, clear all cache
+					clearCache = true;
+				}
+			}
+		}
+		// Indicate that file processing is not yet complete
 		fileDone = false;
 	}
 

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -349,7 +349,7 @@ namespace SIE
 		*/
 		bool Clear(const std::string& a_path);
 
-		bool AddCompletedShader(ShaderClass shaderClass, const RE::BSShader& shader, uint32_t descriptor, ID3DBlob* a_blob, const std::string& a_path = "");
+		bool AddCompletedShader(ShaderClass shaderClass, const RE::BSShader& shader, uint32_t descriptor, ID3DBlob* a_blob);
 		ID3DBlob* GetCompletedShader(const std::string& a_key);
 		ID3DBlob* GetCompletedShader(const SIE::ShaderCompilationTask& a_task);
 		ID3DBlob* GetCompletedShader(ShaderClass shaderClass, const RE::BSShader& shader, uint32_t descriptor);

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -629,11 +629,11 @@ namespace SIE
 		std::mutex computeShadersMutex;
 		CompilationSet compilationSet;
 		std::unordered_map<std::string, ShaderCacheResult> shaderMap{};
-		std::mutex mapMutex;
+		std::mutex mapMutex;                                                            // guard for shaderMap
 		std::unordered_map<std::string, system_clock::time_point> modifiedShaderMap{};  // hashmap when a shader source file last modified
-		std::unordered_map<std::string, std::set<hlslRecord>> hlslToShaderMap{};       // hashmap linking specific hlsl files to shader keys in shaderMap
-
-		std::mutex modifiedMapMutex;
+		std::mutex modifiedMapMutex;                                                    // guard for modifiedShaderMap
+		std::unordered_map<std::string, std::set<hlslRecord>> hlslToShaderMap{};        // hashmap linking specific hlsl files to shader keys in shaderMap
+		std::mutex hlslMapMutex;                                                        // guard for hlslToShaderMap
 
 		// efsw file watcher
 		efsw::FileWatcher* fileWatcher = nullptr;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -238,6 +238,25 @@ namespace Util
 		return result;
 	}
 
+	std::string FixFilePath(const std::string& a_path)
+	{
+		std::string lowerFilePath = a_path;
+
+		// Replace all backslashes with forward slashes
+		std::replace(lowerFilePath.begin(), lowerFilePath.end(), '\\', '/');
+
+		// Remove consecutive forward slashes
+		std::string::iterator newEnd = std::unique(lowerFilePath.begin(), lowerFilePath.end(),
+			[](char a, char b) { return a == '/' && b == '/'; });
+		lowerFilePath.erase(newEnd, lowerFilePath.end());
+
+		// Convert all characters to lowercase
+		std::transform(lowerFilePath.begin(), lowerFilePath.end(), lowerFilePath.begin(),
+			[](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+		return lowerFilePath;
+	}
+
 	std::string WStringToString(const std::wstring& wideString)
 	{
 		std::string result;

--- a/src/Util.h
+++ b/src/Util.h
@@ -24,6 +24,18 @@ namespace Util
 	ID3D11DeviceChild* CompileShader(const wchar_t* FilePath, const std::vector<std::pair<const char*, const char*>>& Defines, const char* ProgramType, const char* Program = "main");
 	std::string DefinesToString(const std::vector<std::pair<const char*, const char*>>& defines);
 	std::string DefinesToString(const std::vector<D3D_SHADER_MACRO>& defines);
+	/**
+	 * @brief Normalizes a file path by replacing backslashes with forward slashes, 
+	 *        removing redundant slashes, and converting all characters to lowercase.
+	 * 
+	 * This function ensures that the file path uses consistent forward slashes
+	 * (`/`), eliminates consecutive slashes (`//`), and converts all characters 
+	 * in the path to lowercase for case-insensitive comparisons.
+	 * 
+	 * @param a_path The original file path to be normalized.
+	 * @return A normalized file path as a lowercase string with single forward slashes.
+	 */
+	std::string FixFilePath(const std::string& a_path);
 	std::string WStringToString(const std::wstring& wideString);
 
 	float4 TryGetWaterData(float offsetX, float offsetY);


### PR DESCRIPTION
Allow clearing of all shaders linked to a specific hlsl file. This is
useful for DEFINE option passing for features.

This includes a fix to lock scope that was revealed.