### PR TITLE
fix: opaque cloud shadow in clear weather

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 project(
 	CommunityShaders
-	VERSION 1.1.7
+	VERSION 1.1.8
 	LANGUAGES CXX
 )
 

--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -17,18 +17,10 @@ void CloudShadows::CheckResourcesSide(int side)
 	context->ClearRenderTargetView(cubemapCloudOccRTVs[side], black);
 }
 
-void CloudShadows::ModifySky(RE::BSRenderPass* Pass)
+void CloudShadows::SkyShaderHacks()
 {
-	auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
-
-	GET_INSTANCE_MEMBER(cubeMapRenderTarget, shadowState);
-
-	if (cubeMapRenderTarget != RE::RENDER_TARGETS_CUBEMAP::kREFLECTIONS)
-		return;
-
-	auto skyProperty = static_cast<const RE::BSSkyShaderProperty*>(Pass->shaderProperty);
-
-	if (skyProperty->uiSkyObjectType == RE::BSSkyShaderProperty::SkyObject::SO_CLOUDS) {
+	if (overrideSky)
+	{
 		auto renderer = RE::BSGraphics::Renderer::GetSingleton();
 		auto& context = State::GetSingleton()->context;
 
@@ -60,6 +52,24 @@ void CloudShadows::ModifySky(RE::BSRenderPass* Pass)
 
 		auto cubemapDepth = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kCUBEMAP_REFLECTIONS];
 		context->PSSetShaderResources(17, 1, &cubemapDepth.depthSRV);
+
+		overrideSky = false;
+	}
+}
+
+void CloudShadows::ModifySky(RE::BSRenderPass* Pass)
+{
+	auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
+
+	GET_INSTANCE_MEMBER(cubeMapRenderTarget, shadowState);
+
+	if (cubeMapRenderTarget != RE::RENDER_TARGETS_CUBEMAP::kREFLECTIONS)
+		return;
+
+	auto skyProperty = static_cast<const RE::BSSkyShaderProperty*>(Pass->shaderProperty);
+
+	if (skyProperty->uiSkyObjectType == RE::BSSkyShaderProperty::SkyObject::SO_CLOUDS) {
+		overrideSky = true;
 	}
 }
 

--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -19,8 +19,7 @@ void CloudShadows::CheckResourcesSide(int side)
 
 void CloudShadows::SkyShaderHacks()
 {
-	if (overrideSky)
-	{
+	if (overrideSky) {
 		auto renderer = RE::BSGraphics::Renderer::GetSingleton();
 		auto& context = State::GetSingleton()->context;
 

--- a/src/Features/CloudShadows.h
+++ b/src/Features/CloudShadows.h
@@ -16,6 +16,9 @@ struct CloudShadows : Feature
 	virtual inline std::string_view GetShaderDefineName() override { return "CLOUD_SHADOWS"; }
 	virtual inline bool HasShaderDefine(RE::BSShader::Type) override { return true; }
 
+	bool overrideSky = false;
+	void SkyShaderHacks();
+
 	Texture2D* texCubemapCloudOcc = nullptr;
 	ID3D11RenderTargetView* cubemapCloudOccRTVs[6] = { nullptr };
 	ID3D11BlendState* cloudShadowBlendState = nullptr;

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -12,8 +12,8 @@
 #include "Util.h"
 
 #include "Deferred.h"
-#include "Features/TerrainBlending.h"
 #include "Features/CloudShadows.h"
+#include "Features/TerrainBlending.h"
 #include "TruePBR.h"
 
 #include "Streamline.h"

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -13,6 +13,7 @@
 
 #include "Deferred.h"
 #include "Features/TerrainBlending.h"
+#include "Features/CloudShadows.h"
 #include "TruePBR.h"
 
 #include "Streamline.h"
@@ -25,6 +26,10 @@ void State::Draw()
 		auto terrainBlending = TerrainBlending::GetSingleton();
 		if (terrainBlending->loaded)
 			terrainBlending->TerrainShaderHacks();
+
+		auto cloudShadows = CloudShadows::GetSingleton();
+		if (cloudShadows->loaded)
+			cloudShadows->SkyShaderHacks();
 
 		TruePBR::GetSingleton()->SetShaderResouces();
 


### PR DESCRIPTION
The first time the game sets new bindings for clouds, cloud shadows does not fully overwrite it. This forces it to always overwrite, fixing this issue.