### PR TITLE
fix: light clustering issues

### DIFF
--- a/features/Light Limit Fix/Shaders/LightLimitFix/ClusterCullingCS.hlsl
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/ClusterCullingCS.hlsl
@@ -34,10 +34,6 @@ bool LightIntersectsCluster(float3 position, float radius, ClusterAABB cluster)
 	if (any(dispatchThreadId >= uint3(CLUSTER_BUILDING_DISPATCH_SIZE_X, CLUSTER_BUILDING_DISPATCH_SIZE_Y, CLUSTER_BUILDING_DISPATCH_SIZE_Z)))
 		return;
 
-	if (all(dispatchThreadId == 0)) {
-		lightIndexCounter[0] = 0;
-	}
-
 	uint visibleLightCount = 0;
 	uint visibleLightIndices[MAX_CLUSTER_LIGHTS];
 

--- a/features/Light Limit Fix/Shaders/LightLimitFix/ClusterCullingCS.hlsl
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/ClusterCullingCS.hlsl
@@ -22,7 +22,7 @@ bool LightIntersectsCluster(float3 position, float radius, ClusterAABB cluster)
 	float3 closest = max(cluster.minPoint.xyz, min(position, cluster.maxPoint.xyz));
 
 	float3 dist = closest - position;
-    return dot(dist, dist) <= radius;
+	return dot(dist, dist) <= radius;
 }
 
 [numthreads(NUMTHREAD_X, NUMTHREAD_Y, NUMTHREAD_Z)] void main(
@@ -60,11 +60,13 @@ bool LightIntersectsCluster(float3 position, float radius, ClusterAABB cluster)
 
 		float radius = light.radius * light.radius;
 
-#	if defined(VR)
-		[branch] if (LightIntersectsCluster(light.positionVS[0], radius, cluster) || LightIntersectsCluster(light.positionVS[1], radius, cluster)) {
-#	else
-		[branch] if (LightIntersectsCluster(light.positionVS[0], radius, cluster)) {
-#	endif
+#if defined(VR)
+		[branch] if (LightIntersectsCluster(light.positionVS[0], radius, cluster) || LightIntersectsCluster(light.positionVS[1], radius, cluster))
+		{
+#else
+		[branch] if (LightIntersectsCluster(light.positionVS[0], radius, cluster))
+		{
+#endif
 			visibleLightIndices[visibleLightCount] = i;
 			visibleLightCount++;
 			if (visibleLightCount >= MAX_CLUSTER_LIGHTS)

--- a/features/Light Limit Fix/Shaders/LightLimitFix/ClusterCullingCS.hlsl
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/ClusterCullingCS.hlsl
@@ -17,12 +17,12 @@ RWStructuredBuffer<LightGrid> lightGrid : register(u2);
 
 groupshared StructuredLight sharedLights[GROUP_SIZE];
 
-bool LightIntersectsCluster(StructuredLight light, ClusterAABB cluster, int eyeIndex = 0)
+bool LightIntersectsCluster(float3 position, float radius, ClusterAABB cluster)
 {
-	float3 closest = max(cluster.minPoint.xyz, min(light.positionVS[eyeIndex].xyz, cluster.maxPoint.xyz));
+	float3 closest = max(cluster.minPoint.xyz, min(position, cluster.maxPoint.xyz));
 
-	float3 dist = closest - light.positionVS[eyeIndex].xyz;
-	return dot(dist, dist) <= (light.radius * light.radius);
+	float3 dist = closest - position;
+    return dot(dist, dist) <= radius;
 }
 
 [numthreads(NUMTHREAD_X, NUMTHREAD_Y, NUMTHREAD_Z)] void main(
@@ -58,15 +58,17 @@ bool LightIntersectsCluster(StructuredLight light, ClusterAABB cluster, int eyeI
 	for (uint i = 0; i < LightCount; i++) {
 		StructuredLight light = lights[i];
 
-		bool updateCluster = LightIntersectsCluster(light, cluster);
-#ifdef VR
-		updateCluster = updateCluster || LightIntersectsCluster(light, cluster, 1);
-#endif  // VR
-		updateCluster = updateCluster && (visibleLightCount < MAX_CLUSTER_LIGHTS);
+		float radius = light.radius * light.radius;
 
-		if (updateCluster) {
+#	if defined(VR)
+		[branch] if (LightIntersectsCluster(light.positionVS[0], radius, cluster) || LightIntersectsCluster(light.positionVS[1], radius, cluster)) {
+#	else
+		[branch] if (LightIntersectsCluster(light.positionVS[0], radius, cluster)) {
+#	endif
 			visibleLightIndices[visibleLightCount] = i;
 			visibleLightCount++;
+			if (visibleLightCount >= MAX_CLUSTER_LIGHTS)
+				break;
 		}
 	}
 

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -121,8 +121,8 @@ public:
 
 	eastl::unique_ptr<Buffer> lights = nullptr;
 	eastl::unique_ptr<Buffer> clusters = nullptr;
-	eastl::unique_ptr<Buffer> lightCounter = nullptr;
-	eastl::unique_ptr<Buffer> lightList = nullptr;
+	eastl::unique_ptr<Buffer> lightIndexCounter = nullptr;
+	eastl::unique_ptr<Buffer> lightIndexList = nullptr;
 	eastl::unique_ptr<Buffer> lightGrid = nullptr;
 
 	std::uint32_t lightCount = 0;


### PR DESCRIPTION
Fixes flickering in VR
Fixes a race condition with lightIndexCounter. All GPUs should now work with the Light Limit Fix feature without issues. Thanks to https://github.com/TheRealMJP