### PR TITLE
build: move fsr cmake and remove warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,15 +44,7 @@ find_package(unordered_dense CONFIG REQUIRED)
 find_package(efsw CONFIG REQUIRED)
 find_package(Tracy CONFIG REQUIRED)
 add_subdirectory(${CMAKE_SOURCE_DIR}/cmake/Streamline)
-
-set(FFX_API_VK OFF)
-set(FFX_API_DX12 OFF)
-set(FFX_ALL OFF)
-set(FFX_FSR3 ON)
-set(FFX_FSR ON)
-set(FFX_AUTO_COMPILE_SHADERS 1)
-
-add_subdirectory(${CMAKE_SOURCE_DIR}/extern/FidelityFX-SDK/sdk)
+include(FidelityFX-SDK)
 
 target_compile_definitions(
 	${PROJECT_NAME}
@@ -85,11 +77,6 @@ target_link_libraries(
 	efsw::efsw
 	Tracy::TracyClient
 	Streamline
-	ffx_backend_dx11_x64
-	ffx_frameinterpolation_x64
-	ffx_fsr3_x64
-	ffx_fsr3upscaler_x64
-	ffx_opticalflow_x64
 )
 
 # https://gitlab.kitware.com/cmake/cmake/-/issues/24922#note_1371990

--- a/cmake/FidelityFX-SDK.cmake
+++ b/cmake/FidelityFX-SDK.cmake
@@ -1,0 +1,18 @@
+set(FFX_API_VK OFF)
+set(FFX_API_DX12 OFF)
+set(FFX_ALL OFF)
+set(FFX_FSR3 ON)
+set(FFX_FSR ON)
+set(FFX_AUTO_COMPILE_SHADERS 1)
+
+add_subdirectory(${CMAKE_SOURCE_DIR}/extern/FidelityFX-SDK/sdk)
+
+target_link_libraries(
+  ${PROJECT_NAME}
+  PRIVATE
+  ffx_backend_dx11_x64
+  ffx_frameinterpolation_x64
+  ffx_fsr3_x64
+  ffx_fsr3upscaler_x64
+  ffx_opticalflow_x64
+)


### PR DESCRIPTION
- Move FSR specific cmake configuration to it's own file
- Remove shader warnings from FidelityFX-SDK submodule