### PR TITLE
feat: better rain fx

### DIFF
--- a/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
+++ b/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
@@ -67,8 +67,8 @@ namespace WetnessEffects
 		float3 rippleNormal = float3(0, 0, 1);
 		float wetness = 0;
 
-		if (wetnessEffectsSettings.EnableSplashes || wetnessEffectsSettings.EnableRipples){
-			for (int i = -1; i <= 1; i++){
+		if (wetnessEffectsSettings.EnableSplashes || wetnessEffectsSettings.EnableRipples) {
+			for (int i = -1; i <= 1; i++) {
 				for (int j = -1; j <= 1; j++) {
 					int2 gridCurr = grid + int2(i, j);
 					float tOffset = float(Random::iqint3(gridCurr)) * uintToFloat;

--- a/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
+++ b/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
@@ -2,6 +2,8 @@
 
 namespace WetnessEffects
 {
+	Texture2D<float4> TexPrecipOcclusion : register(t31);
+
 	// https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
 	float2 EnvBRDFApproxWater(float3 F0, float Roughness, float NoV)
 	{

--- a/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
+++ b/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
@@ -60,15 +60,15 @@ namespace WetnessEffects
 		const float rippleBreadthRcp = rcp(wetnessEffectsSettings.RippleBreadth);
 
 		float2 gridUV = worldPos.xy * wetnessEffectsSettings.RaindropGridSizeRcp;
-		gridUV += normal.xy * 0.5;
+		gridUV += normal.xy;
 		int2 grid = floor(gridUV);
 		gridUV -= grid;
 
 		float3 rippleNormal = float3(0, 0, 1);
 		float wetness = 0;
 
-		if (wetnessEffectsSettings.EnableSplashes || wetnessEffectsSettings.EnableRipples)
-			for (int i = -1; i <= 1; i++)
+		if (wetnessEffectsSettings.EnableSplashes || wetnessEffectsSettings.EnableRipples){
+			for (int i = -1; i <= 1; i++){
 				for (int j = -1; j <= 1; j++) {
 					int2 gridCurr = grid + int2(i, j);
 					float tOffset = float(Random::iqint3(gridCurr)) * uintToFloat;
@@ -124,12 +124,7 @@ namespace WetnessEffects
 						}
 					}
 				}
-
-		if (wetnessEffectsSettings.EnableChaoticRipples) {
-			float3 turbulenceNormal = Random::perlinNoise(float3(worldPos.xy * wetnessEffectsSettings.ChaoticRippleScaleRcp, t * wetnessEffectsSettings.ChaoticRippleSpeed));
-			turbulenceNormal.z = turbulenceNormal.z * .5 + 5;
-			turbulenceNormal = normalize(turbulenceNormal);
-			rippleNormal = normalize(rippleNormal + float3(turbulenceNormal.xy * wetnessEffectsSettings.ChaoticRippleStrength, 0));
+			}
 		}
 
 		wetness *= wetnessEffectsSettings.SplashesStrength;

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -70,6 +70,8 @@ struct LightLimitFixSettings
 
 struct WetnessEffectsSettings
 {
+	row_major float4x4 OcclusionViewProj;
+
 	float Time;
 	float Raining;
 	float Wetness;
@@ -93,25 +95,25 @@ struct WetnessEffectsSettings
 	bool EnableSplashes;
 	bool EnableRipples;
 	bool EnableChaoticRipples;
-	float RaindropFxRange;
-
 	float RaindropGridSizeRcp;
+
 	float RaindropIntervalRcp;
 	float RaindropChance;
 	float SplashesLifetime;
-
 	float SplashesStrength;
+
 	float SplashesMinRadius;
 	float SplashesMaxRadius;
 	float RippleStrength;
-
 	float RippleRadius;
+
 	float RippleBreadth;
 	float RippleLifetimeRcp;
 	float ChaoticRippleStrength;
-
 	float ChaoticRippleScaleRcp;
+
 	float ChaoticRippleSpeed;
+	float pad0[3];
 };
 
 struct SkylightingSettings

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -108,7 +108,6 @@ struct WetnessEffectsSettings
 	float RippleBreadth;
 
 	float RippleLifetimeRcp;
-	float pad0[3];
 };
 
 struct SkylightingSettings

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -94,25 +94,20 @@ struct WetnessEffectsSettings
 
 	bool EnableSplashes;
 	bool EnableRipples;
-	bool EnableChaoticRipples;
 	float RaindropGridSizeRcp;
-
 	float RaindropIntervalRcp;
+
 	float RaindropChance;
 	float SplashesLifetime;
 	float SplashesStrength;
-
 	float SplashesMinRadius;
+
 	float SplashesMaxRadius;
 	float RippleStrength;
 	float RippleRadius;
-
 	float RippleBreadth;
-	float RippleLifetimeRcp;
-	float ChaoticRippleStrength;
-	float ChaoticRippleScaleRcp;
 
-	float ChaoticRippleSpeed;
+	float RippleLifetimeRcp;
 	float pad0[3];
 };
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1783,16 +1783,23 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #		endif
 
 	float4 raindropInfo = float4(0, 0, 1, 0);
-	if (worldSpaceNormal.z > 0 && wetnessEffectsSettings.Raining > 0.0f && wetnessEffectsSettings.EnableRaindropFx &&
-		(dot(input.WorldPosition, input.WorldPosition) < wetnessEffectsSettings.RaindropFxRange * wetnessEffectsSettings.RaindropFxRange)) {
-		if (wetnessOcclusion > 0.0)
+	if (worldSpaceNormal.z > 0 && wetnessEffectsSettings.Raining > 0.0f && wetnessEffectsSettings.EnableRaindropFx) {
+		float4 precipOcclusionTexCoord = mul(wetnessEffectsSettings.OcclusionViewProj, float4(input.WorldPosition.xyz, 1));
+		precipOcclusionTexCoord.y = -precipOcclusionTexCoord.y;
+		float2 precipOcclusionUV = precipOcclusionTexCoord.xy * 0.5 + 0.5;
+		
+		if (saturate(precipOcclusionUV.x) == precipOcclusionUV.x && saturate(precipOcclusionUV.y) == precipOcclusionUV.y){
+			float precipOcclusionZ = WetnessEffects::TexPrecipOcclusion.SampleLevel(SampColorSampler, precipOcclusionUV, 0).x;
+
+			if (precipOcclusionTexCoord.z < precipOcclusionZ + 0.1)
 #		if defined(SKINNED)
-			raindropInfo = WetnessEffects::GetRainDrops(input.ModelPosition.xyz, wetnessEffectsSettings.Time, worldSpaceNormal);
+				raindropInfo = WetnessEffects::GetRainDrops(input.ModelPosition.xyz, wetnessEffectsSettings.Time, worldSpaceNormal);
 #		elif defined(DEFERRED)
-			raindropInfo = WetnessEffects::GetRainDrops(input.WorldPosition.xyz + CameraPosAdjust[eyeIndex].xyz, wetnessEffectsSettings.Time, worldSpaceNormal);
+				raindropInfo = WetnessEffects::GetRainDrops(input.WorldPosition.xyz + CameraPosAdjust[eyeIndex].xyz, wetnessEffectsSettings.Time, worldSpaceNormal);
 #		else
-			raindropInfo = WetnessEffects::GetRainDrops(!FrameParams.y ? input.ModelPosition.xyz : input.WorldPosition.xyz + CameraPosAdjust[eyeIndex].xyz, wetnessEffectsSettings.Time, worldSpaceNormal);
+				raindropInfo = WetnessEffects::GetRainDrops(!FrameParams.y ? input.ModelPosition.xyz : input.WorldPosition.xyz + CameraPosAdjust[eyeIndex].xyz, wetnessEffectsSettings.Time, worldSpaceNormal);
 #		endif
+		}
 	}
 
 	float rainWetness = wetnessEffectsSettings.Wetness * minWetnessAngle * wetnessEffectsSettings.MaxRainWetness;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1787,8 +1787,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		float4 precipOcclusionTexCoord = mul(wetnessEffectsSettings.OcclusionViewProj, float4(input.WorldPosition.xyz, 1));
 		precipOcclusionTexCoord.y = -precipOcclusionTexCoord.y;
 		float2 precipOcclusionUV = precipOcclusionTexCoord.xy * 0.5 + 0.5;
-		
-		if (saturate(precipOcclusionUV.x) == precipOcclusionUV.x && saturate(precipOcclusionUV.y) == precipOcclusionUV.y){
+
+		if (saturate(precipOcclusionUV.x) == precipOcclusionUV.x && saturate(precipOcclusionUV.y) == precipOcclusionUV.y) {
 			float precipOcclusionZ = WetnessEffects::TexPrecipOcclusion.SampleLevel(SampColorSampler, precipOcclusionUV, 0).x;
 
 			if (precipOcclusionTexCoord.z < precipOcclusionZ + 0.1)

--- a/package/Shaders/Particle.hlsl
+++ b/package/Shaders/Particle.hlsl
@@ -248,11 +248,11 @@ PS_OUTPUT main(PS_INPUT input)
 #	endif  // !VR
 
 #	if defined(ENVCUBE)
-	float2 precipitationOcclusionUv = (input.PrecipitationOcclusionTexCoord.xy * 0.5 + 0.5) * TextureSize.x;
+	float2 precipitationOcclusionUV = (input.PrecipitationOcclusionTexCoord.xy * 0.5 + 0.5) * TextureSize.x;
 #		ifdef VR
-	precipitationOcclusionUv *= DynamicResolutionParams1.x;  // only difference in VR
+	precipitationOcclusionUV *= DynamicResolutionParams1.x;  // only difference in VR
 #		endif
-	float precipitationOcclusion = -input.PrecipitationOcclusionTexCoord.z + TexPrecipitationOcclusionTexture.SampleLevel(SampSourceTexture, precipitationOcclusionUv, 0).x;
+	float precipitationOcclusion = -input.PrecipitationOcclusionTexCoord.z + TexPrecipitationOcclusionTexture.Load(float3(precipitationOcclusionUV, 0)).x;
 	float2 underwaterMaskUv = TextureSize.yz * input.Position.xy;
 	float underwaterMask = TexUnderwaterMask.Sample(SampUnderwaterMask, underwaterMaskUv).x;
 	if (precipitationOcclusion - underwaterMask < 0) {

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -41,7 +41,6 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	EnableRaindropFx,
 	EnableSplashes,
 	EnableRipples,
-	EnableChaoticRipples,
 	RaindropGridSize,
 	RaindropInterval,
 	RaindropChance,
@@ -52,10 +51,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	RippleStrength,
 	RippleRadius,
 	RippleBreadth,
-	RippleLifetime,
-	ChaoticRippleStrength,
-	ChaoticRippleScale,
-	ChaoticRippleSpeed)
+	RippleLifetime
+)
 
 void WetnessEffects::DrawSettings()
 {
@@ -85,15 +82,11 @@ void WetnessEffects::DrawSettings()
 		ImGui::Checkbox("Enable Ripples", (bool*)&settings.EnableRipples);
 		if (auto _tt = Util::HoverTooltipWrapper())
 			ImGui::Text("Enables circular ripples on puddles, and to a less extent other wet surfaces");
-		ImGui::Checkbox("Enable Chaotic Ripples", (bool*)&settings.EnableChaoticRipples);
-		if (auto _tt = Util::HoverTooltipWrapper())
-			ImGui::Text("Enables an additional layer of disturbance to wet surfaces.");
 
 		if (ImGui::TreeNodeEx("Raindrops")) {
 			ImGui::BulletText(
 				"At every interval, a raindrop is placed within each grid cell.\n"
-				"Only a set portion of raindrops will actually trigger splashes and ripples.\n"
-				"Chaotic ripples are not affected by raindrop settings.");
+				"Only a set portion of raindrops will actually trigger splashes and ripples.\n");
 
 			ImGui::SliderFloat("Grid Size", &settings.RaindropGridSize, 1.f, 10.f, "%.1f game unit(s)");
 			ImGui::SliderFloat("Interval", &settings.RaindropInterval, 0.1f, 2.f, "%.1f sec");
@@ -122,13 +115,6 @@ void WetnessEffects::DrawSettings()
 				ImGui::Text("As portion of grid size.");
 			ImGui::SliderFloat("Breadth", &settings.RippleBreadth, 0.f, 1.f, "%.2f");
 			ImGui::SliderFloat("Lifetime", &settings.RippleLifetime, 0.f, settings.RaindropInterval, "%.2f sec", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::TreePop();
-		}
-
-		if (ImGui::TreeNodeEx("Chaotic Ripples")) {
-			ImGui::SliderFloat("Strength", &settings.ChaoticRippleStrength, 0.f, .5f, "%.2f");
-			ImGui::SliderFloat("Scale", &settings.ChaoticRippleScale, 0.1f, 5.f, "%.2f", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::SliderFloat("Speed", &settings.ChaoticRippleSpeed, 0.f, 50.f, "%.1f");
 			ImGui::TreePop();
 		}
 
@@ -362,8 +348,6 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 	data.settings.RaindropGridSize = 1.f / settings.RaindropGridSize;
 	data.settings.RaindropInterval = 1.f / settings.RaindropInterval;
 	data.settings.RippleLifetime = settings.RaindropInterval / settings.RippleLifetime;
-	data.settings.ChaoticRippleStrength *= std::clamp(data.Raining, 0.f, 1.f);
-	data.settings.ChaoticRippleScale = 1.f / settings.ChaoticRippleScale;
 
 	return data;
 }

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -230,7 +230,7 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 
 				if (sky->lastWeather && sky->lastWeather->precipitationData && sky->lastWeather->data.flags.any(RE::TESWeather::WeatherDataFlag::kRainy)) {
 					wetnessLastWeather = 1.0f - linearstep((float)sky->lastWeather->data.precipitationEndFadeOut, 255, sky->currentWeatherPct * 255);
-					puddleLastWeather = 1.0f - sky->currentWeatherPct;
+					puddleLastWeather = sqrt(1.0f - sky->currentWeatherPct);
 				}
 
 				data.Wetness = wetnessCurrentWeather + wetnessLastWeather;

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -228,12 +228,14 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 				float puddleLastWeather = 0.0f;
 
 				if (sky->lastWeather && sky->lastWeather->precipitationData && sky->lastWeather->data.flags.any(RE::TESWeather::WeatherDataFlag::kRainy)) {
-					wetnessLastWeather = 1.0f - linearstep((float)sky->lastWeather->data.precipitationEndFadeOut, 255, sky->currentWeatherPct * 255);
+					wetnessLastWeather = 1.0f - linearstep((float)sky->lastWeather->data.precipitationEndFadeOut, 255, sky->currentWeatherPct * 255));
 					puddleLastWeather = pow(1.0f - sky->currentWeatherPct, 0.25f);
 				}
 
-				data.Wetness = wetnessCurrentWeather + wetnessLastWeather;
-				data.PuddleWetness = std::max(data.Wetness, puddleLastWeather) * settings.MaxPuddleWetness * 0.5f;
+				float wetness = std::min(1.0f, wetnessCurrentWeather + wetnessLastWeather);
+
+				data.Wetness = wetness * settings.MaxRainWetness;
+				data.PuddleWetness = std::max(wetness, puddleLastWeather) * settings.MaxPuddleWetness;
 			}
 		}
 	}

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -51,8 +51,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	RippleStrength,
 	RippleRadius,
 	RippleBreadth,
-	RippleLifetime
-)
+	RippleLifetime)
 
 void WetnessEffects::DrawSettings()
 {

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -229,7 +229,7 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 
 				if (sky->lastWeather && sky->lastWeather->precipitationData && sky->lastWeather->data.flags.any(RE::TESWeather::WeatherDataFlag::kRainy)) {
 					wetnessLastWeather = 1.0f - linearstep((float)sky->lastWeather->data.precipitationEndFadeOut, 255, sky->currentWeatherPct * 255);
-					puddleLastWeather = sqrt(1.0f - sky->currentWeatherPct);
+					puddleLastWeather = pow(1.0f - sky->currentWeatherPct, 0.25f);
 				}
 
 				data.Wetness = wetnessCurrentWeather + wetnessLastWeather;

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -153,19 +153,6 @@ void WetnessEffects::DrawSettings()
 	ImGui::Spacing();
 }
 
-class BGSShaderParticleGeometryDataVR : public RE::TESForm
-{
-public:
-	struct SETTING_VALUE
-	{
-		RE::SETTING_VALUE value;
-		float pad0;
-	};
-
-	RE::BSTArray<SETTING_VALUE> data;
-	RE::TESTexture particleTexture;
-};
-
 WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 {
 	PerFrame data{};
@@ -205,16 +192,9 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 
 						auto rain = (RE::BSParticleShaderRainEmitter*)(particleShaderProperty->particleEmitter);
 						if (rain->emitterType.any(RE::BSParticleShaderEmitter::EMITTER_TYPE::kRain)) {
-							if (REL::Module::IsVR()) {
-								auto precipitionData = (BGSShaderParticleGeometryDataVR*)weather->precipitationData;
-								auto maxDensity = precipitionData->data[(uint)RE::BGSShaderParticleGeometryData::DataID::kParticleDensity].value.f;
-								if (maxDensity > 0.0f)
-									currentRaining = rain->density / maxDensity;
-							} else {
-								auto maxDensity = weather->precipitationData->data[(uint)RE::BGSShaderParticleGeometryData::DataID::kParticleDensity].f;
-								if (maxDensity > 0.0f)
-									currentRaining = rain->density / maxDensity;
-							}
+							auto maxDensity = weather->precipitationData->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kParticleDensity).f;
+							if (maxDensity > 0.0f)
+								currentRaining = rain->density / maxDensity;
 						}
 					}
 
