### PR TITLE
feat: pbr skin and hair using vanilla texture

### DIFF
--- a/package/Shaders/Common/PBR.hlsli
+++ b/package/Shaders/Common/PBR.hlsli
@@ -436,7 +436,11 @@ namespace PBR
 		else
 #endif
 		{
+// #	if defined(HAIR)
+// 			transmission += 0.1 * lightProperties.LinearLightColor * GetHairColorMarschner(N, V, L, NdotL, NdotV, VdotL, 0, 1, 0, surfaceProperties);
+// #	else
 			diffuse += lightProperties.LinearLightColor * satNdotL * GetDiffuseDirectLightMultiplierLambert();
+// #	endif
 
 			float3 F;
 #if defined(GLINT)
@@ -532,7 +536,14 @@ namespace PBR
 		else
 #endif
 		{
+#if defined(HAIR)
+		float3 L = normalize(V - N * dot(V, N));
+		float NdotL = dot(N, L);
+		float VdotL = dot(V, L);
+		diffuseLobeWeight = GetHairColorMarschner(N, V, L, NdotL, NdotV, VdotL, 1, 0, 0.2, surfaceProperties);
+#else
 			diffuseLobeWeight = diffuseColor;
+#endif
 
 #if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 			[branch] if ((PBRFlags & Flags::Subsurface) != 0)

--- a/package/Shaders/Common/PBR.hlsli
+++ b/package/Shaders/Common/PBR.hlsli
@@ -436,11 +436,11 @@ namespace PBR
 		else
 #endif
 		{
-// #	if defined(HAIR)
-// 			transmission += 0.1 * lightProperties.LinearLightColor * GetHairColorMarschner(N, V, L, NdotL, NdotV, VdotL, 0, 1, 0, surfaceProperties);
-// #	else
+			// #	if defined(HAIR)
+			// 			transmission += 0.1 * lightProperties.LinearLightColor * GetHairColorMarschner(N, V, L, NdotL, NdotV, VdotL, 0, 1, 0, surfaceProperties);
+			// #	else
 			diffuse += lightProperties.LinearLightColor * satNdotL * GetDiffuseDirectLightMultiplierLambert();
-// #	endif
+			// #	endif
 
 			float3 F;
 #if defined(GLINT)
@@ -537,10 +537,10 @@ namespace PBR
 #endif
 		{
 #if defined(HAIR)
-		float3 L = normalize(V - N * dot(V, N));
-		float NdotL = dot(N, L);
-		float VdotL = dot(V, L);
-		diffuseLobeWeight = GetHairColorMarschner(N, V, L, NdotL, NdotV, VdotL, 1, 0, 0.2, surfaceProperties);
+			float3 L = normalize(V - N * dot(V, N));
+			float NdotL = dot(N, L);
+			float VdotL = dot(V, L);
+			diffuseLobeWeight = GetHairColorMarschner(N, V, L, NdotL, NdotV, VdotL, 1, 0, 0.2, surfaceProperties);
 #else
 			diffuseLobeWeight = diffuseColor;
 #endif

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -857,9 +857,9 @@ float3 GetFacegenRGBTintBaseColor(float3 rawBaseColor, float2 uv)
 float CalculateApproximateAO(float3 skincolor, float2 uv, float scale)
 {
 	float3 baseColorApprox = skincolor;
-    float luminance = 0.2126 * baseColorApprox.r + 0.7152 * baseColorApprox.g + 0.0722 * baseColorApprox.b;
-    float approximateAO = pow(luminance, 2.4) * scale;
-    return saturate(approximateAO);
+	float luminance = 0.2126 * baseColorApprox.r + 0.7152 * baseColorApprox.g + 0.0722 * baseColorApprox.b;
+	float approximateAO = pow(luminance, 2.4) * scale;
+	return saturate(approximateAO);
 }
 
 #	if defined(WORLD_MAP)
@@ -1069,7 +1069,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	float3 nu = wsn + ndx;
 	//float curve = saturate(abs((cross(nl, nr).y - cross(nd,nu).x))*4.0*2048.0/viewPosition.z);
 	//float curve = saturate(length(max(abs(ddx(wsn)), abs(ddy(wsn))))*2048/viewPosition.z);
-	float curve = abs(length(max(abs(ndx), abs(ndy)))*3.14) * 2048.0 / viewPosition.z;
+	float curve = abs(length(max(abs(ndx), abs(ndy))) * 3.14) * 2048.0 / viewPosition.z;
 	//float curve = tan(max(max(abs(ddx(input.TBN0.xyz)),abs(ddy(input.TBN0.xyz))), max(max(abs(ddx(input.TBN1.xyz)),abs(ddy(input.TBN1.xyz))), max(abs(ddx(input.TBN2.xyz)),abs(ddy(input.TBN2.xyz))))))*2048.0/viewPosition.z;
 	float angle = saturate(pow(1 - dot(worldSpaceViewDirection, wsn), 2));
 
@@ -1392,9 +1392,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	baseColor.xyz = pow(baseColor.xyz, 2.4) * 3.14;
 #	endif
 
-// #	if defined(HAIR) && defined(TRUE_PBR)
+	// #	if defined(HAIR) && defined(TRUE_PBR)
 	// baseColor.xyz = Color::GammaToLinear(baseColor.xyz);
-// #	endif
+	// #	endif
 
 #	if defined(LANDSCAPE)
 
@@ -1733,11 +1733,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 #		if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 #			if defined(SKIN)
-		pbrSurfaceProperties.SubsurfaceColor = float3(0.6, 0.2, 0.1);
-		pbrSurfaceProperties.Thickness = 0.5;
+	pbrSurfaceProperties.SubsurfaceColor = float3(0.6, 0.2, 0.1);
+	pbrSurfaceProperties.Thickness = 0.5;
 #			elif defined(HAIR)
-		pbrSurfaceProperties.SubsurfaceColor = pbrSurfaceProperties.BaseColor;
-		pbrSurfaceProperties.Thickness = 0.9;
+	pbrSurfaceProperties.SubsurfaceColor = pbrSurfaceProperties.BaseColor;
+	pbrSurfaceProperties.Thickness = 0.9;
 #			endif
 #			if !defined(SKIN) && !defined(HAIR)
 	[branch] if ((PBRFlags & PBR::Flags::Subsurface) != 0)
@@ -1751,7 +1751,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 			pbrSurfaceProperties.Thickness *= sampledSubsurfaceProperties.w;
 		}
 		pbrSurfaceProperties.Thickness = lerp(pbrSurfaceProperties.Thickness, 1, projectedMaterialWeight);
-
 	}
 	else if ((PBRFlags & PBR::Flags::TwoLayer) != 0)
 	{
@@ -1780,12 +1779,12 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 				coatModelNormal = normalize(mul(tbn, TransformNormal(sampledCoatProperties.xyz)));
 			}
 
-#			if !defined(DRAW_IN_WORLDSPACE)
+#				if !defined(DRAW_IN_WORLDSPACE)
 			[flatten] if (!input.WorldSpace)
 			{
 				coatWorldNormal = normalize(mul(input.World[eyeIndex], float4(coatModelNormal, 0)));
 			}
-#			endif
+#				endif
 		}
 		pbrSurfaceProperties.CoatStrength = lerp(pbrSurfaceProperties.CoatStrength, 0, projectedMaterialWeight);
 	}

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -74,7 +74,7 @@ namespace SIE
 			// if ((descriptor & static_cast<uint32_t>(ShaderCache::LightingShaderFlags::TruePbrDebugSkin)) != 0) {
 			// 	defines[lastIndex++] = { "PBR_SKIN", nullptr };
 			// }
