### PR TITLE
fix: llf fixed alignment issues

### DIFF
--- a/features/Light Limit Fix/Shaders/LightLimitFix/ClusterBuildingCS.hlsl
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/ClusterBuildingCS.hlsl
@@ -61,8 +61,8 @@ float3 IntersectionZPlane(float3 B, float z_dist)
 	float3 minPointVS = min(GetPositionVS(texcoordMin, 1.0f, 0), GetPositionVS(texcoordMin, 1.0f, 1));
 #endif  // !VR
 
-	float clusterNear = LightsNear * pow(LightsFar / max(LightsNear, 1e-5), groupId.z / float(CLUSTER_BUILDING_DISPATCH_SIZE_Z));
-	float clusterFar = LightsNear * pow(LightsFar / max(LightsNear, 1e-5), (groupId.z + 1) / float(CLUSTER_BUILDING_DISPATCH_SIZE_Z));
+	float clusterNear = LightsNear * pow(LightsFar / LightsNear, groupId.z / float(CLUSTER_BUILDING_DISPATCH_SIZE_Z));
+	float clusterFar = LightsNear * pow(LightsFar / LightsNear, (groupId.z + 1) / float(CLUSTER_BUILDING_DISPATCH_SIZE_Z));
 
 	float3 minPointNear = IntersectionZPlane(minPointVS, clusterNear);
 	float3 minPointFar = IntersectionZPlane(minPointVS, clusterFar);

--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -3,9 +3,7 @@ struct StrictLightData
 {
 	StructuredLight StrictLights[15];
 	uint NumStrictLights;
-	float LightsNear;
-	float LightsFar;
-	uint pad0;
+	uint pad0[3];
 };
 
 StructuredBuffer<StructuredLight> lights : register(t50);
@@ -19,12 +17,11 @@ namespace LightLimitFix
 	{
 		const uint3 clusterSize = lightLimitFixSettings.ClusterSize.xyz;
 
-		if (z < strictLights[0].LightsNear || z > strictLights[0].LightsFar)
+		if (z < CameraData.y || z > CameraData.x)
 			return false;
 
-		float nearVal = max(strictLights[0].LightsNear, 1e-5);
-		float clampedZ = clamp(z, nearVal, strictLights[0].LightsFar);
-		uint clusterZ = uint(max((log2(z) - log2(nearVal)) * clusterSize.z / log2(strictLights[0].LightsFar / nearVal), 0.0));
+		float clampedZ = clamp(z, CameraData.y , CameraData.x);
+		uint clusterZ = uint(max((log2(z) - log2(CameraData.y)) * clusterSize.z / log2(CameraData.x / CameraData.y), 0.0));
 		uint3 cluster = uint3(uint2(uv * clusterSize.xy), clusterZ);
 
 		clusterIndex = cluster.x + (clusterSize.x * cluster.y) + (clusterSize.x * clusterSize.y * cluster.z);

--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -20,7 +20,7 @@ namespace LightLimitFix
 		if (z < CameraData.y || z > CameraData.x)
 			return false;
 
-		float clampedZ = clamp(z, CameraData.y , CameraData.x);
+		float clampedZ = clamp(z, CameraData.y, CameraData.x);
 		uint clusterZ = uint(max((log2(z) - log2(CameraData.y)) * clusterSize.z / log2(CameraData.x / CameraData.y), 0.0));
 		uint3 cluster = uint3(uint2(uv * clusterSize.xy), clusterZ);
 

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -58,6 +58,15 @@ struct TerraOccSettings
 	float2 Offset;
 };
 
