### PR TITLE
refactor: shader bindings

### DIFF
--- a/features/Cloud Shadows/Shaders/CloudShadows/CloudShadows.hlsli
+++ b/features/Cloud Shadows/Shaders/CloudShadows/CloudShadows.hlsli
@@ -1,5 +1,5 @@
 
-TextureCube<float4> cloudShadowsTexture : register(t27);
+TextureCube<float4> cloudShadowsTexture : register(t30);
 
 #define CloudHeight (2e3f / 1.428e-2)
 #define PlanetRadius (6371e3f / 1.428e-2)

--- a/features/Cloud Shadows/Shaders/CloudShadows/CloudShadows.hlsli
+++ b/features/Cloud Shadows/Shaders/CloudShadows/CloudShadows.hlsli
@@ -1,5 +1,5 @@
 
-TextureCube<float4> cloudShadowsTexture : register(t30);
+TextureCube<float4> cloudShadowsTexture : register(t25);
 
 #define CloudHeight (2e3f / 1.428e-2)
 #define PlanetRadius (6371e3f / 1.428e-2)

--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -1,5 +1,5 @@
-TextureCube<float4> specularTexture : register(t64);
-TextureCube<float4> specularTextureNoReflections : register(t65);
+TextureCube<float4> specularTexture : register(t40);
+TextureCube<float4> specularTextureNoReflections : register(t41);
 
 namespace DynamicCubemaps
 {

--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -1,5 +1,5 @@
-TextureCube<float4> specularTexture : register(t40);
-TextureCube<float4> specularTextureNoReflections : register(t41);
+TextureCube<float4> specularTexture : register(t30);
+TextureCube<float4> specularTextureNoReflections : register(t31);
 
 namespace DynamicCubemaps
 {

--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -7,10 +7,10 @@ struct StrictLightData
 	uint pad0[2];
 };
 
-StructuredBuffer<StructuredLight> lights : register(t50);
-StructuredBuffer<uint> lightList : register(t51);       //MAX_CLUSTER_LIGHTS * 16^3
-StructuredBuffer<LightGrid> lightGrid : register(t52);  //16^3
-StructuredBuffer<StrictLightData> strictLights : register(t53);
+StructuredBuffer<StructuredLight> lights : register(t35);
+StructuredBuffer<uint> lightList : register(t36);       //MAX_CLUSTER_LIGHTS * 16^3
+StructuredBuffer<LightGrid> lightGrid : register(t37);  //16^3
+StructuredBuffer<StrictLightData> strictLights : register(t38);
 
 namespace LightLimitFix
 {

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/ScreenSpaceShadows.hlsli
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/ScreenSpaceShadows.hlsli
@@ -1,6 +1,6 @@
 #include "Common/Math.hlsli"
 
-Texture2D<unorm half> ScreenSpaceShadowsTexture : register(t17);
+Texture2D<unorm half> ScreenSpaceShadowsTexture : register(t60);
 
 namespace ScreenSpaceShadows
 {

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/ScreenSpaceShadows.hlsli
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/ScreenSpaceShadows.hlsli
@@ -1,6 +1,6 @@
 #include "Common/Math.hlsli"
 
-Texture2D<unorm half> ScreenSpaceShadowsTexture : register(t60);
+Texture2D<unorm half> ScreenSpaceShadowsTexture : register(t45);
 
 namespace ScreenSpaceShadows
 {

--- a/features/Skylighting/Shaders/Skylighting/Skylighting.hlsli
+++ b/features/Skylighting/Shaders/Skylighting/Skylighting.hlsli
@@ -4,7 +4,7 @@
 #include "Common/Spherical Harmonics/SphericalHarmonics.hlsli"
 
 #ifdef PSHADER
-Texture3D<sh2> SkylightingProbeArray : register(t29);
+Texture3D<sh2> SkylightingProbeArray : register(t70);
 #endif
 
 namespace Skylighting

--- a/features/Skylighting/Shaders/Skylighting/Skylighting.hlsli
+++ b/features/Skylighting/Shaders/Skylighting/Skylighting.hlsli
@@ -4,7 +4,7 @@
 #include "Common/Spherical Harmonics/SphericalHarmonics.hlsli"
 
 #ifdef PSHADER
-Texture3D<sh2> SkylightingProbeArray : register(t70);
+Texture3D<sh2> SkylightingProbeArray : register(t50);
 #endif
 
 namespace Skylighting

--- a/features/Terrain Blending/Shaders/TerrainBlending/TerrainBlending.hlsli
+++ b/features/Terrain Blending/Shaders/TerrainBlending/TerrainBlending.hlsli
@@ -1,5 +1,5 @@
 
-Texture2D<float4> TerrainBlendingMaskTexture : register(t35);
+Texture2D<float4> TerrainBlendingMaskTexture : register(t80);
 
 namespace TerrainBlending
 {

--- a/features/Terrain Blending/Shaders/TerrainBlending/TerrainBlending.hlsli
+++ b/features/Terrain Blending/Shaders/TerrainBlending/TerrainBlending.hlsli
@@ -1,5 +1,5 @@
 
-Texture2D<float4> TerrainBlendingMaskTexture : register(t80);
+Texture2D<float4> TerrainBlendingMaskTexture : register(t55);
 
 namespace TerrainBlending
 {

--- a/features/Terrain Shadows/Shaders/TerrainShadows/TerrainShadows.hlsli
+++ b/features/Terrain Shadows/Shaders/TerrainShadows/TerrainShadows.hlsli
@@ -1,4 +1,4 @@
-Texture2D<float2> TexShadowHeight : register(t42);
+Texture2D<float2> TexShadowHeight : register(t90);
 
 namespace TerrainShadows
 {

--- a/features/Terrain Shadows/Shaders/TerrainShadows/TerrainShadows.hlsli
+++ b/features/Terrain Shadows/Shaders/TerrainShadows/TerrainShadows.hlsli
@@ -1,4 +1,4 @@
-Texture2D<float2> TexShadowHeight : register(t90);
+Texture2D<float2> TexShadowHeight : register(t60);
 
 namespace TerrainShadows
 {

--- a/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
+++ b/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
@@ -1,4 +1,4 @@
-Texture2D<float4> WaterCaustics : register(t70);
+Texture2D<float4> WaterCaustics : register(t100);
 
 namespace WaterEffects
 {

--- a/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
+++ b/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
@@ -1,4 +1,4 @@
-Texture2D<float4> WaterCaustics : register(t100);
+Texture2D<float4> WaterCaustics : register(t65);
 
 namespace WaterEffects
 {

--- a/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
+++ b/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
@@ -2,7 +2,7 @@
 
 namespace WetnessEffects
 {
-	Texture2D<float4> TexPrecipOcclusion : register(t110);
+	Texture2D<float4> TexPrecipOcclusion : register(t70);
 
 	// https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
 	float2 EnvBRDFApproxWater(float3 F0, float Roughness, float NoV)

--- a/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
+++ b/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
@@ -2,7 +2,7 @@
 
 namespace WetnessEffects
 {
-	Texture2D<float4> TexPrecipOcclusion : register(t31);
+	Texture2D<float4> TexPrecipOcclusion : register(t110);
 
 	// https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
 	float2 EnvBRDFApproxWater(float3 F0, float Roughness, float NoV)

--- a/package/Shaders/Common/Glints/Glints2023.hlsli
+++ b/package/Shaders/Common/Glints/Glints2023.hlsli
@@ -1,6 +1,6 @@
 #include "Common/Math.hlsli"
 
-Texture2D<float4> _Glint2023NoiseMap : register(t28);
+Texture2D<float4> _Glint2023NoiseMap : register(t20);
 
 namespace Glints
 {

--- a/package/Shaders/Common/ShadowSampling.hlsli
+++ b/package/Shaders/Common/ShadowSampling.hlsli
@@ -5,7 +5,7 @@
 #include "Common/Random.hlsli"
 #include "Common/SharedData.hlsli"
 
-Texture2DArray<float4> SharedTexShadowMapSampler : register(t25);
+Texture2DArray<float4> SharedTexShadowMapSampler : register(t18);
 
 struct PerGeometry
 {
@@ -24,7 +24,7 @@ struct PerGeometry
 	float4x4 CameraViewProjInverse[2];
 };
 
-StructuredBuffer<PerGeometry> SharedPerShadow : register(t26);
+StructuredBuffer<PerGeometry> SharedPerShadow : register(t19);
 
 namespace ShadowSampling
 {

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -135,7 +135,7 @@ cbuffer FeatureData : register(b6)
 	SkylightingSettings skylightingSettings;
 };
 
-Texture2D<float4> TexDepthSampler : register(t20);
+Texture2D<float4> TexDepthSampler : register(t17);
 
 namespace SharedData
 {

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -207,7 +207,7 @@ void Deferred::CopyShadowData()
 			perShadow->srv.get(),
 		};
 
-		context->PSSetShaderResources(25, ARRAYSIZE(srvs), srvs);
+		context->PSSetShaderResources(18, ARRAYSIZE(srvs), srvs);
 	}
 }
 

--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -64,7 +64,7 @@ void CloudShadows::Prepass()
 	auto& context = State::GetSingleton()->context;
 
 	ID3D11ShaderResourceView* srv = texCubemapCloudOcc->srv.get();
-	context->PSSetShaderResources(27, 1, &srv);
+	context->PSSetShaderResources(30, 1, &srv);
 }
 
 void CloudShadows::SetupResources()

--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -64,7 +64,7 @@ void CloudShadows::Prepass()
 	auto& context = State::GetSingleton()->context;
 
 	ID3D11ShaderResourceView* srv = texCubemapCloudOcc->srv.get();
-	context->PSSetShaderResources(30, 1, &srv);
+	context->PSSetShaderResources(25, 1, &srv);
 }
 
 void CloudShadows::SetupResources()

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -508,7 +508,7 @@ void DynamicCubemaps::PostDeferred()
 	auto& context = State::GetSingleton()->context;
 
 	ID3D11ShaderResourceView* views[2] = { (activeReflections ? envReflectionsTexture : envTexture)->srv.get(), envTexture->srv.get() };
-	context->PSSetShaderResources(40, 2, views);
+	context->PSSetShaderResources(30, 2, views);
 }
 
 void DynamicCubemaps::SetupResources()

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -508,7 +508,7 @@ void DynamicCubemaps::PostDeferred()
 	auto& context = State::GetSingleton()->context;
 
 	ID3D11ShaderResourceView* views[2] = { (activeReflections ? envReflectionsTexture : envTexture)->srv.get(), envTexture->srv.get() };
-	context->PSSetShaderResources(64, 2, views);
+	context->PSSetShaderResources(40, 2, views);
 }
 
 void DynamicCubemaps::SetupResources()

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -389,7 +389,7 @@ void LightLimitFix::BSLightingShader_SetupGeometry_After(RE::BSRenderPass*)
 	static Util::FrameChecker frameChecker;
 	if (frameChecker.IsNewFrame()) {
 		ID3D11ShaderResourceView* view = strictLightData->srv.get();
-		context->PSSetShaderResources(53, 1, &view);
+		context->PSSetShaderResources(38, 1, &view);
 	}
 }
 
@@ -458,7 +458,7 @@ void LightLimitFix::Prepass()
 	views[0] = lights->srv.get();
 	views[1] = lightIndexList->srv.get();
 	views[2] = lightGrid->srv.get();
-	context->PSSetShaderResources(50, ARRAYSIZE(views), views);
+	context->PSSetShaderResources(35, ARRAYSIZE(views), views);
 }
 
 bool LightLimitFix::IsValidLight(RE::BSLight* a_light)

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -234,7 +234,7 @@ void ScreenSpaceShadows::Prepass()
 			DrawShadows();
 
 	auto view = screenSpaceShadowsTexture->srv.get();
-	context->PSSetShaderResources(60, 1, &view);
+	context->PSSetShaderResources(45, 1, &view);
 }
 
 void ScreenSpaceShadows::LoadSettings(json& o_json)

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -234,7 +234,7 @@ void ScreenSpaceShadows::Prepass()
 			DrawShadows();
 
 	auto view = screenSpaceShadowsTexture->srv.get();
-	context->PSSetShaderResources(17, 1, &view);
+	context->PSSetShaderResources(60, 1, &view);
 }
 
 void ScreenSpaceShadows::LoadSettings(json& o_json)

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -249,7 +249,7 @@ void Skylighting::Prepass()
 	// set PS shader resource
 	{
 		ID3D11ShaderResourceView* srv = texProbeArray->srv.get();
-		context->PSSetShaderResources(70, 1, &srv);
+		context->PSSetShaderResources(50, 1, &srv);
 	}
 }
 

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -249,7 +249,7 @@ void Skylighting::Prepass()
 	// set PS shader resource
 	{
 		ID3D11ShaderResourceView* srv = texProbeArray->srv.get();
-		context->PSSetShaderResources(29, 1, &srv);
+		context->PSSetShaderResources(70, 1, &srv);
 	}
 }
 

--- a/src/Features/TerrainBlending.cpp
+++ b/src/Features/TerrainBlending.cpp
@@ -188,7 +188,7 @@ void TerrainBlending::OverrideTerrainWorld()
 
 	// Used to get the distance of the surface to the lowest depth
 	auto view = terrainOffsetTexture->srv.get();
-	context->PSSetShaderResources(80, 1, &view);
+	context->PSSetShaderResources(55, 1, &view);
 }
 
 void TerrainBlending::OverrideTerrainDepth()

