### PR TITLE
chore: improve settings, remove PBR settings

### DIFF
--- a/package/Shaders/Common/PBR.hlsli
+++ b/package/Shaders/Common/PBR.hlsli
@@ -448,7 +448,6 @@ namespace PBR
 #endif
 
 			float2 specularBRDF = GetEnvBRDFApproxLazarov(surfaceProperties.Roughness, satNdotV);
-
 			specular *= 1 + surfaceProperties.F0 * (1 / (specularBRDF.x + specularBRDF.y) - 1);
 
 #if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)

--- a/package/Shaders/Common/PBR.hlsli
+++ b/package/Shaders/Common/PBR.hlsli
@@ -400,9 +400,9 @@ namespace PBR
 	{
 		float3 color = 0;
 
-		color += GetHairDiffuseColorMarschner(N, V, L, NdotL, NdotV, VdotL, backlit, area, surfaceProperties);	
+		color += GetHairDiffuseColorMarschner(N, V, L, NdotL, NdotV, VdotL, backlit, area, surfaceProperties);
 		color += GetHairDiffuseAttenuationKajiyaKay(N, V, L, NdotL, NdotV, shadow, surfaceProperties);
-		
+
 		return color;
 	}
 
@@ -454,8 +454,8 @@ namespace PBR
 #if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 			[branch] if ((PBRFlags & Flags::Fuzz) != 0)
 			{
-				float3 fuzzSpecular = GetSpecularDirectLightMultiplierMicroflakes(surfaceProperties.Roughness, surfaceProperties.FuzzColor, satNdotL, satNdotV, satNdotH, satVdotH) * lightProperties.LinearLightColor * satNdotL;		
-				fuzzSpecular *= 1 + surfaceProperties.FuzzColor * (1 / (specularBRDF.x + specularBRDF.y) - 1);		
+				float3 fuzzSpecular = GetSpecularDirectLightMultiplierMicroflakes(surfaceProperties.Roughness, surfaceProperties.FuzzColor, satNdotL, satNdotV, satNdotH, satVdotH) * lightProperties.LinearLightColor * satNdotL;
+				fuzzSpecular *= 1 + surfaceProperties.FuzzColor * (1 / (specularBRDF.x + specularBRDF.y) - 1);
 
 				specular = lerp(specular, fuzzSpecular, surfaceProperties.FuzzWeight);
 			}