@@ -227,16 +207,9 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 						auto particleShaderProperty = netimmerse_cast<RE::BSParticleShaderProperty*>(shaderProp);
 						auto rain = (RE::BSParticleShaderRainEmitter*)(particleShaderProperty->particleEmitter);
 						if (rain->emitterType.any(RE::BSParticleShaderEmitter::EMITTER_TYPE::kRain)) {
-							if (REL::Module::IsVR()) {
-								auto precipitionData = (BGSShaderParticleGeometryDataVR*)weather->precipitationData;
-								auto maxDensity = precipitionData->data[(uint)RE::BGSShaderParticleGeometryData::DataID::kParticleDensity].value.f;
-								if (maxDensity > 0.0f)
-									lastRaining = rain->density / maxDensity;
-							} else {
-								auto maxDensity = weather->precipitationData->data[(uint)RE::BGSShaderParticleGeometryData::DataID::kParticleDensity].f;
-								if (maxDensity > 0.0f)
-									lastRaining = rain->density / maxDensity;
-							}
+							auto maxDensity = weather->precipitationData->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kParticleDensity).f;
+							if (maxDensity > 0.0f)
+								lastRaining = rain->density / maxDensity;
 						}
 					}
 

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -153,11 +153,6 @@ void WetnessEffects::DrawSettings()
 	ImGui::Spacing();
 }
 
