### PR TITLE
feat(UI): add footer with diaginfo

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -211,6 +211,10 @@ HRESULT WINAPI hk_D3D11CreateDeviceAndSwapChainNoStreamline(
 	D3D_FEATURE_LEVEL* pFeatureLevel,
 	ID3D11DeviceContext** ppImmediateContext)
 {
+	DXGI_ADAPTER_DESC adapterDesc;
+	pAdapter->GetDesc(&adapterDesc);
+	State::GetSingleton()->SetAdapterDescription(adapterDesc.Description);
+
 	const D3D_FEATURE_LEVEL featureLevel = D3D_FEATURE_LEVEL_11_1;  // Create a device with only the latest feature level
 	return ptrD3D11CreateDeviceAndSwapChain(pAdapter,
 		DriverType,
@@ -240,8 +244,11 @@ HRESULT WINAPI hk_D3D11CreateDeviceAndSwapChain(
 	D3D_FEATURE_LEVEL* pFeatureLevel,
 	ID3D11DeviceContext** ppImmediateContext)
 {
-	const D3D_FEATURE_LEVEL featureLevel = D3D_FEATURE_LEVEL_11_1;  // Create a device with only the latest feature level
+	DXGI_ADAPTER_DESC adapterDesc;
+	pAdapter->GetDesc(&adapterDesc);
+	State::GetSingleton()->SetAdapterDescription(adapterDesc.Description);
 
+	const D3D_FEATURE_LEVEL featureLevel = D3D_FEATURE_LEVEL_11_1;  // Create a device with only the latest feature level
 	auto result = Streamline::GetSingleton()->CreateDeviceAndSwapChain(
 		pAdapter,
 		DriverType,

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -94,6 +94,8 @@ private:
 
 	void DrawGeneralSettings();
 	void DrawAdvancedSettings();
+	void DrawDisplaySettings();
+	void DrawFooter();
 
 	class CharEvent : public RE::InputEvent
 	{

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -1,5 +1,7 @@
 #include "State.h"
 
+#include <codecvt>
+
 #include <magic_enum.hpp>
 #include <pystring/pystring.h>
 
@@ -508,6 +510,12 @@ void State::EndPerfEvent()
 void State::SetPerfMarker(std::string_view title)
 {
 	pPerf->SetMarker(std::wstring(title.begin(), title.end()).c_str());
+}
+
+void State::SetAdapterDescription(const std::wstring& description)
+{
+	std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+	adapterDescription = converter.to_bytes(description);
 }
 
 void State::UpdateSharedData()

--- a/src/State.h
+++ b/src/State.h
@@ -26,6 +26,7 @@ public:
 	bool updateShader = true;
 	bool settingCustomShader = false;
 	RE::BSShader* currentShader = nullptr;
+	std::string adapterDescription = "";
 
 	uint32_t currentVertexDescriptor = 0;
 	uint32_t currentPixelDescriptor = 0;
@@ -100,6 +101,8 @@ public:
 	void BeginPerfEvent(std::string_view title);
 	void EndPerfEvent();
 	void SetPerfMarker(std::string_view title);
+
+	void SetAdapterDescription(const std::wstring& description);
 
 	bool extendedFrameAnnotations = false;
 

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -89,7 +89,7 @@ void SetupPBRLandscapeTextureParameters(BSLightingShaderMaterialPBRLandscape& ma
 
 void TruePBR::DrawSettings()
 {
-	if (ImGui::TreeNodeEx("PBR", ImGuiTreeNodeFlags_DefaultOpen)) {
+	if (ImGui::CollapsingHeader("PBR", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick)) {
 		if (ImGui::TreeNodeEx("Texture Set Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
 			if (ImGui::BeginCombo("Texture Set", selectedPbrTextureSetName.c_str())) {
 				for (auto& [textureSetName, textureSet] : pbrTextureSets) {


### PR DESCRIPTION
- Add footer with diagnostics info (cs version, game version, if d3d12 proxy is enabled and name of gpu)
  - Looked into adding gpu memory usage, did not get it to work now. Might look into that later
- Removed `Skyrim` and V# from title
- Moved in `Upscaling` and `Frame Generation` under new `Display` listitem
- Moved in `True PBR` back into advanced until we have migrated it into a core feature

<img width="928" alt="image" src="https://github.com/user-attachments/assets/46a64608-d1ad-44b3-b592-79f7c69e038d">
