### PR TITLE
refactor: shader flags

### DIFF
--- a/package/Shaders/Common/Permutation.hlsli
+++ b/package/Shaders/Common/Permutation.hlsli
@@ -17,7 +17,7 @@ namespace LightingFlags
 	static const uint ShadowDir = (1 << 13);
 	static const uint DefShadow = (1 << 14);
 	static const uint ProjectedUV = (1 << 15);
-	static const uint DepthWriteDecals = (1 << 15); // (HAIR technique only)
+	static const uint DepthWriteDecals = (1 << 15);  // (HAIR technique only)
 	static const uint AnisoLighting = (1 << 16);
 	static const uint AmbientSpecular = (1 << 17);
 	static const uint WorldMap = (1 << 18);

--- a/package/Shaders/Common/Permutation.hlsli
+++ b/package/Shaders/Common/Permutation.hlsli
@@ -1,47 +1,59 @@
 
+namespace LightingTechnique
+{
+	static const uint Glowmap = 2;
+}
 
-#define _Glowmap 2
-#define _Hair 6
+namespace LightingFlags
+{
+	static const uint VertexColor = (1 << 0);
+	static const uint Skinned = (1 << 1);
+	static const uint ModelSpaceNormals = (1 << 2);
+	// Flags 3 to 8 are unused
+	static const uint Specular = (1 << 9);
+	static const uint SoftLighting = (1 << 10);
+	static const uint RimLighting = (1 << 11);
+	static const uint BackLighting = (1 << 12);
+	static const uint ShadowDir = (1 << 13);
+	static const uint DefShadow = (1 << 14);
+	static const uint ProjectedUV = (1 << 15);
+	static const uint DepthWriteDecals = (1 << 15); // (HAIR technique only)
+	static const uint AnisoLighting = (1 << 16);
+	static const uint AmbientSpecular = (1 << 17);
+	static const uint WorldMap = (1 << 18);
+	static const uint BaseObjectIsSnow = (1 << 19);
+	static const uint DoAlphaTest = (1 << 20);
+	static const uint Snow = (1 << 21);
+	static const uint CharacterLight = (1 << 22);
+	static const uint AdditionalAlphaMask = (1 << 23);
+}
 
-#define _VC (1 << 0)
-#define _Skinned (1 << 1)
-#define _ModelSpaceNormals (1 << 2)
-// flags 3 to 8 are unused
-#define _Specular (1 << 9)
-#define _SoftLighting (1 << 10)
-#define _RimLighting (1 << 11)
-#define _BackLighting (1 << 12)
-#define _ShadowDir (1 << 13)
-#define _DefShadow (1 << 14)
-#define _ProjectedUV (1 << 15)
-// (HAIR technique only)
-#define _DepthWriteDecals (1 << 15)
-#define _AnisoLighting (1 << 16)
-#define _AmbientSpecular (1 << 17)
-#define _WorldMap (1 << 18)
-#define _BaseObjectIsSnow (1 << 19)
-#define _DoAlphaTest (1 << 20)
-#define _Snow (1 << 21)
-#define _CharacterLight (1 << 22)
-#define _AdditionalAlphaMask (1 << 23)
+namespace WaterFlags
+{
+	static const uint NormalTexCoord = (1 << 1);
+	static const uint Reflections = (1 << 2);
+	static const uint Refractions = (1 << 3);
+	static const uint Depth = (1 << 4);
+	static const uint Interior = (1 << 5);
+	static const uint Wading = (1 << 6);
+	static const uint VertexAlphaDepth = (1 << 7);
+	static const uint Cubemap = (1 << 8);
+	static const uint Flowmap = (1 << 9);
+	static const uint BlendNormals = (1 << 10);
+}
 
-#define _NormalTexCoord (1 << 1)
-#define _Reflections (1 << 2)
-#define _Refractions (1 << 3)
-#define _Depth (1 << 4)
-#define _Interior (1 << 5)
-#define _Wading (1 << 6)
-#define _VertexAlphaDepth (1 << 7)
-#define _Cubemap (1 << 8)
-#define _Flowmap (1 << 9)
-#define _BlendNormals (1 << 10)
+namespace EffectFlags
+{
+	static const uint GrayscaleToColor = (1 << 19);
+	static const uint GrayscaleToAlpha = (1 << 20);
+	static const uint IgnoreTexAlpha = (1 << 21);
+}
 