-static float linearstep(float edge0, float edge1, float x)
-{
-	return std::clamp((x - edge0) / (edge1 - edge0), 0.0f, 1.0f);
-}
-
 WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 {
 	PerFrame data{};
@@ -220,6 +215,10 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 					data.Raining = currentRaining + lastRaining;
 				}
 
+				auto linearstep = [](float edge0, float edge1, float x) {
+					return std::clamp((x - edge0) / (edge1 - edge0), 0.0f, 1.0f);
+				};
+
 				float wetnessCurrentWeather = 0.0f;
 				if (sky->currentWeather && sky->currentWeather->precipitationData && sky->currentWeather->data.flags.any(RE::TESWeather::WeatherDataFlag::kRainy)) {
 					wetnessCurrentWeather = linearstep(abs((float)sky->currentWeather->data.precipitationBeginFadeIn), 255, sky->currentWeatherPct * 255);
@@ -266,11 +265,6 @@ void WetnessEffects::Prepass()
 	auto& context = state->context;
 
 	context->PSSetShaderResources(31, 1, &precipOcclusionTexture.depthSRV);
-}
-
-void WetnessEffects::Reset()
-{
-	requiresUpdate = true;
 }
 
 void WetnessEffects::LoadSettings(json& o_json)

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -260,7 +260,7 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 				auto particleShaderProperty = netimmerse_cast<RE::BSParticleShaderProperty*>(shaderProp);
 				auto rain = (RE::BSParticleShaderRainEmitter*)(particleShaderProperty->particleEmitter);
 				data.OcclusionViewProj = rain->occlusionProjection;