--- a/src/Features/TerrainBlending.cpp
+++ b/src/Features/TerrainBlending.cpp
@@ -188,7 +188,7 @@ void TerrainBlending::OverrideTerrainWorld()
 
 	// Used to get the distance of the surface to the lowest depth
 	auto view = terrainOffsetTexture->srv.get();
-	context->PSSetShaderResources(35, 1, &view);
+	context->PSSetShaderResources(80, 1, &view);
 }
 
 void TerrainBlending::OverrideTerrainDepth()

--- a/src/Features/TerrainShadows.cpp
+++ b/src/Features/TerrainShadows.cpp
@@ -387,6 +387,6 @@ void TerrainShadows::Prepass()
 		std::array<ID3D11ShaderResourceView*, 3> srvs = { nullptr };
 		if (texShadowHeight)
 			srvs.at(2) = texShadowHeight->srv.get();
-		context->PSSetShaderResources(40, (uint)srvs.size(), srvs.data());
+		context->PSSetShaderResources(90, (uint)srvs.size(), srvs.data());
 	}
 }

--- a/src/Features/TerrainShadows.cpp
+++ b/src/Features/TerrainShadows.cpp
@@ -387,6 +387,6 @@ void TerrainShadows::Prepass()
 		std::array<ID3D11ShaderResourceView*, 3> srvs = { nullptr };
 		if (texShadowHeight)
 			srvs.at(2) = texShadowHeight->srv.get();
