### PR TITLE
chore: better skyrim upscaler compat

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -951,35 +951,39 @@ void Menu::DrawDisableAtBootSettings()
 
 void Menu::DrawDisplaySettings()
 {
-	auto& themeSettings = Menu::GetSingleton()->settings.Theme;
+	if (!State::GetSingleton()->upscalerLoaded) {
+		auto& themeSettings = Menu::GetSingleton()->settings.Theme;
 
-	const std::vector<std::pair<std::string, std::function<void()>>> features = {
-		{ "Upscaling", []() { Upscaling::GetSingleton()->DrawSettings(); } },
-		{ "Frame Generation", []() { Streamline::GetSingleton()->DrawSettings(); } }
-	};
+		const std::vector<std::pair<std::string, std::function<void()>>> features = {
+			{ "Upscaling", []() { Upscaling::GetSingleton()->DrawSettings(); } },
+			{ "Frame Generation", []() { Streamline::GetSingleton()->DrawSettings(); } }
+		};
 
-	for (const auto& [featureName, drawFunc] : features) {
-		bool isDisabled = State::GetSingleton()->IsFeatureDisabled(featureName);
+		for (const auto& [featureName, drawFunc] : features) {
+			bool isDisabled = State::GetSingleton()->IsFeatureDisabled(featureName);
 
-		if (featureName == "Frame Generation" && REL::Module::IsVR()) {
-			isDisabled = true;
-		}
-
-		if (!isDisabled) {
-			if (ImGui::CollapsingHeader(featureName.c_str(), ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick)) {
-				drawFunc();
+			if (featureName == "Frame Generation" && REL::Module::IsVR()) {
+				isDisabled = true;
 			}
-		} else {
-			ImGui::PushStyleColor(ImGuiCol_Text, themeSettings.StatusPalette.Disable);
-			ImGui::CollapsingHeader(featureName.c_str(), ImGuiTreeNodeFlags_NoTreePushOnOpen);
-			ImGui::PopStyleColor();
-			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text(
-					"%s has been disabled at boot. "
-					"Reenable in the Advanced -> Disable at Boot Menu.",
-					featureName.c_str());
+
+			if (!isDisabled) {
+				if (ImGui::CollapsingHeader(featureName.c_str(), ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick)) {
+					drawFunc();
+				}
+			} else {
+				ImGui::PushStyleColor(ImGuiCol_Text, themeSettings.StatusPalette.Disable);
+				ImGui::CollapsingHeader(featureName.c_str(), ImGuiTreeNodeFlags_NoTreePushOnOpen);
+				ImGui::PopStyleColor();
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					ImGui::Text(
+						"%s has been disabled at boot. "
+						"Reenable in the Advanced -> Disable at Boot Menu.",
+						featureName.c_str());
+				}
 			}
 		}
+	} else {
+		ImGui::Text("Display options disabled due to Skyrim Upscaler");
 	}
 }
 

--- a/src/Upscaling.h
+++ b/src/Upscaling.h
@@ -115,14 +115,18 @@ public:
 
 	static void InstallHooks()
 	{
-		bool isGOG = !std::filesystem::exists(L"steam_api64.dll");
+		if (!State::GetSingleton()->upscalerLoaded) {
+			bool isGOG = !std::filesystem::exists(L"steam_api64.dll");
 
-		stl::write_thunk_call<Main_UpdateJitter>(REL::RelocationID(75460, 77245).address() + REL::Relocate(0xE5, isGOG ? 0x133 : 0xE2, 0x104));
-		stl::write_thunk_call<TAA_BeginTechnique>(REL::RelocationID(100540, 107270).address() + REL::Relocate(0x3E9, 0x3EA, 0x448));
-		stl::write_thunk_call<TAA_EndTechnique>(REL::RelocationID(100540, 107270).address() + REL::Relocate(0x3F3, 0x3F4, 0x452));
-		logger::info("[Upscaling] Installed hooks");
+			stl::write_thunk_call<Main_UpdateJitter>(REL::RelocationID(75460, 77245).address() + REL::Relocate(0xE5, isGOG ? 0x133 : 0xE2, 0x104));
+			stl::write_thunk_call<TAA_BeginTechnique>(REL::RelocationID(100540, 107270).address() + REL::Relocate(0x3E9, 0x3EA, 0x448));
+			stl::write_thunk_call<TAA_EndTechnique>(REL::RelocationID(100540, 107270).address() + REL::Relocate(0x3F3, 0x3F4, 0x452));
+			logger::info("[Upscaling] Installed hooks");
 
-		RE::UI::GetSingleton()->GetEventSource<RE::MenuOpenCloseEvent>()->AddEventSink(Upscaling::GetSingleton());
-		logger::info("[Upscaling] Registered for MenuOpenCloseEvent");
+			RE::UI::GetSingleton()->GetEventSource<RE::MenuOpenCloseEvent>()->AddEventSink(Upscaling::GetSingleton());
+			logger::info("[Upscaling] Registered for MenuOpenCloseEvent");
+		} else {
+			logger::info("[Upscaling] Not installing hooks due to Skyrim Upscaler");
+		}
 	}
 };


### PR DESCRIPTION
Hides the menu and disables our hooks when the skyrim upscaler is present.

Text in the menu says why it was disabled, and it is logged.