### PR TITLE
refactor: serialize ImVec to array instead of object

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -22,18 +22,6 @@
 #include "Upscaling.h"
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
-	ImVec2,
-	x,
-	y)
-
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
-	ImVec4,
-	x,
-	y,
-	z,
-	w)
-
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	Menu::ThemeSettings,
 	FontScale,
 	BackgroundColor,

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -466,4 +466,26 @@ namespace nlohmann
 		std::array<float, 4> temp = j;
 		v = { temp[0], temp[1], temp[2], temp[3] };
 	}
+
+	void to_json(json& j, const ImVec2& v)
+	{
+		j = json{ v.x, v.y };
+	}
+
+	void from_json(const json& j, ImVec2& v)
+	{
+		std::array<float, 2> temp = j;
+		v = { temp[0], temp[1] };
+	}
+
+	void to_json(json& j, const ImVec4& v)
+	{
+		j = json{ v.x, v.y, v.z, v.w };
+	}
+
+	void from_json(const json& j, ImVec4& v)
+	{
+		std::array<float, 4> temp = j;
+		v = { temp[0], temp[1], temp[2], temp[3] };
+	}
 }

--- a/src/Util.h
+++ b/src/Util.h
@@ -143,4 +143,9 @@ namespace nlohmann
 	void from_json(const json& j, float3& v);
 	void to_json(json& j, const float4& v);
 	void from_json(const json& j, float4& v);
+
+	void to_json(json& j, const ImVec2& v);
+	void from_json(const json& j, ImVec2& v);
+	void to_json(json& j, const ImVec4& v);
+	void from_json(const json& j, ImVec4& v);
 };


### PR DESCRIPTION
because:
1. it's less cloggy
2. it follows the same format as d3d vecs
3. serializations should be placed in Util