-		context->PSSetShaderResources(90, (uint)srvs.size(), srvs.data());
+		context->PSSetShaderResources(60, (uint)srvs.size(), srvs.data());
 	}
 }

--- a/src/Features/WaterEffects.cpp
+++ b/src/Features/WaterEffects.cpp
@@ -17,7 +17,7 @@ void WaterEffects::Prepass()
 {
 	auto& context = State::GetSingleton()->context;
 	auto srv = causticsView.get();
-	context->PSSetShaderResources(70, 1, &srv);
+	context->PSSetShaderResources(100, 1, &srv);
 }
 
 bool WaterEffects::HasShaderDefine(RE::BSShader::Type)

--- a/src/Features/WaterEffects.cpp
+++ b/src/Features/WaterEffects.cpp
@@ -17,7 +17,7 @@ void WaterEffects::Prepass()
 {
 	auto& context = State::GetSingleton()->context;
 	auto srv = causticsView.get();
-	context->PSSetShaderResources(100, 1, &srv);
+	context->PSSetShaderResources(65, 1, &srv);
 }
 
 bool WaterEffects::HasShaderDefine(RE::BSShader::Type)

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -271,7 +271,7 @@ void WetnessEffects::Prepass()
 	auto state = State::GetSingleton();
 	auto& context = state->context;
 