-				data.Raining = rain->emitterType.any(RE::BSParticleShaderEmitter::EMITTER_TYPE::kRain) && rain->alpha > 0.0;
+				data.Raining = rain->emitterType.any(RE::BSParticleShaderEmitter::EMITTER_TYPE::kRain) && rain->density > 0.0;
 			}
 			if (precip->currentPrecip && precip->lastPrecip) {
 				precipObject = precip->lastPrecip;
@@ -268,7 +268,7 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 				auto shaderProp = netimmerse_cast<RE::BSShaderProperty*>(effect.get());
 				auto particleShaderProperty = netimmerse_cast<RE::BSParticleShaderProperty*>(shaderProp);
 				auto rain = (RE::BSParticleShaderRainEmitter*)(particleShaderProperty->particleEmitter);
-				data.Raining = data.Raining || (rain->emitterType.any(RE::BSParticleShaderEmitter::EMITTER_TYPE::kRain) && rain->alpha > 0.0);
+				data.Raining = data.Raining || (rain->emitterType.any(RE::BSParticleShaderEmitter::EMITTER_TYPE::kRain) && rain->density > 0.0);
 			}
 		}
 	}

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -228,7 +228,7 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 				float puddleLastWeather = 0.0f;
 
 				if (sky->lastWeather && sky->lastWeather->precipitationData && sky->lastWeather->data.flags.any(RE::TESWeather::WeatherDataFlag::kRainy)) {
-					wetnessLastWeather = 1.0f - linearstep((float)sky->lastWeather->data.precipitationEndFadeOut, 255, sky->currentWeatherPct * 255));
+					wetnessLastWeather = 1.0f - linearstep((float)sky->lastWeather->data.precipitationEndFadeOut, 255, sky->currentWeatherPct * 255);
 					puddleLastWeather = pow(1.0f - sky->currentWeatherPct, 0.25f);
 				}
 

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -234,8 +234,8 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 
 				float wetness = std::min(1.0f, wetnessCurrentWeather + wetnessLastWeather);
 
