### PR TITLE
refactor: move hooks out of State

### DIFF
--- a/src/State.cpp
+++ b/src/State.cpp
@@ -292,9 +292,7 @@ void State::PostPostLoad()
 		logger::info("Skyrim Upscaler detected");
 	else
 		logger::info("Skyrim Upscaler not detected");
-	Deferred::Hooks::Install();
-	TruePBR::GetSingleton()->PostPostLoad();
-	Upscaling::InstallHooks();
+	// No hooks should be here, hook in XSEPlugin::MessageHandler()
 }
 
 bool State::ValidateCache(CSimpleIniA& a_ini)

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -85,7 +85,6 @@ void MessageHandler(SKSE::MessagingInterface::Message* message)
 				Deferred::Hooks::Install();
 				TruePBR::GetSingleton()->PostPostLoad();
 				Upscaling::InstallHooks();
-				Hooks::InstallD3DHooks();
 				Hooks::Install();
 				FrameAnnotations::OnPostPostLoad();
 
@@ -170,5 +169,7 @@ bool Load()
 		}
 	}
 
+	if (errors.empty())
+		Hooks::InstallD3DHooks();
 	return true;
 }


### PR DESCRIPTION
Hooks should be in XSEPlugin so they can all be found. A similar refactor should be done for SetupResources and other areas where State is being piggybacked.