-	context->PSSetShaderResources(110, 1, &precipOcclusionTexture.depthSRV);
+	context->PSSetShaderResources(70, 1, &precipOcclusionTexture.depthSRV);
 }
 
 void WetnessEffects::LoadSettings(json& o_json)

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -271,7 +271,7 @@ void WetnessEffects::Prepass()
 	auto state = State::GetSingleton();
 	auto& context = state->context;
 
-	context->PSSetShaderResources(31, 1, &precipOcclusionTexture.depthSRV);
+	context->PSSetShaderResources(110, 1, &precipOcclusionTexture.depthSRV);
 }
 
 void WetnessEffects::LoadSettings(json& o_json)

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -694,7 +694,7 @@ void State::UpdateSharedData()
 	auto terrainBlending = TerrainBlending::GetSingleton();
 	auto srv = (terrainBlending->loaded ? terrainBlending->blendedDepthTexture16->srv.get() : depth.depthSRV);
 
-	context->PSSetShaderResources(20, 1, &srv);
+	context->PSSetShaderResources(17, 1, &srv);
 }
 
 void State::ClearDisabledFeatures()

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -265,7 +265,7 @@ void TruePBR::PrePass()
 	if (!glintsNoiseTexture)
 		SetupGlintsTexture();
 	ID3D11ShaderResourceView* srv = glintsNoiseTexture->srv.get();
-	context->PSSetShaderResources(28, 1, &srv);
+	context->PSSetShaderResources(20, 1, &srv);
 }
 
 void TruePBR::SetupGlintsTexture()


### PR DESCRIPTION
Refactors shading bindings so that they are not random.

Each feature is allocated 5 slots in alphabetical order, with 5 left for SSGI to use in the future.