+struct LightLimitFixSettings
+{
+	uint EnableContactShadows;
+	uint EnableLightsVisualisation;
+	uint LightsVisualisationMode;
+	float LightsFar;
+	uint4 ClusterSize;
+};
+
 struct WetnessEffectsSettings
 {
 	float Time;
@@ -65,47 +74,43 @@ struct WetnessEffectsSettings
 	float Wetness;
 	float PuddleWetness;
 
-	uint EnableWetnessEffects;
+	bool EnableWetnessEffects;
 	float MaxRainWetness;
 	float MaxPuddleWetness;
 	float MaxShoreWetness;
+
 	uint ShoreRange;
 	float PuddleRadius;
 	float PuddleMaxAngle;
 	float PuddleMinWetness;
+
 	float MinRainWetness;
 	float SkinWetness;
 	float WeatherTransitionSpeed;
+	bool EnableRaindropFx;
 
-	uint EnableRaindropFx;
-	uint EnableSplashes;
-	uint EnableRipples;
-	uint EnableChaoticRipples;
+	bool EnableSplashes;
+	bool EnableRipples;
+	bool EnableChaoticRipples;
 	float RaindropFxRange;
+
 	float RaindropGridSizeRcp;
 	float RaindropIntervalRcp;
 	float RaindropChance;
 	float SplashesLifetime;
+
 	float SplashesStrength;
 	float SplashesMinRadius;
 	float SplashesMaxRadius;
 	float RippleStrength;
+
 	float RippleRadius;
 	float RippleBreadth;
 	float RippleLifetimeRcp;
 	float ChaoticRippleStrength;
+
 	float ChaoticRippleScaleRcp;
 	float ChaoticRippleSpeed;
-};
-
-struct LightLimitFixSettings
-{
-	uint EnableContactShadows;
-	uint EnableLightsVisualisation;
-	uint LightsVisualisationMode;
-	uint pad0;
-
-	uint4 ClusterSize;
 };
 
 struct SkylightingSettings
@@ -119,14 +124,14 @@ struct SkylightingSettings
 
 	float MinDiffuseVisibility;
 	float MinSpecularVisibility;
-	uint pad2[2];
+	uint pad0[2];
 };
 
 struct PBRSettings
 {
-	uint UseMultipleScattering;
-	uint UseMultiBounceAO;
-	uint2 pad0;
+	bool UseMultipleScattering;
+	bool UseMultiBounceAO;
+	uint pad0[2];
 };
 
 cbuffer FeatureData : register(b6)
@@ -135,8 +140,8 @@ cbuffer FeatureData : register(b6)
 	CPMSettings extendedMaterialSettings;
 	CubemapCreatorSettings cubemapCreatorSettings;
 	TerraOccSettings terraOccSettings;
-	WetnessEffectsSettings wetnessEffectsSettings;
 	LightLimitFixSettings lightLimitFixSettings;
+	WetnessEffectsSettings wetnessEffectsSettings;
 	SkylightingSettings skylightingSettings;
 	PBRSettings pbrSettings;
 };

--- a/src/FeatureBuffer.cpp
+++ b/src/FeatureBuffer.cpp
@@ -33,8 +33,8 @@ std::pair<unsigned char*, size_t> GetFeatureBufferData()
 		ExtendedMaterials::GetSingleton()->settings,
 		DynamicCubemaps::GetSingleton()->settings,
 		TerrainShadows::GetSingleton()->GetCommonBufferData(),
-		WetnessEffects::GetSingleton()->GetCommonBufferData(),
 		LightLimitFix::GetSingleton()->GetCommonBufferData(),
+		WetnessEffects::GetSingleton()->GetCommonBufferData(),
 		Skylighting::GetSingleton()->cbData,
 		TruePBR::GetSingleton()->settings);
 }

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -122,7 +122,7 @@ void LightLimitFix::SetupResources()
 		screenSize.x *= .5;
 	clusterSize[0] = ((uint)screenSize.x + 63) / 64;
 	clusterSize[1] = ((uint)screenSize.y + 63) / 64;
