### PR TITLE
fix: water parallax on angled surfaces

### DIFF
--- a/features/Water Lighting/Shaders/WaterLighting/WaterParallax.hlsli
+++ b/features/Water Lighting/Shaders/WaterLighting/WaterParallax.hlsli
@@ -67,8 +67,7 @@ namespace WaterLighting
 
 	float2 GetParallaxOffset(PS_INPUT input, float3 normalScalesRcp, uint eyeIndex)
 	{
-
-#	if defined(VC)
+#if defined(VC)
 		float3 reflectPlaneWS = mul(CameraViewInverse[eyeIndex], float4(ReflectPlane[eyeIndex].xyz, 1.0));
 
 		float3x3 tbn = CalculateTBN(reflectPlaneWS.xyz, -input.WPosition.xyz, input.TexCoord1.xy);

--- a/features/Water Lighting/Shaders/WaterLighting/WaterParallax.hlsli
+++ b/features/Water Lighting/Shaders/WaterLighting/WaterParallax.hlsli
@@ -45,42 +45,11 @@ namespace WaterLighting
 		return 1.0 - length(heights);
 	}
 
-	// http://www.thetenthplanet.de/archives/1180
-	float3x3 CalculateTBN(float3 N, float3 p, float2 uv)
+	float2 GetParallaxOffset(PS_INPUT input, float3 normalScalesRcp)
 	{
-		// get edge vectors of the pixel triangle
-		float3 dp1 = ddx_coarse(p);
-		float3 dp2 = ddy_coarse(p);
-		float2 duv1 = ddx_coarse(uv);
-		float2 duv2 = ddy_coarse(uv);
-
-		// solve the linear system
-		float3 dp2perp = cross(dp2, N);
-		float3 dp1perp = cross(N, dp1);
-		float3 T = dp2perp * duv1.x + dp1perp * duv2.x;
-		float3 B = dp2perp * duv1.y + dp1perp * duv2.y;
-
-		// construct a scale-invariant frame
-		float invmax = rsqrt(max(dot(T, T), dot(B, B)));
-		return float3x3(T * invmax, B * invmax, N);
-	}
-
-	float2 GetParallaxOffset(PS_INPUT input, float3 normalScalesRcp, uint eyeIndex)
-	{
-
-#	if defined(VC)
-		float3 reflectPlaneWS = mul(CameraViewInverse[eyeIndex], float4(ReflectPlane[eyeIndex].xyz, 1.0));
-
-		float3x3 tbn = CalculateTBN(reflectPlaneWS.xyz, -input.WPosition.xyz, input.TexCoord1.xy);
-
-		float3 viewDirection = normalize(input.WPosition.xyz);
-		float3 viewDirectionTS = normalize(mul(tbn, viewDirection));
-
-		float2 parallaxOffsetTS = viewDirectionTS.xy / -viewDirectionTS.z;
-#else
 		float3 viewDirection = normalize(input.WPosition.xyz);
 		float2 parallaxOffsetTS = viewDirection.xy / -viewDirection.z;
-#endif
+
 		// Parallax scale is also multiplied by normalScalesRcp
 		parallaxOffsetTS *= 20.0;
 

--- a/features/Water Lighting/Shaders/WaterLighting/WaterParallax.hlsli
+++ b/features/Water Lighting/Shaders/WaterLighting/WaterParallax.hlsli
@@ -67,8 +67,7 @@ namespace WaterLighting
 
 	float2 GetParallaxOffset(PS_INPUT input, float3 normalScalesRcp)
 	{
-
-#	if defined(VC)
+#if defined(VC)
 		float3 reflectPlaneWS = mul(CameraViewInverse[0], float4(ReflectPlane[0].xyz, 1.0));
 
 		float3x3 tbn = CalculateTBN(reflectPlaneWS.xyz, -input.WPosition.xyz, input.TexCoord1.xy);
@@ -77,10 +76,10 @@ namespace WaterLighting
 		float3 viewDirectionTS = normalize(mul(tbn, viewDirection));
 
 		float2 parallaxOffsetTS = viewDirectionTS.xy / -viewDirectionTS.z;
-#	else
+#else
 		float3 viewDirection = normalize(input.WPosition.xyz);
 		float2 parallaxOffsetTS = viewDirection.xy / -viewDirection.z;
-#	endif
+#endif
 		// Parallax scale is also multiplied by normalScalesRcp
 		parallaxOffsetTS *= 20.0;
 

--- a/features/Water Lighting/Shaders/WaterLighting/WaterParallax.hlsli
+++ b/features/Water Lighting/Shaders/WaterLighting/WaterParallax.hlsli
@@ -65,11 +65,11 @@ namespace WaterLighting
 		return float3x3(T * invmax, B * invmax, N);
 	}
 
-	float2 GetParallaxOffset(PS_INPUT input, float3 normalScalesRcp)
+	float2 GetParallaxOffset(PS_INPUT input, float3 normalScalesRcp, uint eyeIndex)
 	{
 
 #	if defined(VC)
-		float3 reflectPlaneWS = mul(CameraViewInverse[0], float4(ReflectPlane[0].xyz, 1.0));
+		float3 reflectPlaneWS = mul(CameraViewInverse[eyeIndex], float4(ReflectPlane[eyeIndex].xyz, 1.0));
 
 		float3x3 tbn = CalculateTBN(reflectPlaneWS.xyz, -input.WPosition.xyz, input.TexCoord1.xy);
 

--- a/features/Water Lighting/Shaders/WaterLighting/WaterParallax.hlsli
+++ b/features/Water Lighting/Shaders/WaterLighting/WaterParallax.hlsli
@@ -45,11 +45,42 @@ namespace WaterLighting
 		return 1.0 - length(heights);
 	}
 
+	// http://www.thetenthplanet.de/archives/1180
+	float3x3 CalculateTBN(float3 N, float3 p, float2 uv)
+	{
+		// get edge vectors of the pixel triangle
+		float3 dp1 = ddx_coarse(p);
+		float3 dp2 = ddy_coarse(p);
+		float2 duv1 = ddx_coarse(uv);
+		float2 duv2 = ddy_coarse(uv);
+
+		// solve the linear system
+		float3 dp2perp = cross(dp2, N);
+		float3 dp1perp = cross(N, dp1);
+		float3 T = dp2perp * duv1.x + dp1perp * duv2.x;
+		float3 B = dp2perp * duv1.y + dp1perp * duv2.y;
+
+		// construct a scale-invariant frame
+		float invmax = rsqrt(max(dot(T, T), dot(B, B)));
+		return float3x3(T * invmax, B * invmax, N);
+	}
+
 	float2 GetParallaxOffset(PS_INPUT input, float3 normalScalesRcp)
 	{
+
+#	if defined(VC)
+		float3 reflectPlaneWS = mul(CameraViewInverse[0], float4(ReflectPlane[0].xyz, 1.0));
+
+		float3x3 tbn = CalculateTBN(reflectPlaneWS.xyz, -input.WPosition.xyz, input.TexCoord1.xy);
+
+		float3 viewDirection = normalize(input.WPosition.xyz);
+		float3 viewDirectionTS = normalize(mul(tbn, viewDirection));
+
+		float2 parallaxOffsetTS = viewDirectionTS.xy / -viewDirectionTS.z;
+#	else
 		float3 viewDirection = normalize(input.WPosition.xyz);
 		float2 parallaxOffsetTS = viewDirection.xy / -viewDirection.z;
-
+#	endif
 		// Parallax scale is also multiplied by normalScalesRcp
 		parallaxOffsetTS *= 20.0;
 

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -455,7 +455,7 @@ float3 GetWaterNormal(PS_INPUT input, float distanceFactor, float normalsDepthFa
 	float3 normalScalesRcp = rcp(input.NormalsScale.xyz);
 
 #			if defined(WATER_PARALLAX)
-	float2 parallaxOffset = WaterLighting::GetParallaxOffset(input, normalScalesRcp);
+	float2 parallaxOffset = WaterLighting::GetParallaxOffset(input, normalScalesRcp, eyeIndex);
 #			endif
 
 #			if defined(FLOWMAP)

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -441,7 +441,7 @@ float3 GetFlowmapNormal(PS_INPUT input, float2 uvShift, float multiplier, float 
 #				undef WATER_LIGHTING
 #			endif
 
-#			if defined(WATER_LIGHTING)
+#			if defined(WATER_LIGHTING) && !defined(VC)
 #				define WATER_PARALLAX
 #				include "WaterLighting/WaterParallax.hlsli"
 #			endif
@@ -455,7 +455,7 @@ float3 GetWaterNormal(PS_INPUT input, float distanceFactor, float normalsDepthFa
 	float3 normalScalesRcp = rcp(input.NormalsScale.xyz);
 
 #			if defined(WATER_PARALLAX)
-	float2 parallaxOffset = WaterLighting::GetParallaxOffset(input, normalScalesRcp, eyeIndex);
+	float2 parallaxOffset = WaterLighting::GetParallaxOffset(input, normalScalesRcp);
 #			endif
 
 #			if defined(FLOWMAP)


### PR DESCRIPTION
On water surfaces with vertex colours, we assume it is a water mesh, and disable parallax on them.
