### PR TITLE
chore: remove unused llf flags

### DIFF
--- a/features/Light Limit Fix/Shaders/LightLimitFix/Common.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/Common.hlsli
@@ -12,8 +12,6 @@ namespace LightFlags
 	static const uint PortalStrict = (1 << 0);
 	static const uint Shadow = (1 << 1);
 	static const uint Simple = (1 << 2);
-	static const uint Particle = (1 << 3);
-	static const uint Billboard = (1 << 4);
 }
 
 struct ClusterAABB

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -885,7 +885,6 @@ void LightLimitFix::UpdateLights()
 								}
 
 								clusteredLight.lightFlags.set(LightFlags::Simple);
-								clusteredLight.lightFlags.set(LightFlags::Particle);
 
 								AddCachedParticleLights(lightsData, clusteredLight);
 
@@ -943,7 +942,6 @@ void LightLimitFix::UpdateLights()
 				SetLightPosition(light, position);  // Light is complete for both eyes by now
 
 				light.lightFlags.set(LightFlags::Simple);
-				light.lightFlags.set(LightFlags::Billboard);
 
 				AddCachedParticleLights(lightsData, light);
 			}
@@ -959,7 +957,6 @@ void LightLimitFix::UpdateLights()
 				clusteredLight.positionWS[1].data.z += eyePositionOffset.z / (float)clusteredLights;
 			}
 			clusteredLight.lightFlags.set(LightFlags::Simple);
-			clusteredLight.lightFlags.set(LightFlags::Particle);
 			AddCachedParticleLights(lightsData, clusteredLight);
 		}
 	}

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -29,9 +29,7 @@ public:
 	{
 		PortalStrict = (1 << 0),
 		Shadow = (1 << 1),
-		Simple = (1 << 2),
-		Particle = (1 << 3),
-		Billboard = (1 << 4)
+		Simple = (1 << 2)
 	};
 
 	struct PositionOpt


### PR DESCRIPTION
Particle lights are deprecated so there is no future use for these flags. They are not used at the moment anyway.