### PR TITLE
fix: fix deferred vs forward rendering

### DIFF
--- a/package/Shaders/Common/Permutation.hlsli
+++ b/package/Shaders/Common/Permutation.hlsli
@@ -54,6 +54,7 @@ namespace ExtraFlags
 	static const uint InWorld = (1 << 0);
 	static const uint IsBeastRace = (1 << 1);
 	static const uint EffectShadows = (1 << 2);
+	static const uint IsDecal = (1 << 3);
 }
 
 cbuffer PerShader : register(b4)

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -760,9 +760,10 @@ PS_OUTPUT main(PS_INPUT input)
 	psout.MotionVectors = float4(screenMotionVector, 0.0, psout.Diffuse.w);
 #		endif
 
-	psout.Specular = float4(0.0.xxx, psout.Diffuse.w);
-	psout.Albedo = float4(baseColor.xyz * psout.Diffuse.w, psout.Diffuse.w);
-	psout.Reflectance = float4(0.0.xxx, psout.Diffuse.w);
+	psout.Specular = float4(0.0.xxx, finalColor.w);
+	psout.Albedo = float4(0.0.xxx, finalColor.w);
+	psout.Reflectance = float4(0.0.xxx, finalColor.w);
+	psout.Masks = float4(0.0.xxx, finalColor.w);
 
 #	elif defined(MOTIONVECTORS_NORMALS)
 	float2 screenMotionVector = GetSSMotionVector(input.WorldPosition, input.PreviousWorldPosition, eyeIndex);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -980,10 +980,8 @@ float GetSnowParameterY(float texProjTmp, float alpha)
 #		include "TerrainBlending/TerrainBlending.hlsli"
 #	endif
 
-#	if defined(SSS)
-#		if defined(SKIN)
-#			undef SOFT_LIGHTING
-#		endif
+#	if defined(SSS) && defined(SKIN) && defined(DEFERRED)
+#		undef SOFT_LIGHTING
 #	endif
 
 #	if defined(TERRAIN_SHADOWS)
