### PR TITLE
fix: cloud shadows issues

### DIFF
--- a/features/Cloud Shadows/Shaders/CloudShadows/CloudShadows.hlsli
+++ b/features/Cloud Shadows/Shaders/CloudShadows/CloudShadows.hlsli
@@ -1,6 +1,6 @@
 namespace CloudShadows
 {
-	TextureCube<float4> CloudShadowsTexture : register(t25);
+	TextureCube<float> CloudShadowsTexture : register(t25);
 
 	const static float CloudHeight = 2e3f / 1.428e-2;
 	const static float PlanetRadius = (6371e3f / 1.428e-2);
@@ -20,7 +20,7 @@ namespace CloudShadows
 	float GetCloudShadowMult(float3 worldPosition, SamplerState textureSampler)
 	{
 		float3 cloudSampleDir = GetCloudShadowSampleDir(worldPosition, SharedData::DirLightDirection.xyz).xyz;
-		float cloudCubeSample = CloudShadowsTexture.SampleLevel(textureSampler, cloudSampleDir, 0).w;
+		float cloudCubeSample = CloudShadowsTexture.SampleLevel(textureSampler, cloudSampleDir, 0).x;
 		return 1.0 - saturate(cloudCubeSample);
 	}
 }

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -7,7 +7,7 @@
 namespace SharedData
 {
 
-#if defined(PSHADER) || defined(COMPUTESHADER)
+#if defined(PSHADER) || defined(CSHADER) || defined(COMPUTESHADER)
 	cbuffer SharedData : register(b5)
 	{
 		float4 WaterData[25];

--- a/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
+++ b/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
@@ -16,10 +16,10 @@ Texture3D<float4> NoiseTex : register(t3);
 RWTexture3D<float4> DensityRW : register(u0);
 RWTexture3D<float4> DensityCopyRW : register(u1);
 
-#define LinearSampler ShadowmapSampler
+#	define LinearSampler ShadowmapSampler
 
-#include "Common/Framebuffer.hlsli"
-#include "Common/SharedData.hlsli"
+#	include "Common/Framebuffer.hlsli"
+#	include "Common/SharedData.hlsli"
 
 #	if defined(TERRAIN_SHADOWS)
 #		include "TerrainShadows/TerrainShadows.hlsli"
@@ -29,7 +29,7 @@ RWTexture3D<float4> DensityCopyRW : register(u1);
 #		include "CloudShadows/CloudShadows.hlsli"
 #	endif
 
-#include "Common/ShadowSampling.hlsli"
+#	include "Common/ShadowSampling.hlsli"
 
 cbuffer PerTechnique : register(b0)
 {

--- a/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
+++ b/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
@@ -16,6 +16,21 @@ Texture3D<float4> NoiseTex : register(t3);
 RWTexture3D<float4> DensityRW : register(u0);
 RWTexture3D<float4> DensityCopyRW : register(u1);
 
+#define LinearSampler ShadowmapSampler
+
+#include "Common/Framebuffer.hlsli"
+#include "Common/SharedData.hlsli"
+
+#	if defined(TERRAIN_SHADOWS)
+#		include "TerrainShadows/TerrainShadows.hlsli"
+#	endif
+
+#	if defined(CLOUD_SHADOWS)
+#		include "CloudShadows/CloudShadows.hlsli"
+#	endif
+
+#include "Common/ShadowSampling.hlsli"
+
 cbuffer PerTechnique : register(b0)
 {
 #	ifndef VR
@@ -126,6 +141,9 @@ cbuffer PerTechnique : register(b0)
 	float LdotN = dot(normalize(-positionWS.xyz), normalize(DirLightDirection));
 	float phaseFactor = (1 - PhaseScattering * PhaseScattering) / (4 * Math::PI * (1 - LdotN * PhaseScattering));
 	float phaseContribution = lerp(1, phaseFactor, PhaseContribution);
+
+	if (shadowContribution != 0.0)
+		shadowContribution *= ShadowSampling::GetWorldShadow(positionWS.xyz, PosAdjust[eyeIndex].xyz, eyeIndex);
 
 	float vl = shadowContribution * densityContribution * phaseContribution;
 

--- a/package/Shaders/Sky.hlsl
+++ b/package/Shaders/Sky.hlsl
@@ -187,6 +187,8 @@ cbuffer AlphaTestRefCB : register(b11)
 #		include "CloudShadows/CloudShadows.hlsli"
 #	endif
 
+Texture2D<float> TexDepthSampler : register(t17);
+
 PS_OUTPUT main(PS_INPUT input)
 {
 	PS_OUTPUT psout;
@@ -245,8 +247,13 @@ PS_OUTPUT main(PS_INPUT input)
 	psout.MotionVectors = float4(screenMotionVector, 0, psout.Color.w);
 	psout.Normal = float4(0.5, 0.5, 0, psout.Color.w);
 
-#	if defined(CLOUD_SHADOWS) && defined(CLOUDS) && !defined(DEFERRED)
-	psout.CloudShadows = psout.Color;
+#	if defined(CLOUD_SHADOWS) && defined(CLOUDS) && !defined(DEFERRED)	
+	psout.CloudShadows = float4(1, 1, 1, psout.Color.w);
+	
+	float depth = TexDepthSampler.Load(int3(input.Position.xy, 0));
+	if (depth < input.Position.z)
+		psout.Color.w = 0;
+
 #	endif
 
 	return psout;

--- a/package/Shaders/Sky.hlsl
+++ b/package/Shaders/Sky.hlsl
@@ -247,9 +247,9 @@ PS_OUTPUT main(PS_INPUT input)
 	psout.MotionVectors = float4(screenMotionVector, 0, psout.Color.w);
 	psout.Normal = float4(0.5, 0.5, 0, psout.Color.w);
 
-#	if defined(CLOUD_SHADOWS) && defined(CLOUDS) && !defined(DEFERRED)	
+#	if defined(CLOUD_SHADOWS) && defined(CLOUDS) && !defined(DEFERRED)
 	psout.CloudShadows = float4(1, 1, 1, psout.Color.w);
-	
+
 	float depth = TexDepthSampler.Load(int3(input.Position.xy, 0));
 	if (depth < input.Position.z)
 		psout.Color.w = 0;

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -274,6 +274,8 @@ void Deferred::StartDeferred()
 	if (!shaderCache.IsEnabled())
 		return;
 
+	State::GetSingleton()->UpdateSharedData();
+
 	auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
 	GET_INSTANCE_MEMBER(renderTargets, shadowState)
 	GET_INSTANCE_MEMBER(setRenderTargetMode, shadowState)

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -274,8 +274,6 @@ void Deferred::StartDeferred()
 	if (!shaderCache.IsEnabled())
 		return;
 
-	State::GetSingleton()->UpdateSharedData();
-
 	auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
 	GET_INSTANCE_MEMBER(renderTargets, shadowState)
 	GET_INSTANCE_MEMBER(setRenderTargetMode, shadowState)

--- a/src/Deferred.h
+++ b/src/Deferred.h
@@ -22,6 +22,7 @@ public:
 
 	void SetupResources();
 	void CopyShadowData();
+	void EarlyPrepasses();
 	void StartDeferred();
 	void OverrideBlendStates();
 	void ResetBlendStates();
@@ -80,6 +81,17 @@ public:
 
 	struct Hooks
 	{
+		struct Main_RenderShadowMaps
+		{
+			static void thunk()
+			{
+				func();
+				GetSingleton()->EarlyPrepasses();
+
+			}
+			static inline REL::Relocation<decltype(thunk)> func;
+		};
+
 		struct Main_RenderWorld
 		{
 			static void thunk(bool a1)
@@ -166,6 +178,8 @@ public:
 
 		static void Install()
 		{
+			stl::write_thunk_call<Main_RenderShadowMaps>(REL::RelocationID(35560, 36559).address() + REL::Relocate(0x2EC, 0x2EC, 0x248));
+
 			stl::write_thunk_call<Main_RenderWorld>(REL::RelocationID(35560, 36559).address() + REL::Relocate(0x831, 0x841, 0x791));
 			stl::write_thunk_call<Main_RenderWorld_Start>(REL::RelocationID(99938, 106583).address() + REL::Relocate(0x8E, 0x84));
 			stl::write_thunk_call<Main_RenderWorld_BlendedDecals>(REL::RelocationID(99938, 106583).address() + REL::Relocate(0x319, 0x308, 0x321));

--- a/src/Deferred.h
+++ b/src/Deferred.h
@@ -87,7 +87,6 @@ public:
 			{
 				func();
 				GetSingleton()->EarlyPrepasses();
-
 			}
 			static inline REL::Relocation<decltype(thunk)> func;
 		};

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -32,6 +32,7 @@ struct Feature
 
 	virtual void DrawSettings() {}
 	virtual void Prepass() {}
+	virtual void EarlyPrepass() {}
 
 	virtual void DataLoaded() {}
 	virtual void PostPostLoad() {}

--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -63,7 +63,7 @@ void CloudShadows::ModifySky(RE::BSRenderPass* Pass)
 	}
 }
 
-void CloudShadows::Prepass()
+void CloudShadows::EarlyPrepass()
 {
 	if ((RE::Sky::GetSingleton()->mode.get() != RE::Sky::Mode::kFull) ||
 		!RE::Sky::GetSingleton()->currentClimate)
@@ -73,6 +73,7 @@ void CloudShadows::Prepass()
 
 	ID3D11ShaderResourceView* srv = texCubemapCloudOcc->srv.get();
 	context->PSSetShaderResources(25, 1, &srv);
+	context->CSSetShaderResources(25, 1, &srv);
 }
 
 void CloudShadows::SetupResources()

--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -57,7 +57,7 @@ void CloudShadows::ModifySky(RE::BSRenderPass* Pass)
 		UINT sampleMask = 0xffffffff;
 
 		context->OMSetBlendState(cloudShadowBlendState, blendFactor, sampleMask);
-	
+
 		auto cubemapDepth = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kCUBEMAP_REFLECTIONS];
 		context->PSSetShaderResources(17, 1, &cubemapDepth.depthSRV);
 	}
@@ -107,12 +107,12 @@ void CloudShadows::SetupResources()
 		blendDesc.IndependentBlendEnable = false;
 
 		blendDesc.RenderTarget[0].BlendEnable = true;
-		blendDesc.RenderTarget[0].SrcBlend = D3D11_BLEND_SRC_ALPHA;      
-		blendDesc.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;            
-		blendDesc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;            
-		blendDesc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_SRC_ALPHA;        
-		blendDesc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;        
-		blendDesc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;       
+		blendDesc.RenderTarget[0].SrcBlend = D3D11_BLEND_SRC_ALPHA;
+		blendDesc.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
+		blendDesc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
+		blendDesc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_SRC_ALPHA;
+		blendDesc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
+		blendDesc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
 		blendDesc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
 
 		DX::ThrowIfFailed(device->CreateBlendState(&blendDesc, &cloudShadowBlendState));

--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -90,7 +90,7 @@ void CloudShadows::SetupResources()
 		reflections.texture->GetDesc(&texDesc);
 		reflections.SRV->GetDesc(&srvDesc);
 
-		texDesc.Format = srvDesc.Format = DXGI_FORMAT_R16_FLOAT;
+		texDesc.Format = srvDesc.Format = DXGI_FORMAT_R8_UNORM;
 
 		texCubemapCloudOcc = new Texture2D(texDesc);
 		texCubemapCloudOcc->CreateSRV(srvDesc);

--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -36,8 +36,8 @@ void CloudShadows::ModifySky(RE::BSRenderPass* Pass)
 
 		// render targets
 		ID3D11RenderTargetView* rtvs[4];
-		ID3D11DepthStencilView* depthStencil;
-		context->OMGetRenderTargets(3, rtvs, &depthStencil);
+		ID3D11DepthStencilView* dsv;
+		context->OMGetRenderTargets(3, rtvs, &dsv);
 
 		int side = -1;
 		for (int i = 0; i < 6; ++i)
@@ -51,7 +51,15 @@ void CloudShadows::ModifySky(RE::BSRenderPass* Pass)
 		CheckResourcesSide(side);
 
 		rtvs[3] = cubemapCloudOccRTVs[side];
-		context->OMSetRenderTargets(4, rtvs, depthStencil);
+		context->OMSetRenderTargets(4, rtvs, nullptr);
+
+		float blendFactor[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
+		UINT sampleMask = 0xffffffff;
+
+		context->OMSetBlendState(cloudShadowBlendState, blendFactor, sampleMask);
+	
+		auto cubemapDepth = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kCUBEMAP_REFLECTIONS];
+		context->PSSetShaderResources(17, 1, &cubemapDepth.depthSRV);
 	}
 }
 
@@ -82,7 +90,7 @@ void CloudShadows::SetupResources()
 		reflections.texture->GetDesc(&texDesc);
 		reflections.SRV->GetDesc(&srvDesc);
 
-		texDesc.Format = srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+		texDesc.Format = srvDesc.Format = DXGI_FORMAT_R16_FLOAT;
 
 		texCubemapCloudOcc = new Texture2D(texDesc);
 		texCubemapCloudOcc->CreateSRV(srvDesc);
@@ -92,5 +100,21 @@ void CloudShadows::SetupResources()
 			rtvDesc.Format = texDesc.Format;
 			DX::ThrowIfFailed(device->CreateRenderTargetView(texCubemapCloudOcc->resource.get(), &rtvDesc, cubemapCloudOccRTVs + i));
 		}
