### PR TITLE
feat: add incompatibility check for PrivateProfileRedirector < 0.6.2

### DIFF
--- a/src/Util.h
+++ b/src/Util.h
@@ -6,3 +6,4 @@
 #include "Utils/GameSetting.h"
 #include "Utils/Serialize.h"
 #include "Utils/UI.h"
+#include "Utils/WinApi.h"

--- a/src/Utils/Format.cpp
+++ b/src/Utils/Format.cpp
@@ -25,6 +25,7 @@ namespace Util
 		}
 		return result;
 	}
+
 	std::string DefinesToString(const std::vector<D3D_SHADER_MACRO>& defines)
 	{
 		std::string result;

--- a/src/Utils/WinApi.cpp
+++ b/src/Utils/WinApi.cpp
@@ -1,0 +1,30 @@
+#include "WinApi.h"
+
+namespace Util
+{
+	std::optional<REL::Version> GetDllVersion(const std::wstring& dllPath)
+	{
+		DWORD handle = 0;
+		DWORD size = GetFileVersionInfoSize(dllPath.c_str(), &handle);
+		if (size == 0) {
+			return std::nullopt;
+		}
+
+		std::vector<BYTE> buffer(size);
+		if (!GetFileVersionInfo(dllPath.c_str(), handle, size, buffer.data())) {
+			return std::nullopt;
+		}
+
+		VS_FIXEDFILEINFO* fileInfo = nullptr;
+		UINT fileInfoSize = 0;
+		if (!VerQueryValue(buffer.data(), L"\\", reinterpret_cast<void**>(&fileInfo), &fileInfoSize)) {
+			return std::nullopt;
+		}
+
+		if (fileInfoSize == sizeof(VS_FIXEDFILEINFO)) {
+			return REL::Version(HIWORD(fileInfo->dwFileVersionMS), LOWORD(fileInfo->dwFileVersionMS), HIWORD(fileInfo->dwFileVersionLS), LOWORD(fileInfo->dwFileVersionLS));
+		}
+
+		return std::nullopt;
+	}
+}  // namespace Util

--- a/src/Utils/WinApi.h
+++ b/src/Utils/WinApi.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace Util
+{
+	std::optional<REL::Version> GetDllVersion(const std::wstring& dllPath);
+}  // namespace Util

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -154,6 +154,11 @@ bool Load()
 		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.158.0", true);
 	}
 
+	auto privateProfileRedirectorVersion = Util::GetDllVersion(L"Data/SKSE/Plugins/PrivateProfileRedirector.dll");
+	if (privateProfileRedirectorVersion.has_value() && privateProfileRedirectorVersion.value().compare(REL::Version(0, 6, 2)) == std::strong_ordering::less) {
+		stl::report_and_fail("Old version of PrivateProfileRedirector detected, 0.6.2+ required if using it."sv);
+	}
+
 	auto messaging = SKSE::GetMessagingInterface();
 	messaging->RegisterListener("SKSE", MessageHandler);
 


### PR DESCRIPTION
- Will start like normal if no PrivateProfileRedirector is detected or if it's at least 0.6.2.
- Will give this message if an old version was detected
![image](https://github.com/user-attachments/assets/10298b59-c803-4705-b811-4c43263728b3)

fix #624