-				data.Wetness = wetness * settings.MaxRainWetness;
-				data.PuddleWetness = std::max(wetness, puddleLastWeather) * settings.MaxPuddleWetness;
+				data.Wetness = wetness;
+				data.PuddleWetness = std::max(wetness, puddleLastWeather);
 			}
 		}
 	}
@@ -251,8 +251,8 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 
 	// Calculating some parameters on cpu
 	data.settings.RaindropChance *= data.Raining;
-	data.settings.RaindropGridSize = 1.f / settings.RaindropGridSize;
-	data.settings.RaindropInterval = 1.f / settings.RaindropInterval;
+	data.settings.RaindropGridSize = 1.0f / settings.RaindropGridSize;
+	data.settings.RaindropInterval = 1.0f / settings.RaindropInterval;
 	data.settings.RippleLifetime = settings.RaindropInterval / settings.RippleLifetime;
 
 	return data;

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -282,7 +282,7 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 	data.settings.MaxShoreWetness = settings.EnableWetnessEffects ? settings.MaxShoreWetness : 0.0f;
 
 	// Calculating some parameters on cpu
-	data.settings.RaindropChance *= data.Raining;
+	data.settings.RaindropChance *= data.Raining * data.Raining;
 	data.settings.RaindropGridSize = 1.0f / settings.RaindropGridSize;
 	data.settings.RaindropInterval = 1.0f / settings.RaindropInterval;
 	data.settings.RippleLifetime = settings.RaindropInterval / settings.RippleLifetime;

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -223,7 +223,7 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 					data.Raining = currentRaining + lastRaining;
 				}
 