-			
+
 			for (auto* feature : Feature::GetFeatureList()) {
 				if (feature->loaded && feature->HasShaderDefine(RE::BSShader::Type::Lighting)) {
 					defines[lastIndex++] = { feature->GetShaderDefineName().data(), nullptr };

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -68,7 +68,13 @@ namespace SIE
 					defines[lastIndex++] = { "GLINT", nullptr };
 				}
 			}
-
+			if ((descriptor & static_cast<uint32_t>(ShaderCache::LightingShaderFlags::VtPbr)) != 0) {
+				defines[lastIndex++] = { "PBR_HS", nullptr };
+			}
+			// if ((descriptor & static_cast<uint32_t>(ShaderCache::LightingShaderFlags::TruePbrDebugSkin)) != 0) {
+			// 	defines[lastIndex++] = { "PBR_SKIN", nullptr };
+			// }
+			
 			for (auto* feature : Feature::GetFeatureList()) {
 				if (feature->loaded && feature->HasShaderDefine(RE::BSShader::Type::Lighting)) {
 					defines[lastIndex++] = { feature->GetShaderDefineName().data(), nullptr };

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -470,6 +470,7 @@ namespace SIE
 			// Community Shaders start
 			TruePbr = 1 << 3,
 			Deferred = 1 << 4,
+			VtPbr = 1 << 5,
 			// Community Shaders end
 			Specular = 1 << 9,
 			SoftLighting = 1 << 10,

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -265,6 +265,15 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 			}
 		}
 
