### PR TITLE
fix: fix shader-specific clear

### DIFF
--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -444,6 +444,7 @@ void DynamicCubemaps::UpdateCubemap()
 {
 	TracyD3D11Zone(State::GetSingleton()->tracyCtx, "Cubemap Update");
 	if (recompileFlag) {
+		logger::debug("Recompiling for Dynamic Cubemaps");
 		auto& shaderCache = SIE::ShaderCache::Instance();
 		if (!shaderCache.Clear("Data//Shaders//ISReflectionsRayTracing.hlsl"))
 			// if can't find specific hlsl file cache, clear all image space files

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -2013,6 +2013,7 @@ namespace SIE
 			}
 			computeShaders[static_cast<size_t>(a_type)].clear();
 		}
+		ClearShaderMap(a_type);
 		compilationSet.Clear();
 	}
 
@@ -2436,6 +2437,22 @@ namespace SIE
 	bool ShaderCache::IsHideErrors()
 	{
 		return hideError;
+	}
+
+	void ShaderCache::ClearShaderMap(RE::BSShader::Type a_type)
+	{
+		std::string_view shaderTypeStr = magic_enum::enum_name(a_type);
+
+		std::unique_lock lockM{ SIE::ShaderCache::mapMutex };
+		logger::debug("Clearing shaderMap of {}", shaderTypeStr);
+		for (auto it = shaderMap.begin(); it != shaderMap.end();) {
+			auto typeInKey = SIE::SShaderCache::GetTypeFromShaderString(it->first);
+			if (typeInKey == shaderTypeStr) {
+				it = shaderMap.erase(it);
+			} else {
+				++it;
+			}
+		}
 	}
 
 	void ShaderCache::InsertModifiedShaderMap(const std::string& a_shader, std::chrono::time_point<std::chrono::system_clock> a_time)

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -381,6 +381,14 @@ namespace SIE
 		void IterateShaderBlock(bool a_forward = true);
 		bool IsHideErrors();
 
+		/**
+		 * @brief Clears all shaders of a specific type from the shader map.
+		 * 
+		 * This function removes all shaders of the specified type (`RE::BSShader::Type`) from the shader map. 
+		 * 
+		 * @param a_type The shader type (e.g., Grass, Sky, Water) to be cleared from the map.
+		 */
+		void ClearShaderMap(RE::BSShader::Type a_type);
 		void InsertModifiedShaderMap(const std::string& a_shader, std::chrono::time_point<std::chrono::system_clock> a_time);
 		std::chrono::time_point<std::chrono::system_clock> GetModifiedShaderMapTime(const std::string& a_shader);
 


### PR DESCRIPTION
Failure to clear shaderMap resulted in a cached copy being detected but not actually available in the relevant shader array. This would result in vanilla shaders being used instead.