### PR TITLE
fix: detect lack of d3d11.1 support, TAA sharpening

### DIFF
--- a/src/State.cpp
+++ b/src/State.cpp
@@ -493,6 +493,8 @@ void State::SetupResources()
 	device = reinterpret_cast<ID3D11Device*>(renderer->GetRuntimeData().forwarder);
 	context->QueryInterface(__uuidof(pPerf), reinterpret_cast<void**>(&pPerf));
 
+	featureLevel = device->GetFeatureLevel();
+
 	tracyCtx = TracyD3D11Context(device, context);
 }
 

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -111,6 +111,8 @@ void State::Setup()
 			feature->SetupResources();
 	Deferred::GetSingleton()->SetupResources();
 	Streamline::GetSingleton()->SetupResources();
+	if (!upscalerLoaded)
+		Upscaling::GetSingleton()->CreateUpscalingResources();
 	if (initialized)
 		return;
 	initialized = true;

--- a/src/State.h
+++ b/src/State.h
@@ -161,7 +161,8 @@ public:
 	float2 screenSize = {};
 	ID3D11DeviceContext* context = nullptr;
 	ID3D11Device* device = nullptr;
-
+	D3D_FEATURE_LEVEL featureLevel;
+	
 	TracyD3D11Ctx tracyCtx = nullptr;  // Tracy context
 
 	void ClearDisabledFeatures();

--- a/src/State.h
+++ b/src/State.h
@@ -162,7 +162,7 @@ public:
 	ID3D11DeviceContext* context = nullptr;
 	ID3D11Device* device = nullptr;
 	D3D_FEATURE_LEVEL featureLevel;
-	
+
 	TracyD3D11Ctx tracyCtx = nullptr;  // Tracy context
 
 	void ClearDisabledFeatures();

--- a/src/Upscaling.cpp
+++ b/src/Upscaling.cpp
@@ -30,7 +30,7 @@ void Upscaling::DrawSettings()
 	bool featureDLSS = streamline->featureDLSS;
 	uint* currentUpscaleMode = featureDLSS ? &settings.upscaleMethod : &settings.upscaleMethodNoDLSS;
 	uint availableModes = (state->isVR && state->upscalerLoaded) ? (featureDLSS ? 2 : 1) : (featureDLSS ? 3 : 2);
-	
+
 	if (State::GetSingleton()->featureLevel != D3D_FEATURE_LEVEL_11_1)
 		availableModes = 1;
 
@@ -132,7 +132,7 @@ Upscaling::UpscaleMethod Upscaling::GetUpscaleMethod()
 	if (State::GetSingleton()->featureLevel != D3D_FEATURE_LEVEL_11_1)
 		return (Upscaling::UpscaleMethod)settings.upscaleMethodNoFSR;
 
-	if(Streamline::GetSingleton()->featureDLSS)
+	if (Streamline::GetSingleton()->featureDLSS)
 		return (Upscaling::UpscaleMethod)settings.upscaleMethod;
 
 	return (Upscaling::UpscaleMethod)settings.upscaleMethodNoDLSS;

--- a/src/Upscaling.cpp
+++ b/src/Upscaling.cpp
@@ -399,7 +399,7 @@ void Upscaling::SharpenTAA()
 	}
 
 	state->EndPerfEvent();
-	
+
 	context->CopyResource(outputTextureResource, upscalingTexture->resource.get());
 }
 

--- a/src/Upscaling.h
+++ b/src/Upscaling.h
@@ -42,7 +42,8 @@ public:
 	struct Settings
 	{
 		uint upscaleMethod = (uint)UpscaleMethod::kDLSS;
-		uint upscaleMethodNoDLSS = (uint)UpscaleMethod::kFSR;
+		uint upscaleMethodNoDLSS = (uint)UpscaleMethod::kFSR;			
+		uint upscaleMethodNoFSR = (uint)UpscaleMethod::kTAA;
 		float sharpness = 0.5f;
 		uint dlssPreset = (uint)sl::DLSSPreset::ePresetC;
 	};

--- a/src/Upscaling.h
+++ b/src/Upscaling.h
@@ -147,7 +147,7 @@ public:
 			stl::write_thunk_call<Main_UpdateJitter>(REL::RelocationID(75460, 77245).address() + REL::Relocate(0xE5, isGOG ? 0x133 : 0xE2, 0x104));
 			stl::write_thunk_call<TAA_BeginTechnique>(REL::RelocationID(100540, 107270).address() + REL::Relocate(0x3E9, 0x3EA, 0x448));
 			stl::write_thunk_call<TAA_EndTechnique>(REL::RelocationID(100540, 107270).address() + REL::Relocate(0x3F3, 0x3F4, 0x452));