-	clusterSize[2] = 16;
+	clusterSize[2] = 32;
 	uint clusterCount = clusterSize[0] * clusterSize[1] * clusterSize[2];
 
 	{
@@ -300,9 +300,6 @@ void LightLimitFix::BSLightingShader_SetupGeometry_After(RE::BSRenderPass*)
 {
 	auto& context = State::GetSingleton()->context;
 	auto accumulator = RE::BSGraphics::BSShaderAccumulator::GetCurrentAccumulator();
-
-	strictLightDataTemp.LightsNear = lightsNear;
-	strictLightDataTemp.LightsFar = lightsFar;
 
 	static bool wasEmpty = false;
 	static bool wasWorld = false;
@@ -593,19 +590,6 @@ void LightLimitFix::AddCachedParticleLights(eastl::vector<LightData>& lightsData
 
 	light.color *= dimmer;
 
-	float distantLightFadeStart = lightsFar * lightsFar * (lightFadeStart / lightFadeEnd);
-	float distantLightFadeEnd = lightsFar * lightsFar;
-
-	if (distance < distantLightFadeStart || distantLightFadeEnd == 0.0f) {
-		dimmer = 1.0f;
-	} else if (distance <= distantLightFadeEnd) {
-		dimmer = 1.0f - ((distance - distantLightFadeStart) / (distantLightFadeEnd - distantLightFadeStart));
-	} else {
-		dimmer = 0.0f;
-	}
-
-	light.color *= dimmer;
-
 	if ((light.color.x + light.color.y + light.color.z) > 1e-4 && light.radius > 1e-4) {
 		for (int eyeIndex = 0; eyeIndex < eyeCount; eyeIndex++)
 			light.positionVS[eyeIndex].data = DirectX::SimpleMath::Vector3::Transform(light.positionWS[eyeIndex].data, viewMatrixCached[eyeIndex]);
@@ -635,8 +619,8 @@ void LightLimitFix::UpdateLights()
 	static float& cameraNear = (*(float*)(REL::RelocationID(517032, 403540).address() + 0x40));
 	static float& cameraFar = (*(float*)(REL::RelocationID(517032, 403540).address() + 0x44));
 
-	lightsNear = std::max(1.0f, cameraNear);
-	lightsFar = std::min(16384.0f, cameraFar);
+	lightsNear = cameraNear;
+	lightsFar = cameraFar;
 
 	auto shadowSceneNode = RE::BSShaderManager::State::GetSingleton().shadowSceneNode[0];
 
@@ -667,26 +651,6 @@ void LightLimitFix::UpdateLights()
 					light.radius = runtimeData.radius.x;
 
 					SetLightPosition(light, niLight->world.translate);
-
-					static float& lightFadeStart = (*(float*)REL::RelocationID(527668, 414582).address());
-					static float& lightFadeEnd = (*(float*)REL::RelocationID(527669, 414583).address());
-
-					float distance = CalculateLightDistance(light.positionWS[0].data, light.radius);
-
-					float distantLightFadeStart = lightsFar * lightsFar * (lightFadeStart / lightFadeEnd);
-					float distantLightFadeEnd = lightsFar * lightsFar;
-
-					float dimmer;
-
-					if (distance < distantLightFadeStart || distantLightFadeEnd == 0.0f) {
-						dimmer = 1.0f;
-					} else if (distance <= distantLightFadeEnd) {
-						dimmer = 1.0f - ((distance - distantLightFadeStart) / (distantLightFadeEnd - distantLightFadeStart));
-					} else {
-						dimmer = 0.0f;
-					}
-
-					light.color *= dimmer;
 
 					if ((light.color.x + light.color.y + light.color.z) > 1e-4 && light.radius > 1e-4) {
 						lightsData.push_back(light);
@@ -817,7 +781,6 @@ void LightLimitFix::UpdateLights()
 				updateData.InvProjMatrix[1] = DirectX::XMMatrixInverse(nullptr, Util::GetCameraData(1).projMatrixUnjittered);
 			updateData.LightsNear = lightsNear;
 			updateData.LightsFar = lightsFar;
-			;
 
 			lightBuildingCB->Update(updateData);
 
@@ -834,6 +797,8 @@ void LightLimitFix::UpdateLights()
 			context->CSSetUnorderedAccessViews(0, 1, &null_uav, nullptr);
 
 			_fov = fov;
+			_lightsNear = lightsNear;
+			_lightsFar = lightsFar;
 		}
 	}
 

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -71,7 +71,7 @@ public:
 		uint EnableContactShadows;
 		uint EnableLightsVisualisation;
 		uint LightsVisualisationMode;
-		uint pad0;
+		float pad0;
 		uint ClusterSize[4];
 	};
 
@@ -81,9 +81,7 @@ public:
 	{
 		LightData StrictLights[15];
 		uint NumStrictLights;
-		float LightsNear;
-		float LightsFar;
-		uint pad0;
+		uint pad0[3];
 	};
 
 	StrictLightData strictLightDataTemp;


### PR DESCRIPTION
Fixed alignment issues breaking the light limit fix.
Set the lightsnear and lightsfar to be the camera near and far.
Set the z slices to 32, so xyz are all the same as UE4.