### PR TITLE
feat: group not loaded features in UI

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -498,16 +498,24 @@ void Menu::DrawSettings()
 			menuList.push_back("Core Features"s);
 			std::ranges::copy(
 				sortedFeatureList | std::ranges::views::filter([](Feature* feat) {
-					return feat->IsCore();
+					return feat->IsCore() && feat->loaded;
 				}),
 				std::back_inserter(menuList));
 
 			menuList.push_back("Features"s);
 			std::ranges::copy(
 				sortedFeatureList | std::ranges::views::filter([](Feature* feat) {
-					return !feat->IsCore();
+					return !feat->IsCore() && feat->loaded;
 				}),
 				std::back_inserter(menuList));
+
+			auto unloadedFeatures = sortedFeatureList | std::ranges::views::filter([](Feature* feat) {
+				return !feat->loaded;
+			});
+			if (std::ranges::distance(unloadedFeatures) != 0) {
+				menuList.push_back("Unloaded Features"s);
+				std::ranges::copy(unloadedFeatures, std::back_inserter(menuList));
+			}
 
 			ImGui::TableNextColumn();
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 0.0f);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7310f3f8-4d66-4428-b311-9b7c4e9d9af3)

Now groups not loaded features into it's own group in UI. This was done to cause less confusion for endusers why some features are grey