-				float wetnessCurrentWeather = 0.0f;	
+				float wetnessCurrentWeather = 0.0f;
 				if (sky->currentWeather && sky->currentWeather->precipitationData && sky->currentWeather->data.flags.any(RE::TESWeather::WeatherDataFlag::kRainy)) {
 					wetnessCurrentWeather = linearstep(abs((float)sky->currentWeather->data.precipitationBeginFadeIn), 255, sky->currentWeatherPct * 255);
 				}
@@ -242,8 +242,8 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 		}
 	}
 
-	static size_t rainTimer = 0;                                       // size_t for precision
-	if (!RE::UI::GetSingleton()->GameIsPaused())                       
+	static size_t rainTimer = 0;  // size_t for precision
+	if (!RE::UI::GetSingleton()->GameIsPaused())
 		rainTimer += (size_t)(RE::GetSecondsSinceLastFrame() * 1000);  // BSTimer::delta is always 0 for some reason
 	data.Time = rainTimer / 1000.f;
 

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -221,7 +221,7 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 
 				float wetnessCurrentWeather = 0.0f;
 				if (sky->currentWeather && sky->currentWeather->precipitationData && sky->currentWeather->data.flags.any(RE::TESWeather::WeatherDataFlag::kRainy)) {
-					wetnessCurrentWeather = linearstep(abs((float)sky->currentWeather->data.precipitationBeginFadeIn), 255, sky->currentWeatherPct * 255);
+					wetnessCurrentWeather = linearstep(255.0f + (float)sky->currentWeather->data.precipitationBeginFadeIn, 255, sky->currentWeatherPct * 255);
 				}
 
 				float wetnessLastWeather = 0.0f;

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -212,7 +212,7 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 						}
 					}
 
-					data.Raining = currentRaining + lastRaining;
+					data.Raining = std::min(1.0f, currentRaining + lastRaining);
 				}
 
 				auto linearstep = [](float edge0, float edge1, float x) {

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -156,7 +156,6 @@ void WetnessEffects::DrawSettings()
 class BGSShaderParticleGeometryDataVR : public RE::TESForm
 {
 public:
-
 	struct SETTING_VALUE
 	{
 		RE::SETTING_VALUE value;
@@ -217,7 +216,6 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 									currentRaining = rain->density / maxDensity;
 							}
 						}
-	
 					}
 
 					if (precip->lastPrecip && sky->lastWeather && sky->lastWeather->precipitationData) {

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -2,9 +2,6 @@
 
 #include "Util.h"
 
-const float MIN_START_PERCENTAGE = 0.05f;
-const float TRANSITION_DENOMINATOR = 256.0f;
-
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	WetnessEffects::Settings,
 	EnableWetnessEffects,

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -220,8 +220,11 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 				};
 
 				float wetnessCurrentWeather = 0.0f;
+				float puddleCurrentWeather = 0.0f;
+
 				if (sky->currentWeather && sky->currentWeather->precipitationData && sky->currentWeather->data.flags.any(RE::TESWeather::WeatherDataFlag::kRainy)) {
 					wetnessCurrentWeather = linearstep(255.0f + (float)sky->currentWeather->data.precipitationBeginFadeIn, 255, sky->currentWeatherPct * 255);
+					puddleCurrentWeather = pow(wetnessCurrentWeather, 2.0f);
 				}
 
 				float wetnessLastWeather = 0.0f;
@@ -229,13 +232,14 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 
 				if (sky->lastWeather && sky->lastWeather->precipitationData && sky->lastWeather->data.flags.any(RE::TESWeather::WeatherDataFlag::kRainy)) {
 					wetnessLastWeather = 1.0f - linearstep((float)sky->lastWeather->data.precipitationEndFadeOut, 255, sky->currentWeatherPct * 255);
-					puddleLastWeather = pow(1.0f - sky->currentWeatherPct, 0.25f);
+					puddleLastWeather = pow(std::max(wetnessLastWeather, 1.0f - sky->currentWeatherPct), 0.25f);
 				}
 
 				float wetness = std::min(1.0f, wetnessCurrentWeather + wetnessLastWeather);