@@ -1907,11 +1905,18 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #	endif
 
 	if (extraDirShadows) {
-#	if defined(DEFERRED) && defined(SCREEN_SPACE_SHADOWS)
-#		if defined(SOFT_LIGHTING) || defined(BACK_LIGHTING) || defined(RIM_LIGHTING)
-		if (dirLightAngle > 0.0)
+#	if defined(SCREEN_SPACE_SHADOWS)
+#		if defined(DEFERRED)
+		bool useScreenSpaceShadows = true;
+#		else
+		bool useScreenSpaceShadows = ExtraShaderDescriptor & ExtraFlags::IsDecal;
 #		endif
-		{
+
+#		if defined(SOFT_LIGHTING) || defined(BACK_LIGHTING) || defined(RIM_LIGHTING)
+		useScreenSpaceShadows = useScreenSpaceShadows && (dirLightAngle > 0.0);
+#		endif
+
+		if (useScreenSpaceShadows){
 			dirDetailShadow = ScreenSpaceShadows::GetScreenSpaceShadow(input.Position.xyz, screenUV, screenNoise, viewPosition, eyeIndex);
 #		if defined(TREE_ANIM)
 			PerGeometry sD = SharedPerShadow[0];

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1916,7 +1916,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 		useScreenSpaceShadows = useScreenSpaceShadows && (dirLightAngle > 0.0);
 #		endif
 
-		if (useScreenSpaceShadows){
+		if (useScreenSpaceShadows) {
 			dirDetailShadow = ScreenSpaceShadows::GetScreenSpaceShadow(input.Position.xyz, screenUV, screenNoise, viewPosition, eyeIndex);
 #		if defined(TREE_ANIM)
 			PerGeometry sD = SharedPerShadow[0];

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -26,18 +26,6 @@ struct BlendStates
 		return blendStates;
 	}
 
-	static std::array<ID3D11BlendState**, 6> GetBlendStates()
-	{
-		auto blendStates = GetSingleton();
-		return {
-			&blendStates->a[0][0][1][0],
-			&blendStates->a[0][0][10][0],
-			&blendStates->a[1][0][1][0],
-			&blendStates->a[1][0][11][0],
-			&blendStates->a[2][0][1][0],
-			&blendStates->a[3][0][11][0]
-		};
-	}
 };
 
 void SetupRenderTarget(RE::RENDER_TARGET target, D3D11_TEXTURE2D_DESC texDesc, D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc, D3D11_RENDER_TARGET_VIEW_DESC rtvDesc, D3D11_UNORDERED_ACCESS_VIEW_DESC uavDesc, DXGI_FORMAT format)
@@ -262,24 +250,6 @@ void Deferred::StartDeferred()
 
 	State::GetSingleton()->UpdateSharedData();
 
-	static std::once_flag setup;
-	std::call_once(setup, [&]() {
-		auto& device = State::GetSingleton()->device;
-
-		auto blendStates = BlendStates::GetBlendStates();
-
-		for (int i = 0; i < blendStates.size(); ++i) {
-			forwardBlendStates[i] = *blendStates[i];
-
-			D3D11_BLEND_DESC blendDesc;
-			forwardBlendStates[i]->GetDesc(&blendDesc);
-
-			blendDesc.IndependentBlendEnable = false;
-
-			DX::ThrowIfFailed(device->CreateBlendState(&blendDesc, &deferredBlendStates[i]));
-		}
-	});
-
 	auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
 	GET_INSTANCE_MEMBER(renderTargets, shadowState)
 	GET_INSTANCE_MEMBER(setRenderTargetMode, shadowState)
@@ -331,6 +301,8 @@ void Deferred::StartDeferred()
 	}
 
 	PrepassPasses();
+
+	OverrideBlendStates();
 }
 
 void Deferred::DeferredPasses()
@@ -513,31 +485,63 @@ void Deferred::EndDeferred()
 	stateUpdateFlags.set(RE::BSGraphics::ShaderFlags::DIRTY_RENDERTARGET);  // Run OMSetRenderTargets again
 
 	deferredPass = false;
+
+	ResetBlendStates();
 }
 
 void Deferred::OverrideBlendStates()
 {
-	auto blendStates = BlendStates::GetBlendStates();
+	auto blendStates = BlendStates::GetSingleton();
 
 	static std::once_flag setup;
 	std::call_once(setup, [&]() {
 		auto& device = State::GetSingleton()->device;
 
-		for (int i = 0; i < blendStates.size(); ++i) {
-			forwardBlendStates[i] = *blendStates[i];
+		for (int a = 0; a < 7; a++){
+			for (int b = 0; b < 2; b++) {
+				for (int c = 0; c < 13; c++) {
+					for (int d = 0; d < 2; d++) {
+						forwardBlendStates[a][b][c][d] = blendStates->a[a][b][c][d];
 
-			D3D11_BLEND_DESC blendDesc;
-			forwardBlendStates[i]->GetDesc(&blendDesc);
+						if (auto blendState = forwardBlendStates[a][b][c][d]) {
+							D3D11_BLEND_DESC blendDesc;
+							forwardBlendStates[a][b][c][d]->GetDesc(&blendDesc);
 
-			blendDesc.IndependentBlendEnable = false;
+							blendDesc.IndependentBlendEnable = true;
 
-			DX::ThrowIfFailed(device->CreateBlendState(&blendDesc, &deferredBlendStates[i]));
+							// Start at 1 to ignore Diffuse
+							for (int i = 0; i < 8; i++)
+							{
+								blendDesc.RenderTarget[i].BlendEnable = blendDesc.RenderTarget[0].BlendEnable;
+								blendDesc.RenderTarget[i].SrcBlend = D3D11_BLEND_SRC_ALPHA;
+								blendDesc.RenderTarget[i].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
+								blendDesc.RenderTarget[i].BlendOp = D3D11_BLEND_OP_ADD;
+								blendDesc.RenderTarget[i].SrcBlendAlpha = D3D11_BLEND_SRC_ALPHA;
+								blendDesc.RenderTarget[i].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
+								blendDesc.RenderTarget[i].BlendOpAlpha = D3D11_BLEND_OP_ADD;
+								blendDesc.RenderTarget[i].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+							}
+
+							DX::ThrowIfFailed(device->CreateBlendState(&blendDesc, &deferredBlendStates[a][b][c][d]));
+						} else {
+							deferredBlendStates[a][b][c][d] = nullptr;
+						}
+					}
+				}
+			}
 		}
 	});
 
 	// Set modified blend states
-	for (int i = 0; i < blendStates.size(); ++i)
-		*blendStates[i] = deferredBlendStates[i];
+	for (int a = 0; a < 7; a++) {
+		for (int b = 0; b < 2; b++) {
+			for (int c = 0; c < 13; c++) {
+				for (int d = 0; d < 2; d++) {
+					blendStates->a[a][b][c][d] = deferredBlendStates[a][b][c][d];
+				}
+			}
+		}
+	}
 
 	auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
 	GET_INSTANCE_MEMBER(stateUpdateFlags, shadowState)
@@ -547,11 +551,18 @@ void Deferred::OverrideBlendStates()
 
 void Deferred::ResetBlendStates()
 {
-	auto blendStates = BlendStates::GetBlendStates();
+	auto blendStates = BlendStates::GetSingleton();
 
 	// Restore modified blend states
-	for (int i = 0; i < blendStates.size(); ++i)
-		*blendStates[i] = forwardBlendStates[i];
+	for (int a = 0; a < 7; a++) {
+		for (int b = 0; b < 2; b++) {
+			for (int c = 0; c < 13; c++) {
+				for (int d = 0; d < 2; d++) {
+					blendStates->a[a][b][c][d] = forwardBlendStates[a][b][c][d];
+				}
+			}
+		}
+	}
 
 	auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
 	GET_INSTANCE_MEMBER(stateUpdateFlags, shadowState)

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -25,7 +25,6 @@ struct BlendStates
 		static auto blendStates = reinterpret_cast<BlendStates*>(REL::RelocationID(524749, 411364).address());
 		return blendStates;
 	}
-
 };
 
 void SetupRenderTarget(RE::RENDER_TARGET target, D3D11_TEXTURE2D_DESC texDesc, D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc, D3D11_RENDER_TARGET_VIEW_DESC rtvDesc, D3D11_UNORDERED_ACCESS_VIEW_DESC uavDesc, DXGI_FORMAT format)
@@ -497,7 +496,7 @@ void Deferred::OverrideBlendStates()
 	std::call_once(setup, [&]() {
 		auto& device = State::GetSingleton()->device;
 
-		for (int a = 0; a < 7; a++){
+		for (int a = 0; a < 7; a++) {
 			for (int b = 0; b < 2; b++) {
 				for (int c = 0; c < 13; c++) {
 					for (int d = 0; d < 2; d++) {
@@ -510,8 +509,7 @@ void Deferred::OverrideBlendStates()
 							blendDesc.IndependentBlendEnable = true;
 
 							// Start at 1 to ignore Diffuse
-							for (int i = 0; i < 8; i++)
-							{
+							for (int i = 0; i < 8; i++) {
 								blendDesc.RenderTarget[i].BlendEnable = blendDesc.RenderTarget[0].BlendEnable;
 								blendDesc.RenderTarget[i].SrcBlend = D3D11_BLEND_SRC_ALPHA;
 								blendDesc.RenderTarget[i].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -40,6 +40,9 @@ void State::Draw()
 			}
 		}
 
+		if (Deferred::GetSingleton()->inDecals)
+			currentExtraDescriptor |= (uint32_t)ExtraShaderDescriptors::IsDecal;
+
 		if (forceUpdatePermutationBuffer || currentPixelDescriptor != lastPixelDescriptor || currentExtraDescriptor != lastExtraDescriptor) {
 			PermutationCB data{};
 			data.VertexShaderDescriptor = currentVertexDescriptor;

--- a/src/State.h
+++ b/src/State.h
@@ -121,6 +121,7 @@ public:
 		InWorld = 1 << 0,
 		IsBeastRace = 1 << 1,
 		EffectShadows = 1 << 2,
+		IsDecal = 1 << 3
 	};
 
 	void UpdateSharedData();


### PR DESCRIPTION
Fixes blood effects not rendering properly because they require additive blending but are not rendering in forward. This pull request modifies where deferred rendering ends, so that it does not touch blood effects. As a side effect it also means certain parts of faces like beards, eyebrows, as well as blended roads, cannot use deferred rendering anymore. This is unfortunate but a required change. This does mean that we can now use the alpha channel   of all deferred buffers in the future, however.

SOFT_LIGHTING flag is now not disabled in forward rendering to preserve anything that needs it.

Screenspace shadows still apply to decals using a new IsDecal descriptor.