+	}
+	{
+		D3D11_BLEND_DESC blendDesc = {};
+		blendDesc.AlphaToCoverageEnable = false;
+		blendDesc.IndependentBlendEnable = false;
+
+		blendDesc.RenderTarget[0].BlendEnable = true;
+		blendDesc.RenderTarget[0].SrcBlend = D3D11_BLEND_SRC_ALPHA;      
+		blendDesc.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;            
+		blendDesc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;            
+		blendDesc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_SRC_ALPHA;        
+		blendDesc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;        
+		blendDesc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;       
+		blendDesc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+
+		DX::ThrowIfFailed(device->CreateBlendState(&blendDesc, &cloudShadowBlendState));
 	}
 }

--- a/src/Features/CloudShadows.h
+++ b/src/Features/CloudShadows.h
@@ -16,13 +16,9 @@ struct CloudShadows : Feature
 	virtual inline std::string_view GetShaderDefineName() override { return "CLOUD_SHADOWS"; }
 	virtual inline bool HasShaderDefine(RE::BSShader::Type) override { return true; }
 
-	bool isCubemapPass = false;
-	ID3D11BlendState* resetBlendState = nullptr;
-	std::set<ID3D11BlendState*> mappedBlendStates;
-	std::map<ID3D11BlendState*, ID3D11BlendState*> modifiedBlendStates;
-
 	Texture2D* texCubemapCloudOcc = nullptr;
 	ID3D11RenderTargetView* cubemapCloudOccRTVs[6] = { nullptr };
