### PR TITLE
perf: optimize particle lights

### DIFF
--- a/features/Light Limit Fix/Shaders/LightLimitFix/Common.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/Common.hlsli
@@ -7,8 +7,14 @@
 #define GROUP_SIZE (NUMTHREAD_X * NUMTHREAD_Y * NUMTHREAD_Z)
 #define MAX_CLUSTER_LIGHTS 128
 
-#define Llf_PortalStrictLight (1 << 0)
-#define Llf_ShadowLight (1 << 1)
+namespace LightFlags
+{
+	static const uint PortalStrict = (1 << 0);
+	static const uint Shadow = (1 << 1);
+	static const uint Simple = (1 << 2);
+	static const uint Particle = (1 << 3);
+	static const uint Billboard = (1 << 4);
+}
 
 struct ClusterAABB
 {

--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -109,7 +109,7 @@ namespace LightLimitFix
 	bool IsLightIgnored(StructuredLight light)
 	{
 		bool lightIgnored = false;
-		if ((light.lightFlags & Llf_PortalStrictLight) && strictLights[0].RoomIndex >= 0) {
+		if ((light.lightFlags & LightFlags::PortalStrict) && strictLights[0].RoomIndex >= 0) {
 			lightIgnored = true;
 			int roomIndex = strictLights[0].RoomIndex;
 			[unroll] for (int flagsIndex = 0; flagsIndex < 4; ++flagsIndex)

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -629,7 +629,7 @@ PS_OUTPUT main(PS_INPUT input)
 			{
 				uint light_index = lightList[lightOffset + i];
 				StructuredLight light = lights[light_index];
-				if (LightLimitFix::IsLightIgnored(light)) {
+				if (LightLimitFix::IsLightIgnored(light) || light.lightFlags & Llf_ShadowLight) {
 					continue;
 				}
 				float3 lightDirection = light.positionWS[eyeIndex].xyz - input.WorldPosition.xyz;

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -629,7 +629,7 @@ PS_OUTPUT main(PS_INPUT input)
 			{
 				uint light_index = lightList[lightOffset + i];
 				StructuredLight light = lights[light_index];
-				if (LightLimitFix::IsLightIgnored(light) || light.lightFlags & Llf_ShadowLight) {
+				if (LightLimitFix::IsLightIgnored(light) || light.lightFlags & LightFlags::Shadow) {
 					continue;
 				}
 				float3 lightDirection = light.positionWS[eyeIndex].xyz - input.WorldPosition.xyz;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2116,7 +2116,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 			uint clusteredLightIndex = lightList[lightOffset + (lightIndex - strictLights[0].NumStrictLights)];
 			light = lights[clusteredLightIndex];
 
-			if (LightLimitFix::IsLightIgnored(light)) {
+			if (LightLimitFix::IsLightIgnored(light) || (!(PixelShaderDescriptor & _DefShadow) && light.lightFlags & Llf_ShadowLight)) {
 				continue;
 			}
 		}
@@ -2132,7 +2132,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		float lightShadow = 1.f;
 
 		float shadowComponent = 1.0;
-		if ((PixelShaderDescriptor & _DefShadow) && (light.lightFlags & Llf_ShadowLight)) {
+		if (light.lightFlags & Llf_ShadowLight) {
 			shadowComponent = shadowColor[light.shadowLightIndex];
 			lightShadow *= shadowComponent;
 		}

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2116,7 +2116,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 			uint clusteredLightIndex = lightList[lightOffset + (lightIndex - strictLights[0].NumStrictLights)];
 			light = lights[clusteredLightIndex];
 
-			if (LightLimitFix::IsLightIgnored(light) || (!(PixelShaderDescriptor & _DefShadow) && light.lightFlags & Llf_ShadowLight)) {
+			if (LightLimitFix::IsLightIgnored(light) || (!(PixelShaderDescriptor & _DefShadow) && light.lightFlags & LightFlags::Shadow)) {
 				continue;
 			}
 		}
@@ -2129,10 +2129,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 		float intensityMultiplier = 1 - intensityFactor * intensityFactor;
 		float3 lightColor = light.color.xyz * intensityMultiplier;
-		float lightShadow = 1.f;
+		float lightShadow = 1.0;
 
 		float shadowComponent = 1.0;
-		if (light.lightFlags & Llf_ShadowLight) {
+		if (light.lightFlags & LightFlags::Shadow) {
 			shadowComponent = shadowColor[light.shadowLightIndex];
 			lightShadow *= shadowComponent;
 		}
@@ -2140,8 +2140,13 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		float3 normalizedLightDirection = normalize(lightDirection);
 		float lightAngle = dot(worldSpaceNormal.xyz, normalizedLightDirection.xyz);
 
-		float contactShadow = 1;
-		[branch] if (inWorld && !FrameParams.z && lightLimitFixSettings.EnableContactShadows && shadowComponent != 0.0 && lightAngle > 0.0)
+		float contactShadow = 1.0;
+		[branch] if (
+			inWorld && !FrameParams.z && 
+			lightLimitFixSettings.EnableContactShadows && 
+			!(light.lightFlags & LightFlags::Simple) && 
+			shadowComponent != 0.0 && 
+			lightAngle > 0.0)
 		{
 			float3 normalizedLightDirectionVS = normalize(light.positionVS[eyeIndex].xyz - viewPosition.xyz);
 			contactShadow = LightLimitFix::ContactShadows(viewPosition, screenNoise, normalizedLightDirectionVS, contactShadowSteps, eyeIndex);
@@ -2158,7 +2163,13 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		float parallaxShadow = 1;
 
 #			if defined(EMAT)
-		[branch] if (extendedMaterialSettings.EnableShadows && lightAngle > 0.0 && shadowComponent != 0.0 && contactShadow != 0.0)
+		[branch] if (
+			extendedMaterialSettings.EnableShadows && 
+			!(light.lightFlags & LightFlags::Simple) &&
+			lightAngle > 0.0 && 
+			shadowComponent != 0.0 && 
+			contactShadow != 0.0
+		)
 		{
 			float3 lightDirectionTS = normalize(mul(refractedLightDirection, tbn).xyz);
 #				if defined(PARALLAX)
@@ -2192,9 +2203,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #				endif
 		}
 #			else
-		lightColor *= parallaxShadow * lightShadow;
+		lightColor *= lightShadow;
 
-		float3 lightDiffuseColor = lightColor * contactShadow * saturate(lightAngle.xxx);
+		float3 lightDiffuseColor = lightColor * contactShadow * parallaxShadow * saturate(lightAngle.xxx);
 
 #				if defined(SOFT_LIGHTING) || defined(RIM_LIGHTING) || defined(BACK_LIGHTING)
 		float lightBacklighting = 1.0 + saturate(dot(worldSpaceViewDirection, -normalizedLightDirection.xyz));

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2142,10 +2142,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 		float contactShadow = 1.0;
 		[branch] if (
-			inWorld && !FrameParams.z && 
-			lightLimitFixSettings.EnableContactShadows && 
-			!(light.lightFlags & LightFlags::Simple) && 
-			shadowComponent != 0.0 && 
+			inWorld && !FrameParams.z &&
+			lightLimitFixSettings.EnableContactShadows &&
+			!(light.lightFlags & LightFlags::Simple) &&
+			shadowComponent != 0.0 &&
 			lightAngle > 0.0)
 		{
 			float3 normalizedLightDirectionVS = normalize(light.positionVS[eyeIndex].xyz - viewPosition.xyz);
@@ -2164,12 +2164,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 #			if defined(EMAT)
 		[branch] if (
-			extendedMaterialSettings.EnableShadows && 
+			extendedMaterialSettings.EnableShadows &&
 			!(light.lightFlags & LightFlags::Simple) &&
-			lightAngle > 0.0 && 
-			shadowComponent != 0.0 && 
-			contactShadow != 0.0
-		)
+			lightAngle > 0.0 &&
+			shadowComponent != 0.0 &&
+			contactShadow != 0.0)
 		{
 			float3 lightDirectionTS = normalize(mul(refractedLightDirection, tbn).xyz);
 #				if defined(PARALLAX)

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -868,7 +868,7 @@ PS_OUTPUT main(PS_INPUT input)
 		{
 			uint light_index = lightList[lightOffset + i];
 			StructuredLight light = lights[light_index];
-			if (LightLimitFix::IsLightIgnored(light)) {
+			if (LightLimitFix::IsLightIgnored(light) || light.lightFlags & Llf_ShadowLight) {
 				continue;
 			}
 

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -868,7 +868,7 @@ PS_OUTPUT main(PS_INPUT input)
 		{
 			uint light_index = lightList[lightOffset + i];
 			StructuredLight light = lights[light_index];
-			if (LightLimitFix::IsLightIgnored(light) || light.lightFlags & Llf_ShadowLight) {
+			if (LightLimitFix::IsLightIgnored(light) || light.lightFlags & LightFlags::Shadow) {
 				continue;
 			}
 

--- a/src/Features/LightLimitFIx/ParticleLights.h
+++ b/src/Features/LightLimitFIx/ParticleLights.h
@@ -9,12 +9,6 @@ public:
 		return &singleton;
 	}
 
-	enum class Flicker
-	{
-		None = 0,
-		Normal = 1
-	};
-
 	struct Config
 	{
 		bool cull = false;

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -918,7 +918,7 @@ void LightLimitFix::UpdateLights()
 				auto position = particleLight.first->world.translate;
 
 				SetLightPosition(light, position);  // Light is complete for both eyes by now
-				
+
 				light.lightFlags.set(LightFlags::Simple);
 				light.lightFlags.set(LightFlags::Billboard);
 

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -875,6 +875,9 @@ void LightLimitFix::UpdateLights()
 								clusteredLight.positionWS[1].data.z += eyePositionOffset.z / (float)clusteredLights;
 							}
 
+							clusteredLight.lightFlags.set(LightFlags::Simple);
+							clusteredLight.lightFlags.set(LightFlags::Particle);
+
 							AddCachedParticleLights(lightsData, clusteredLight);
 
 							clusteredLights = 0;
@@ -915,6 +918,9 @@ void LightLimitFix::UpdateLights()
 				auto position = particleLight.first->world.translate;
 
 				SetLightPosition(light, position);  // Light is complete for both eyes by now
+				
+				light.lightFlags.set(LightFlags::Simple);
+				light.lightFlags.set(LightFlags::Billboard);
 
 				AddCachedParticleLights(lightsData, light);
 			}
@@ -929,6 +935,8 @@ void LightLimitFix::UpdateLights()
 				clusteredLight.positionWS[1].data.y += eyePositionOffset.y / (float)clusteredLights;
 				clusteredLight.positionWS[1].data.z += eyePositionOffset.z / (float)clusteredLights;
 			}
+			clusteredLight.lightFlags.set(LightFlags::Simple);
+			clusteredLight.lightFlags.set(LightFlags::Particle);
 			AddCachedParticleLights(lightsData, clusteredLight);
 		}
 	}

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -29,7 +29,6 @@ void LightLimitFix::DrawSettings()
 	ImGui::Checkbox("checkRoomNodes", &checkRoomNodes);
 	ImGui::Checkbox("cullingShader", &cullingShader);
 
-
 	if (ImGui::TreeNodeEx("Particle Lights", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Checkbox("Enable Particle Lights", &settings.EnableParticleLights);
 		if (auto _tt = Util::HoverTooltipWrapper()) {
@@ -385,7 +384,6 @@ void LightLimitFix::BSLightingShader_SetupGeometry_After(RE::BSRenderPass*)
 	const int roomIndex = strictLightDataTemp.RoomIndex;
 
 	if (!isEmpty || (isEmpty && !wasEmpty) || isWorld != wasWorld || previousRoomIndex != roomIndex) {
-
 		if (copyStrictLightsData) {
 			D3D11_MAPPED_SUBRESOURCE mapped;
 			DX::ThrowIfFailed(context->Map(strictLightData->resource.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));
@@ -539,7 +537,6 @@ LightLimitFix::ParticleLightReference LightLimitFix::GetParticleLightConfigs(RE:
 			if (!shaderProperty->lightData) {
 				if (auto material = shaderProperty->GetMaterial()) {
 					if (!material->sourceTexturePath.empty()) {
-
 						std::string textureName = ExtractTextureStem(material->sourceTexturePath.c_str());
 						if (textureName.size() < 1) {
 							particleLightsReferences.insert({ (RE::NiNode*)a_pass->geometry, { false } });

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -990,7 +990,6 @@ void LightLimitFix::UpdateLights()
 		LightCullingCB updateData{};
 		updateData.LightCount = lightCount;
 		lightCullingCB->Update(updateData);
-		
 
 		ID3D11Buffer* buffer = lightCullingCB->CB();
 		context->CSSetConstantBuffers(0, 1, &buffer);
@@ -1002,7 +1001,7 @@ void LightLimitFix::UpdateLights()
 		context->CSSetUnorderedAccessViews(0, 3, uavs, nullptr);
 
 		context->CSSetShader(clusterCullingCS, nullptr, 0);
-		context->Dispatch((clusterSize[0] + 15) / 16, (clusterSize[1] + 15) / 16, (clusterSize[2] + 3) / 4);	
+		context->Dispatch((clusterSize[0] + 15) / 16, (clusterSize[1] + 15) / 16, (clusterSize[2] + 3) / 4);
 	}
 
 	context->CSSetShader(nullptr, nullptr, 0);

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -515,7 +515,6 @@ LightLimitFix::ParticleLightReference LightLimitFix::GetParticleLightConfigs(RE:
 		if (auto shaderProperty = netimmerse_cast<RE::BSEffectShaderProperty*>(a_pass->shaderProperty)) {
 			if (!shaderProperty->lightData) {
 				if (auto material = shaderProperty->GetMaterial()) {
-
 					// Check if it's a valid particle light
 					bool billboard = false;
 					if (!netimmerse_cast<RE::NiParticleSystem*>(a_pass->geometry)) {

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -646,10 +646,10 @@ bool LightLimitFix::AddParticleLight(RE::BSRenderPass* a_pass, ParticleLightRefe
 	}
 
 	RE::NiColorA color = a_reference.baseColor;
-	color.red = material->baseColor.red * material->baseColorScale;
-	color.green = material->baseColor.green * material->baseColorScale;
-	color.blue = material->baseColor.blue * material->baseColorScale;
-	color.alpha = material->baseColor.alpha * shaderProperty->alpha;
+	color.red *= material->baseColor.red * material->baseColorScale;
+	color.green *= material->baseColor.green * material->baseColorScale;
+	color.blue *= material->baseColor.blue * material->baseColorScale;
+	color.alpha *= material->baseColor.alpha * shaderProperty->alpha;
 
 	if (auto emittance = shaderProperty->unk88) {
 		color.red *= emittance->red;

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -15,7 +15,6 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	EnableParticleLightsDetection,
 	ParticleLightsSaturation,
 	EnableParticleLightsOptimization,
-	ParticleLightsOptimisationClusterRadius,
 	ParticleBrightness,
 	ParticleRadius,
 	BillboardBrightness,
@@ -47,12 +46,9 @@ void LightLimitFix::DrawSettings()
 
 		ImGui::Checkbox("Enable Optimization", &settings.EnableParticleLightsOptimization);
 		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text("Merges vertices which are close enough to each other to significantly improve performance.");
+			ImGui::Text("Merges vertices which are close enough to each other to improve performance.");
 		}
-		ImGui::SliderInt("Optimisation Cluster Radius", (int*)&settings.ParticleLightsOptimisationClusterRadius, 1, 64);
-		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text("Radius to use for clustering lights.");
-		}
+
 		ImGui::Spacing();
 		ImGui::Spacing();
 
@@ -865,7 +861,7 @@ void LightLimitFix::UpdateLights()
 						auto averagePosition = clusteredLight.positionWS[0].data / (float)clusteredLights;
 						float positionDiff = positionWS.GetDistance({ averagePosition.x, averagePosition.y, averagePosition.z });
 
-						if ((radiusDiff + positionDiff) > settings.ParticleLightsOptimisationClusterRadius || !settings.EnableParticleLightsOptimization) {
+						if ((radiusDiff + positionDiff) > 32.0f || !settings.EnableParticleLightsOptimization) {
 							clusteredLight.radius /= (float)clusteredLights;
 							clusteredLight.positionWS[0].data /= (float)clusteredLights;
 							clusteredLight.positionWS[1].data = clusteredLight.positionWS[0].data;

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -256,12 +256,14 @@ void LightLimitFix::SetupResources()
 void LightLimitFix::Reset()
 {
 	for (auto& particleLight : particleLights) {
-		if (const auto particleSystem = netimmerse_cast<RE::NiParticleSystem*>(particleLight.first)) {
-			if (auto particleData = particleSystem->GetParticleRuntimeData().particleData.get()) {
-				particleData->DecRefCount();
+		if (!particleLight.billboard) {
+			if (const auto particleSystem = static_cast<RE::NiParticleSystem*>(particleLight.node)) {
+				if (auto particleData = particleSystem->GetParticleRuntimeData().particleData.get()) {
+					particleData->DecRefCount();
+				}
 			}
 		}
-		particleLight.first->DecRefCount();
+		particleLight.node->DecRefCount();
 	}
 	particleLights.clear();
 	std::swap(particleLights, queuedParticleLights);
@@ -510,28 +512,33 @@ LightLimitFix::ParticleLightReference LightLimitFix::GetParticleLightConfigs(RE:
 {
 	// see https://www.nexusmods.com/skyrimspecialedition/articles/1391
 	if (settings.EnableParticleLights) {
-		{
-			auto it = particleLightsReferences.find((RE::NiNode*)a_pass->geometry);
-			if (it != particleLightsReferences.end())
-				return (*it).second;
-		}
-
-		bool billboardLight = false;
-		if (!netimmerse_cast<RE::NiParticleSystem*>(a_pass->geometry)) {
-			if (auto parent = a_pass->geometry->parent) {
-				if (auto billboardNode = netimmerse_cast<RE::NiBillboardNode*>(parent)) {
-					billboardLight = true;
-				} else {
-					return { false };
-				}
-			} else {
-				return { false };
-			}
-		}
-
 		if (auto shaderProperty = netimmerse_cast<RE::BSEffectShaderProperty*>(a_pass->shaderProperty)) {
 			if (!shaderProperty->lightData) {
 				if (auto material = shaderProperty->GetMaterial()) {
+
+					// Check if it's a valid particle light
+					bool billboard = false;
+					if (!netimmerse_cast<RE::NiParticleSystem*>(a_pass->geometry)) {
+						if (auto parent = a_pass->geometry->parent) {
+							if (auto billboardNode = netimmerse_cast<RE::NiBillboardNode*>(parent)) {
+								billboard = true;
+							} else {
+								return { false };
+							}
+						} else {
+							return { false };
+						}
+					}
+
+					// Already scanned
+					{
+						auto it = particleLightsReferences.find(reinterpret_cast<RE::NiNode*>(a_pass->geometry));
+						if (it != particleLightsReferences.end())
+							return (*it).second;
+					}
+
+					// Not scanned, scan now
+
 					if (!material->sourceTexturePath.empty()) {
 						std::string textureName = ExtractTextureStem(material->sourceTexturePath.c_str());
 						if (textureName.size() < 1) {
@@ -565,11 +572,12 @@ LightLimitFix::ParticleLightReference LightLimitFix::GetParticleLightConfigs(RE:
 						}
 
 						ParticleLightReference reference{ true };
+						reference.billboard = billboard;
 						reference.config = config;
 						reference.gradientConfig = gradientConfig;
 						reference.baseColor = { 1, 1, 1, 1 };
 
-						if (billboardLight) {
+						if (billboard) {
 							if (auto rendererData = a_pass->geometry->GetGeometryRuntimeData().rendererData) {
 								if (auto triShape = a_pass->geometry->AsTriShape()) {
 									uint32_t vertexSize = rendererData->vertexDesc.GetSize();
@@ -602,7 +610,7 @@ LightLimitFix::ParticleLightReference LightLimitFix::GetParticleLightConfigs(RE:
 							}
 						}
 
-						particleLightsReferences.insert({ (RE::NiNode*)a_pass->geometry, reference });
+						particleLightsReferences.insert({ reinterpret_cast<RE::NiNode*>(a_pass->geometry), reference });
 						return reference;
 					}
 				}
@@ -633,15 +641,18 @@ bool LightLimitFix::CheckParticleLights(RE::BSRenderPass* a_pass, uint32_t)
 
 bool LightLimitFix::AddParticleLight(RE::BSRenderPass* a_pass, ParticleLightReference a_reference)
 {
-	auto shaderProperty = netimmerse_cast<RE::BSEffectShaderProperty*>(a_pass->shaderProperty);
+	auto shaderProperty = static_cast<RE::BSEffectShaderProperty*>(a_pass->shaderProperty);
 	auto material = shaderProperty->GetMaterial();
 	auto config = a_reference.config;
 	auto gradientConfig = a_reference.gradientConfig;
 
 	a_pass->geometry->IncRefCount();
-	if (auto particleSystem = netimmerse_cast<RE::NiParticleSystem*>(a_pass->geometry)) {
-		if (auto particleData = particleSystem->GetParticleRuntimeData().particleData.get()) {
-			particleData->IncRefCount();
+
+	if (!a_reference.billboard) {
+		if (auto particleSystem = static_cast<RE::NiParticleSystem*>(a_pass->geometry)) {
+			if (auto particleData = particleSystem->GetParticleRuntimeData().particleData.get()) {
+				particleData->IncRefCount();
+			}
 		}
 	}
 
@@ -668,7 +679,14 @@ bool LightLimitFix::AddParticleLight(RE::BSRenderPass* a_pass, ParticleLightRefe
 		color.blue *= config->colorMult.blue;
 	}
 
-	queuedParticleLights.insert({ a_pass->geometry, { color, *config } });
+	color.alpha = config->radiusMult;
+
+	ParticleLightInfo info;
+	info.billboard = a_reference.billboard;
+	info.node = a_pass->geometry;
+	info.color = color;
+
+	queuedParticleLights.push_back(info);
 	return true;
 }
 
@@ -834,84 +852,85 @@ void LightLimitFix::UpdateLights()
 		auto eyePositionOffset = eyePositionCached[0] - eyePositionCached[1];
 
 		for (const auto& particleLight : particleLights) {
-			if (const auto particleSystem = netimmerse_cast<RE::NiParticleSystem*>(particleLight.first);
-				particleSystem && particleSystem->GetParticleRuntimeData().particleData.get()) {
-				// Process BSGeometry
-				auto particleData = particleSystem->GetParticleRuntimeData().particleData.get();
+			if (!particleLight.billboard) {
+				auto particleSystem = static_cast<RE::NiParticleSystem*>(particleLight.node);
+				if (particleSystem && particleSystem->GetParticleRuntimeData().particleData.get()) {
+					// Process BSGeometry
+					auto particleData = particleSystem->GetParticleRuntimeData().particleData.get();
 
-				auto numVertices = particleData->GetActiveVertexCount();
-				for (std::uint32_t p = 0; p < numVertices; p++) {
-					float radius = particleData->GetParticlesRuntimeData().sizes[p] * 70.0f;
+					auto numVertices = particleData->GetActiveVertexCount();
+					for (std::uint32_t p = 0; p < numVertices; p++) {
+						float radius = particleData->GetParticlesRuntimeData().sizes[p] * 70.0f;
 
-					auto initialPosition = particleData->GetParticlesRuntimeData().positions[p];
-					if (!particleSystem->GetParticleSystemRuntimeData().isWorldspace) {
-						// Detect first-person meshes
-						if ((particleLight.first->GetModelData().modelBound.radius * particleLight.first->world.scale) != particleLight.first->worldBound.radius)
-							initialPosition += particleLight.first->worldBound.center;
-						else
-							initialPosition += particleLight.first->world.translate;
-					}
-
-					RE::NiPoint3 positionWS = initialPosition - eyePositionCached[0];
-
-					if (clusteredLights) {
-						auto averageRadius = clusteredLight.radius / (float)clusteredLights;
-						float radiusDiff = abs(averageRadius - radius);
-
-						auto averagePosition = clusteredLight.positionWS[0].data / (float)clusteredLights;
-						float positionDiff = positionWS.GetDistance({ averagePosition.x, averagePosition.y, averagePosition.z });
-
-						if ((radiusDiff + positionDiff) > 32.0f || !settings.EnableParticleLightsOptimization) {
-							clusteredLight.radius /= (float)clusteredLights;
-							clusteredLight.positionWS[0].data /= (float)clusteredLights;
-							clusteredLight.positionWS[1].data = clusteredLight.positionWS[0].data;
-							if (eyeCount == 2) {
-								clusteredLight.positionWS[1].data.x += eyePositionOffset.x / (float)clusteredLights;
-								clusteredLight.positionWS[1].data.y += eyePositionOffset.y / (float)clusteredLights;
-								clusteredLight.positionWS[1].data.z += eyePositionOffset.z / (float)clusteredLights;
-							}
-
-							clusteredLight.lightFlags.set(LightFlags::Simple);
-							clusteredLight.lightFlags.set(LightFlags::Particle);
-
-							AddCachedParticleLights(lightsData, clusteredLight);
-
-							clusteredLights = 0;
-							clusteredLight.color = { 0, 0, 0 };
-							clusteredLight.radius = 0;
-							clusteredLight.positionWS[0].data = { 0, 0, 0 };
+						auto initialPosition = particleData->GetParticlesRuntimeData().positions[p];
+						if (!particleSystem->GetParticleSystemRuntimeData().isWorldspace) {
+							// Detect first-person meshes
+							if ((particleLight.node->GetModelData().modelBound.radius * particleLight.node->world.scale) != particleLight.node->worldBound.radius)
+								initialPosition += particleLight.node->worldBound.center;
+							else
+								initialPosition += particleLight.node->world.translate;
 						}
+
+						RE::NiPoint3 positionWS = initialPosition - eyePositionCached[0];
+
+						if (clusteredLights) {
+							auto averageRadius = clusteredLight.radius / (float)clusteredLights;
+							float radiusDiff = abs(averageRadius - radius);
+
+							auto averagePosition = clusteredLight.positionWS[0].data / (float)clusteredLights;
+							float positionDiff = positionWS.GetDistance({ averagePosition.x, averagePosition.y, averagePosition.z });
+
+							if ((radiusDiff + positionDiff) > 32.0f || !settings.EnableParticleLightsOptimization) {
+								clusteredLight.radius /= (float)clusteredLights;
+								clusteredLight.positionWS[0].data /= (float)clusteredLights;
+								clusteredLight.positionWS[1].data = clusteredLight.positionWS[0].data;
+								if (eyeCount == 2) {
+									clusteredLight.positionWS[1].data.x += eyePositionOffset.x / (float)clusteredLights;
+									clusteredLight.positionWS[1].data.y += eyePositionOffset.y / (float)clusteredLights;
+									clusteredLight.positionWS[1].data.z += eyePositionOffset.z / (float)clusteredLights;
+								}
+
+								clusteredLight.lightFlags.set(LightFlags::Simple);
+								clusteredLight.lightFlags.set(LightFlags::Particle);
+
+								AddCachedParticleLights(lightsData, clusteredLight);
+
+								clusteredLights = 0;
+								clusteredLight.color = { 0, 0, 0 };
+								clusteredLight.radius = 0;
+								clusteredLight.positionWS[0].data = { 0, 0, 0 };
+							}
+						}
+
+						float alpha = particleLight.color.alpha * particleData->GetParticlesRuntimeData().color[p].alpha;
+						float3 color;
+						color.x = particleLight.color.red * particleData->GetParticlesRuntimeData().color[p].red;
+						color.y = particleLight.color.green * particleData->GetParticlesRuntimeData().color[p].green;
+						color.z = particleLight.color.blue * particleData->GetParticlesRuntimeData().color[p].blue;
+						clusteredLight.color += Saturation(color, settings.ParticleLightsSaturation) * alpha * settings.ParticleBrightness;
+
+						clusteredLight.radius += radius * particleLight.color.alpha * settings.ParticleRadius;
+						clusteredLight.positionWS[0].data.x += positionWS.x;
+						clusteredLight.positionWS[0].data.y += positionWS.y;
+						clusteredLight.positionWS[0].data.z += positionWS.z;
+
+						clusteredLights++;
 					}
-
-					float alpha = particleLight.second.color.alpha * particleData->GetParticlesRuntimeData().color[p].alpha;
-					float3 color;
-					color.x = particleLight.second.color.red * particleData->GetParticlesRuntimeData().color[p].red;
-					color.y = particleLight.second.color.green * particleData->GetParticlesRuntimeData().color[p].green;
-					color.z = particleLight.second.color.blue * particleData->GetParticlesRuntimeData().color[p].blue;
-					clusteredLight.color += Saturation(color, settings.ParticleLightsSaturation) * alpha * settings.ParticleBrightness;
-
-					clusteredLight.radius += radius * settings.ParticleRadius * particleLight.second.config.radiusMult;
-					clusteredLight.positionWS[0].data.x += positionWS.x;
-					clusteredLight.positionWS[0].data.y += positionWS.y;
-					clusteredLight.positionWS[0].data.z += positionWS.z;
-
-					clusteredLights++;
 				}
-
 			} else {
 				// Process billboard
 				LightData light{};
 
-				light.color.x = particleLight.second.color.red;
-				light.color.y = particleLight.second.color.green;
-				light.color.z = particleLight.second.color.blue;
+				light.color.x = particleLight.color.red;
+				light.color.y = particleLight.color.green;
+				light.color.z = particleLight.color.blue;
 
 				light.color = Saturation(light.color, settings.ParticleLightsSaturation);
 
-				light.color *= particleLight.second.color.alpha * settings.BillboardBrightness;
-				light.radius = particleLight.first->worldBound.radius * settings.BillboardRadius * particleLight.second.config.radiusMult;
+				light.color *= particleLight.color.alpha * settings.BillboardBrightness;
+				light.radius = particleLight.node->worldBound.radius * particleLight.color.alpha * settings.BillboardRadius;
 
-				auto position = particleLight.first->world.translate;
+				auto position = particleLight.node->world.translate;
 
 				SetLightPosition(light, position);  // Light is complete for both eyes by now
 

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -312,30 +312,6 @@ public:
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 
-		struct BSLightingShaderProperty_GetRenderPasses
-		{
-			static RE::BSShaderProperty::RenderPassArray* thunk(RE::BSLightingShaderProperty* property, RE::BSGeometry* geometry, std::uint32_t renderFlags, RE::BSShaderAccumulator* accumulator)
-			{
-				auto renderPasses = func(property, geometry, renderFlags, accumulator);
-				if (renderPasses == nullptr) {
-					return renderPasses;
-				}
-
-				auto currentPass = renderPasses->head;
-				while (currentPass != nullptr) {
-					if (currentPass->shader->shaderType == RE::BSShader::Type::Lighting) {
-						constexpr uint32_t LightingTechniqueStart = 0x4800002D;
-						// So that we always have shadow mask bound.
-						currentPass->passEnum = ((currentPass->passEnum - LightingTechniqueStart) | static_cast<uint32_t>(SIE::ShaderCache::LightingShaderFlags::DefShadow)) + LightingTechniqueStart;
-					}
-					currentPass = currentPass->next;
-				}
-
-				return renderPasses;
-			}
-			static inline REL::Relocation<decltype(thunk)> func;
-		};
-
 		struct NiNode_Destroy
 		{
 			static void thunk(RE::NiNode* This)
@@ -353,8 +329,6 @@ public:
 			stl::write_thunk_call<BSBatchRenderer__RenderPassImmediately3>(REL::RelocationID(100871, 107667).address() + REL::Relocate(0xEE, 0xED));
 
 			stl::write_thunk_call<AIProcess_CalculateLightValue_GetLuminance>(REL::RelocationID(38900, 39946).address() + REL::Relocate(0x1C9, 0x1D3));
-
-			stl::write_vfunc<0x2A, BSLightingShaderProperty_GetRenderPasses>(RE::VTABLE_BSLightingShaderProperty[0]);
 
 			stl::write_vfunc<0x6, BSLightingShader_SetupGeometry>(RE::VTABLE_BSLightingShader[0]);
 			stl::write_vfunc<0x6, BSEffectShader_SetupGeometry>(RE::VTABLE_BSEffectShader[0]);

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -337,7 +337,7 @@ public:
 			stl::write_thunk_call<BSLightingShader_SetupGeometry_GeometrySetupConstantPointLights>(REL::RelocationID(100565, 107300).address() + REL::Relocate(0x523, 0xB0E, 0x5fe));
 
 			stl::detour_thunk<NiNode_Destroy>(REL::RelocationID(68937, 70288));
-			
+
 			logger::info("[LLF] Installed hooks");
 		}
 	};

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -363,7 +363,7 @@ public:
 			logger::info("[LLF] Installed hooks");
 
 			stl::write_thunk_call<BSLightingShader_SetupGeometry_GeometrySetupConstantPointLights>(REL::RelocationID(100565, 107300).address() + REL::Relocate(0x523, 0xB0E, 0x5fe));
-	
+
 			stl::detour_thunk<NiNode_Destroy>(REL::RelocationID(68937, 70288));
 		}
 	};

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -334,11 +334,11 @@ public:
 			stl::write_vfunc<0x6, BSEffectShader_SetupGeometry>(RE::VTABLE_BSEffectShader[0]);
 			stl::write_vfunc<0x6, BSWaterShader_SetupGeometry>(RE::VTABLE_BSWaterShader[0]);
 
-			logger::info("[LLF] Installed hooks");
-
 			stl::write_thunk_call<BSLightingShader_SetupGeometry_GeometrySetupConstantPointLights>(REL::RelocationID(100565, 107300).address() + REL::Relocate(0x523, 0xB0E, 0x5fe));
 
 			stl::detour_thunk<NiNode_Destroy>(REL::RelocationID(68937, 70288));
+			
+			logger::info("[LLF] Installed hooks");
 		}
 	};
 

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -137,23 +137,23 @@ public:
 
 	struct ParticleLightInfo
 	{
+		bool billboard;
+		RE::BSGeometry* node;
 		RE::NiColorA color;
-		ParticleLights::Config& config;
 	};
-
-	using ConfigPair = std::pair<ParticleLights::Config*, ParticleLights::GradientConfig*>;
 
 	struct ParticleLightReference
 	{
 		bool valid;
+		bool billboard;
 		ParticleLights::Config* config;
 		ParticleLights::GradientConfig* gradientConfig;
 		RE::NiColorA baseColor;
 	};
 
 	eastl::hash_map<RE::NiNode*, ParticleLightReference> particleLightsReferences;
-	eastl::hash_map<RE::BSGeometry*, ParticleLightInfo> queuedParticleLights;
-	eastl::hash_map<RE::BSGeometry*, ParticleLightInfo> particleLights;
+	eastl::vector<ParticleLightInfo> queuedParticleLights;
+	eastl::vector<ParticleLightInfo> particleLights;
 
 	void CleanupParticleLights(RE::NiNode* a_node);
 

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -25,12 +25,6 @@ public:
 
 	bool HasShaderDefine(RE::BSShader::Type) override { return true; };
 
-	bool cullingShader = true;
-	bool checkParticleLights = true;
-	bool copyStrictLightsData = true;
-	bool copyData = true;
-	bool checkRoomNodes = true;
-
 	enum class LightFlags : std::uint32_t
 	{
 		PortalStrict = (1 << 0),

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -198,7 +198,6 @@ public:
 		float BillboardBrightness = 1.0f;
 		float BillboardRadius = 1.0f;
 		bool EnableParticleLightsOptimization = true;
-		uint ParticleLightsOptimisationClusterRadius = 32;
 	};
 
 	uint clusterSize[3] = { 16 };

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -35,6 +35,9 @@ public:
 	{
 		PortalStrict = (1 << 0),
 		Shadow = (1 << 1),
+		Simple = (1 << 2),
+		Particle = (1 << 3),
+		Billboard = (1 << 4)
 	};
 
 	struct PositionOpt

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -7,11 +7,10 @@
 #include "State.h"
 #include "TruePBR.h"
 #include "Upscaling.h"
+#include "Feature.h"
 
 #include "ENB/ENBSeriesAPI.h"
-#include "Features/ExtendedMaterials.h"
-#include "Features/LightLimitFIx/ParticleLights.h"
-#include "Features/LightLimitFix.h"
+
 #define DLLEXPORT __declspec(dllexport)
 
 std::list<std::string> errors;

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -1,13 +1,13 @@
 #include "Hooks.h"
 
 #include "Deferred.h"
+#include "Feature.h"
 #include "FrameAnnotations.h"
 #include "Menu.h"
 #include "ShaderCache.h"
 #include "State.h"
 #include "TruePBR.h"
 #include "Upscaling.h"
-#include "Feature.h"
 
 #include "ENB/ENBSeriesAPI.h"
 


### PR DESCRIPTION
Optimised particle light scanning. It now only scans once, storing the cache result, including the scan of the vertex colours. If the material is modified it will still be reflected ingame.
Contact shadows and parallax shadows are disabled on particle lights.
Light flags use a fake enum in HLSL.
Removed the GetRenderPasses hook since it's not needed.
Disabled shadows on non DefShadow shaders, and disabled on water/effect shaders.
Fixed parallax shadows being applied incorrectly.
Replaced the particle lights map with a vector.
Removed the particle light optimisation radius setting, to simplify.