-#define _GrayscaleToColor (1 << 19)
-#define _GrayscaleToAlpha (1 << 20)
-#define _IgnoreTexAlpha (1 << 21)
-
-#define _InWorld (1 << 0)
-#define _IsBeastRace (1 << 1)
+namespace ExtraFlags
+{
+	static const uint InWorld = (1 << 0);
+	static const uint IsBeastRace = (1 << 1);
+}
 
 cbuffer PerShader : register(b4)
 {

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -532,14 +532,14 @@ float3 GetLightingColor(float3 msPosition, float3 worldPosition, float4 screenPo
 	if ((ExtendedFlags & Effect_Shadows) != 0) {
 		if (InMapMenu)
 			color = DirLightColorShared * angleShadow;
-		else if (!InInterior && (ExtraShaderDescriptor & _InWorld))
+		else if (!InInterior && (ExtraShaderDescriptor & ExtraFlags::InWorld))
 			color = DirLightColorShared * GetEffectShadow(worldPosition, normalize(worldPosition), screenPosition, eyeIndex);
 		else
 			color = DirLightColorShared * 0.5;
 	} else {
 		if (InMapMenu)
 			color = DirLightColorShared * angleShadow;
-		else if (!InInterior && (ExtraShaderDescriptor & _InWorld))
+		else if (!InInterior && (ExtraShaderDescriptor & ExtraFlags::InWorld))
 			color = DirLightColorShared * GetWorldShadow(worldPosition, length(worldPosition), 0.0, eyeIndex) * angleShadow * 0.5;
 		else
 			color = DirLightColorShared * 0.5;
@@ -619,7 +619,7 @@ PS_OUTPUT main(PS_INPUT input)
 	if (LightingInfluence.x > 0.0) {
 		float3 viewPosition = mul(CameraView[eyeIndex], float4(input.WorldPosition.xyz, 1)).xyz;
 		float2 screenUV = FrameBuffer::ViewToUV(viewPosition, true, eyeIndex);
-		bool inWorld = ExtraShaderDescriptor & _InWorld;
+		bool inWorld = ExtraShaderDescriptor & ExtraFlags::InWorld;
 
 		uint clusterIndex = 0;
 		if (inWorld && LightLimitFix::GetClusterIndex(screenUV, viewPosition.z, clusterIndex)) {
@@ -650,12 +650,12 @@ PS_OUTPUT main(PS_INPUT input)
 	float4 baseTexColor = float4(1, 1, 1, 1);
 	float4 baseColor = float4(1, 1, 1, 1);
 #	if !defined(TEXTURE)
-	[branch] if (PixelShaderDescriptor & _GrayscaleToColor || PixelShaderDescriptor & _GrayscaleToAlpha)
+	[branch] if (PixelShaderDescriptor & EffectFlags::GrayscaleToColor || PixelShaderDescriptor & EffectFlags::GrayscaleToAlpha)
 #	endif
 	{
 		baseTexColor = TexBaseSampler.Sample(SampBaseSampler, input.TexCoord0.xy);
 		baseColor *= baseTexColor;
-		if (PixelShaderDescriptor & _IgnoreTexAlpha || PixelShaderDescriptor & _GrayscaleToAlpha) {
+		if (PixelShaderDescriptor & EffectFlags::IgnoreTexAlpha || PixelShaderDescriptor & EffectFlags::GrayscaleToAlpha) {
 			baseColor.w = 1;
 		}
 	}
@@ -709,10 +709,10 @@ PS_OUTPUT main(PS_INPUT input)
 	baseColorScale = MembraneVars.z;
 #	endif
 
-	if (PixelShaderDescriptor & _GrayscaleToAlpha)
+	if (PixelShaderDescriptor & EffectFlags::GrayscaleToAlpha)
 		alpha = TexGrayscaleSampler.Sample(SampGrayscaleSampler, float2(baseTexColor.w, alpha)).w;
 
-	[branch] if (PixelShaderDescriptor & _GrayscaleToColor)
+	[branch] if (PixelShaderDescriptor & EffectFlags::GrayscaleToColor)
 	{
 		float2 grayscaleToColorUv = float2(baseTexColor.y, baseColorMul.x);
 #	if defined(MEMBRANE)

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -536,12 +536,12 @@ float3 GetWaterNormal(PS_INPUT input, float distanceFactor, float normalsDepthFa
 float3 GetWaterSpecularColor(PS_INPUT input, float3 normal, float3 viewDirection,
 	float distanceFactor, float refractionsDepthFactor, uint a_eyeIndex = 0)
 {
-	if (PixelShaderDescriptor & _Reflections) {
+	if (PixelShaderDescriptor & WaterFlags::Reflections) {
 		float3 finalSsrReflectionColor = 0.0.xxx;
 		float ssrFraction = 0;
 		float3 reflectionColor = 0;
 
-		if (PixelShaderDescriptor & _Cubemap) {
+		if (PixelShaderDescriptor & WaterFlags::Cubemap) {
 			float3 R = reflect(viewDirection, normal);
 #			if defined(DYNAMIC_CUBEMAPS)
 #				if defined(SKYLIGHTING)
@@ -597,7 +597,7 @@ float3 GetWaterSpecularColor(PS_INPUT input, float3 normal, float3 viewDirection
 		}
 
 #			if !defined(LOD) && NUM_SPECULAR_LIGHTS == 0
-		if (PixelShaderDescriptor & _Cubemap) {
+		if (PixelShaderDescriptor & WaterFlags::Cubemap) {
 			float2 ssrReflectionUv = (DynamicResolutionParams2.xy * input.HPosition.xy) * SSRParams.zw + SSRParams2.x * normal.xy;
 			float2 ssrReflectionUvDR = FrameBuffer::GetDynamicResolutionAdjustedScreenPosition(ssrReflectionUv);
 			float4 ssrReflectionColorBlurred = SSRReflectionTex.Sample(SSRReflectionSampler, ssrReflectionUvDR);
@@ -650,7 +650,7 @@ float3 GetLdotN(float3 normal)
 #			if defined(UNDERWATER)
 	return 1;
 #			else
-	if (PixelShaderDescriptor & _Interior)
+	if (PixelShaderDescriptor & WaterFlags::Interior)
 		return 1;
 	return saturate(dot(SunDir.xyz, normal));
 #			endif
@@ -715,7 +715,7 @@ float3 GetWaterDiffuseColor(PS_INPUT input, float3 normal, float3 viewDirection,
 	float3 refractionColor = RefractionTex.Sample(RefractionSampler, refractionUV).xyz;
 	float3 refractionDiffuseColor = lerp(ShallowColor.xyz, DeepColor.xyz, distanceMul.y);
 
-	if (!(PixelShaderDescriptor & _Interior)) {
+	if (!(PixelShaderDescriptor & WaterFlags::Interior)) {
 #				if defined(SKYLIGHTING)
 		float3 skylightingPosition = lerp(input.WPosition.xyz, refractionWorldPosition.xyz, noise);
 
@@ -752,7 +752,7 @@ float3 GetSunColor(float3 normal, float3 viewDirection)
 #			if defined(UNDERWATER)
 	return 0.0.xxx;
 #			else
-	if (PixelShaderDescriptor & _Interior)
+	if (PixelShaderDescriptor & WaterFlags::Interior)
 		return 0.0.xxx;
 
 	float3 reflectionDirection = reflect(viewDirection, normal);
@@ -896,7 +896,7 @@ PS_OUTPUT main(PS_INPUT input)
 #				else
 	float3 sunColor = GetSunColor(normal, viewDirection);
 
-	if (!(PixelShaderDescriptor & _Interior)) {
+	if (!(PixelShaderDescriptor & WaterFlags::Interior)) {
 		sunColor *= GetWaterShadow(screenNoise, input.WPosition.xyz, eyeIndex);
 	}
 


### PR DESCRIPTION
Shader flags in HLSL now use fake enums which match the CPP code.