@@ -556,9 +556,9 @@ namespace PBR
 			[branch] if ((PBRFlags & Flags::TwoLayer) != 0)
 			{
 				float2 coatSpecularBRDF = GetEnvBRDFApproxLazarov(surfaceProperties.CoatRoughness, NdotV);
-				float3 coatSpecularLobeWeight = surfaceProperties.CoatF0 * coatSpecularBRDF.x + coatSpecularBRDF.y;	
+				float3 coatSpecularLobeWeight = surfaceProperties.CoatF0 * coatSpecularBRDF.x + coatSpecularBRDF.y;
 				coatSpecularLobeWeight *= 1 + surfaceProperties.CoatF0 * (1 / (coatSpecularBRDF.x + coatSpecularBRDF.y) - 1);
-				
+
 				float3 coatF = GetFresnelFactorSchlick(surfaceProperties.CoatF0, NdotV);
 
 				float3 layerAttenuation = 1 - coatF * surfaceProperties.CoatStrength;

--- a/package/Shaders/Common/PBR.hlsli
+++ b/package/Shaders/Common/PBR.hlsli
@@ -400,12 +400,9 @@ namespace PBR
 	{
 		float3 color = 0;
 
-		color += GetHairDiffuseColorMarschner(N, V, L, NdotL, NdotV, VdotL, backlit, area, surfaceProperties);
-		[branch] if (pbrSettings.UseMultipleScattering)
-		{
-			color += GetHairDiffuseAttenuationKajiyaKay(N, V, L, NdotL, NdotV, shadow, surfaceProperties);
-		}
-
+		color += GetHairDiffuseColorMarschner(N, V, L, NdotL, NdotV, VdotL, backlit, area, surfaceProperties);	
+		color += GetHairDiffuseAttenuationKajiyaKay(N, V, L, NdotL, NdotV, shadow, surfaceProperties);
+		
 		return color;
 	}
 
@@ -450,21 +447,15 @@ namespace PBR
 			specular += GetSpecularDirectLightMultiplierMicrofacet(surfaceProperties.Roughness, surfaceProperties.F0, satNdotL, satNdotV, satNdotH, satVdotH, F) * lightProperties.LinearLightColor * satNdotL;
 #endif
 
-			float2 specularBRDF = 0;
-			[branch] if (pbrSettings.UseMultipleScattering)
-			{
-				specularBRDF = GetEnvBRDFApproxLazarov(surfaceProperties.Roughness, satNdotV);
-				specular *= 1 + surfaceProperties.F0 * (1 / (specularBRDF.x + specularBRDF.y) - 1);
-			}
+			float2 specularBRDF = GetEnvBRDFApproxLazarov(surfaceProperties.Roughness, satNdotV);
+
+			specular *= 1 + surfaceProperties.F0 * (1 / (specularBRDF.x + specularBRDF.y) - 1);
 
 #if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 			[branch] if ((PBRFlags & Flags::Fuzz) != 0)
 			{
-				float3 fuzzSpecular = GetSpecularDirectLightMultiplierMicroflakes(surfaceProperties.Roughness, surfaceProperties.FuzzColor, satNdotL, satNdotV, satNdotH, satVdotH) * lightProperties.LinearLightColor * satNdotL;
-				[branch] if (pbrSettings.UseMultipleScattering)
-				{
-					fuzzSpecular *= 1 + surfaceProperties.FuzzColor * (1 / (specularBRDF.x + specularBRDF.y) - 1);
-				}
+				float3 fuzzSpecular = GetSpecularDirectLightMultiplierMicroflakes(surfaceProperties.Roughness, surfaceProperties.FuzzColor, satNdotL, satNdotV, satNdotH, satVdotH) * lightProperties.LinearLightColor * satNdotL;		
+				fuzzSpecular *= 1 + surfaceProperties.FuzzColor * (1 / (specularBRDF.x + specularBRDF.y) - 1);		
 
 				specular = lerp(specular, fuzzSpecular, surfaceProperties.FuzzWeight);
 			}
@@ -559,21 +550,15 @@ namespace PBR
 			specularLobeWeight = surfaceProperties.F0 * specularBRDF.x + specularBRDF.y;
 
 			diffuseLobeWeight *= (1 - specularLobeWeight);
-
-			[branch] if (pbrSettings.UseMultipleScattering)
-			{
-				specularLobeWeight *= 1 + surfaceProperties.F0 * (1 / (specularBRDF.x + specularBRDF.y) - 1);
-			}
+			specularLobeWeight *= 1 + surfaceProperties.F0 * (1 / (specularBRDF.x + specularBRDF.y) - 1);
 
 #if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 			[branch] if ((PBRFlags & Flags::TwoLayer) != 0)
 			{
 				float2 coatSpecularBRDF = GetEnvBRDFApproxLazarov(surfaceProperties.CoatRoughness, NdotV);
-				float3 coatSpecularLobeWeight = surfaceProperties.CoatF0 * coatSpecularBRDF.x + coatSpecularBRDF.y;
-				[branch] if (pbrSettings.UseMultipleScattering)
-				{
-					coatSpecularLobeWeight *= 1 + surfaceProperties.CoatF0 * (1 / (coatSpecularBRDF.x + coatSpecularBRDF.y) - 1);
-				}
+				float3 coatSpecularLobeWeight = surfaceProperties.CoatF0 * coatSpecularBRDF.x + coatSpecularBRDF.y;	
+				coatSpecularLobeWeight *= 1 + surfaceProperties.CoatF0 * (1 / (coatSpecularBRDF.x + coatSpecularBRDF.y) - 1);
+				
 				float3 coatF = GetFresnelFactorSchlick(surfaceProperties.CoatF0, NdotV);
 
 				float3 layerAttenuation = 1 - coatF * surfaceProperties.CoatStrength;
@@ -599,11 +584,9 @@ namespace PBR
 
 		float3 diffuseAO = surfaceProperties.AO;
 		float3 specularAO = SpecularAOLagarde(NdotV, surfaceProperties.AO, surfaceProperties.Roughness);
-		[branch] if (pbrSettings.UseMultiBounceAO)
-		{
-			diffuseAO = MultiBounceAO(diffuseColor, diffuseAO.x).y;
-			specularAO = MultiBounceAO(surfaceProperties.F0, specularAO.x).y;
-		}
+
+		diffuseAO = MultiBounceAO(diffuseColor, diffuseAO.x).y;
+		specularAO = MultiBounceAO(surfaceProperties.F0, specularAO.x).y;
 
 		diffuseLobeWeight *= diffuseAO / Math::PI;
 		specularLobeWeight *= specularAO;

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -124,13 +124,6 @@ struct SkylightingSettings
 	uint pad0[2];
 };
 
-struct PBRSettings
-{
-	bool UseMultipleScattering;
-	bool UseMultiBounceAO;
-	uint pad0[2];
-};
-
 cbuffer FeatureData : register(b6)
 {
 	GrassLightingSettings grassLightingSettings;
@@ -140,7 +133,6 @@ cbuffer FeatureData : register(b6)
 	LightLimitFixSettings lightLimitFixSettings;
 	WetnessEffectsSettings wetnessEffectsSettings;
 	SkylightingSettings skylightingSettings;
-	PBRSettings pbrSettings;
 };
 
 Texture2D<float4> TexDepthSampler : register(t20);

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -21,8 +21,15 @@
 
 void Feature::Load(json& o_json)
 {
-	if (o_json[GetName()].is_structured())
-		LoadSettings(o_json[GetName()]);
+	if (o_json[GetName()].is_structured()) {
+		logger::info("Loading {} settings", GetName());
+		try {
+			LoadSettings(o_json[GetName()]);
+		} catch (...) {
+			logger::warn("Invalid settings for {}, using default.", GetName());
+			RestoreDefaultSettings();
+		}
+	}
 
 	// Convert string to wstring
 	auto ini_filename = std::format("{}.ini", GetShortName());

--- a/src/FeatureBuffer.cpp
+++ b/src/FeatureBuffer.cpp
@@ -35,6 +35,6 @@ std::pair<unsigned char*, size_t> GetFeatureBufferData()
 		TerrainShadows::GetSingleton()->GetCommonBufferData(),
 		LightLimitFix::GetSingleton()->GetCommonBufferData(),
 		WetnessEffects::GetSingleton()->GetCommonBufferData(),
-		Skylighting::GetSingleton()->GetCommonBufferData(),
-		TruePBR::GetSingleton()->settings);
+		Skylighting::GetSingleton()->GetCommonBufferData()
+	);
 }

