### PR TITLE
fix(UI): change missing feature ini color

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -86,15 +86,6 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	EffectToggleKey,
 	Theme)
 
-namespace ImGui
-{
-	ImVec2 GetNativeViewportSizeScaled(float scale)
-	{
-		const auto Size = GetMainViewport()->Size;
-		return { Size.x * scale, Size.y * scale };
-	}
-}
-
 void Menu::SetupImGuiStyle() const
 {
 	auto& style = ImGui::GetStyle();
@@ -242,8 +233,8 @@ void Menu::DrawSettings()
 {
 	ImGui::DockSpaceOverViewport(NULL, ImGuiDockNodeFlags_PassthruCentralNode);
 
-	ImGui::SetNextWindowPos(ImGui::GetNativeViewportSizeScaled(0.5f), ImGuiCond_FirstUseEver, ImVec2(0.5f, 0.5f));
-	ImGui::SetNextWindowSize(ImGui::GetNativeViewportSizeScaled(0.8f), ImGuiCond_FirstUseEver);
+	ImGui::SetNextWindowPos(Util::GetNativeViewportSizeScaled(0.5f), ImGuiCond_FirstUseEver, ImVec2(0.5f, 0.5f));
+	ImGui::SetNextWindowSize(Util::GetNativeViewportSizeScaled(0.8f), ImGuiCond_FirstUseEver);
 
 	auto title = std::format("Community Shaders {}", Util::GetFormattedVersion(Plugin::VERSION));
 
@@ -363,7 +354,7 @@ void Menu::DrawSettings()
 					} else if (isLoaded) {
 						textColor = ImGui::GetStyleColorVec4(ImGuiCol_Text);
 					} else if (hasFailedMessage) {
-						textColor = themeSettings.StatusPalette.Error;
+						textColor = feat->version.empty() ? themeSettings.StatusPalette.Disable : themeSettings.StatusPalette.Error;
 					} else {
 						textColor = themeSettings.StatusPalette.RestartNeeded;
 					}
@@ -1038,10 +1029,10 @@ void Menu::DrawOverlay()
 		ImGui::ProgressBar(percent, ImVec2(0.0f, 0.0f), progressOverlay.c_str());
 		if (!shaderCache.backgroundCompilation && shaderCache.menuLoaded) {
 			auto skipShadersText = fmt::format(
-				"Press {} to proceed without completing shader compilation. "
-				"WARNING: Uncompiled shaders will have visual errors or cause stuttering when loading.",
+				"Press {} to proceed without completing shader compilation. ",
 				KeyIdToString(settings.SkipCompilationKey));
 			ImGui::TextUnformatted(skipShadersText.c_str());
+			ImGui::TextUnformatted("WARNING: Uncompiled shaders will have visual errors or cause stuttering when loading.");
 		}
 
 		ImGui::End();

--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -38,4 +38,10 @@ namespace Util
 		(*data) = percentageData * 1e-2f;
 		return retval;
 	}
+
+	ImVec2 GetNativeViewportSizeScaled(float scale)
+	{
+		const auto Size = ImGui::GetMainViewport()->Size;
+		return { Size.x * scale, Size.y * scale };
+	}
 }  // namespace Util

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -38,4 +38,5 @@ namespace Util
 	};
 
 	bool PercentageSlider(const char* label, float* data, float lb = 0.f, float ub = 100.f, const char* format = "%.1f %%");
+	ImVec2 GetNativeViewportSizeScaled(float scale);
 }  // namespace Util


### PR DESCRIPTION
- Make features that are not loaded (aka not added for some reason) grey instead of red
  - Only make it red when there is an actual error
- Fixed compile window being too wide when showing extra message

before:
![image](https://github.com/user-attachments/assets/56ebdf3d-7306-4b46-88a2-7040c9cc1603)

after:
![image](https://github.com/user-attachments/assets/f2adb211-c48a-41c2-91d2-90b86c33f96b)


compile window now: (split up the last warning into it's own line)
![image](https://github.com/user-attachments/assets/78ff93a6-92fa-431a-961e-1edc2f161a22)