+				float puddleWetness = std::min(1.0f, puddleCurrentWeather + puddleLastWeather);
 
 				data.Wetness = wetness;
-				data.PuddleWetness = std::max(wetness, puddleLastWeather);
+				data.PuddleWetness = puddleWetness;
 			}
 		}
 	}

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -153,6 +153,20 @@ void WetnessEffects::DrawSettings()
 	ImGui::Spacing();
 }
 
+class BGSShaderParticleGeometryDataVR : public RE::TESForm
+{
+public:
+
+	struct SETTING_VALUE
+	{
+		RE::SETTING_VALUE value;
+		float pad0;
+	};
+
+	RE::BSTArray<SETTING_VALUE> data;
+	RE::TESTexture particleTexture;
+};
+
 WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 {
 	PerFrame data{};
@@ -189,12 +203,21 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 						auto& effect = precipObject->GetGeometryRuntimeData().properties[RE::BSGeometry::States::kEffect];
 						auto shaderProp = netimmerse_cast<RE::BSShaderProperty*>(effect.get());
 						auto particleShaderProperty = netimmerse_cast<RE::BSParticleShaderProperty*>(shaderProp);
+
 						auto rain = (RE::BSParticleShaderRainEmitter*)(particleShaderProperty->particleEmitter);
 						if (rain->emitterType.any(RE::BSParticleShaderEmitter::EMITTER_TYPE::kRain)) {
-							auto maxDensity = weather->precipitationData->data[(uint)RE::BGSShaderParticleGeometryData::DataID::kParticleDensity].f;
-							if (maxDensity > 0.0f)
-								currentRaining = rain->density / maxDensity;
+							if (REL::Module::IsVR()) {
+								auto precipitionData = (BGSShaderParticleGeometryDataVR*)weather->precipitationData;
+								auto maxDensity = precipitionData->data[(uint)RE::BGSShaderParticleGeometryData::DataID::kParticleDensity].value.f;
+								if (maxDensity > 0.0f)
+									currentRaining = rain->density / maxDensity;
+							} else {
+								auto maxDensity = weather->precipitationData->data[(uint)RE::BGSShaderParticleGeometryData::DataID::kParticleDensity].f;
+								if (maxDensity > 0.0f)
+									currentRaining = rain->density / maxDensity;
+							}
 						}
+	
 					}
 
 					if (precip->lastPrecip && sky->lastWeather && sky->lastWeather->precipitationData) {
@@ -206,9 +229,16 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 						auto particleShaderProperty = netimmerse_cast<RE::BSParticleShaderProperty*>(shaderProp);
 						auto rain = (RE::BSParticleShaderRainEmitter*)(particleShaderProperty->particleEmitter);
 						if (rain->emitterType.any(RE::BSParticleShaderEmitter::EMITTER_TYPE::kRain)) {
-							auto maxDensity = weather->precipitationData->data[(uint)RE::BGSShaderParticleGeometryData::DataID::kParticleDensity].f;
-							if (maxDensity > 0.0f)
-								lastRaining = rain->density / maxDensity;
+							if (REL::Module::IsVR()) {
+								auto precipitionData = (BGSShaderParticleGeometryDataVR*)weather->precipitationData;
+								auto maxDensity = precipitionData->data[(uint)RE::BGSShaderParticleGeometryData::DataID::kParticleDensity].value.f;
+								if (maxDensity > 0.0f)
+									lastRaining = rain->density / maxDensity;
+							} else {
+								auto maxDensity = weather->precipitationData->data[(uint)RE::BGSShaderParticleGeometryData::DataID::kParticleDensity].f;
+								if (maxDensity > 0.0f)
+									lastRaining = rain->density / maxDensity;
+							}
 						}
 					}
 

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -182,7 +182,7 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 						}
 					}
 
-					if (precip->currentPrecip && sky->currentWeather->precipitationData) {
+					if (precip->currentPrecip && sky->currentWeather && sky->currentWeather->precipitationData) {
 						auto& precipObject = precip->currentPrecip;
 						auto weather = sky->currentWeather;
 
@@ -197,7 +197,7 @@ WetnessEffects::PerFrame WetnessEffects::GetCommonBufferData()
 						}
 					}
 