--- a/src/FeatureBuffer.cpp
+++ b/src/FeatureBuffer.cpp
@@ -35,6 +35,5 @@ std::pair<unsigned char*, size_t> GetFeatureBufferData()
 		TerrainShadows::GetSingleton()->GetCommonBufferData(),
 		LightLimitFix::GetSingleton()->GetCommonBufferData(),
 		WetnessEffects::GetSingleton()->GetCommonBufferData(),
-		Skylighting::GetSingleton()->GetCommonBufferData()
-	);
+		Skylighting::GetSingleton()->GetCommonBufferData());
 }

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -256,20 +256,16 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 			}
 		}
 
-		auto truePBR = TruePBR::GetSingleton();
-		auto& pbrJson = settings[truePBR->GetShortName()];
-		if (pbrJson.is_object()) {
-			logger::info("Loading 'TruePBR' settings");
-			truePBR->LoadSettings(pbrJson);
-		} else {
-			logger::warn("Missing settings for TruePBR, using default.");
-		}
-
 		auto upscaling = Upscaling::GetSingleton();
 		auto& upscalingJson = settings[upscaling->GetShortName()];
 		if (upscalingJson.is_object()) {
-			logger::info("Loading 'Upscaling' settings");
-			upscaling->LoadSettings(upscalingJson);
+			logger::info("Loading Upscaling settings");
+			try {
+				upscaling->LoadSettings(upscalingJson);
+			} catch (...) {
+				logger::warn("Invalid settings for Upscaling, using default.");
+				upscaling->RestoreDefaultSettings();
+			}
 		} else {
 			logger::warn("Missing settings for Upscaling, using default.");
 		}
@@ -342,10 +338,6 @@ void State::Save(ConfigMode a_configMode)
 	general["Enable Async"] = shaderCache.IsAsync();
 
 	settings["General"] = general;
-
-	auto truePBR = TruePBR::GetSingleton();
-	auto& pbrJson = settings[truePBR->GetShortName()];
-	truePBR->SaveSettings(pbrJson);
 
 	auto upscaling = Upscaling::GetSingleton();
 	auto& upscalingJson = settings[upscaling->GetShortName()];

--- a/src/State.h
+++ b/src/State.h
@@ -33,9 +33,9 @@ public:
 	spdlog::level::level_enum logLevel = spdlog::level::info;
 	std::string shaderDefinesString = "";
 	std::vector<std::pair<std::string, std::string>> shaderDefines{};  // data structure to parse string into; needed to avoid dangling pointers
-	const std::string testConfigPath = "Data\\SKSE\\Plugins\\CommunityShaders\\TestSettings.json";
-	const std::string userConfigPath = "Data\\SKSE\\Plugins\\CommunityShaders\\UserSettings.json";
-	const std::string defaultConfigPath = "Data\\SKSE\\Plugins\\CommunityShaders\\DefaultSettings.json";
+	const std::string testConfigPath = "Data\\SKSE\\Plugins\\CommunityShaders\\SettingsTest.json";
+	const std::string userConfigPath = "Data\\SKSE\\Plugins\\CommunityShaders\\SettingsUser.json";
+	const std::string defaultConfigPath = "Data\\SKSE\\Plugins\\CommunityShaders\\SettingsDefault.json";
 
 	bool upscalerLoaded = false;
 

