### PR TITLE
feat: allow disabling of upscaling/framegeneration

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -658,10 +658,11 @@ namespace Hooks
 	void InstallD3DHooks()
 	{
 		auto streamline = Streamline::GetSingleton();
+		auto state = State::GetSingleton();
 
 		streamline->LoadInterposer();
 
-		if (streamline->interposer) {
+		if (streamline->interposer && !state->IsFeatureDisabled("Frame Generation")) {
 			Streamline::InstallHooks();
 
 			logger::info("Hooking D3D11CreateDeviceAndSwapChain");
@@ -669,7 +670,7 @@ namespace Hooks
 
 			logger::info("Hooking CreateDXGIFactory");
 			*(uintptr_t*)&ptrCreateDXGIFactory = SKSE::PatchIAT(hk_CreateDXGIFactory, "dxgi.dll", !REL::Module::IsVR() ? "CreateDXGIFactory" : "CreateDXGIFactory1");
-		} else {
+		} else if (!state->IsFeatureDisabled("Upscaling")) {
 			logger::info("Hooking D3D11CreateDeviceAndSwapChain");
 			*(uintptr_t*)&ptrD3D11CreateDeviceAndSwapChain = SKSE::PatchIAT(hk_D3D11CreateDeviceAndSwapChainNoStreamline, "d3d11.dll", "D3D11CreateDeviceAndSwapChain");
 		}

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -235,6 +235,11 @@ void State::Load(ConfigMode a_configMode)
 			logger::warn("Invalid entry for feature '{}' in 'Disable at Boot', expected boolean.", featureName);
 		}
 	}
+	for (const auto& [featureName, _] : specialFeatures) {
+		if (IsFeatureDisabled(featureName)) {
+			logger::info("Special Feature '{}' disabled at boot", featureName);
+		}
+	}
 
 	auto truePBR = TruePBR::GetSingleton();
 	auto& pbrJson = settings[truePBR->GetShortName()];

--- a/src/Streamline.cpp
+++ b/src/Streamline.cpp
@@ -47,6 +47,10 @@ void Streamline::DrawSettings()
 
 void Streamline::LoadInterposer()
 {
+	if (State::GetSingleton()->IsFeatureDisabled("Frame Generation")) {
+		return;
+	}
+
 	interposer = LoadLibraryW(L"Data/SKSE/Plugins/Streamline/sl.interposer.dll");
 	if (interposer == nullptr) {
 		DWORD errorCode = GetLastError();

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -84,7 +84,9 @@ void MessageHandler(SKSE::MessagingInterface::Message* message)
 				state->PostPostLoad();  // state should load first so basic information is populated
 				Deferred::Hooks::Install();
 				TruePBR::GetSingleton()->PostPostLoad();
-				Upscaling::InstallHooks();
+				if (!state->IsFeatureDisabled("Upscaling")) {
+					Upscaling::InstallHooks();
+				}
 				Hooks::Install();
 				FrameAnnotations::OnPostPostLoad();
 


### PR DESCRIPTION
Disables special features
Prereqs:

- [x] #644
- [x] #645 

I did not disable TruePBR as I have no idea which hooks are necessary. 
@Jonahex thoughts? I'm not sure if it's as simple as disabling postpostload and dataloaded calls or if you have hooks buried elsewhere.  This also become moot if it's turned into a regular feature since #644 handles those.

Note, disabling upscaling/framegen is necessary to allow renderdoc to work again.
closes #606 