### PR TITLE
chore(UI): tighter footer

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -207,13 +207,13 @@ void Menu::DrawSettings()
 	ImGui::SetNextWindowPos(ImGui::GetNativeViewportSizeScaled(0.5f), ImGuiCond_FirstUseEver, ImVec2(0.5f, 0.5f));
 	ImGui::SetNextWindowSize(ImGui::GetNativeViewportSizeScaled(0.8f), ImGuiCond_FirstUseEver);
 
-	auto title = "Community Shaders";
+	auto title = std::format("Community Shaders {}", Util::GetFormattedVersion(Plugin::VERSION));
 
-	ImGui::Begin(title, &IsEnabled, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoScrollbar);
+	ImGui::Begin(title.c_str(), &IsEnabled, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoScrollbar);
 	{
 		if (!ImGui::IsWindowDocked()) {
 			ImGui::SetWindowFontScale(1.5f);
-			ImGui::TextUnformatted(title);
+			ImGui::TextUnformatted(title.c_str());
 			ImGui::SetWindowFontScale(1.f);
 
 			ImGui::Spacing();
@@ -285,10 +285,9 @@ void Menu::DrawSettings()
 		ImGui::SeparatorEx(ImGuiSeparatorFlags_Horizontal, 3.0f);
 		ImGui::Spacing();
 
-		float footer_height = ImGui::GetTextLineHeightWithSpacing() + 76 - ImGui::GetStyle().WindowPadding.y;
-		float content_height = ImGui::GetContentRegionAvail().y - footer_height;
+		float footer_height = ImGui::GetFrameHeightWithSpacing() + ImGui::GetStyle().ItemSpacing.y * 2 + 3.0f;  // text + separator
 
-		ImGui::BeginChild("Menus Table", ImVec2(0, content_height));
+		ImGui::BeginChild("Menus Table", ImVec2(0, -footer_height));
 		if (ImGui::BeginTable("Menus Table", 2, ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_Resizable)) {
 			ImGui::TableSetupColumn("##ListOfMenus", 0, 2);
 			ImGui::TableSetupColumn("##MenuConfig", 0, 8);
@@ -699,29 +698,13 @@ void Menu::DrawDisplaySettings()
 	}
 }
 
-static std::string GetFormattedVersion(const REL::Version& version)
-{
-	const auto& v = version.string(".");
-	return v.substr(0, v.find_last_of("."));
-}
-
 void Menu::DrawFooter()
 {
-	if (ImGui::BeginTable("##Footer", 4, ImGuiTableFlags_SizingStretchSame)) {
-		ImGui::TableNextColumn();
-		ImGui::TextUnformatted(std::format("CS Version: {}", GetFormattedVersion(Plugin::VERSION).c_str()).c_str());
-
-		ImGui::TableNextColumn();
-		ImGui::TextUnformatted(std::format("Game Version: {} {}", magic_enum::enum_name(REL::Module::GetRuntime()), GetFormattedVersion(REL::Module::get().version()).c_str()).c_str());
-
-		ImGui::TableNextColumn();
-		ImGui::TextUnformatted(std::format("D3D12 Interop: {}", Streamline::GetSingleton()->featureDLSSG && !REL::Module::IsVR() ? "Active" : "Inactive").c_str());
-
-		ImGui::TableNextColumn();
-		ImGui::TextUnformatted(std::format("GPU: {}", State::GetSingleton()->adapterDescription.c_str()).c_str());
-
-		ImGui::EndTable();
-	}
+	ImGui::BulletText(std::format("Game Version: {} {}", magic_enum::enum_name(REL::Module::GetRuntime()), Util::GetFormattedVersion(REL::Module::get().version()).c_str()).c_str());
+	ImGui::SameLine();
+	ImGui::BulletText(std::format("D3D12 Interop: {}", Streamline::GetSingleton()->featureDLSSG && !REL::Module::IsVR() ? "Active" : "Inactive").c_str());
+	ImGui::SameLine();
+	ImGui::BulletText(std::format("GPU: {}", State::GetSingleton()->adapterDescription.c_str()).c_str());
 }
 
 void Menu::DrawOverlay()

--- a/src/Util.h
+++ b/src/Util.h
@@ -15,6 +15,12 @@
 
 namespace Util
 {
+	inline std::string GetFormattedVersion(const REL::Version& version)
+	{
+		const auto& v = version.string(".");
+		return v.substr(0, v.find_last_of("."));
+	}
+
 	void StoreTransform3x4NoScale(DirectX::XMFLOAT3X4& Dest, const RE::NiTransform& Source);
 	ID3D11ShaderResourceView* GetSRVFromRTV(ID3D11RenderTargetView* a_rtv);
 	ID3D11RenderTargetView* GetRTVFromSRV(ID3D11ShaderResourceView* a_srv);


### PR DESCRIPTION
- CS version moved to header
- tighter and adaptive footer height
- no table bc you need very wide window to show all text -> they are bullet texts now

![Screenshot 2024-10-14 162010](https://github.com/user-attachments/assets/5835d5f4-e176-49c0-aa4a-c65d6c6c1200)