--- a/src/State.h
+++ b/src/State.h
@@ -33,9 +33,9 @@ public:
 	spdlog::level::level_enum logLevel = spdlog::level::info;
 	std::string shaderDefinesString = "";
 	std::vector<std::pair<std::string, std::string>> shaderDefines{};  // data structure to parse string into; needed to avoid dangling pointers
-	const std::string testConfigPath = "Data\\SKSE\\Plugins\\CommunityShadersTEST.json";
-	const std::string userConfigPath = "Data\\SKSE\\Plugins\\CommunityShadersUSER.json";
-	const std::string defaultConfigPath = "Data\\SKSE\\Plugins\\CommunityShaders.json";
+	const std::string testConfigPath = "Data\\SKSE\\Plugins\\CommunityShaders\\TestSettings.json";
+	const std::string userConfigPath = "Data\\SKSE\\Plugins\\CommunityShaders\\UserSettings.json";
+	const std::string defaultConfigPath = "Data\\SKSE\\Plugins\\CommunityShaders\\DefaultSettings.json";
 
 	bool upscalerLoaded = false;
 

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -250,15 +250,6 @@ void TruePBR::DrawSettings()
 			}
 			ImGui::TreePop();
 		}
-
-		bool useMultipleScattering = settings.useMultipleScattering;
-		bool useMultiBounceAO = settings.useMultiBounceAO;
-		if (ImGui::Checkbox("Use Multiple Scattering", &useMultipleScattering)) {
-			settings.useMultipleScattering = useMultipleScattering;
-		}
-		if (ImGui::Checkbox("Use Multi-bounce AO", &useMultiBounceAO)) {
-			settings.useMultiBounceAO = useMultiBounceAO;
-		}
 	}
 }
 
@@ -266,22 +257,6 @@ void TruePBR::SetupResources()
 {
 	SetupTextureSetData();
 	SetupMaterialObjectData();
-}
-
-void TruePBR::LoadSettings(json& o_json)
-{
-	if (o_json["Use Multiple Scattering"].is_boolean()) {
-		settings.useMultipleScattering = o_json["Use Multiple Scattering"];
-	}
-	if (o_json["Use Multi-bounce AO"].is_boolean()) {
-		settings.useMultiBounceAO = o_json["Use Multi-bounce AO"];
-	}
-}
-
-void TruePBR::SaveSettings(json& o_json)
-{
-	o_json["Use Multiple Scattering"] = (bool)settings.useMultipleScattering;
-	o_json["Use Multi-bounce AO"] = (bool)settings.useMultiBounceAO;
 }
 
 void TruePBR::PrePass()

--- a/src/TruePBR.h
+++ b/src/TruePBR.h
@@ -24,8 +24,6 @@ public:
 
 	void DrawSettings();
 	void SetupResources();
-	void LoadSettings(json& o_json);
-	void SaveSettings(json& o_json);
 	void PrePass();
 	void PostPostLoad();
 	void DataLoaded();
@@ -37,14 +35,6 @@ public:
 	eastl::unique_ptr<Texture2D> glintsNoiseTexture = nullptr;
 
 	std::unordered_map<uint32_t, std::string> editorIDs;
-
-	struct Settings
-	{
-		uint32_t useMultipleScattering = true;
-		uint32_t useMultiBounceAO = true;
-		uint32_t pad[2];
-	} settings{};
-	static_assert(sizeof(Settings) % 16 == 0);
 
 	struct PBRTextureSetData
 	{

--- a/src/Upscaling.cpp
+++ b/src/Upscaling.cpp
@@ -118,6 +118,11 @@ void Upscaling::LoadSettings(json& o_json)
 	}
 }
 
+void Upscaling::RestoreDefaultSettings()
+{
+	settings = {};
+}
+
 Upscaling::UpscaleMethod Upscaling::GetUpscaleMethod()
 {
 	auto streamline = Streamline::GetSingleton();

--- a/src/Upscaling.h
+++ b/src/Upscaling.h
@@ -52,6 +52,7 @@ public:
 	void DrawSettings();
 	void SaveSettings(json& o_json);
 	void LoadSettings(json& o_json);
+	void RestoreDefaultSettings();
 
 	UpscaleMethod GetUpscaleMethod();
 


### PR DESCRIPTION
If settings error they reset to default using a try catch loop. No more crashes.
Settings are relocated under the CommunityShaders folder. They could be under their own Settings folder in that, but that might be annoying. I think it may be good though considering we will probably split things up more.
Settings files are renamed to be clearer.
PBR settings removed, they were pretty much testing code.
