### PR TITLE
fix: upscaling fixes

### DIFF
--- a/src/FidelityFX.cpp
+++ b/src/FidelityFX.cpp
@@ -107,7 +107,7 @@ void FidelityFX::Upscale(Texture2D* a_color, Texture2D* a_alphaMask, float2 a_ji
 
 		dispatchParameters.flags = 0;
 
-		if (!fsrContext.data && ffxFsr3ContextDispatchUpscale(&fsrContext, &dispatchParameters) != FFX_OK)
+		if (ffxFsr3ContextDispatchUpscale(&fsrContext, &dispatchParameters) != FFX_OK)
 			logger::critical("[FidelityFX] Failed to dispatch upscaling!");
 	}
 }

--- a/src/Upscaling.cpp
+++ b/src/Upscaling.cpp
@@ -152,7 +152,7 @@ ID3D11ComputeShader* Upscaling::GetEncodeTexturesCS()
 void Upscaling::UpdateJitter()
 {
 	auto upscaleMethod = GetUpscaleMethod();
-	if (upscaleMethod != UpscaleMethod::kTAA) {
+	if (upscaleMethod == UpscaleMethod::kFSR || upscaleMethod == UpscaleMethod::kDLSS) {
 		static auto gameViewport = RE::BSGraphics::State::GetSingleton();
 		auto state = State::GetSingleton();
 
@@ -214,7 +214,7 @@ void Upscaling::Upscale()
 		static auto& temporalAAMask = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kTEMPORAL_AA_MASK];
 
 		{
-			ID3D11ShaderResourceView* views[2] = { temporalAAMask.SRV };
+			ID3D11ShaderResourceView* views[1] = { temporalAAMask.SRV };
 			context->CSSetShaderResources(0, ARRAYSIZE(views), views);
 
 			ID3D11UnorderedAccessView* uavs[1] = { alphaMaskTexture->uav.get() };
@@ -252,7 +252,7 @@ void Upscaling::Upscale()
 		state->EndPerfEvent();
 	}
 
-	if (upscaleMethod == UpscaleMethod::kFSR && settings.sharpness > 0.0f) {
+	if (upscaleMethod != UpscaleMethod::kFSR && settings.sharpness > 0.0f) {
 		state->BeginPerfEvent("Sharpening");
 
 		context->CopyResource(inputTextureResource, upscalingTexture->resource.get());


### PR DESCRIPTION
reverts https://github.com/doodlum/skyrim-community-shaders/pull/628 because it just disables FSR and the attempted fix was for uncontrolled behaviour which made no sense
fixes sharpening applying to fsr instead of dlss