+		auto truePBR = TruePBR::GetSingleton();
+		auto& truePBRJson = settings[truePBR->GetShortName()];
+		if (truePBRJson.is_object()) {
+			logger::info("Loading TruePBR debug skin/hair settings");
+			truePBR->LoadDebugSkinHairSettings(truePBRJson);
+		} else {
+			logger::warn("Missing debug skin/hair settings for TruePBR, using default.");
+		}
+
 		auto upscaling = Upscaling::GetSingleton();
 		auto& upscalingJson = settings[upscaling->GetShortName()];
 		if (upscalingJson.is_object()) {
@@ -354,6 +363,10 @@ void State::Save(ConfigMode a_configMode)
 	general["Enable Async"] = shaderCache.IsAsync();
 
 	settings["General"] = general;
+
+	auto truePBR = TruePBR::GetSingleton();
+	auto& truePBRJson = settings[truePBR->GetShortName()];
+	truePBR->SaveDebugSkinHairSettings(truePBRJson);
 
 	auto upscaling = Upscaling::GetSingleton();
 	auto& upscalingJson = settings[upscaling->GetShortName()];

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -113,18 +113,18 @@ void TruePBR::DrawSettings()
 		if (ImGui::TreeNodeEx("Experimental Vanilla to PBR Skin / Hair", ImGuiTreeNodeFlags_DefaultOpen)) {
 			ImGui::Checkbox("Enable Skin", &debugSkinHairSettings.EnablePBRSkin);
 			// if (debugSkinHairSettings.EnablePBRSkin) {
-				ImGui::SliderFloat("Skin Roughness", &debugSkinHairSettings.SkinRoughnessScale, 0.f, 1.f, "%.3f");
-				ImGui::SliderFloat("Skin Specular Level", &debugSkinHairSettings.SkinSpecularLevel, 0.f, 0.1f, "%.4f");
-				if (auto _tt = Util::HoverTooltipWrapper())
-					ImGui::Text("This \"Specular\" here is the same as the \"Specular\" in the PBR material object data. 0.028 is the default value for skin.");
-				ImGui::SliderFloat("Skin Specular Texture Multiplier", &debugSkinHairSettings.SkinSpecularTexMultiplier, 0.f, 10.f, "%.3f");
-				if (auto _tt = Util::HoverTooltipWrapper())
-					ImGui::Text("A multiplier for the vanilla specular texture. It will be used to modify the roughness of the skin.");
+			ImGui::SliderFloat("Skin Roughness", &debugSkinHairSettings.SkinRoughnessScale, 0.f, 1.f, "%.3f");
+			ImGui::SliderFloat("Skin Specular Level", &debugSkinHairSettings.SkinSpecularLevel, 0.f, 0.1f, "%.4f");
+			if (auto _tt = Util::HoverTooltipWrapper())
+				ImGui::Text("This \"Specular\" here is the same as the \"Specular\" in the PBR material object data. 0.028 is the default value for skin.");
+			ImGui::SliderFloat("Skin Specular Texture Multiplier", &debugSkinHairSettings.SkinSpecularTexMultiplier, 0.f, 10.f, "%.3f");
+			if (auto _tt = Util::HoverTooltipWrapper())
+				ImGui::Text("A multiplier for the vanilla specular texture. It will be used to modify the roughness of the skin.");
 			// }
 			ImGui::Checkbox("Enable Hair", &debugSkinHairSettings.EnablePBRHair);
 			// if (debugSkinHairSettings.EnablePBRHair) {
-				ImGui::SliderFloat("Hair Roughness", &debugSkinHairSettings.HairRoughnessScale, 0.f, 1.f, "%.3f");
-				ImGui::SliderFloat("Hair Specular Level", &debugSkinHairSettings.HairSpecularLevel, 0.f, 0.1f, "%.4f");
+			ImGui::SliderFloat("Hair Roughness", &debugSkinHairSettings.HairRoughnessScale, 0.f, 1.f, "%.3f");
+			ImGui::SliderFloat("Hair Specular Level", &debugSkinHairSettings.HairSpecularLevel, 0.f, 0.1f, "%.4f");
 			// }
 			if (ImGui::Button("Reset")) {
 				ResetDebugSkinHairSettings();
@@ -729,7 +729,7 @@ struct BSLightingShaderProperty_GetRenderPasses
 		bool isPbr = false;
 
 		TruePBR::DebugSkinHairSettings debugSkinHairSettings = TruePBR::GetSingleton()->GetDebugSkinHairSettings();
-		
+
 		if (property->flags.any(RE::BSShaderProperty::EShaderPropertyFlag::kVertexLighting) && (property->material->GetFeature() == RE::BSShaderMaterial::Feature::kDefault || property->material->GetFeature() == RE::BSShaderMaterial::Feature::kMultiTexLandLODBlend)) {
 			isPbr = true;
 		}
@@ -967,7 +967,6 @@ struct BSLightingShader_SetupMaterial
 						}
 					}
 				}
