### PR TITLE
feat: automatic effect shader colours

### DIFF
--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -522,7 +522,7 @@ float3 GetLightingColor(float3 msPosition, float3 worldPosition, float4 screenPo
 	float4 lightFadeMul = 1.0.xxxx - saturate(PLightingRadiusInverseSquared * lightDistanceSquared);
 
 	float3 color = 0.0;
-	float angleShadow = saturate(DirLightDirectionShared.z * DirLightDirectionShared.z);
+	float angleShadow = saturate(DirLightDirectionShared.z) * saturate(DirLightDirectionShared.z);
 
 #		if defined(EFFECT_SHADOWS)
 	if (InMapMenu)

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -524,7 +524,7 @@ float3 GetLightingColor(float3 msPosition, float3 worldPosition, float4 screenPo
 	float3 color = 0.0;
 	float angleShadow = saturate(DirLightDirectionShared.z * DirLightDirectionShared.z);
 
-#			if defined(EFFECT_SHADOWS)
+#		if defined(EFFECT_SHADOWS)
 	if (InMapMenu)
 		color = DirLightColorShared * angleShadow;
 	else if (!InInterior && (ExtraShaderDescriptor & _InWorld))

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -521,27 +521,27 @@ float3 GetLightingColor(float3 msPosition, float3 worldPosition, float4 screenPo
 	float4 lightDistanceSquared = (PLightPositionX[eyeIndex] - msPosition.xxxx) * (PLightPositionX[eyeIndex] - msPosition.xxxx) + (PLightPositionY[eyeIndex] - msPosition.yyyy) * (PLightPositionY[eyeIndex] - msPosition.yyyy) + (PLightPositionZ[eyeIndex] - msPosition.zzzz) * (PLightPositionZ[eyeIndex] - msPosition.zzzz);
 	float4 lightFadeMul = 1.0.xxxx - saturate(PLightingRadiusInverseSquared * lightDistanceSquared);
 
-	float3 color = DLightColor.xyz;
-#		if defined(EFFECT_WEATHER)
+	float3 color = 0.0;
+	float angleShadow = saturate(DirLightDirectionShared.z * DirLightDirectionShared.z);
+
+	#define EFFECT_SHADOWS
 #			if defined(EFFECT_SHADOWS)
-	if (!InInterior && !InMapMenu && (ExtraShaderDescriptor & _InWorld)) {
-		color = DirLightColorShared * GetEffectShadow(worldPosition, normalize(worldPosition), screenPosition, eyeIndex) * 0.5;
-
-		float3 directionalAmbientColor = DirectionalAmbientShared._14_24_34;
-		color += directionalAmbientColor;
-	} else {
-		color = DirLightColorShared * 0.5;
-
-		float3 directionalAmbientColor = DirectionalAmbientShared._14_24_34;
-		color += directionalAmbientColor;
-	}
+	if (InMapMenu)
+		color = DirLightColorShared * angleShadow;
+	else if (!InInterior && (ExtraShaderDescriptor & _InWorld))
+		color = DirLightColorShared * GetEffectShadow(worldPosition, normalize(worldPosition), screenPosition, eyeIndex);
+	else
+		color = DirLightColorShared * 0.5;	
 #			else
-	color = DirLightColorShared * 0.5;
-
-	float3 directionalAmbientColor = DirectionalAmbientShared._14_24_34;
-	color += directionalAmbientColor;
+	if (InMapMenu)
+		color = DirLightColorShared * angleShadow;
+	else if (!InInterior && (ExtraShaderDescriptor & _InWorld))
+		color = DirLightColorShared * GetWorldShadow(worldPosition, length(worldPosition), 0.0, eyeIndex) * angleShadow * 0.5;
+	else
+		color = DirLightColorShared * 0.5;
 #			endif
-#		endif
+
+	color += DirectionalAmbientShared._14_24_34;
 
 	color.x += dot(PLightColorR * lightFadeMul, 1.0.xxxx);
 	color.y += dot(PLightColorG * lightFadeMul, 1.0.xxxx);

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -524,22 +524,22 @@ float3 GetLightingColor(float3 msPosition, float3 worldPosition, float4 screenPo
 	float3 color = 0.0;
 	float angleShadow = saturate(DirLightDirectionShared.z * DirLightDirectionShared.z);
 
-	#define EFFECT_SHADOWS
-#			if defined(EFFECT_SHADOWS)
+#		define EFFECT_SHADOWS
+#		if defined(EFFECT_SHADOWS)
 	if (InMapMenu)
 		color = DirLightColorShared * angleShadow;
 	else if (!InInterior && (ExtraShaderDescriptor & _InWorld))
 		color = DirLightColorShared * GetEffectShadow(worldPosition, normalize(worldPosition), screenPosition, eyeIndex);
 	else
-		color = DirLightColorShared * 0.5;	
-#			else
+		color = DirLightColorShared * 0.5;
+#		else
 	if (InMapMenu)
 		color = DirLightColorShared * angleShadow;
 	else if (!InInterior && (ExtraShaderDescriptor & _InWorld))
 		color = DirLightColorShared * GetWorldShadow(worldPosition, length(worldPosition), 0.0, eyeIndex) * angleShadow * 0.5;
 	else
 		color = DirLightColorShared * 0.5;
-#			endif
+#		endif
 
 	color += DirectionalAmbientShared._14_24_34;
 

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -524,7 +524,6 @@ float3 GetLightingColor(float3 msPosition, float3 worldPosition, float4 screenPo
 	float3 color = 0.0;
 	float angleShadow = saturate(DirLightDirectionShared.z * DirLightDirectionShared.z);
 
-	#define EFFECT_SHADOWS
 #			if defined(EFFECT_SHADOWS)
 	if (InMapMenu)
 		color = DirLightColorShared * angleShadow;


### PR DESCRIPTION
If EFFECT_SHADOWS is not present, as a fallback cloud shadows and terrain shadows are applied, alongside an angle-based shadowing so that as the sun goes over the horizon the sunlight decreases.