-					if (precip->lastPrecip && sky->lastWeather->precipitationData) {
+					if (precip->lastPrecip && sky->lastWeather && sky->lastWeather->precipitationData) {
 						auto& precipObject = precip->lastPrecip;
 						auto weather = sky->lastWeather;
 

--- a/src/Features/WetnessEffects.h
+++ b/src/Features/WetnessEffects.h
@@ -65,17 +65,7 @@ public:
 
 	PerFrame GetCommonBufferData();
 
-	bool requiresUpdate = true;
-	float wetnessDepth = 0.0f;
-	float puddleDepth = 0.0f;
-	float lastGameTimeValue = 0.0f;
-	uint32_t currentWeatherID = 0;
-	uint32_t lastWeatherID = 0;
-	float previousWeatherTransitionPercentage = 0.0f;
-
 	virtual void Prepass() override;
-
-	virtual void Reset() override;
 
 	virtual void DrawSettings() override;
 

--- a/src/Features/WetnessEffects.h
+++ b/src/Features/WetnessEffects.h
@@ -22,8 +22,8 @@ public:
 	struct Settings
 	{
 		uint EnableWetnessEffects = true;
-		float MaxRainWetness = 1.0f;
-		float MaxPuddleWetness = 2.667f;
+		float MaxRainWetness = 0.75f;
+		float MaxPuddleWetness = 2.5f;
 		float MaxShoreWetness = 0.5f;
 		uint ShoreRange = 32;
 		float PuddleRadius = 1.0f;

--- a/src/Features/WetnessEffects.h
+++ b/src/Features/WetnessEffects.h
@@ -22,8 +22,8 @@ public:
 	struct Settings
 	{
 		uint EnableWetnessEffects = true;
-		float MaxRainWetness = 0.75f;
-		float MaxPuddleWetness = 2.5f;
+		float MaxRainWetness = 1.0f;
+		float MaxPuddleWetness = 1.5f;
 		float MaxShoreWetness = 0.5f;
 		uint ShoreRange = 32;
 		float PuddleRadius = 1.0f;

--- a/src/Features/WetnessEffects.h
+++ b/src/Features/WetnessEffects.h
@@ -23,7 +23,7 @@ public:
 	{
 		uint EnableWetnessEffects = true;
 		float MaxRainWetness = 1.0f;
-		float MaxPuddleWetness = 1.5f;
+		float MaxPuddleWetness = 2.5f;
 		float MaxShoreWetness = 0.5f;
 		uint ShoreRange = 32;
 		float PuddleRadius = 1.0f;

--- a/src/Features/WetnessEffects.h
+++ b/src/Features/WetnessEffects.h
@@ -37,7 +37,6 @@ public:
 		uint EnableRaindropFx = true;
 		uint EnableSplashes = true;
 		uint EnableRipples = true;
-		uint EnableChaoticRipples = true;
 		float RaindropGridSize = 4.f;
 		float RaindropInterval = .5f;
 		float RaindropChance = .3f;
@@ -49,9 +48,6 @@ public:
 		float RippleRadius = 1.f;
 		float RippleBreadth = .5f;
 		float RippleLifetime = .15f;
-		float ChaoticRippleStrength = .1f;
-		float ChaoticRippleScale = 1.f;
-		float ChaoticRippleSpeed = 20.f;
 	};
 
 	struct alignas(16) PerFrame

--- a/src/Features/WetnessEffects.h
+++ b/src/Features/WetnessEffects.h
@@ -83,8 +83,6 @@ public:
 	virtual void SaveSettings(json& o_json) override;
 
 	virtual void RestoreDefaultSettings() override;
-	float CalculateWeatherTransitionPercentage(float skyCurrentWeatherPct, float beginFade, bool fadeIn);
-	void CalculateWetness(RE::TESWeather* weather, RE::Sky* sky, float seconds, float& wetness, float& puddleWetness);
 
 	virtual bool SupportsVR() override { return true; };
 };

--- a/src/Features/WetnessEffects.h
+++ b/src/Features/WetnessEffects.h
@@ -38,7 +38,6 @@ public:
 		uint EnableSplashes = true;
 		uint EnableRipples = true;
 		uint EnableChaoticRipples = true;
-		float RaindropFxRange = 1000.f;
 		float RaindropGridSize = 4.f;
 		float RaindropInterval = .5f;
 		float RaindropChance = .3f;
@@ -57,12 +56,13 @@ public:
 
 	struct alignas(16) PerFrame
 	{
+		REX::W32::XMFLOAT4X4 OcclusionViewProj;
 		float Time;
 		float Raining;
 		float Wetness;
 		float PuddleWetness;
 		Settings settings;
-		uint pad0[2];
+		uint pad0[3];
 	};
 
 	Settings settings;
@@ -76,6 +76,8 @@ public:
 	uint32_t currentWeatherID = 0;
 	uint32_t lastWeatherID = 0;
 	float previousWeatherTransitionPercentage = 0.0f;
+
+	virtual void Prepass() override;
 
 	virtual void Reset() override;
 


### PR DESCRIPTION
Rain now uses the precipitation occlusion map correctly.
Removed chaotic ripples since the default settings did nothing and the look was questionable when the strength was increased.
Rain now uses the rain particle data to fade in and out exactly in-line with the particles themselves.
Wetness and puddle code is reworked to be consistent across saves and in terms of its behaviour. It should now be easy to understand and extend from.