+	ID3D11BlendState* cloudShadowBlendState = nullptr;
 
 	virtual void SetupResources() override;
 

--- a/src/Features/CloudShadows.h
+++ b/src/Features/CloudShadows.h
@@ -25,7 +25,7 @@ struct CloudShadows : Feature
 	void CheckResourcesSide(int side);
 	void ModifySky(RE::BSRenderPass* Pass);
 
-	virtual void Prepass() override;
+	virtual void EarlyPrepass() override;
 
 	virtual inline void PostPostLoad() override { Hooks::Install(); }
 

--- a/src/Features/TerrainShadows.cpp
+++ b/src/Features/TerrainShadows.cpp
@@ -399,7 +399,7 @@ void TerrainShadows::UpdateShadow()
 	context->CSSetConstantBuffers(0, 1, &old.buffer);
 }
 
-void TerrainShadows::Prepass()
+void TerrainShadows::EarlyPrepass()
 {
 	LoadHeightmap();
 
@@ -416,5 +416,6 @@ void TerrainShadows::Prepass()
 
 		std::array<ID3D11ShaderResourceView*, 1> srvs = { texShadowHeight->srv.get() };
 		context->PSSetShaderResources(60, (uint)srvs.size(), srvs.data());
+		context->CSSetShaderResources(60, (uint)srvs.size(), srvs.data());
 	}
 }

