### PR TITLE
fix: fix padding for StructuredLight

### DIFF
--- a/features/Light Limit Fix/Shaders/LightLimitFix/Common.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/Common.hlsli
@@ -1,3 +1,5 @@
+#ifndef __LLF_COMMON_DEPENDENCY_HLSL__
+#define __LLF_COMMON_DEPENDENCY_HLSL__
 
 #define NUMTHREAD_X 16
 #define NUMTHREAD_Y 16
@@ -24,4 +26,7 @@ struct StructuredLight
 	float radius;
 	float4 positionWS[2];
 	float4 positionVS[2];
+	float pad0[4];
 };
+
+#endif  //__LLF_COMMON_DEPENDENCY_HLSL__

--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -1,19 +1,4 @@
-struct LightGrid
-{
-	uint offset;
-	uint lightCount;
-	float pad0[2];
-};
-
-struct StructuredLight
-{
-	float3 color;
-	float radius;
-	float4 positionWS[2];
-	float4 positionVS[2];
-	float pad0[4];
-};
-
+#include "LightLimitFix\Common.hlsli"
 struct StrictLightData
 {
 	StructuredLight StrictLights[15];


### PR DESCRIPTION
Includes a use of common for the llf hlsl struct definition and a compile warning fix.