### PR TITLE
perf: ssr optimisation

### DIFF
--- a/package/Shaders/ISReflectionsRayTracing.hlsl
+++ b/package/Shaders/ISReflectionsRayTracing.hlsl
@@ -64,18 +64,18 @@ float4 GetReflectionColor(
 			float3 binaryMinRaySample = prevRaySample;
 			float3 binaryMaxRaySample = raySample;
 			float3 binaryRaySample = raySample;
-			uint2 binaryRaySampleDims = round(ConvertRaySample(binaryRaySample.xy, eyeIndex) * BufferDim);
-			uint2 prevBinaryRaySampleDims;
+			uint2 binaryRaySampleCoords = round(ConvertRaySample(binaryRaySample.xy, eyeIndex) * BufferDim);
+			uint2 prevBinaryRaySampleCoords;
 			float depthThicknessFactor;
 
 			for (int k = i; k < iterations; k++)
 			{
-				prevBinaryRaySampleDims = binaryRaySampleDims;
+				prevBinaryRaySampleCoords = binaryRaySampleCoords;
 				binaryRaySample = lerp(binaryMinRaySample, binaryMaxRaySample, 0.5);
-				binaryRaySampleDims = round(ConvertRaySample(binaryRaySample.xy, eyeIndex) * BufferDim);
+				binaryRaySampleCoords = round(ConvertRaySample(binaryRaySample.xy, eyeIndex) * BufferDim);
 
 				// Check if the optimal sampling location has already been found
-				if (all(binaryRaySampleDims == prevBinaryRaySampleDims))
+				if (all(binaryRaySampleCoords == prevBinaryRaySampleCoords))
 					break;
 
 				iterationDepth = DepthTex.SampleLevel(DepthSampler, ConvertRaySample(binaryRaySample.xy, eyeIndex), 0);			

--- a/package/Shaders/ISReflectionsRayTracing.hlsl
+++ b/package/Shaders/ISReflectionsRayTracing.hlsl
@@ -66,8 +66,7 @@ float4 GetReflectionColor(
 			uint2 prevBinaryRaySampleCoords;
 			float depthThicknessFactor;
 
-			for (int k = i; k < iterations; k++)
-			{
+			for (int k = i; k < iterations; k++) {
 				prevBinaryRaySampleCoords = binaryRaySampleCoords;
 				binaryRaySample = lerp(binaryMinRaySample, binaryMaxRaySample, 0.5);
 				binaryRaySampleCoords = round(ConvertRaySample(binaryRaySample.xy, eyeIndex) * BufferDim);

--- a/package/Shaders/ISReflectionsRayTracing.hlsl
+++ b/package/Shaders/ISReflectionsRayTracing.hlsl
@@ -48,17 +48,19 @@ float4 GetReflectionColor(
 {
 	float3 prevRaySample;
 	float3 raySample = projPosition;
-
-	for (int i = 0; i < iterations - 1; i++) {
-		prevRaySample = raySample;
+    
+	for (int i = 0; i < iterations - 1; i++)
+	{
+		prevRaySample = raySample;	
 		raySample = projPosition + (float(i) / float(iterations)) * projReflectionDirection;
 
 		if (FrameBuffer::isOutsideFrame(raySample.xy, true))
 			return 0.0;
 
 		float iterationDepth = DepthTex.SampleLevel(DepthSampler, ConvertRaySample(raySample.xy, eyeIndex), 0);
-
-		if (saturate((raySample.z - iterationDepth) / SSRParams.y) > 0.0) {
+				
+		if (saturate((raySample.z - iterationDepth) / SSRParams.y) > 0.0)
+		{
 			float3 binaryMinRaySample = prevRaySample;
 			float3 binaryMaxRaySample = raySample;
 			float3 binaryRaySample = raySample;
@@ -76,10 +78,10 @@ float4 GetReflectionColor(
 				if (all(binaryRaySampleCoords == prevBinaryRaySampleCoords))
 					break;
 
-				iterationDepth = DepthTex.SampleLevel(DepthSampler, ConvertRaySample(binaryRaySample.xy, eyeIndex), 0);
-
+				iterationDepth = DepthTex.SampleLevel(DepthSampler, ConvertRaySample(binaryRaySample.xy, eyeIndex), 0);			
+				
 				// Compute expected depth vs actual depth
-				depthThicknessFactor = 1.0 - saturate((binaryRaySample.z - iterationDepth) / SSRParams.y);
+				depthThicknessFactor = 1.0 - saturate(abs(binaryRaySample.z - iterationDepth) / SSRParams.y);
 
 				if (iterationDepth < binaryRaySample.z)
 					binaryMaxRaySample = binaryRaySample;
@@ -90,37 +92,37 @@ float4 GetReflectionColor(
 			// Early exit
 			if (depthThicknessFactor <= 0.0)
 				return 0.0;
-
+				
 			// Cubemap skies blend better
-			float4 skyDepths = DepthTex.GatherRed(DepthSampler, ConvertRaySample(binaryRaySample.xy, eyeIndex), 0);
-			float skyFadeFactor = dot(skyDepths != 1.0, 0.25);
+			float skyFadeFactor = iterationDepth != 1.0;
 
 			// Early exit
 			if (skyFadeFactor <= 0.0)
 				return 0.0;
-
+				
 			// Fade based on ray length)
 			float ssrMarchingRadiusFadeFactor = 1.0 - saturate(length(binaryRaySample - projPosition) / rayLength);
 
 			float2 uvResultScreenCenterOffset = binaryRaySample.xy - 0.5;
 
-#	ifdef VR
+#		ifdef VR
 			float centerDistance = abs(uvResultScreenCenterOffset.xy * 2.0);
 
 			// Make VR fades consistent by taking the closer of the two eyes
 			// Based on concepts from https://cuteloong.github.io/publications/scssr24/
 			float2 otherEyeUvResultScreenCenterOffset = Stereo::ConvertMonoUVToOtherEye(float3(binaryRaySample.xy, iterationDepth), eyeIndex).xy - 0.5;
 			centerDistance = min(centerDistance, abs(otherEyeUvResultScreenCenterOffset * 2.0));
-#	else
+#		else
 			float2 centerDistance = abs(uvResultScreenCenterOffset.xy * 2.0);
-#	endif
-
+#		endif
+			
 			// Fade out around screen edges
-			float2 centerDistanceFadeFactor = sqrt(saturate(1.0 - centerDistance));
+			float2 centerDistanceFadeFactor = pow(saturate(1.0 - centerDistance), 0.25);
 
 			float fadeFactor = depthThicknessFactor * skyFadeFactor * sqrt(ssrMarchingRadiusFadeFactor) * min(centerDistanceFadeFactor.x, centerDistanceFadeFactor.y);
-
-			if (fadeFactor > 0.0) {
+			
+			if (fadeFactor > 0.0)
+			{
 				float3 color = ColorTex.SampleLevel(ColorSampler, ConvertRaySample(binaryRaySample.xy, eyeIndex), 0);
 
 				// Final sample to world-space
@@ -177,7 +179,7 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float3 viewPosition = positionVS;
 	float3 viewDirection = normalize(viewPosition);
-
+	
 	float3 reflectionDirection = reflect(viewDirection, viewNormal);
 	float viewAttenuation = saturate(dot(viewDirection, reflectionDirection));
 	[branch] if (viewAttenuation < 0)

--- a/package/Shaders/ISReflectionsRayTracing.hlsl
+++ b/package/Shaders/ISReflectionsRayTracing.hlsl
@@ -48,19 +48,17 @@ float4 GetReflectionColor(
 {
 	float3 prevRaySample;
 	float3 raySample = projPosition;
-    
-	for (int i = 0; i < iterations - 1; i++)
-	{
-		prevRaySample = raySample;	
+
+	for (int i = 0; i < iterations - 1; i++) {
+		prevRaySample = raySample;
 		raySample = projPosition + (float(i) / float(iterations)) * projReflectionDirection;
 
 		if (FrameBuffer::isOutsideFrame(raySample.xy, true))
 			return 0.0;
 
 		float iterationDepth = DepthTex.SampleLevel(DepthSampler, ConvertRaySample(raySample.xy, eyeIndex), 0);
-				
-		if (saturate((raySample.z - iterationDepth) / SSRParams.y) > 0.0)
-		{
+
+		if (saturate((raySample.z - iterationDepth) / SSRParams.y) > 0.0) {
 			float3 binaryMinRaySample = prevRaySample;
 			float3 binaryMaxRaySample = raySample;
 			float3 binaryRaySample = raySample;
@@ -77,8 +75,8 @@ float4 GetReflectionColor(
 				if (all(binaryRaySampleCoords == prevBinaryRaySampleCoords))
 					break;
 
-				iterationDepth = DepthTex.SampleLevel(DepthSampler, ConvertRaySample(binaryRaySample.xy, eyeIndex), 0);			
-				
+				iterationDepth = DepthTex.SampleLevel(DepthSampler, ConvertRaySample(binaryRaySample.xy, eyeIndex), 0);
+
 				// Compute expected depth vs actual depth
 				depthThicknessFactor = 1.0 - saturate(abs(binaryRaySample.z - iterationDepth) / SSRParams.y);
 
@@ -91,37 +89,36 @@ float4 GetReflectionColor(
 			// Early exit
 			if (depthThicknessFactor <= 0.0)
 				return 0.0;
-				
+
 			// Cubemap skies blend better
 			float skyFadeFactor = iterationDepth != 1.0;
 
 			// Early exit
 			if (skyFadeFactor <= 0.0)
 				return 0.0;
-				
+
 			// Fade based on ray length)
 			float ssrMarchingRadiusFadeFactor = 1.0 - saturate(length(binaryRaySample - projPosition) / rayLength);
 
 			float2 uvResultScreenCenterOffset = binaryRaySample.xy - 0.5;
 
-#		ifdef VR
+#	ifdef VR
 			float centerDistance = abs(uvResultScreenCenterOffset.xy * 2.0);
 
 			// Make VR fades consistent by taking the closer of the two eyes
 			// Based on concepts from https://cuteloong.github.io/publications/scssr24/
 			float2 otherEyeUvResultScreenCenterOffset = Stereo::ConvertMonoUVToOtherEye(float3(binaryRaySample.xy, iterationDepth), eyeIndex).xy - 0.5;
 			centerDistance = min(centerDistance, abs(otherEyeUvResultScreenCenterOffset * 2.0));
-#		else
+#	else
 			float2 centerDistance = abs(uvResultScreenCenterOffset.xy * 2.0);
-#		endif
-			
+#	endif
+
 			// Fade out around screen edges
 			float2 centerDistanceFadeFactor = pow(saturate(1.0 - centerDistance), 0.25);
 
 			float fadeFactor = depthThicknessFactor * skyFadeFactor * sqrt(ssrMarchingRadiusFadeFactor) * min(centerDistanceFadeFactor.x, centerDistanceFadeFactor.y);
-			
-			if (fadeFactor > 0.0)
-			{
+
+			if (fadeFactor > 0.0) {
 				float3 color = ColorTex.SampleLevel(ColorSampler, ConvertRaySample(binaryRaySample.xy, eyeIndex), 0);
 
 				// Final sample to world-space
@@ -178,7 +175,7 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float3 viewPosition = positionVS;
 	float3 viewDirection = normalize(viewPosition);
-	
+
 	float3 reflectionDirection = reflect(viewDirection, viewNormal);
 	float viewAttenuation = saturate(dot(viewDirection, reflectionDirection));
 	[branch] if (viewAttenuation < 0)

--- a/package/Shaders/ISReflectionsRayTracing.hlsl
+++ b/package/Shaders/ISReflectionsRayTracing.hlsl
@@ -1,8 +1,8 @@
 #include "Common/DummyVSTexCoord.hlsl"
 #include "Common/FrameBuffer.hlsli"
-#include "Common/VR.hlsli"
 #include "Common/MotionBlur.hlsli"
 #include "Common/SharedData.hlsli"
+#include "Common/VR.hlsli"
 
 typedef VS_OUTPUT PS_INPUT;
 
@@ -42,7 +42,7 @@ float2 ConvertRaySamplePrevious(float2 raySample, uint eyeIndex)
 }
 
 float4 GetReflectionColor(
-	float3 projReflectionDirection, 
+	float3 projReflectionDirection,
 	float3 projPosition,
 	uint eyeIndex)
 {
@@ -104,8 +104,8 @@ float4 GetReflectionColor(
 			centerDistance = min(centerDistance, 2.0 * length(otherEyeUvResultScreenCenterOffset));
 #	else
 			float centerDistance = min(1.0, 2.0 * length(uvResultScreenCenterOffset.xy));
-#		endif
-			
+#	endif
+
 			// Fade out around screen edges
 			float centerDistanceFadeFactor = smoothstep(0.0, 0.25, 1.0 - centerDistance);
 			float fadeFactor = depthThicknessFactor * ssrMarchingRadiusFadeFactor * centerDistanceFadeFactor;

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -599,7 +599,7 @@ float3 GetWaterSpecularColor(PS_INPUT input, float3 normal, float3 viewDirection
 #			if !defined(LOD) && NUM_SPECULAR_LIGHTS == 0
 		if (PixelShaderDescriptor & WaterFlags::Cubemap) {
 			float pointingDirection = saturate(dot(viewDirection, R));
-			if (SSRParams.x > 0.0 && pointingDirection > 0.0){
+			if (SSRParams.x > 0.0 && pointingDirection > 0.0) {
 				float2 ssrReflectionUv = ((DynamicResolutionParams2.xy * input.HPosition.xy) * SSRParams.zw) + SSRParams2.x * normal.xy;
 				float2 ssrReflectionUvDR = FrameBuffer::GetDynamicResolutionAdjustedScreenPosition(ssrReflectionUv);
 				float4 ssrReflectionColorBlurred = SSRReflectionTex.Sample(SSRReflectionSampler, ssrReflectionUvDR);

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -598,8 +598,9 @@ float3 GetWaterSpecularColor(PS_INPUT input, float3 normal, float3 viewDirection
 
 #			if !defined(LOD) && NUM_SPECULAR_LIGHTS == 0
 		if (PixelShaderDescriptor & WaterFlags::Cubemap) {
-			float pointingDirection = saturate(dot(viewDirection, R));
-			if (SSRParams.x > 0.0 && pointingDirection > 0.0) {
+			float pointingDirection = dot(viewDirection, R);
+			float pointingAlignment = dot(reflect(viewDirection, float3(0, 0, 1)), R);
+			if (SSRParams.x > 0.0 && pointingDirection > 0.0 && pointingAlignment > 0.0){
 				float2 ssrReflectionUv = ((DynamicResolutionParams2.xy * input.HPosition.xy) * SSRParams.zw) + SSRParams2.x * normal.xy;
 				float2 ssrReflectionUvDR = FrameBuffer::GetDynamicResolutionAdjustedScreenPosition(ssrReflectionUv);
 				float4 ssrReflectionColorBlurred = SSRReflectionTex.Sample(SSRReflectionSampler, ssrReflectionUvDR);
@@ -609,7 +610,7 @@ float3 GetWaterSpecularColor(PS_INPUT input, float3 normal, float3 viewDirection
 				float4 ssrReflectionColor = lerp(ssrReflectionColorRaw, ssrReflectionColorBlurred, effectiveBlurFactor);
 
 				finalSsrReflectionColor = max(0, ssrReflectionColor.xyz);
-				ssrFraction = saturate(ssrReflectionColor.w * distanceFactor * SSRParams.x) * pointingDirection;
+				ssrFraction = saturate(ssrReflectionColor.w * distanceFactor * SSRParams.x) * min(pointingDirection, pointingAlignment);
 			}
 		}
 #			endif
@@ -725,7 +726,7 @@ DiffuseOutput GetWaterDiffuseColor(PS_INPUT input, float3 normal, float3 viewDir
 		skylighting = lerp(1.0, skylighting, Skylighting::getFadeOutFactor(input.WPosition.xyz));
 
 		float3 refractionDiffuseColorSkylight = Skylighting::mixDiffuse(skylightingSettings, skylighting);
-		refractionDiffuseColorSkylight = Color::LinearToGamma(Color::GammaToLinear(refractionDiffuseColor) * refractionDiffuseColorSkylight);
+		refractionDiffuseColor = Color::LinearToGamma(Color::GammaToLinear(refractionDiffuseColor) * refractionDiffuseColorSkylight);
 #				endif
 	}
 

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -599,7 +599,7 @@ float3 GetWaterSpecularColor(PS_INPUT input, float3 normal, float3 viewDirection
 #			if !defined(LOD) && NUM_SPECULAR_LIGHTS == 0
 		if (PixelShaderDescriptor & WaterFlags::Cubemap) {
 			float pointingDirection = saturate(dot(viewDirection, R));
-			if (SSRParams.x > 0.0 && pointingDirection > 0.0) {
+			if (SSRParams.x > 0.0 && pointingDirection > 0.0){
 				float2 ssrReflectionUv = ((DynamicResolutionParams2.xy * input.HPosition.xy) * SSRParams.zw) + SSRParams2.x * normal.xy;
 				float2 ssrReflectionUvDR = FrameBuffer::GetDynamicResolutionAdjustedScreenPosition(ssrReflectionUv);
 				float4 ssrReflectionColorBlurred = SSRReflectionTex.Sample(SSRReflectionSampler, ssrReflectionUvDR);
@@ -609,7 +609,7 @@ float3 GetWaterSpecularColor(PS_INPUT input, float3 normal, float3 viewDirection
 				float4 ssrReflectionColor = lerp(ssrReflectionColorRaw, ssrReflectionColorBlurred, effectiveBlurFactor);
 
 				finalSsrReflectionColor = max(0, ssrReflectionColor.xyz);
-				ssrFraction = saturate(ssrReflectionColor.w * distanceFactor * SSRParams.x * pointingDirection);
+				ssrFraction = saturate(ssrReflectionColor.w * distanceFactor * SSRParams.x) * pointingDirection;
 			}
 		}
 #			endif

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -600,7 +600,7 @@ float3 GetWaterSpecularColor(PS_INPUT input, float3 normal, float3 viewDirection
 		if (PixelShaderDescriptor & WaterFlags::Cubemap) {
 			float pointingDirection = dot(viewDirection, R);
 			float pointingAlignment = dot(reflect(viewDirection, float3(0, 0, 1)), R);
-			if (SSRParams.x > 0.0 && pointingDirection > 0.0 && pointingAlignment > 0.0){
+			if (SSRParams.x > 0.0 && pointingDirection > 0.0 && pointingAlignment > 0.0) {
 				float2 ssrReflectionUv = ((DynamicResolutionParams2.xy * input.HPosition.xy) * SSRParams.zw) + SSRParams2.x * normal.xy;
 				float2 ssrReflectionUvDR = FrameBuffer::GetDynamicResolutionAdjustedScreenPosition(ssrReflectionUv);
 				float4 ssrReflectionColorBlurred = SSRReflectionTex.Sample(SSRReflectionSampler, ssrReflectionUvDR);


### PR DESCRIPTION
As soon as SSR converges in the second pass, it exits. This is decided by if the sample coordinates of the texture do not change. i.e. we cannot get any better sampling realistically.

Iterations are increased because in most scenarios we never hit this amount anyway.

Blends with the dynamic cubemap if the sky is reflected, because the dynamic cubemap has reflections in all directions matching the actual normal.

Also fixes skylighting on water.