--- a/src/Features/TerrainShadows.h
+++ b/src/Features/TerrainShadows.h
@@ -73,7 +73,7 @@ struct TerrainShadows : public Feature
 
 	virtual void DrawSettings() override;
 
-	virtual void Prepass() override;
+	virtual void EarlyPrepass() override;
 	void LoadHeightmap();
 	void Precompute();
 	void UpdateShadow();

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -535,6 +535,17 @@ namespace Hooks
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
+	struct CreateDepthStencil_Reflections
+	{
+		static void thunk(RE::BSGraphics::Renderer* This, uint32_t a_target, RE::BSGraphics::DepthStencilTargetProperties* a_properties)
+		{
+			a_properties->height = 128;
+			a_properties->width = 128;
+			func(This, a_target, a_properties);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
 	// Sky Reflection Fix
 	struct TESWaterReflections_Update_Actor_GetLOSPosition
 	{
@@ -687,6 +698,7 @@ namespace Hooks
 		stl::write_thunk_call<CreateRenderTarget_MotionVectors>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0x4F0, 0x4EF, 0x64E));
 		stl::write_thunk_call<CreateDepthStencil_PrecipitationMask>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0x1245, 0x123B, 0x1917));
 		stl::write_thunk_call<CreateCubemapRenderTarget_Reflections>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0xA25, 0xA25, 0xCD2));
+		stl::write_thunk_call<CreateDepthStencil_Reflections>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0xA59, 0xA59, 0xD13));
 
 #ifdef TRACY_ENABLE
 		stl::write_thunk_call<Main_Update>(REL::RelocationID(35551, 36544).address() + REL::Relocate(0x11F, 0x160));


### PR DESCRIPTION
Changes:
Single channel cloud shadows texture that uses standard alpha blending.
Does manual depth testing so that we can render the whole cloud shadows texture whilst not rendering over the terrain.
Fixes cloud shadows not modifying the blend state so was not rendering.
Sets the cubemap depth stencil to the right resolution.
Terrain and cloud shadows in the VL.
