### PR TITLE
build: fix build if using defined vckpg commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ SKSE core plugin for community-driven advanced graphics modifications.
 - [Vcpkg](https://github.com/microsoft/vcpkg)
   - Install vcpkg using the directions in vcpkg's [Quick Start Guide](https://github.com/microsoft/vcpkg#quick-start-windows)
   - After install, add a new environment variable named `VCPKG_ROOT` with the value as the path to the folder containing vcpkg
+  - Make sure your local vcpkg repo matches the commit id specified in `builtin-baseline` in `vcpkg.json` otherwise you might get another version of a non pinned vcpkg dependency causing undefined behaviour
 
 ## User Requirements
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -44,7 +44,7 @@
       "name": "magic-enum",
       "version": "0.9.6",
       "port-version": 1
-  }
+    }
   ],
-  "builtin-baseline": "1dc5ee30eb1032221d29f281f4a94b73f06b4284"
+  "builtin-baseline": "98aa6396292d57e737a6ef999d4225ca488859d5"
 }


### PR DESCRIPTION
If using specified vcpkg commit id specified in `builtin-baseline` in vcpkg.json it fails to configure cmake due to `magic-enum 0.9.6#1` being unavailable. 

This fixes that by bumping vcpkg to latest with said dependency present. Also update readme with how to make sure your local vcpkg repo is synced up