### PR TITLE
fix(VR): fix vr offset and bump address lib dependency

### DIFF
--- a/src/Upscaling.h
+++ b/src/Upscaling.h
@@ -147,7 +147,7 @@ public:
 			stl::write_thunk_call<Main_UpdateJitter>(REL::RelocationID(75460, 77245).address() + REL::Relocate(0xE5, isGOG ? 0x133 : 0xE2, 0x104));
 			stl::write_thunk_call<TAA_BeginTechnique>(REL::RelocationID(100540, 107270).address() + REL::Relocate(0x3E9, 0x3EA, 0x448));
 			stl::write_thunk_call<TAA_EndTechnique>(REL::RelocationID(100540, 107270).address() + REL::Relocate(0x3F3, 0x3F4, 0x452));
-			stl::write_thunk_call<BSImageSpacerShader_RenderPassImmediately>(REL::RelocationID(100951, 107733).address() + REL::Relocate(0x82, 0x78));
+			stl::write_thunk_call<BSImageSpacerShader_RenderPassImmediately>(REL::RelocationID(100951, 107733).address() + REL::Relocate(0x82, 0x78, 0x7E));
 			stl::detour_thunk<BSImageSpacerShader_Render>(REL::RelocationID(99023, 105674));
 
 			logger::info("[Upscaling] Installed hooks");

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -151,7 +151,7 @@ bool Load()
 	}
 
 	if (REL::Module::IsVR()) {
-		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.159.0", true);
+		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.160.0", true);
 	}
 
 	auto privateProfileRedirectorVersion = Util::GetDllVersion(L"Data/SKSE/Plugins/PrivateProfileRedirector.dll");


### PR DESCRIPTION
Requires a new version of vr address lib, PR here -> https://github.com/alandtse/skyrim_vr_address_library/pull/79