-			stl::write_thunk_call<BSImageSpacerShader_RenderPassImmediately>(REL::RelocationID(100951, 107733).address() + REL::Relocate(0x82, 0x78));
+			stl::write_thunk_call<BSImageSpacerShader_RenderPassImmediately>(REL::RelocationID(100951, 107733).address() + REL::Relocate(0x82, 0x78, 0x7E));
 			stl::detour_thunk<BSImageSpacerShader_Render>(REL::RelocationID(99023, 105674));
 
 			logger::info("[Upscaling] Installed hooks");

--- a/src/Upscaling.h
+++ b/src/Upscaling.h
@@ -42,7 +42,7 @@ public:
 	struct Settings
 	{
 		uint upscaleMethod = (uint)UpscaleMethod::kDLSS;
-		uint upscaleMethodNoDLSS = (uint)UpscaleMethod::kFSR;			
+		uint upscaleMethodNoDLSS = (uint)UpscaleMethod::kFSR;
 		uint upscaleMethodNoFSR = (uint)UpscaleMethod::kTAA;
 		float sharpness = 0.5f;
 		uint dlssPreset = (uint)sl::DLSSPreset::ePresetC;

--- a/src/Upscaling.h
+++ b/src/Upscaling.h
@@ -41,8 +41,8 @@ public:
 
 	struct Settings
 	{
-		uint upscaleMethod = (uint)UpscaleMethod::kDLSS;
-		uint upscaleMethodNoDLSS = (uint)UpscaleMethod::kFSR;
+		uint upscaleMethod = (uint)UpscaleMethod::kTAA;
+		uint upscaleMethodNoDLSS = (uint)UpscaleMethod::kTAA;
 		uint upscaleMethodNoFSR = (uint)UpscaleMethod::kTAA;
 		float sharpness = 0.5f;
 		uint dlssPreset = (uint)sl::DLSSPreset::ePresetC;
@@ -69,6 +69,7 @@ public:
 
 	void UpdateJitter();
 	void Upscale();
+	void SharpenTAA();
 
 	Texture2D* upscalingTexture;
 	Texture2D* alphaMaskTexture;
@@ -109,6 +110,30 @@ public:
 				singleton->Upscale();
 			else
 				func(a_shader, a_null);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	struct BSImageSpacerShader_RenderPassImmediately
+	{
+		static void thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags)
+		{
+			func(Pass, Technique, AlphaTest, RenderFlags);
+			auto singleton = GetSingleton();
+			auto upscaleMode = singleton->GetUpscaleMethod();
+			if (singleton->validTaaPass && upscaleMode == UpscaleMethod::kTAA)
+				singleton->SharpenTAA();
+			singleton->validTaaPass = false;
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	struct BSImageSpacerShader_Render
+	{
+		static void thunk(RE::ImageSpaceManager* a_manager, uint unk1, uint unk2)
+		{
+			func(a_manager, unk1, unk2);
+			auto singleton = GetSingleton();
 			singleton->validTaaPass = false;
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
@@ -122,6 +147,9 @@ public:
 			stl::write_thunk_call<Main_UpdateJitter>(REL::RelocationID(75460, 77245).address() + REL::Relocate(0xE5, isGOG ? 0x133 : 0xE2, 0x104));
 			stl::write_thunk_call<TAA_BeginTechnique>(REL::RelocationID(100540, 107270).address() + REL::Relocate(0x3E9, 0x3EA, 0x448));
 			stl::write_thunk_call<TAA_EndTechnique>(REL::RelocationID(100540, 107270).address() + REL::Relocate(0x3F3, 0x3F4, 0x452));
+			stl::write_thunk_call<BSImageSpacerShader_RenderPassImmediately>(REL::RelocationID(100951, 107733).address() + REL::Relocate(0x82, 0x78));
+			stl::detour_thunk<BSImageSpacerShader_Render>(REL::RelocationID(99023, 105674));
+
 			logger::info("[Upscaling] Installed hooks");
 
 			RE::UI::GetSingleton()->GetEventSource<RE::MenuOpenCloseEvent>()->AddEventSink(Upscaling::GetSingleton());

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -151,7 +151,7 @@ bool Load()
 	}
 
 	if (REL::Module::IsVR()) {
-		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.159.0", true);
+		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.160.0", true);
 	}
 
 	auto privateProfileRedirectorVersion = Util::GetDllVersion(L"Data/SKSE/Plugins/PrivateProfileRedirector.dll");


### PR DESCRIPTION
This means that older GPUs can still run CS.
TAA is improved because it now has RCAS.
TAA is the default for everything because it has much better performance and most people will not care about better AA, and runs on everything.