-				
 
 				{
 					std::array<float, 4> PBRProjectedUVParams1;
@@ -1114,7 +1113,7 @@ struct BSLightingShader_SetupMaterial
 						shadowState->SetPSTextureAddressMode(4, static_cast<RE::BSGraphics::TextureAddressMode>(tMaterial->textureClampMode));
 						shadowState->SetPSTextureFilterMode(4, RE::BSGraphics::TextureFilterMode::kAnisotropic);
 					}
-					shadowState->SetPSConstant(float4(1.0,1.0,1.0,1.0), RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.TintColor);
+					shadowState->SetPSConstant(float4(1.0, 1.0, 1.0, 1.0), RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.TintColor);
 				}
 				if (lightingType == FacegenRGBTint) {
 					auto* facegenMaterial = static_cast<const RE::BSLightingShaderMaterialFacegenTint*>(tMaterial);
@@ -1125,7 +1124,7 @@ struct BSLightingShader_SetupMaterial
 					}
 					shadowState->SetPSConstant(facegenMaterial->tintColor, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.TintColor);
 				}
-		
+
 				std::array<float, 3> PBRParams1;
 				PBRParams1[0] = debugSkinHairSettings.SkinRoughnessScale;
 				PBRParams1[1] = 0.f;
@@ -1156,7 +1155,7 @@ struct BSLightingShader_SetupMaterial
 			{
 				shadowState->SetPSConstant(shaderFlags, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.PBRFlags);
 				shadowState->SetPSConstant(tMaterial->specularColor, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.SpecularColor);
-				shadowState->SetPSConstant(float4(0.0,0.0,0.0,0.0), RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.EnvmapData);
+				shadowState->SetPSConstant(float4(0.0, 0.0, 0.0, 0.0), RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.EnvmapData);
 			}
 
 			{
@@ -1211,7 +1210,7 @@ struct BSLightingShader_SetupGeometry
 		}
 
 		TruePBR::DebugSkinHairSettings debugSkinHairSettings = TruePBR::GetSingleton()->GetDebugSkinHairSettings();
-		if (debugSkinHairSettings.EnablePBRSkin ) {
+		if (debugSkinHairSettings.EnablePBRSkin) {
 			shader->currentRawTechnique |= static_cast<uint32_t>(SIE::ShaderCache::LightingShaderFlags::VtPbr);
 		}
 		if (debugSkinHairSettings.EnablePBRHair) {

--- a/src/TruePBR.h
+++ b/src/TruePBR.h
@@ -90,4 +90,21 @@ public:
 	PBRMaterialObjectData* selectedPbrMaterialObject = nullptr;
 
 	RE::BGSTextureSet* currentTextureSet = nullptr;
+
+	struct DebugSkinHairSettings
+	{
+		bool EnablePBRSkin = false;
+		bool EnablePBRHair = false;
+		float SkinRoughnessScale = 0.7f;
+		float SkinSpecularLevel = 0.028f;
+		float SkinSpecularTexMultiplier = 3.0f;
+		float HairRoughnessScale = 0.4f;
+		float HairSpecularLevel = 0.045f;
+	} debugSkinHairSettings;
+
+	DebugSkinHairSettings GetDebugSkinHairSettings();
+	void SaveDebugSkinHairSettings(json& o_json);
+	void LoadDebugSkinHairSettings(json& o_json);
+	void ResetDebugSkinHairSettings();
+	void DebugSkinHairSettingsLog();
 };

--- a/src/TruePBR.h
+++ b/src/TruePBR.h
@@ -95,10 +95,10 @@ public:
 	{
 		bool EnablePBRSkin = false;
 		bool EnablePBRHair = false;
-		float SkinRoughnessScale = 0.7f;
-		float SkinSpecularLevel = 0.028f;
-		float SkinSpecularTexMultiplier = 3.0f;
-		float HairRoughnessScale = 0.4f;
+		float SkinRoughnessScale = 0.6f;
+		float SkinSpecularLevel = 0.0277f;
+		float SkinSpecularTexMultiplier = 3.14f;
+		float HairRoughnessScale = 0.5f;
 		float HairSpecularLevel = 0.045f;
 	} debugSkinHairSettings;
 


### PR DESCRIPTION
Since it's barely possible to patch all body mods, custom faces, skin mods, like we usually do for pbr textures, this might be a better way so we could see skin rendered in pbr. Basically it's just using specular texture as inverted roughness adding a roughness slider. Result is rather good i would say.
Hair on the other hand is not so satisfying. It looked good on most vanilla hair and some hair mods. Many hair mods were not properly made and looks weird with this. Anyway it's togglable so user could just choose what they like.