### PR TITLE
perf: cpu performance of important GetSingleton calls

### DIFF
--- a/cmake/XSEPlugin.cmake
+++ b/cmake/XSEPlugin.cmake
@@ -83,7 +83,7 @@ if(CMAKE_GENERATOR MATCHES "Visual Studio")
 		/Zc:trigraphs
 		/Zc:wchar_t
 		/wd4200 # nonstandard extension used : zero-sized array in struct/union
-		/arch:AVX
+		# /arch:AVX
 	)
 
 	target_compile_options(${PROJECT_NAME} PUBLIC "$<$<CONFIG:DEBUG>:${SC_DEBUG_OPTS}>")

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -4,6 +4,7 @@
 #include "State.h"
 #include "TruePBR.h"
 #include "Util.h"
+#include "VariableCache.h"
 
 #include "Features/DynamicCubemaps.h"
 #include "Features/ScreenSpaceGI.h"
@@ -220,16 +221,15 @@ void Deferred::EarlyPrepasses()
 
 	State::GetSingleton()->UpdateSharedData();
 
-	ZoneScoped;
-	TracyD3D11Zone(State::GetSingleton()->tracyCtx, "Early Prepass");
+	auto variableCache = VariableCache::GetSingleton();
 
-	auto context = RE::BSGraphics::Renderer::GetSingleton()->GetRuntimeData().context;
+	ZoneScoped;
+	TracyD3D11Zone(variableCache->state->tracyCtx, "Early Prepass");
+
+	auto context = variableCache->context;
 	context->OMSetRenderTargets(0, nullptr, nullptr);  // Unbind all bound render targets
 
-	auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
-	GET_INSTANCE_MEMBER(stateUpdateFlags, shadowState)
-
-	stateUpdateFlags.set(RE::BSGraphics::ShaderFlags::DIRTY_RENDERTARGET);  // Run OMSetRenderTargets again
+	variableCache->stateUpdateFlags->set(RE::BSGraphics::ShaderFlags::DIRTY_RENDERTARGET);  // Run OMSetRenderTargets again
 
 	for (auto* feature : Feature::GetFeatureList()) {
 		if (feature->loaded) {

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -733,7 +733,7 @@ void Deferred::Hooks::Main_RenderWorld_Start::thunk(RE::BSBatchRenderer* This, u
 void Deferred::Hooks::Main_RenderWorld_BlendedDecals::thunk(RE::BSShaderAccumulator* This, uint32_t RenderFlags)
 {
 	auto deferred = VariableCache::GetSingleton()->deferred;
-	
+
 	// Deferred blended decals
 	deferred->inBlendedDecals = true;
 	func(This, RenderFlags);

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -173,7 +173,7 @@ void Deferred::SetupResources()
 
 void Deferred::CopyShadowData()
 {
-	/*ZoneScoped;
+	ZoneScoped;
 	TracyD3D11Zone(State::GetSingleton()->tracyCtx, "CopyShadowData");
 
 	auto& context = State::GetSingleton()->context;
@@ -208,7 +208,7 @@ void Deferred::CopyShadowData()
 		};
 
 		context->PSSetShaderResources(18, ARRAYSIZE(srvs), srvs);
-	}*/
+	}
 }
 
 void Deferred::EarlyPrepasses()
@@ -333,158 +333,158 @@ void Deferred::StartDeferred()
 
 void Deferred::DeferredPasses()
 {
-	//ZoneScoped;
-	//TracyD3D11Zone(State::GetSingleton()->tracyCtx, "Deferred");
+	ZoneScoped;
+	TracyD3D11Zone(State::GetSingleton()->tracyCtx, "Deferred");
 
-	//auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	//auto& context = State::GetSingleton()->context;
+	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
+	auto& context = State::GetSingleton()->context;
 
-	//{
-	//	static REL::Relocation<ID3D11Buffer**> perFrame{ REL::RelocationID(524768, 411384) };
-	//	ID3D11Buffer* buffers[1] = { *perFrame.get() };
-	//	ID3D11Buffer* vrBuffer = nullptr;
+	{
+		static REL::Relocation<ID3D11Buffer**> perFrame{ REL::RelocationID(524768, 411384) };
+		ID3D11Buffer* buffers[1] = { *perFrame.get() };
+		ID3D11Buffer* vrBuffer = nullptr;
 
-	//	if (REL::Module::IsVR()) {
-	//		static REL::Relocation<ID3D11Buffer**> VRValues{ REL::Offset(0x3180688) };
-	//		vrBuffer = *VRValues.get();
-	//	}
-	//	if (vrBuffer) {
-	//		context->CSSetConstantBuffers(12, 1, buffers);
-	//		context->CSSetConstantBuffers(13, 1, &vrBuffer);
-	//	} else {
-	//		context->CSSetConstantBuffers(12, 1, buffers);
-	//	}
-	//}
+		if (REL::Module::IsVR()) {
+			static REL::Relocation<ID3D11Buffer**> VRValues{ REL::Offset(0x3180688) };
+			vrBuffer = *VRValues.get();
+		}
+		if (vrBuffer) {
+			context->CSSetConstantBuffers(12, 1, buffers);
+			context->CSSetConstantBuffers(13, 1, &vrBuffer);
+		} else {
+			context->CSSetConstantBuffers(12, 1, buffers);
+		}
+	}
 
-	//auto specular = renderer->GetRuntimeData().renderTargets[SPECULAR];
-	//auto albedo = renderer->GetRuntimeData().renderTargets[ALBEDO];
-	//auto normalRoughness = renderer->GetRuntimeData().renderTargets[NORMALROUGHNESS];
-	//auto masks = renderer->GetRuntimeData().renderTargets[MASKS];
-	//auto masks2 = renderer->GetRuntimeData().renderTargets[MASKS2];
+	auto specular = renderer->GetRuntimeData().renderTargets[SPECULAR];
+	auto albedo = renderer->GetRuntimeData().renderTargets[ALBEDO];
+	auto normalRoughness = renderer->GetRuntimeData().renderTargets[NORMALROUGHNESS];
+	auto masks = renderer->GetRuntimeData().renderTargets[MASKS];
+	auto masks2 = renderer->GetRuntimeData().renderTargets[MASKS2];
 
-	//auto main = renderer->GetRuntimeData().renderTargets[forwardRenderTargets[0]];
-	//auto normals = renderer->GetRuntimeData().renderTargets[forwardRenderTargets[2]];
-	//auto depth = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kPOST_ZPREPASS_COPY];
-	//auto reflectance = renderer->GetRuntimeData().renderTargets[REFLECTANCE];
+	auto main = renderer->GetRuntimeData().renderTargets[forwardRenderTargets[0]];
+	auto normals = renderer->GetRuntimeData().renderTargets[forwardRenderTargets[2]];
+	auto depth = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kPOST_ZPREPASS_COPY];
+	auto reflectance = renderer->GetRuntimeData().renderTargets[REFLECTANCE];
 
-	//auto motionVectors = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMOTION_VECTOR];
+	auto motionVectors = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMOTION_VECTOR];
 
-	//bool interior = true;
-	//if (auto sky = RE::Sky::GetSingleton())
-	//	interior = sky->mode.get() != RE::Sky::Mode::kFull;
+	bool interior = true;
+	if (auto sky = RE::Sky::GetSingleton())
+		interior = sky->mode.get() != RE::Sky::Mode::kFull;
 
-	//auto skylighting = Skylighting::GetSingleton();
+	auto skylighting = Skylighting::GetSingleton();
 
-	//auto ssgi = ScreenSpaceGI::GetSingleton();
-	//if (ssgi->loaded)
-	//	ssgi->DrawSSGI(prevDiffuseAmbientTexture);
-	//auto [ssgi_ao, ssgi_y, ssgi_cocg, ssgi_gi_spec] = ssgi->GetOutputTextures();
-	//bool ssgi_hq_spec = ssgi->settings.EnableExperimentalSpecularGI;
+	auto ssgi = ScreenSpaceGI::GetSingleton();
+	if (ssgi->loaded)
+		ssgi->DrawSSGI(prevDiffuseAmbientTexture);
+	auto [ssgi_ao, ssgi_y, ssgi_cocg, ssgi_gi_spec] = ssgi->GetOutputTextures();
+	bool ssgi_hq_spec = ssgi->settings.EnableExperimentalSpecularGI;
 
-	//auto dispatchCount = Util::GetScreenDispatchCount();
+	auto dispatchCount = Util::GetScreenDispatchCount();
 
-	//if (ssgi->loaded) {
-	//	// Ambient Composite
-	//	{
-	//		TracyD3D11Zone(State::GetSingleton()->tracyCtx, "Ambient Composite");
+	if (ssgi->loaded) {
+		// Ambient Composite
+		{
+			TracyD3D11Zone(State::GetSingleton()->tracyCtx, "Ambient Composite");
 
-	//		ID3D11ShaderResourceView* srvs[9]{
-	//			albedo.SRV,
-	//			normalRoughness.SRV,
-	//			skylighting->loaded || REL::Module::IsVR() ? depth.depthSRV : nullptr,
-	//			skylighting->loaded ? skylighting->texProbeArray->srv.get() : nullptr,
-	//			skylighting->loaded ? skylighting->stbn_vec3_2Dx1D_128x128x64.get() : nullptr,
-	//			masks2.SRV,
-	//			ssgi_ao,
-	//			ssgi_y,
-	//			ssgi_cocg,
-	//		};
+			ID3D11ShaderResourceView* srvs[9]{
+				albedo.SRV,
+				normalRoughness.SRV,
+				skylighting->loaded || REL::Module::IsVR() ? depth.depthSRV : nullptr,
+				skylighting->loaded ? skylighting->texProbeArray->srv.get() : nullptr,
+				skylighting->loaded ? skylighting->stbn_vec3_2Dx1D_128x128x64.get() : nullptr,
+				masks2.SRV,
+				ssgi_ao,
+				ssgi_y,
+				ssgi_cocg,
+			};
 
-	//		context->CSSetShaderResources(0, ARRAYSIZE(srvs), srvs);
+			context->CSSetShaderResources(0, ARRAYSIZE(srvs), srvs);
 
-	//		ID3D11UnorderedAccessView* uavs[2]{ main.UAV, prevDiffuseAmbientTexture->uav.get() };
-	//		context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
+			ID3D11UnorderedAccessView* uavs[2]{ main.UAV, prevDiffuseAmbientTexture->uav.get() };
+			context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
 
-	//		auto shader = interior ? GetComputeAmbientCompositeInterior() : GetComputeAmbientComposite();
-	//		context->CSSetShader(shader, nullptr, 0);
+			auto shader = interior ? GetComputeAmbientCompositeInterior() : GetComputeAmbientComposite();
+			context->CSSetShader(shader, nullptr, 0);
 
-	//		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
-	//	}
+			context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
+		}
 
-	//	// Clear
-	//	{
-	//		ID3D11ShaderResourceView* views[6]{ nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
-	//		context->CSSetShaderResources(0, ARRAYSIZE(views), views);
+		// Clear
+		{
+			ID3D11ShaderResourceView* views[6]{ nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
+			context->CSSetShaderResources(0, ARRAYSIZE(views), views);
 
-	//		ID3D11UnorderedAccessView* uavs[2]{ nullptr, nullptr };
-	//		context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
+			ID3D11UnorderedAccessView* uavs[2]{ nullptr, nullptr };
+			context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
 
-	//		context->CSSetShader(nullptr, nullptr, 0);
-	//	}
-	//}
+			context->CSSetShader(nullptr, nullptr, 0);
+		}
+	}
 
-	//auto sss = SubsurfaceScattering::GetSingleton();
-	//if (sss->loaded)
-	//	sss->DrawSSS();
+	auto sss = SubsurfaceScattering::GetSingleton();
+	if (sss->loaded)
+		sss->DrawSSS();
 
-	//auto dynamicCubemaps = DynamicCubemaps::GetSingleton();
-	//if (dynamicCubemaps->loaded)
-	//	dynamicCubemaps->UpdateCubemap();
+	auto dynamicCubemaps = DynamicCubemaps::GetSingleton();
+	if (dynamicCubemaps->loaded)
+		dynamicCubemaps->UpdateCubemap();
 
-	//auto terrainBlending = TerrainBlending::GetSingleton();
+	auto terrainBlending = TerrainBlending::GetSingleton();
 
-	//// Deferred Composite
-	//{
-	//	TracyD3D11Zone(State::GetSingleton()->tracyCtx, "Deferred Composite");
+	// Deferred Composite
+	{
+		TracyD3D11Zone(State::GetSingleton()->tracyCtx, "Deferred Composite");
 
-	//	ID3D11ShaderResourceView* srvs[15]{
-	//		specular.SRV,
-	//		albedo.SRV,
-	//		normalRoughness.SRV,
-	//		masks.SRV,
-	//		masks2.SRV,
-	//		dynamicCubemaps->loaded || REL::Module::IsVR() ? (terrainBlending->loaded ? terrainBlending->blendedDepthTexture16->srv.get() : depth.depthSRV) : nullptr,
-	//		dynamicCubemaps->loaded ? reflectance.SRV : nullptr,
-	//		dynamicCubemaps->loaded ? dynamicCubemaps->envTexture->srv.get() : nullptr,
-	//		dynamicCubemaps->loaded ? dynamicCubemaps->envReflectionsTexture->srv.get() : nullptr,
-	//		dynamicCubemaps->loaded && skylighting->loaded ? skylighting->texProbeArray->srv.get() : nullptr,
-	//		dynamicCubemaps->loaded && skylighting->loaded ? skylighting->stbn_vec3_2Dx1D_128x128x64.get() : nullptr,
-	//		ssgi_ao,
-	//		ssgi_hq_spec ? nullptr : ssgi_y,
-	//		ssgi_hq_spec ? nullptr : ssgi_cocg,
-	//		ssgi_hq_spec ? ssgi_gi_spec : nullptr,
-	//	};
+		ID3D11ShaderResourceView* srvs[15]{
+			specular.SRV,
+			albedo.SRV,
+			normalRoughness.SRV,
+			masks.SRV,
+			masks2.SRV,
+			dynamicCubemaps->loaded || REL::Module::IsVR() ? (terrainBlending->loaded ? terrainBlending->blendedDepthTexture16->srv.get() : depth.depthSRV) : nullptr,
+			dynamicCubemaps->loaded ? reflectance.SRV : nullptr,
+			dynamicCubemaps->loaded ? dynamicCubemaps->envTexture->srv.get() : nullptr,
+			dynamicCubemaps->loaded ? dynamicCubemaps->envReflectionsTexture->srv.get() : nullptr,
+			dynamicCubemaps->loaded && skylighting->loaded ? skylighting->texProbeArray->srv.get() : nullptr,
+			dynamicCubemaps->loaded && skylighting->loaded ? skylighting->stbn_vec3_2Dx1D_128x128x64.get() : nullptr,
+			ssgi_ao,
+			ssgi_hq_spec ? nullptr : ssgi_y,
+			ssgi_hq_spec ? nullptr : ssgi_cocg,
+			ssgi_hq_spec ? ssgi_gi_spec : nullptr,
+		};
 
-	//	if (dynamicCubemaps->loaded)
-	//		context->CSSetSamplers(0, 1, &linearSampler);
+		if (dynamicCubemaps->loaded)
+			context->CSSetSamplers(0, 1, &linearSampler);
 
-	//	context->CSSetShaderResources(0, ARRAYSIZE(srvs), srvs);
+		context->CSSetShaderResources(0, ARRAYSIZE(srvs), srvs);
 
-	//	ID3D11UnorderedAccessView* uavs[3]{ main.UAV, normals.UAV, motionVectors.UAV };
-	//	context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
+		ID3D11UnorderedAccessView* uavs[3]{ main.UAV, normals.UAV, motionVectors.UAV };
+		context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
 
-	//	auto shader = interior ? GetComputeMainCompositeInterior() : GetComputeMainComposite();
-	//	context->CSSetShader(shader, nullptr, 0);
+		auto shader = interior ? GetComputeMainCompositeInterior() : GetComputeMainComposite();
+		context->CSSetShader(shader, nullptr, 0);
 
-	//	context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
-	//}
+		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
+	}
 
-	//// Clear
-	//{
-	//	ID3D11ShaderResourceView* views[10]{ nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
-	//	context->CSSetShaderResources(0, ARRAYSIZE(views), views);
+	// Clear
+	{
+		ID3D11ShaderResourceView* views[10]{ nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
+		context->CSSetShaderResources(0, ARRAYSIZE(views), views);
 
-	//	ID3D11UnorderedAccessView* uavs[3]{ nullptr, nullptr, nullptr };
-	//	context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
+		ID3D11UnorderedAccessView* uavs[3]{ nullptr, nullptr, nullptr };
+		context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
 
-	//	ID3D11Buffer* buffers[1] = { nullptr };
-	//	context->CSSetConstantBuffers(12, 1, buffers);
+		ID3D11Buffer* buffers[1] = { nullptr };
+		context->CSSetConstantBuffers(12, 1, buffers);
 
-	//	context->CSSetShader(nullptr, nullptr, 0);
-	//}
+		context->CSSetShader(nullptr, nullptr, 0);
+	}
 
-	//if (dynamicCubemaps->loaded)
-	//	dynamicCubemaps->PostDeferred();
+	if (dynamicCubemaps->loaded)
+		dynamicCubemaps->PostDeferred();
 }
 
 void Deferred::EndDeferred()

--- a/src/Deferred.h
+++ b/src/Deferred.h
@@ -83,95 +83,43 @@ public:
 	{
 		struct Main_RenderShadowMaps
 		{
-			static void thunk()
-			{
-				func();
-				GetSingleton()->EarlyPrepasses();
-			}
+			static void thunk();
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 
 		struct Main_RenderWorld
 		{
-			static void thunk(bool a1)
-			{
-				GetSingleton()->inWorld = true;
-				func(a1);
-				GetSingleton()->inWorld = false;
-			}
-
+			static void thunk(bool a1);
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 
 		struct Main_RenderWorld_Start
 		{
-			static void thunk(RE::BSBatchRenderer* This, uint32_t StartRange, uint32_t EndRanges, uint32_t RenderFlags, int GeometryGroup)
-			{
-				// Here is where the first opaque objects start rendering
-				GetSingleton()->StartDeferred();
-				func(This, StartRange, EndRanges, RenderFlags, GeometryGroup);  // RenderBatches
-			}
+			static void thunk(RE::BSBatchRenderer* This, uint32_t StartRange, uint32_t EndRanges, uint32_t RenderFlags, int GeometryGroup);
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 
 		struct Main_RenderWorld_BlendedDecals
 		{
-			static void thunk(RE::BSShaderAccumulator* This, uint32_t RenderFlags)
-			{
-				// Deferred blended decals
-				GetSingleton()->inBlendedDecals = true;
-				func(This, RenderFlags);
-				GetSingleton()->inBlendedDecals = false;
-
-				GetSingleton()->EndDeferred();
-
-				// Blended decals
-				GetSingleton()->inDecals = true;
-				func(This, RenderFlags);
-				GetSingleton()->inDecals = false;
-
-				// After this point, water starts rendering
-			}
+			static void thunk(RE::BSShaderAccumulator* This, uint32_t RenderFlags);
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 
 		struct BSShaderAccumulator_BlendedDecals_RenderGeometryGroup
 		{
-			static void thunk(RE::BSBatchRenderer* This, uint32_t StartRange, uint32_t EndRanges, uint32_t RenderFlags, int GeometryGroup)
-			{
-				if (GetSingleton()->inBlendedDecals) {
-					func(This, StartRange, EndRanges, RenderFlags, 12);
-				} else {
-					func(This, StartRange, EndRanges, RenderFlags, GeometryGroup);
-				}
-			}
-
+			static void thunk(RE::BSBatchRenderer* This, uint32_t StartRange, uint32_t EndRanges, uint32_t RenderFlags, int GeometryGroup);
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 
 		struct BSShaderAccumulator_FirstPerson_BlendedDecals
 		{
-			static void thunk(RE::BSShaderAccumulator* This, uint32_t RenderFlags)
-			{
-				GetSingleton()->inBlendedDecals = true;
-				func(This, RenderFlags);
-				GetSingleton()->inBlendedDecals = false;
-				func(This, RenderFlags);
-				GetSingleton()->inDecals = false;
-			}
+			static void thunk(RE::BSShaderAccumulator* This, uint32_t RenderFlags);
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 
 		struct BSShaderAccumulator_ShadowMapOrMask_BlendedDecals
 		{
-			static void thunk(RE::BSShaderAccumulator* This, uint32_t RenderFlags)
-			{
-				GetSingleton()->inBlendedDecals = true;
-				func(This, RenderFlags);
-				GetSingleton()->inBlendedDecals = false;
-				func(This, RenderFlags);
-				GetSingleton()->inDecals = false;
-			}
+			static void thunk(RE::BSShaderAccumulator* This, uint32_t RenderFlags);
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 

--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -4,6 +4,7 @@
 
 #include "Deferred.h"
 #include "Util.h"
+#include "VariableCache.h"
 
 void CloudShadows::CheckResourcesSide(int side)
 {
@@ -20,8 +21,9 @@ void CloudShadows::CheckResourcesSide(int side)
 void CloudShadows::SkyShaderHacks()
 {
 	if (overrideSky) {
-		auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-		auto& context = State::GetSingleton()->context;
+		auto variableCache = VariableCache::GetSingleton();
+		auto renderer = variableCache->renderer;
+		auto context = variableCache->context;
 
 		auto reflections = renderer->GetRendererData().cubemapRenderTargets[RE::RENDER_TARGET_CUBEMAP::kREFLECTIONS];
 
@@ -58,7 +60,7 @@ void CloudShadows::SkyShaderHacks()
 
 void CloudShadows::ModifySky(RE::BSRenderPass* Pass)
 {
-	auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
+	auto shadowState = VariableCache::GetSingleton()->shadowState;
 
 	GET_INSTANCE_MEMBER(cubeMapRenderTarget, shadowState);
 

--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -131,7 +131,6 @@ void CloudShadows::SetupResources()
 	}
 }
 
-
 void CloudShadows::Hooks::BSSkyShader_SetupMaterial::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
 {
 	VariableCache::GetSingleton()->cloudShadows->ModifySky(Pass);

--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -130,3 +130,10 @@ void CloudShadows::SetupResources()
 		DX::ThrowIfFailed(device->CreateBlendState(&blendDesc, &cloudShadowBlendState));
 	}
 }
+
+
+void CloudShadows::Hooks::BSSkyShader_SetupMaterial::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
+{
+	VariableCache::GetSingleton()->cloudShadows->ModifySky(Pass);
+	func(This, Pass, RenderFlags);
+}

--- a/src/Features/CloudShadows.h
+++ b/src/Features/CloudShadows.h
@@ -36,11 +36,7 @@ struct CloudShadows : Feature
 	{
 		struct BSSkyShader_SetupMaterial
 		{
-			static void thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
-			{
-				GetSingleton()->ModifySky(Pass);
-				func(This, Pass, RenderFlags);
-			}
+			static void thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags);
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 

--- a/src/Features/GrassCollision.cpp
+++ b/src/Features/GrassCollision.cpp
@@ -2,6 +2,7 @@
 
 #include "State.h"
 #include "Util.h"
+#include "VariableCache.h"
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	GrassCollision::Settings,
@@ -228,4 +229,10 @@ bool GrassCollision::HasShaderDefine(RE::BSShader::Type shaderType)
 	default:
 		return false;
 	}
+}
+
+void GrassCollision::Hooks::BSGrassShader_SetupGeometry::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
+{
+	VariableCache::GetSingleton()->grassCollision->Update();
+	func(This, Pass, RenderFlags);
 }

--- a/src/Features/GrassCollision.h
+++ b/src/Features/GrassCollision.h
@@ -66,11 +66,7 @@ struct GrassCollision : Feature
 	{
 		struct BSGrassShader_SetupGeometry
 		{
-			static void thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
-			{
-				GetSingleton()->Update();
-				func(This, Pass, RenderFlags);
-			}
+			static void thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags);
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -1026,13 +1026,11 @@ void LightLimitFix::UpdateLights()
 	context->CSSetUnorderedAccessViews(0, 3, null_uavs, nullptr);
 }
 
-
 void LightLimitFix::Hooks::BSBatchRenderer_RenderPassImmediately::thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags)
 {
 	if (VariableCache::GetSingleton()->lightLimitFix->CheckParticleLights(Pass, Technique))
-		func(Pass, Technique, AlphaTest, RenderFlags);	
+		func(Pass, Technique, AlphaTest, RenderFlags);
 }
-
 
 void LightLimitFix::Hooks::BSLightingShader_SetupGeometry::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
 {

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -129,7 +129,7 @@ void LightLimitFix::CleanupParticleLights(RE::NiNode* a_node)
 
 void LightLimitFix::SetupResources()
 {
-	auto screenSize = Util::ConvertToDynamic(VariableCache::GetSingleton()->state->screenSize);
+	auto screenSize = Util::ConvertToDynamic(State::GetSingleton()->screenSize);
 	if (REL::Module::IsVR())
 		screenSize.x *= .5;
 	clusterSize[0] = ((uint)screenSize.x + 63) / 64;

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -3,6 +3,7 @@
 #include "Shadercache.h"
 #include "State.h"
 #include "Util.h"
+#include "VariableCache.h"
 
 static constexpr uint CLUSTER_MAX_LIGHTS = 256;
 static constexpr uint MAX_LIGHTS = 1024;
@@ -93,7 +94,7 @@ void LightLimitFix::DrawSettings()
 		}
 		currentEnableLightsVisualisation = settings.EnableLightsVisualisation;
 		if (previousEnableLightsVisualisation != currentEnableLightsVisualisation) {
-			State::GetSingleton()->SetDefines(settings.EnableLightsVisualisation ? "LLFDEBUG" : "");
+			VariableCache::GetSingleton()->state->SetDefines(settings.EnableLightsVisualisation ? "LLFDEBUG" : "");
 			shaderCache.Clear(RE::BSShader::Type::Lighting);
 			previousEnableLightsVisualisation = currentEnableLightsVisualisation;
 		}
@@ -105,7 +106,7 @@ void LightLimitFix::DrawSettings()
 
 	if (ImGui::TreeNodeEx("Statistics", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Text(std::format("Clustered Light Count : {}", lightCount).c_str());
-		ImGui::Text(std::format("Particle Lights Count : {}", particleLights.size()).c_str());
+		ImGui::Text(std::format("Particle Lights Count : {}", currentParticleLights.size()).c_str());
 
 		ImGui::TreePop();
 	}
@@ -128,7 +129,7 @@ void LightLimitFix::CleanupParticleLights(RE::NiNode* a_node)
 
 void LightLimitFix::SetupResources()
 {
-	auto screenSize = Util::ConvertToDynamic(State::GetSingleton()->screenSize);
+	auto screenSize = Util::ConvertToDynamic(VariableCache::GetSingleton()->state->screenSize);
 	if (REL::Module::IsVR())
 		screenSize.x *= .5;
 	clusterSize[0] = ((uint)screenSize.x + 63) / 64;
@@ -235,7 +236,7 @@ void LightLimitFix::SetupResources()
 
 void LightLimitFix::Reset()
 {
-	for (auto& particleLight : particleLights) {
+	for (auto& particleLight : currentParticleLights) {
 		if (!particleLight.billboard) {
 			if (const auto particleSystem = static_cast<RE::NiParticleSystem*>(particleLight.node)) {
 				if (auto particleData = particleSystem->GetParticleRuntimeData().particleData.get()) {
@@ -245,8 +246,8 @@ void LightLimitFix::Reset()
 		}
 		particleLight.node->DecRefCount();
 	}
-	particleLights.clear();
-	std::swap(particleLights, queuedParticleLights);
+	currentParticleLights.clear();
+	std::swap(currentParticleLights, queuedParticleLights);
 }
 
 void LightLimitFix::LoadSettings(json& o_json)
@@ -283,9 +284,10 @@ RE::NiNode* GetParentRoomNode(RE::NiAVObject* object)
 
 void LightLimitFix::BSLightingShader_SetupGeometry_Before(RE::BSRenderPass* a_pass)
 {
-	auto& shaderCache = SIE::ShaderCache::Instance();
+	auto variableCache = VariableCache::GetSingleton();
+	auto shaderCache = variableCache->shaderCache;
 
-	if (!shaderCache.IsEnabled())
+	if (!shaderCache->IsEnabled())
 		return;
 
 	strictLightDataTemp.NumStrictLights = 0;
@@ -302,13 +304,14 @@ void LightLimitFix::BSLightingShader_SetupGeometry_Before(RE::BSRenderPass* a_pa
 
 void LightLimitFix::BSLightingShader_SetupGeometry_GeometrySetupConstantPointLights(RE::BSRenderPass* a_pass, DirectX::XMMATRIX&, uint32_t, uint32_t, float, Space)
 {
-	auto& shaderCache = SIE::ShaderCache::Instance();
+	auto variableCache = VariableCache::GetSingleton();
+	auto shaderCache = variableCache->shaderCache;
 
-	if (!shaderCache.IsEnabled())
+	if (!shaderCache->IsEnabled())
 		return;
 
 	auto accumulator = RE::BSGraphics::BSShaderAccumulator::GetCurrentAccumulator();
-	bool inWorld = accumulator->GetRuntimeData().activeShadowSceneNode == RE::BSShaderManager::State::GetSingleton().shadowSceneNode[0];
+	bool inWorld = accumulator->GetRuntimeData().activeShadowSceneNode == variableCache->smState->shadowSceneNode[0];
 
 	strictLightDataTemp.NumStrictLights = inWorld ? 0 : (a_pass->numLights - 1);
 
@@ -342,19 +345,17 @@ void LightLimitFix::BSLightingShader_SetupGeometry_GeometrySetupConstantPointLig
 
 void LightLimitFix::BSLightingShader_SetupGeometry_After(RE::BSRenderPass*)
 {
-	auto& shaderCache = SIE::ShaderCache::Instance();
+	auto variableCache = VariableCache::GetSingleton();
+	auto shaderCache = variableCache->shaderCache;
+	auto context = variableCache->context;
+	auto smState = variableCache->smState;
 
-	if (!shaderCache.IsEnabled())
+	if (!shaderCache->IsEnabled())
 		return;
 
-	static auto& context = State::GetSingleton()->context;
 	auto accumulator = RE::BSGraphics::BSShaderAccumulator::GetCurrentAccumulator();
 
-	static bool wasEmpty = false;
-	static bool wasWorld = false;
-	static int previousRoomIndex = -1;
-
-	static auto shadowSceneNode = RE::BSShaderManager::State::GetSingleton().shadowSceneNode[0];
+	auto shadowSceneNode = smState->shadowSceneNode[0];
 
 	const bool isEmpty = strictLightDataTemp.NumStrictLights == 0;
 	const bool isWorld = accumulator->GetRuntimeData().activeShadowSceneNode == shadowSceneNode;
@@ -367,7 +368,6 @@ void LightLimitFix::BSLightingShader_SetupGeometry_After(RE::BSRenderPass*)
 		previousRoomIndex = roomIndex;
 	}
 
-	static Util::FrameChecker frameChecker;
 	if (frameChecker.IsNewFrame()) {
 		ID3D11Buffer* buffer = { strictLightDataCB->CB() };
 		context->PSSetConstantBuffers(3, 1, &buffer);
@@ -411,9 +411,10 @@ float LightLimitFix::CalculateLuminance(CachedParticleLight& light, RE::NiPoint3
 
 void LightLimitFix::AddParticleLightLuminance(RE::NiPoint3& targetPosition, int& numHits, float& lightLevel)
 {
-	auto& shaderCache = SIE::ShaderCache::Instance();
+	auto variableCache = VariableCache::GetSingleton();
+	auto shaderCache = variableCache->shaderCache;
 
-	if (!shaderCache.IsEnabled())
+	if (!shaderCache->IsEnabled())
 		return;
 
 	std::lock_guard<std::shared_mutex> lk{ cachedParticleLightsMutex };
@@ -431,7 +432,8 @@ void LightLimitFix::AddParticleLightLuminance(RE::NiPoint3& targetPosition, int&
 
 void LightLimitFix::Prepass()
 {
-	static auto& context = State::GetSingleton()->context;
+	auto variableCache = VariableCache::GetSingleton();
+	auto context = variableCache->context;
 
 	UpdateLights();
 
@@ -482,6 +484,9 @@ std::string ExtractTextureStem(std::string_view a_path)
 
 LightLimitFix::ParticleLightReference LightLimitFix::GetParticleLightConfigs(RE::BSRenderPass* a_pass)
 {
+	auto variableCache = VariableCache::GetSingleton();
+	auto particleLights = variableCache->particleLights;
+
 	// see https://www.nexusmods.com/skyrimspecialedition/articles/1391
 	if (settings.EnableParticleLights) {
 		if (auto shaderProperty = netimmerse_cast<RE::BSEffectShaderProperty*>(a_pass->shaderProperty)) {
@@ -517,7 +522,7 @@ LightLimitFix::ParticleLightReference LightLimitFix::GetParticleLightConfigs(RE:
 							return { false };
 						}
 
-						auto& configs = ParticleLights::GetSingleton()->particleLightConfigs;
+						auto& configs = particleLights->particleLightConfigs;
 						auto it = configs.find(textureName);
 						if (it == configs.end()) {
 							particleLightsReferences.insert({ (RE::NiNode*)a_pass->geometry, { false } });
@@ -533,7 +538,7 @@ LightLimitFix::ParticleLightReference LightLimitFix::GetParticleLightConfigs(RE:
 								return { false };
 							}
 
-							auto& gradientConfigs = ParticleLights::GetSingleton()->particleLightGradientConfigs;
+							auto& gradientConfigs = particleLights->particleLightGradientConfigs;
 							auto itGradient = gradientConfigs.find(textureName);
 							if (itGradient == gradientConfigs.end()) {
 								particleLightsReferences.insert({ (RE::NiNode*)a_pass->geometry, { false } });
@@ -593,9 +598,10 @@ LightLimitFix::ParticleLightReference LightLimitFix::GetParticleLightConfigs(RE:
 
 bool LightLimitFix::CheckParticleLights(RE::BSRenderPass* a_pass, uint32_t)
 {
-	auto& shaderCache = SIE::ShaderCache::Instance();
+	auto variableCache = VariableCache::GetSingleton();
+	auto shaderCache = variableCache->shaderCache;
 
-	if (!shaderCache.IsEnabled())
+	if (!shaderCache->IsEnabled())
 		return true;
 
 	auto reference = GetParticleLightConfigs(a_pass);
@@ -727,13 +733,13 @@ namespace RE
 
 void LightLimitFix::UpdateLights()
 {
-	static float& cameraNear = (*(float*)(REL::RelocationID(517032, 403540).address() + 0x40));
-	static float& cameraFar = (*(float*)(REL::RelocationID(517032, 403540).address() + 0x44));
+	auto variableCache = VariableCache::GetSingleton();
+	auto smState = variableCache->smState;
 
-	lightsNear = cameraNear;
-	lightsFar = cameraFar;
+	lightsNear = *variableCache->cameraNear;
+	lightsFar = *variableCache->cameraFar;
 
-	static auto shadowSceneNode = RE::BSShaderManager::State::GetSingleton().shadowSceneNode[0];
+	auto shadowSceneNode = smState->shadowSceneNode[0];
 
 	// Cache data since cameraData can become invalid in first-person
 
@@ -824,7 +830,7 @@ void LightLimitFix::UpdateLights()
 
 		auto eyePositionOffset = eyePositionCached[0] - eyePositionCached[1];
 
-		for (const auto& particleLight : particleLights) {
+		for (const auto& particleLight : currentParticleLights) {
 			if (!particleLight.billboard) {
 				auto particleSystem = static_cast<RE::NiParticleSystem*>(particleLight.node);
 				if (particleSystem && particleSystem->GetParticleRuntimeData().particleData.get()) {
@@ -942,7 +948,7 @@ void LightLimitFix::UpdateLights()
 		}
 	}
 
-	static auto& context = State::GetSingleton()->context;
+	auto context = variableCache->context;
 
 	{
 		auto projMatrixUnjittered = Util::GetCameraData(0).projMatrixUnjittered;
@@ -1018,4 +1024,55 @@ void LightLimitFix::UpdateLights()
 
 	ID3D11UnorderedAccessView* null_uavs[3] = { nullptr };
 	context->CSSetUnorderedAccessViews(0, 3, null_uavs, nullptr);
+}
+
+
+void LightLimitFix::Hooks::BSBatchRenderer_RenderPassImmediately::thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags)
+{
+	if (VariableCache::GetSingleton()->lightLimitFix->CheckParticleLights(Pass, Technique))
+		func(Pass, Technique, AlphaTest, RenderFlags);	
+}
+
+
+void LightLimitFix::Hooks::BSLightingShader_SetupGeometry::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
+{
+	auto singleton = VariableCache::GetSingleton()->lightLimitFix;
+	singleton->BSLightingShader_SetupGeometry_Before(Pass);
+	func(This, Pass, RenderFlags);
+	singleton->BSLightingShader_SetupGeometry_After(Pass);
+}
+
+void LightLimitFix::Hooks::BSEffectShader_SetupGeometry::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
+{
+	func(This, Pass, RenderFlags);
+	auto singleton = VariableCache::GetSingleton()->lightLimitFix;
+	singleton->BSLightingShader_SetupGeometry_Before(Pass);
+	singleton->BSLightingShader_SetupGeometry_After(Pass);
+};
+
+void LightLimitFix::Hooks::BSWaterShader_SetupGeometry::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
+{
+	func(This, Pass, RenderFlags);
+	auto singleton = VariableCache::GetSingleton()->lightLimitFix;
+	singleton->BSLightingShader_SetupGeometry_Before(Pass);
+	singleton->BSLightingShader_SetupGeometry_After(Pass);
+};
+
+float LightLimitFix::Hooks::AIProcess_CalculateLightValue_GetLuminance::thunk(RE::ShadowSceneNode* shadowSceneNode, RE::NiPoint3& targetPosition, int& numHits, float& sunLightLevel, float& lightLevel, RE::NiLight& refLight, int32_t shadowBitMask)
+{
+	auto ret = func(shadowSceneNode, targetPosition, numHits, sunLightLevel, lightLevel, refLight, shadowBitMask);
+	VariableCache::GetSingleton()->lightLimitFix->AddParticleLightLuminance(targetPosition, numHits, ret);
+	return ret;
+}
+
+void LightLimitFix::Hooks::BSLightingShader_SetupGeometry_GeometrySetupConstantPointLights::thunk(RE::BSGraphics::PixelShader* PixelShader, RE::BSRenderPass* Pass, DirectX::XMMATRIX& Transform, uint32_t LightCount, uint32_t ShadowLightCount, float WorldScale, Space RenderSpace)
+{
+	VariableCache::GetSingleton()->lightLimitFix->BSLightingShader_SetupGeometry_GeometrySetupConstantPointLights(Pass, Transform, LightCount, ShadowLightCount, WorldScale, RenderSpace);
+	func(PixelShader, Pass, Transform, LightCount, ShadowLightCount, WorldScale, RenderSpace);
+}
+
+void LightLimitFix::Hooks::NiNode_Destroy::thunk(RE::NiNode* This)
+{
+	VariableCache::GetSingleton()->lightLimitFix->CleanupParticleLights(This);
+	func(This);
 }

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -1,14 +1,14 @@
 #pragma once
 #include <DirectXMath.h>
 #include <d3d11.h>
+#include <shared_mutex>
 
 #include "Buffer.h"
 #include "Util.h"
-#include <shared_mutex>
-
 #include "Feature.h"
 #include "ShaderCache.h"
-#include <Features/LightLimitFix/ParticleLights.h>
+
+#include "Features/LightLimitFix/ParticleLights.h"
 
 struct LightLimitFix : Feature
 {
@@ -145,13 +145,18 @@ public:
 
 	eastl::hash_map<RE::NiNode*, ParticleLightReference> particleLightsReferences;
 	eastl::vector<ParticleLightInfo> queuedParticleLights;
-	eastl::vector<ParticleLightInfo> particleLights;
+	eastl::vector<ParticleLightInfo> currentParticleLights;
 
 	void CleanupParticleLights(RE::NiNode* a_node);
 
 	RE::NiPoint3 eyePositionCached[2]{};
 	Matrix viewMatrixCached[2]{};
 	Matrix viewMatrixInverseCached[2]{};
+
+	bool wasEmpty = false;
+	bool wasWorld = false;
+	int previousRoomIndex = -1;
+	Util::FrameChecker frameChecker;
 
 	virtual void SetupResources() override;
 	virtual void Reset() override;
@@ -222,105 +227,53 @@ public:
 
 	struct Hooks
 	{
-		struct BSBatchRenderer__RenderPassImmediately1
+		struct BSBatchRenderer_RenderPassImmediately
 		{
-			static void thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags)
-			{
-				if (GetSingleton()->CheckParticleLights(Pass, Technique))
-					func(Pass, Technique, AlphaTest, RenderFlags);
-			}
-			static inline REL::Relocation<decltype(thunk)> func;
-		};
-
-		struct BSBatchRenderer__RenderPassImmediately2
-		{
-			static void thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags)
-			{
-				if (GetSingleton()->CheckParticleLights(Pass, Technique))
-					func(Pass, Technique, AlphaTest, RenderFlags);
-			}
-			static inline REL::Relocation<decltype(thunk)> func;
-		};
-
-		struct BSBatchRenderer__RenderPassImmediately3
-		{
-			static void thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags)
-			{
-				if (GetSingleton()->CheckParticleLights(Pass, Technique))
-					func(Pass, Technique, AlphaTest, RenderFlags);
-			}
+			static void thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags);
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 
 		struct BSLightingShader_SetupGeometry
 		{
-			static void thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
-			{
-				GetSingleton()->BSLightingShader_SetupGeometry_Before(Pass);
-				func(This, Pass, RenderFlags);
-				GetSingleton()->BSLightingShader_SetupGeometry_After(Pass);
-			}
+			static void thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags);
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 
 		struct BSEffectShader_SetupGeometry
 		{
-			static void thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
-			{
-				func(This, Pass, RenderFlags);
-				GetSingleton()->BSLightingShader_SetupGeometry_Before(Pass);
-				GetSingleton()->BSLightingShader_SetupGeometry_After(Pass);
-			}
+			static void thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags);
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 
 		struct BSWaterShader_SetupGeometry
 		{
-			static void thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
-			{
-				func(This, Pass, RenderFlags);
-				GetSingleton()->BSLightingShader_SetupGeometry_Before(Pass);
-				GetSingleton()->BSLightingShader_SetupGeometry_After(Pass);
-			}
+			static void thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags);
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 
 		struct AIProcess_CalculateLightValue_GetLuminance
 		{
-			static float thunk(RE::ShadowSceneNode* shadowSceneNode, RE::NiPoint3& targetPosition, int& numHits, float& sunLightLevel, float& lightLevel, RE::NiLight& refLight, int32_t shadowBitMask)
-			{
-				auto ret = func(shadowSceneNode, targetPosition, numHits, sunLightLevel, lightLevel, refLight, shadowBitMask);
-				GetSingleton()->AddParticleLightLuminance(targetPosition, numHits, ret);
-				return ret;
-			}
+			static float thunk(RE::ShadowSceneNode* shadowSceneNode, RE::NiPoint3& targetPosition, int& numHits, float& sunLightLevel, float& lightLevel, RE::NiLight& refLight, int32_t shadowBitMask);
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 
 		struct BSLightingShader_SetupGeometry_GeometrySetupConstantPointLights
 		{
-			static void thunk(RE::BSGraphics::PixelShader* PixelShader, RE::BSRenderPass* Pass, DirectX::XMMATRIX& Transform, uint32_t LightCount, uint32_t ShadowLightCount, float WorldScale, Space RenderSpace)
-			{
-				GetSingleton()->BSLightingShader_SetupGeometry_GeometrySetupConstantPointLights(Pass, Transform, LightCount, ShadowLightCount, WorldScale, RenderSpace);
-				func(PixelShader, Pass, Transform, LightCount, ShadowLightCount, WorldScale, RenderSpace);
-			}
+			static void thunk(RE::BSGraphics::PixelShader* PixelShader, RE::BSRenderPass* Pass, DirectX::XMMATRIX& Transform, uint32_t LightCount, uint32_t ShadowLightCount, float WorldScale, Space RenderSpace);
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 
 		struct NiNode_Destroy
 		{
-			static void thunk(RE::NiNode* This)
-			{
-				GetSingleton()->CleanupParticleLights(This);
-				func(This);
-			}
+			static void thunk(RE::NiNode* This);
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 
 		static void Install()
 		{
-			stl::write_thunk_call<BSBatchRenderer__RenderPassImmediately1>(REL::RelocationID(100877, 107673).address() + REL::Relocate(0x1E5, 0x1EE));
-			stl::write_thunk_call<BSBatchRenderer__RenderPassImmediately2>(REL::RelocationID(100852, 107642).address() + REL::Relocate(0x29E, 0x28F));
-			stl::write_thunk_call<BSBatchRenderer__RenderPassImmediately3>(REL::RelocationID(100871, 107667).address() + REL::Relocate(0xEE, 0xED));
+			stl::write_thunk_call<BSBatchRenderer_RenderPassImmediately>(REL::RelocationID(100877, 107673).address() + REL::Relocate(0x1E5, 0x1EE));
+			stl::write_thunk_call<BSBatchRenderer_RenderPassImmediately>(REL::RelocationID(100852, 107642).address() + REL::Relocate(0x29E, 0x28F));
+			stl::write_thunk_call<BSBatchRenderer_RenderPassImmediately>(REL::RelocationID(100871, 107667).address() + REL::Relocate(0xEE, 0xED));
 
 			stl::write_thunk_call<AIProcess_CalculateLightValue_GetLuminance>(REL::RelocationID(38900, 39946).address() + REL::Relocate(0x1C9, 0x1D3));
 

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -4,9 +4,9 @@
 #include <shared_mutex>
 
 #include "Buffer.h"
-#include "Util.h"
 #include "Feature.h"
 #include "ShaderCache.h"
+#include "Util.h"
 
 #include "Features/LightLimitFix/ParticleLights.h"
 

--- a/src/FrameAnnotations.cpp
+++ b/src/FrameAnnotations.cpp
@@ -1,6 +1,7 @@
 #include "FrameAnnotations.h"
 
 #include "State.h"
+#include "VariableCache.h"
 
 #pragma comment(lib, "dxguid.lib")
 
@@ -11,10 +12,10 @@ namespace FrameAnnotations
 	{
 		static void thunk(RE::BSShader* shader, RE::BSRenderPass* pass, uint32_t renderFlags)
 		{
-			if (State::GetSingleton()->extendedFrameAnnotations) {
+			if (VariableCache::GetSingleton()->state->frameAnnotations) {
 				const std::string passName = std::format("[{}:{:X}] <{}> {}", magic_enum::enum_name(ShaderType), pass->passEnum,
 					pass->accumulationHint, pass->geometry->name.c_str());
-				State::GetSingleton()->BeginPerfEvent(passName);
+				VariableCache::GetSingleton()->state->BeginPerfEvent(passName);
 			}
 
 			func(shader, pass, renderFlags);
@@ -30,8 +31,8 @@ namespace FrameAnnotations
 		{
 			func(shader, pass, renderFlags);
 
-			if (State::GetSingleton()->extendedFrameAnnotations) {
-				State::GetSingleton()->EndPerfEvent();
+			if (VariableCache::GetSingleton()->state->frameAnnotations) {
+				VariableCache::GetSingleton()->state->EndPerfEvent();
 			}
 		}
 
@@ -43,11 +44,11 @@ namespace FrameAnnotations
 	{
 		static void thunk(void* imageSpaceShader, RE::BSTriShape* shape, RE::ImageSpaceEffectParam* param)
 		{
-			State::GetSingleton()->BeginPerfEvent(std::format("{} Draw", magic_enum::enum_name(EffectType)));
+			VariableCache::GetSingleton()->state->BeginPerfEvent(std::format("{} Draw", magic_enum::enum_name(EffectType)));
 
 			func(imageSpaceShader, shape, param);
 
-			State::GetSingleton()->EndPerfEvent();
+			VariableCache::GetSingleton()->state->EndPerfEvent();
 		}
 
 		static inline REL::Relocation<decltype(thunk)> func;
@@ -58,11 +59,11 @@ namespace FrameAnnotations
 	{
 		static void thunk(void* imageSpaceShader, uint32_t a1, uint32_t a2, uint32_t a3)
 		{
-			State::GetSingleton()->BeginPerfEvent(std::format("{} Dispatch", magic_enum::enum_name(EffectType)));
+			VariableCache::GetSingleton()->state->BeginPerfEvent(std::format("{} Dispatch", magic_enum::enum_name(EffectType)));
 
 			func(imageSpaceShader, a1, a2, a3);
 
-			State::GetSingleton()->EndPerfEvent();
+			VariableCache::GetSingleton()->state->EndPerfEvent();
 		}
 
 		static inline REL::Relocation<decltype(thunk)> func;
@@ -72,16 +73,16 @@ namespace FrameAnnotations
 	{
 		static void thunk(RE::BSGraphics::BSShaderAccumulator* shaderAccumulator, uint32_t renderFlags)
 		{
-			const bool extendedFrameAnnotations = State::GetSingleton()->extendedFrameAnnotations;
-			if (extendedFrameAnnotations) {
-				State::GetSingleton()->BeginPerfEvent(std::format("BSShaderAccumulator::FinishAccumulatingDispatch [{}] <{}>",
+			const bool frameAnnotations = VariableCache::GetSingleton()->state->frameAnnotations;
+			if (frameAnnotations) {
+				VariableCache::GetSingleton()->state->BeginPerfEvent(std::format("BSShaderAccumulator::FinishAccumulatingDispatch [{}] <{}>",
 					static_cast<uint32_t>(shaderAccumulator->GetRuntimeData().renderMode), renderFlags));
 			}
 
 			func(shaderAccumulator, renderFlags);
 
-			if (extendedFrameAnnotations) {
-				State::GetSingleton()->EndPerfEvent();
+			if (frameAnnotations) {
+				VariableCache::GetSingleton()->state->EndPerfEvent();
 			}
 		}
 
@@ -92,11 +93,11 @@ namespace FrameAnnotations
 	{
 		static void thunk(RE::NiAVObject* camera, int a2, bool a3, bool a4, bool a5)
 		{
-			State::GetSingleton()->BeginPerfEvent(std::format("Cubemap {}", camera->name.c_str()));
+			VariableCache::GetSingleton()->state->BeginPerfEvent(std::format("Cubemap {}", camera->name.c_str()));
 
 			func(camera, a2, a3, a4, a5);
 
-			State::GetSingleton()->EndPerfEvent();
+			VariableCache::GetSingleton()->state->EndPerfEvent();
 		}
 
 		static inline REL::Relocation<decltype(thunk)> func;
@@ -106,11 +107,11 @@ namespace FrameAnnotations
 	{
 		static void thunk(RE::BSShadowLight* light, void* a2)
 		{
-			State::GetSingleton()->BeginPerfEvent("Directional Light Shadowmaps");
+			VariableCache::GetSingleton()->state->BeginPerfEvent("Directional Light Shadowmaps");
 
 			func(light, a2);
 
-			State::GetSingleton()->EndPerfEvent();
+			VariableCache::GetSingleton()->state->EndPerfEvent();
 		}
 
 		static inline REL::Relocation<decltype(thunk)> func;
@@ -120,11 +121,11 @@ namespace FrameAnnotations
 	{
 		static void thunk(RE::BSShadowLight* light, void* a2)
 		{
-			State::GetSingleton()->BeginPerfEvent("Spot Light Shadowmaps");
+			VariableCache::GetSingleton()->state->BeginPerfEvent("Spot Light Shadowmaps");
 
 			func(light, a2);
 
-			State::GetSingleton()->EndPerfEvent();
+			VariableCache::GetSingleton()->state->EndPerfEvent();
 		}
 
 		static inline REL::Relocation<decltype(thunk)> func;
@@ -134,11 +135,11 @@ namespace FrameAnnotations
 	{
 		static void thunk(RE::BSShadowLight* light, void* a2)
 		{
-			State::GetSingleton()->BeginPerfEvent("Omnidirectional Light Shadowmaps");
+			VariableCache::GetSingleton()->state->BeginPerfEvent("Omnidirectional Light Shadowmaps");
 
 			func(light, a2);
 
-			State::GetSingleton()->EndPerfEvent();
+			VariableCache::GetSingleton()->state->EndPerfEvent();
 		}
 
 		static inline REL::Relocation<decltype(thunk)> func;
@@ -150,16 +151,16 @@ namespace FrameAnnotations
 			void* passIndexList,
 			uint32_t renderFlags)
 		{
-			const bool extendedFrameAnnotations = State::GetSingleton()->extendedFrameAnnotations;
-			if (extendedFrameAnnotations) {
-				State::GetSingleton()->BeginPerfEvent(std::format("BSBatchRenderer::RenderBatches ({:X})[{}] <{}>", *currentPass, *bucketIndex,
+			const bool frameAnnotations = VariableCache::GetSingleton()->state->frameAnnotations;
+			if (frameAnnotations) {
+				VariableCache::GetSingleton()->state->BeginPerfEvent(std::format("BSBatchRenderer::RenderBatches ({:X})[{}] <{}>", *currentPass, *bucketIndex,
 					renderFlags));
 			}
 
 			const bool result = func(renderer, currentPass, bucketIndex, passIndexList, renderFlags);
 
-			if (extendedFrameAnnotations) {
-				State::GetSingleton()->EndPerfEvent();
+			if (frameAnnotations) {
+				VariableCache::GetSingleton()->state->EndPerfEvent();
 			}
 
 			return result;
@@ -171,11 +172,11 @@ namespace FrameAnnotations
 	{
 		static void thunk(bool a1, bool a2)
 		{
-			State::GetSingleton()->BeginPerfEvent("Depth");
+			VariableCache::GetSingleton()->state->BeginPerfEvent("Depth");
 
 			func(a1, a2);
 
-			State::GetSingleton()->EndPerfEvent();
+			VariableCache::GetSingleton()->state->EndPerfEvent();
 		};
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -184,11 +185,11 @@ namespace FrameAnnotations
 	{
 		static void thunk(bool a1)
 		{
-			State::GetSingleton()->BeginPerfEvent("Shadowmasks");
+			VariableCache::GetSingleton()->state->BeginPerfEvent("Shadowmasks");
 
 			func(a1);
 
-			State::GetSingleton()->EndPerfEvent();
+			VariableCache::GetSingleton()->state->EndPerfEvent();
 		};
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -197,11 +198,11 @@ namespace FrameAnnotations
 	{
 		static void thunk(bool a1)
 		{
-			State::GetSingleton()->BeginPerfEvent("World");
+			VariableCache::GetSingleton()->state->BeginPerfEvent("World");
 
 			func(a1);
 
-			State::GetSingleton()->EndPerfEvent();
+			VariableCache::GetSingleton()->state->EndPerfEvent();
 		};
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -210,11 +211,11 @@ namespace FrameAnnotations
 	{
 		static void thunk(bool a1, bool a2)
 		{
-			State::GetSingleton()->BeginPerfEvent("First Person View");
+			VariableCache::GetSingleton()->state->BeginPerfEvent("First Person View");
 
 			func(a1, a2);
 
-			State::GetSingleton()->EndPerfEvent();
+			VariableCache::GetSingleton()->state->EndPerfEvent();
 		};
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -223,11 +224,11 @@ namespace FrameAnnotations
 	{
 		static void thunk()
 		{
-			State::GetSingleton()->BeginPerfEvent("Water Effects");
+			VariableCache::GetSingleton()->state->BeginPerfEvent("Water Effects");
 
 			func();
 
-			State::GetSingleton()->EndPerfEvent();
+			VariableCache::GetSingleton()->state->EndPerfEvent();
 		};
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -236,11 +237,11 @@ namespace FrameAnnotations
 	{
 		static void thunk(void* a1, bool a2, bool a3)
 		{
-			State::GetSingleton()->BeginPerfEvent("Player View");
+			VariableCache::GetSingleton()->state->BeginPerfEvent("Player View");
 
 			func(a1, a2, a3);
 
-			State::GetSingleton()->EndPerfEvent();
+			VariableCache::GetSingleton()->state->EndPerfEvent();
 		};
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -249,11 +250,11 @@ namespace FrameAnnotations
 	{
 		static void thunk(void* accumulator, uint32_t renderFlags)
 		{
-			State::GetSingleton()->BeginPerfEvent("Effects");
+			VariableCache::GetSingleton()->state->BeginPerfEvent("Effects");
 
 			func(accumulator, renderFlags);
 
-			State::GetSingleton()->EndPerfEvent();
+			VariableCache::GetSingleton()->state->EndPerfEvent();
 		};
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -262,16 +263,16 @@ namespace FrameAnnotations
 	{
 		static void thunk(void* shaderAccumulator, uint32_t firstPass, uint32_t lastPass, uint32_t renderFlags, int groupIndex)
 		{
-			const bool extendedFrameAnnotations = State::GetSingleton()->extendedFrameAnnotations;
-			if (extendedFrameAnnotations) {
-				State::GetSingleton()->BeginPerfEvent(std::format("BSShaderAccumulator::RenderBatches ({:X}:{:X})[{}] <{}>", firstPass, lastPass, groupIndex,
+			const bool frameAnnotations = VariableCache::GetSingleton()->state->frameAnnotations;
+			if (frameAnnotations) {
+				VariableCache::GetSingleton()->state->BeginPerfEvent(std::format("BSShaderAccumulator::RenderBatches ({:X}:{:X})[{}] <{}>", firstPass, lastPass, groupIndex,
 					renderFlags));
 			}
 
 			func(shaderAccumulator, firstPass, lastPass, renderFlags, groupIndex);
 
-			if (extendedFrameAnnotations) {
-				State::GetSingleton()->EndPerfEvent();
+			if (frameAnnotations) {
+				VariableCache::GetSingleton()->state->EndPerfEvent();
 			}
 		};
 		static inline REL::Relocation<decltype(thunk)> func;
@@ -281,15 +282,15 @@ namespace FrameAnnotations
 	{
 		static void thunk(void* passList, uint32_t renderFlags)
 		{
-			const bool extendedFrameAnnotations = State::GetSingleton()->extendedFrameAnnotations;
-			if (extendedFrameAnnotations) {
-				State::GetSingleton()->BeginPerfEvent(std::format("BSShaderAccumulator::RenderPersistentPassList <{}>", renderFlags));
+			const bool frameAnnotations = VariableCache::GetSingleton()->state->frameAnnotations;
+			if (frameAnnotations) {
+				VariableCache::GetSingleton()->state->BeginPerfEvent(std::format("BSShaderAccumulator::RenderPersistentPassList <{}>", renderFlags));
 			}
 
 			func(passList, renderFlags);
 
-			if (extendedFrameAnnotations) {
-				State::GetSingleton()->EndPerfEvent();
+			if (frameAnnotations) {
+				VariableCache::GetSingleton()->state->EndPerfEvent();
 			}
 		};
 		static inline REL::Relocation<decltype(thunk)> func;
@@ -299,17 +300,20 @@ namespace FrameAnnotations
 	{
 		static void thunk(void* a1, void* a2, bool a3)
 		{
-			State::GetSingleton()->BeginPerfEvent("Volumetric Lighting");
+			VariableCache::GetSingleton()->state->BeginPerfEvent("Volumetric Lighting");
 
 			func(a1, a2, a3);
 
-			State::GetSingleton()->EndPerfEvent();
+			VariableCache::GetSingleton()->state->EndPerfEvent();
 		};
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
 	void OnPostPostLoad()
 	{
+		if (!State::GetSingleton()->frameAnnotations)
+			return;
+
 		stl::write_vfunc<0x6, BSShader_SetupGeometry<RE::BSShader::Type::Lighting>>(
 			RE::VTABLE_BSLightingShader[0]);
 		stl::write_vfunc<0x6, BSShader_SetupGeometry<RE::BSShader::Type::Effect>>(
@@ -921,6 +925,9 @@ namespace FrameAnnotations
 
 	void OnDataLoaded()
 	{
+		if (!State::GetSingleton()->frameAnnotations)
+			return;
+
 		auto renderer = RE::BSGraphics::Renderer::GetSingleton();
 
 		for (size_t renderTargetIndex = 0;

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -66,34 +66,38 @@ struct BSShader_LoadShaders
 	static void thunk(RE::BSShader* shader, std::uintptr_t stream)
 	{
 		func(shader, stream);
-		auto& shaderCache = SIE::ShaderCache::Instance();
 
-		if (shaderCache.IsDiskCache() || shaderCache.IsDump()) {
-			if (shaderCache.IsDiskCache()) {
-				TruePBR::GetSingleton()->GenerateShaderPermutations(shader);
+		auto variableCache = VariableCache::GetSingleton();
+		auto state = variableCache->state;
+		auto shaderCache = variableCache->shaderCache;
+		auto truePBR = variableCache->truePBR;
+
+		if (shaderCache->IsDiskCache() || shaderCache->IsDump()) {
+			if (shaderCache->IsDiskCache()) {
+				truePBR->GenerateShaderPermutations(shader);
 			}
 
 			for (const auto& entry : shader->vertexShaders) {
-				if (entry->shader && shaderCache.IsDump()) {
+				if (entry->shader && shaderCache->IsDump()) {
 					const auto& bytecode = GetShaderBytecode(entry->shader);
 					DumpShader((REX::BSShader*)shader, entry, bytecode);
 				}
 				auto vertexShaderDesriptor = entry->id;
 				auto pixelShaderDescriptor = entry->id;
-				State::GetSingleton()->ModifyShaderLookup(*shader, vertexShaderDesriptor, pixelShaderDescriptor);
-				shaderCache.GetVertexShader(*shader, vertexShaderDesriptor);
+				state->ModifyShaderLookup(*shader, vertexShaderDesriptor, pixelShaderDescriptor);
+				shaderCache->GetVertexShader(*shader, vertexShaderDesriptor);
 			}
 			for (const auto& entry : shader->pixelShaders) {
-				if (entry->shader && shaderCache.IsDump()) {
+				if (entry->shader && shaderCache->IsDump()) {
 					const auto& bytecode = GetShaderBytecode(entry->shader);
 					DumpShader((REX::BSShader*)shader, entry, bytecode);
 				}
 				auto vertexShaderDesriptor = entry->id;
 				auto pixelShaderDescriptor = entry->id;
-				State::GetSingleton()->ModifyShaderLookup(*shader, vertexShaderDesriptor, pixelShaderDescriptor);
-				shaderCache.GetPixelShader(*shader, pixelShaderDescriptor);
-				State::GetSingleton()->ModifyShaderLookup(*shader, vertexShaderDesriptor, pixelShaderDescriptor, true);
-				shaderCache.GetPixelShader(*shader, pixelShaderDescriptor);
+				state->ModifyShaderLookup(*shader, vertexShaderDesriptor, pixelShaderDescriptor);
+				shaderCache->GetPixelShader(*shader, pixelShaderDescriptor);
+				state->ModifyShaderLookup(*shader, vertexShaderDesriptor, pixelShaderDescriptor, true);
+				shaderCache->GetPixelShader(*shader, pixelShaderDescriptor);
 			}
 		}
 		BSShaderHooks::hk_LoadShaders((REX::BSShader*)shader, stream);
@@ -106,7 +110,6 @@ bool Hooks::BSShader_BeginTechnique::thunk(RE::BSShader* shader, uint32_t vertex
 	auto variableCache = VariableCache::GetSingleton();
 	auto state = variableCache->state;
 	auto shaderCache = variableCache->shaderCache;
-	auto shadowState = variableCache->shadowState;
 
 	state->updateShader = true;
 	state->currentShader = shader;

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -128,11 +128,15 @@ bool Hooks::BSShader_BeginTechnique::thunk(RE::BSShader* shader, uint32_t vertex
 			shaderFound = false;
 		} else {
 			state->settingCustomShader = true;
-			shadowState->SetVertexShader(vertexShader);
+			state->context->VSSetShader(reinterpret_cast<ID3D11VertexShader*>(vertexShader->shader), NULL, NULL);
+			*variableCache->currentVertexShader = vertexShader;
+			variableCache->stateUpdateFlags->set(RE::BSGraphics::DIRTY_VERTEX_DESC);
 			if (skipPixelShader) {
 				pixelShader = nullptr;
 			}
-			shadowState->SetPixelShader(pixelShader);
+			*variableCache->currentPixelShader = pixelShader;
+			if (pixelShader)
+				state->context->PSSetShader(reinterpret_cast<ID3D11PixelShader*>(pixelShader->shader), NULL, NULL);
 			state->settingCustomShader = false;
 			shaderFound = true;
 		}

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -493,7 +493,6 @@ namespace Hooks
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
-
 	struct BSShader__BeginTechnique_SetPixelShader
 	{
 		static void thunk(RE::BSGraphics::Renderer*, RE::BSGraphics::PixelShader* a_pixelShader)
@@ -508,7 +507,7 @@ namespace Hooks
 					auto type = currentShader->shaderType.get();
 					if (type > 0 && type < RE::BSShader::Type::Total) {
 						if (state->enabledClasses[type - 1]) {
-							RE::BSGraphics::PixelShader* pixelShader = shaderCache->GetPixelShader(*currentShader, state->modifiedPixelDescriptor);	
+							RE::BSGraphics::PixelShader* pixelShader = shaderCache->GetPixelShader(*currentShader, state->modifiedPixelDescriptor);
 							if (pixelShader) {
 								state->context->PSSetShader(reinterpret_cast<ID3D11PixelShader*>(pixelShader->shader), NULL, NULL);
 								*variableCache->currentPixelShader = a_pixelShader;
@@ -520,7 +519,7 @@ namespace Hooks
 			}
 
 			*variableCache->currentPixelShader = a_pixelShader;
-			
+
 			if (a_pixelShader)
 				variableCache->context->PSSetShader(reinterpret_cast<ID3D11PixelShader*>(a_pixelShader->shader), NULL, NULL);
 		}

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -324,7 +324,8 @@ struct BSInputDeviceManager_PollInputDevices
 	static void thunk(RE::BSTEventSource<RE::InputEvent*>* a_dispatcher, RE::InputEvent* const* a_events)
 	{
 		bool blockedDevice = true;
-		auto menu = Menu::GetSingleton();
+		auto variableCache = VariableCache::GetSingleton();
+		auto menu = variableCache->menu;
 
 		if (a_events) {
 			menu->ProcessInputEvents(a_events);
@@ -334,7 +335,7 @@ struct BSInputDeviceManager_PollInputDevices
 					// Check that the device is not a Gamepad or VR controller. If it is, unblock input.
 					bool vrDevice = false;
 #ifdef ENABLE_SKYRIM_VR
-					vrDevice = (REL::Module::IsVR() && ((device == RE::INPUT_DEVICES::INPUT_DEVICE::kVivePrimary) ||
+					vrDevice = (variableCache->isVR && ((device == RE::INPUT_DEVICES::INPUT_DEVICE::kVivePrimary) ||
 														   (device == RE::INPUT_DEVICES::INPUT_DEVICE::kViveSecondary) ||
 														   (device == RE::INPUT_DEVICES::INPUT_DEVICE::kOculusPrimary) ||
 														   (device == RE::INPUT_DEVICES::INPUT_DEVICE::kOculusSecondary) ||

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -157,7 +157,9 @@ namespace EffectExtensions
 			func(shader, pass, renderFlags);
 			if (auto* shaderProperty = static_cast<RE::BSShaderProperty*>(pass->geometry->GetGeometryRuntimeData().properties[1].get())) {
 				if (shaderProperty->flags.any(RE::BSShaderProperty::EShaderPropertyFlag::kUniformScale)) {
-					State::GetSingleton()->currentExtraDescriptor |= (uint)State::ExtraShaderDescriptors::EffectShadows;
+					auto variableCache = VariableCache::GetSingleton();
+					auto state = variableCache->state;
+					state->currentExtraDescriptor |= (uint)State::ExtraShaderDescriptors::EffectShadows;
 				}
 			}
 		}

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -106,7 +106,7 @@ bool Hooks::BSShader_BeginTechnique::thunk(RE::BSShader* shader, uint32_t vertex
 	auto variableCache = VariableCache::GetSingleton();
 	auto state = variableCache->state;
 	auto shaderCache = variableCache->shaderCache;
-	auto rendererShadowState = variableCache->rendererShadowState;
+	auto shadowState = variableCache->shadowState;
 
 	state->updateShader = true;
 	state->currentShader = shader;
@@ -128,11 +128,11 @@ bool Hooks::BSShader_BeginTechnique::thunk(RE::BSShader* shader, uint32_t vertex
 			shaderFound = false;
 		} else {
 			state->settingCustomShader = true;
-			rendererShadowState->SetVertexShader(vertexShader);
+			shadowState->SetVertexShader(vertexShader);
 			if (skipPixelShader) {
 				pixelShader = nullptr;
 			}
-			rendererShadowState->SetPixelShader(pixelShader);
+			shadowState->SetPixelShader(pixelShader);
 			state->settingCustomShader = false;
 			shaderFound = true;
 		}

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -654,9 +654,10 @@ namespace Hooks
 		{
 			static void thunk(RE::BSGraphics::Renderer* renderer, RE::BSGraphics::ComputeShader* shader, uint32_t threadGroupCountX, uint32_t threadGroupCountY, uint32_t threadGroupCountZ)
 			{
-				auto state = State::GetSingleton();
+				auto variableCache = VariableCache::GetSingleton();
+				auto state = variableCache->state;
+				auto shaderCache = variableCache->shaderCache;
 				if (state->enabledClasses[RE::BSShader::Type::ImageSpace]) {
-					auto& shaderCache = SIE::ShaderCache::Instance();
 					RE::BSImagespaceShader* isShader = CurrentlyDispatchedShader;
 					uint32_t techniqueId = CurrentComputeShaderTechniqueId;
 					if (CurrentlyDispatchedShader == nullptr) {
@@ -668,7 +669,7 @@ namespace Hooks
 						}
 					}
 					if (isShader != nullptr) {
-						if (auto* computeShader = shaderCache.GetComputeShader(*isShader, techniqueId)) {
+						if (auto* computeShader = shaderCache->GetComputeShader(*isShader, techniqueId)) {
 							shader = computeShader;
 						}
 					}

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -385,7 +385,7 @@ namespace Hooks
 			}
 			Menu::GetSingleton()->Init(swapchain, device, context);
 
-			VariableCache::GetSingleton()->InitializeVariables();
+			VariableCache::GetSingleton()->OnInit();
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -856,7 +856,7 @@ void Menu::DrawAdvancedSettings()
 			ImGui::Text(std::format("Shader Compiler : {}", shaderCache.GetShaderStatsString()).c_str());
 			ImGui::TreePop();
 		}
-		ImGui::Checkbox("Extended Frame Annotations", &State::GetSingleton()->extendedFrameAnnotations);
+		ImGui::Checkbox("Frame Annotations", &State::GetSingleton()->frameAnnotations);
 	}
 
 	if (ImGui::CollapsingHeader("Replace Original Shaders", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick)) {

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1394,7 +1394,6 @@ namespace SIE
 		std::unique_ptr<RE::BSGraphics::VertexShader> CreateVertexShader(ID3DBlob& shaderData,
 			const RE::BSShader& shader, uint32_t descriptor)
 		{
-			static const auto device = REL::Relocation<ID3D11Device**>(RE::Offset::D3D11Device);
 			static const auto perTechniqueBuffersArray =
 				REL::Relocation<ID3D11Buffer**>(RELOCATION_ID(524755, 411371));
 			static const auto perMaterialBuffersArray =
@@ -1453,7 +1452,6 @@ namespace SIE
 		std::unique_ptr<RE::BSGraphics::PixelShader> CreatePixelShader(ID3DBlob& shaderData,
 			const RE::BSShader& shader, uint32_t descriptor)
 		{
-			static const auto device = REL::Relocation<ID3D11Device**>(RE::Offset::D3D11Device);
 			static const auto perTechniqueBuffersArray =
 				REL::Relocation<ID3D11Buffer**>(RELOCATION_ID(524761, 411377));
 			static const auto perMaterialBuffersArray =
@@ -2285,14 +2283,14 @@ namespace SIE
 	{
 		if (const auto shaderBlob =
 				SShaderCache::CompileShader(ShaderClass::Vertex, shader, descriptor, isDiskCache)) {
-			static const auto device = REL::Relocation<ID3D11Device**>(RE::Offset::D3D11Device);
+			auto device = VariableCache::GetSingleton()->device;
 
 			auto newShader = SShaderCache::CreateVertexShader(*shaderBlob, shader,
 				descriptor);
 
 			std::lock_guard lockGuard(vertexShadersMutex);
 
-			const auto result = (*device)->CreateVertexShader(shaderBlob->GetBufferPointer(),
+			const auto result = device->CreateVertexShader(shaderBlob->GetBufferPointer(),
 				newShader->byteCodeSize, nullptr, reinterpret_cast<ID3D11VertexShader**>(&newShader->shader));
 			if (FAILED(result)) {
 				logger::error("Failed to create vertex shader {}::{:X}",
@@ -2314,13 +2312,13 @@ namespace SIE
 	{
 		if (const auto shaderBlob =
 				SShaderCache::CompileShader(ShaderClass::Pixel, shader, descriptor, isDiskCache)) {
-			static const auto device = REL::Relocation<ID3D11Device**>(RE::Offset::D3D11Device);
+			auto device = VariableCache::GetSingleton()->device;
 
 			auto newShader = SShaderCache::CreatePixelShader(*shaderBlob, shader,
 				descriptor);
 
 			std::lock_guard lockGuard(pixelShadersMutex);
-			const auto result = (*device)->CreatePixelShader(shaderBlob->GetBufferPointer(),
+			const auto result = device->CreatePixelShader(shaderBlob->GetBufferPointer(),
 				shaderBlob->GetBufferSize(), nullptr, reinterpret_cast<ID3D11PixelShader**>(&newShader->shader));
 			if (FAILED(result)) {
 				logger::error("Failed to create pixel shader {}::{:X}",
@@ -2343,13 +2341,13 @@ namespace SIE
 	{
 		if (const auto shaderBlob =
 				SShaderCache::CompileShader(ShaderClass::Compute, shader, descriptor, isDiskCache)) {
-			static const auto device = REL::Relocation<ID3D11Device**>(RE::Offset::D3D11Device);
+			auto device = VariableCache::GetSingleton()->device;
 
 			auto newShader = SShaderCache::CreateComputeShader(*shaderBlob, shader,
 				descriptor);
 
 			std::lock_guard lockGuard(computeShadersMutex);
-			const auto result = (*device)->CreateComputeShader(shaderBlob->GetBufferPointer(),
+			const auto result = device->CreateComputeShader(shaderBlob->GetBufferPointer(),
 				shaderBlob->GetBufferSize(), nullptr, reinterpret_cast<ID3D11ComputeShader**>(&newShader->shader));
 			if (FAILED(result)) {
 				logger::error("Failed to create pixel shader {}::{:X}",

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1776,13 +1776,15 @@ namespace SIE
 			}
 		}
 
-		auto key = SIE::SShaderCache::GetShaderString(ShaderClass::Compute, shader, descriptor, true);
-		if (blockedKeyIndex != -1 && !blockedKey.empty() && key == blockedKey) {
-			if (std::find(blockedIDs.begin(), blockedIDs.end(), descriptor) == blockedIDs.end()) {
-				blockedIDs.push_back(descriptor);
-				logger::debug("Skipping blocked shader {:X}:{} total: {}", descriptor, blockedKey, blockedIDs.size());
+		if (state->IsDeveloperMode()) {
+			auto key = SIE::SShaderCache::GetShaderString(ShaderClass::Compute, shader, descriptor, true);
+			if (blockedKeyIndex != -1 && !blockedKey.empty() && key == blockedKey) {
+				if (std::find(blockedIDs.begin(), blockedIDs.end(), descriptor) == blockedIDs.end()) {
+					blockedIDs.push_back(descriptor);
+					logger::debug("Skipping blocked shader {:X}:{} total: {}", descriptor, blockedKey, blockedIDs.size());
+				}
+				return nullptr;
 			}
-			return nullptr;
 		}
 
 		{

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -10,6 +10,7 @@
 #include "Deferred.h"
 #include "Feature.h"
 #include "State.h"
+#include "VariableCache.h"
 
 #include "Features/DynamicCubemaps.h"
 
@@ -1676,7 +1677,7 @@ namespace SIE
 			}
 		}
 
-		auto state = State::GetSingleton();
+		auto state = VariableCache::GetSingleton()->state;
 		if (state->isVR && strcmp(shader.fxpFilename, "OBBOcclusionTesting") == 0)
 			// use vanilla shader
 			return nullptr;
@@ -1685,13 +1686,15 @@ namespace SIE
 			return nullptr;
 		}
 
-		auto key = SIE::SShaderCache::GetShaderString(ShaderClass::Vertex, shader, descriptor, true);
-		if (blockedKeyIndex != -1 && !blockedKey.empty() && key == blockedKey) {
-			if (std::find(blockedIDs.begin(), blockedIDs.end(), descriptor) == blockedIDs.end()) {
-				blockedIDs.push_back(descriptor);
-				logger::debug("Skipping blocked shader {:X}:{} total: {}", descriptor, blockedKey, blockedIDs.size());
+		if (state->IsDeveloperMode()) {
+			auto key = SIE::SShaderCache::GetShaderString(ShaderClass::Vertex, shader, descriptor, true);
+			if (blockedKeyIndex != -1 && !blockedKey.empty() && key == blockedKey) {
+				if (std::find(blockedIDs.begin(), blockedIDs.end(), descriptor) == blockedIDs.end()) {
+					blockedIDs.push_back(descriptor);
+					logger::debug("Skipping blocked shader {:X}:{} total: {}", descriptor, blockedKey, blockedIDs.size());
+				}
+				return nullptr;
 			}
-			return nullptr;
 		}
 
 		{
@@ -1715,7 +1718,7 @@ namespace SIE
 	RE::BSGraphics::PixelShader* ShaderCache::GetPixelShader(const RE::BSShader& shader,
 		uint32_t descriptor)
 	{
-		auto state = State::GetSingleton();
+		auto state = VariableCache::GetSingleton()->state;
 		if (state->isVR && strcmp(shader.fxpFilename, "OBBOcclusionTesting") == 0)
 			// use vanilla shader
 			return nullptr;
@@ -1731,13 +1734,15 @@ namespace SIE
 			}
 		}
 
-		auto key = SIE::SShaderCache::GetShaderString(ShaderClass::Pixel, shader, descriptor, true);
-		if (blockedKeyIndex != -1 && !blockedKey.empty() && key == blockedKey) {
-			if (std::find(blockedIDs.begin(), blockedIDs.end(), descriptor) == blockedIDs.end()) {
-				blockedIDs.push_back(descriptor);
-				logger::debug("Skipping blocked shader {:X}:{} total: {}", descriptor, blockedKey, blockedIDs.size());
+		if (state->IsDeveloperMode()) {
+			auto key = SIE::SShaderCache::GetShaderString(ShaderClass::Pixel, shader, descriptor, true);
+			if (blockedKeyIndex != -1 && !blockedKey.empty() && key == blockedKey) {
+				if (std::find(blockedIDs.begin(), blockedIDs.end(), descriptor) == blockedIDs.end()) {
+					blockedIDs.push_back(descriptor);
+					logger::debug("Skipping blocked shader {:X}:{} total: {}", descriptor, blockedKey, blockedIDs.size());
+				}
+				return nullptr;
 			}
-			return nullptr;
 		}
 
 		{

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -42,7 +42,7 @@ void State::Draw()
 		if (deferred->inWorld) {
 			currentExtraDescriptor |= (uint32_t)ExtraShaderDescriptors::InWorld;
 		}
-		
+
 		if (deferred->inDecals)
 			currentExtraDescriptor |= (uint32_t)ExtraShaderDescriptors::IsDecal;
 

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -82,7 +82,7 @@ void State::Draw()
 					// Only check against non-shader bits
 					currentPixelDescriptor &= ~modifiedPixelDescriptor;
 
-					if (IsDeveloperMode()) {
+					if (frameAnnotations) {
 						BeginPerfEvent(std::format("Draw: CS {}::{:x}::{}", magic_enum::enum_name(currentShader->shaderType.get()), currentPixelDescriptor, currentShader->fxpFilename));
 						SetPerfMarker(std::format("Defines: {}", SIE::ShaderCache::GetDefinesString(*currentShader, currentPixelDescriptor)));
 						EndPerfEvent();
@@ -215,8 +215,8 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 				shaderCache.backgroundCompilationThreadCount = std::clamp(advanced["Background Compiler Threads"].get<int32_t>(), 1, static_cast<int32_t>(std::thread::hardware_concurrency()));
 			if (advanced["Use FileWatcher"].is_boolean())
 				shaderCache.SetFileWatcher(advanced["Use FileWatcher"]);
-			if (advanced["Extended Frame Annotations"].is_boolean())
-				extendedFrameAnnotations = advanced["Extended Frame Annotations"];
+			if (advanced["Frame Annotations"].is_boolean())
+				frameAnnotations = advanced["Frame Annotations"];
 		}
 
 		if (settings["General"].is_object()) {
@@ -347,7 +347,7 @@ void State::Save(ConfigMode a_configMode)
 	advanced["Compiler Threads"] = shaderCache.compilationThreadCount;
 	advanced["Background Compiler Threads"] = shaderCache.backgroundCompilationThreadCount;
 	advanced["Use FileWatcher"] = shaderCache.UseFileWatcher();
-	advanced["Extended Frame Annotations"] = extendedFrameAnnotations;
+	advanced["Frame Annotations"] = frameAnnotations;
 	settings["Advanced"] = advanced;
 
 	json general;

--- a/src/State.h
+++ b/src/State.h
@@ -7,8 +7,8 @@
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
-#include <FeatureBuffer.h>
 #include "Util.h"
+#include <FeatureBuffer.h>
 
 class State
 {

--- a/src/State.h
+++ b/src/State.h
@@ -8,6 +8,7 @@
 using json = nlohmann::json;
 
 #include <FeatureBuffer.h>
+#include "Util.h"
 
 class State
 {
@@ -155,6 +156,8 @@ public:
 
 	ConstantBuffer* sharedDataCB = nullptr;
 	ConstantBuffer* featureDataCB = nullptr;
+
+	Util::FrameChecker frameChecker;
 
 	// Skyrim constants
 	bool isVR = false;

--- a/src/State.h
+++ b/src/State.h
@@ -106,7 +106,7 @@ public:
 
 	void SetAdapterDescription(const std::wstring& description);
 
-	bool extendedFrameAnnotations = false;
+	bool frameAnnotations = false;
 
 	uint lastVertexDescriptor = 0;
 	uint lastPixelDescriptor = 0;
@@ -172,6 +172,8 @@ public:
 	bool SetFeatureDisabled(const std::string& featureName, bool isDisabled);
 	bool IsFeatureDisabled(const std::string& featureName);
 	std::unordered_map<std::string, bool>& GetDisabledFeatures();
+
+	bool useFrameAnnotations = false;
 
 	// Features that are more special then others
 	std::unordered_map<std::string, bool> specialFeatures = {

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -1159,7 +1159,8 @@ struct TESObjectLAND_SetupMaterial
 				}
 				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kMultiTextureLandscape, true);
 				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kReceiveShadows, true);
-				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kCastShadows, variableCache->bDrawLandShadows->GetBool());
+
+				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kCastShadows, true);
 				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kNoLODLandBlend, noLODLandBlend);
 
 				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kVertexLighting, true);

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -1513,7 +1513,7 @@ struct TESBoundObject_Clone3D
 struct BGSTextureSet_ToShaderTextureSet
 {
 	static RE::BSShaderTextureSet* thunk(RE::BGSTextureSet* textureSet)
-	{			
+	{
 		auto truePBR = VariableCache::GetSingleton()->truePBR;
 		truePBR->currentTextureSet = textureSet;
 

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -1596,12 +1596,11 @@ void TruePBR::SetupDefaultPBRLandTextureSet()
 	}
 }
 
-void TruePBR::SetShaderResouces()
+void TruePBR::SetShaderResouces(ID3D11DeviceContext* a_context)
 {
-	auto context = State::GetSingleton()->context;
 	for (uint32_t textureIndex = 0; textureIndex < ExtendedRendererState::NumPSTextures; ++textureIndex) {
 		if (extendedRendererState.PSResourceModifiedBits & (1 << textureIndex)) {
-			context->PSSetShaderResources(ExtendedRendererState::FirstPSTexture + textureIndex, 1, &extendedRendererState.PSTexture[textureIndex]);
+			a_context->PSSetShaderResources(ExtendedRendererState::FirstPSTexture + textureIndex, 1, &extendedRendererState.PSTexture[textureIndex]);
 		}
 	}
 	extendedRendererState.PSResourceModifiedBits = 0;

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -7,6 +7,7 @@
 #include "ShaderCache.h"
 #include "State.h"
 #include "Util.h"
+#include "VariableCache.h"
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	GlintParameters,
@@ -261,7 +262,7 @@ void TruePBR::SetupResources()
 
 void TruePBR::PrePass()
 {
-	auto context = State::GetSingleton()->context;
+	auto context = VariableCache::GetSingleton()->context;
 	if (!glintsNoiseTexture)
 		SetupGlintsTexture();
 	ID3D11ShaderResourceView* srv = glintsNoiseTexture->srv.get();
@@ -310,7 +311,7 @@ void TruePBR::SetupGlintsTexture()
 
 	// Generate the noise
 	{
-		auto context = State::GetSingleton()->context;
+		auto context = VariableCache::GetSingleton()->context;
 
 		struct OldState
 		{
@@ -507,22 +508,23 @@ namespace Permutations
 
 void TruePBR::GenerateShaderPermutations(RE::BSShader* shader)
 {
-	auto& shaderCache = SIE::ShaderCache::Instance();
+	auto state = VariableCache::GetSingleton()->state;
+	auto shaderCache = VariableCache::GetSingleton()->shaderCache;
 	if (shader->shaderType == RE::BSShader::Type::Lighting) {
 		const auto pixelPermutations = Permutations::GeneratePBRLightingPixelPermutations();
 		for (auto descriptor : pixelPermutations) {
 			auto vertexShaderDesriptor = descriptor;
 			auto pixelShaderDescriptor = descriptor;
-			State::GetSingleton()->ModifyShaderLookup(*shader, vertexShaderDesriptor, pixelShaderDescriptor);
-			std::ignore = shaderCache.GetPixelShader(*shader, pixelShaderDescriptor);
+			state->ModifyShaderLookup(*shader, vertexShaderDesriptor, pixelShaderDescriptor);
+			std::ignore = shaderCache->GetPixelShader(*shader, pixelShaderDescriptor);
 		}
 	} else if (shader->shaderType == RE::BSShader::Type::Grass) {
 		const auto pixelPermutations = Permutations::GeneratePBRGrassPixelPermutations();
 		for (auto descriptor : pixelPermutations) {
 			auto vertexShaderDesriptor = descriptor;
 			auto pixelShaderDescriptor = descriptor;
-			State::GetSingleton()->ModifyShaderLookup(*shader, vertexShaderDesriptor, pixelShaderDescriptor);
-			std::ignore = shaderCache.GetPixelShader(*shader, pixelShaderDescriptor);
+			state->ModifyShaderLookup(*shader, vertexShaderDesriptor, pixelShaderDescriptor);
+			std::ignore = shaderCache->GetPixelShader(*shader, pixelShaderDescriptor);
 		}
 	}
 }
@@ -715,8 +717,10 @@ struct BSLightingShader_SetupMaterial
 		auto lightingFlags = shader->currentRawTechnique & ~(~0u << 24);
 		auto lightingType = static_cast<SIE::ShaderCache::LightingShaderTechniques>((shader->currentRawTechnique >> 24) & 0x3F);
 		if (!(lightingType == LODLand || lightingType == LODLandNoise) && (lightingFlags & static_cast<uint32_t>(SIE::ShaderCache::LightingShaderFlags::TruePbr))) {
-			auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
-			auto renderer = RE::BSGraphics::Renderer::GetSingleton();
+			auto shadowState = VariableCache::GetSingleton()->shadowState;
+			auto renderer = VariableCache::GetSingleton()->renderer;
+			auto graphicsState = VariableCache::GetSingleton()->graphicsState;
+			auto smState = VariableCache::GetSingleton()->smState;
 
 			RE::BSGraphics::Renderer::PrepareVSConstantGroup(RE::BSGraphics::ConstantGroupLevel::PerMaterial);
 			RE::BSGraphics::Renderer::PreparePSConstantGroup(RE::BSGraphics::ConstantGroupLevel::PerMaterial);
@@ -763,7 +767,7 @@ struct BSLightingShader_SetupMaterial
 					for (uint32_t textureIndex = 0; textureIndex < BSLightingShaderMaterialPBRLandscape::NumTiles; ++textureIndex) {
 						if (pbrMaterial->isPbr[textureIndex]) {
 							flags |= (1 << textureIndex);
-							if (pbrMaterial->landscapeDisplacementTextures[textureIndex] != nullptr && pbrMaterial->landscapeDisplacementTextures[textureIndex] != RE::BSGraphics::State::GetSingleton()->GetRuntimeData().defaultTextureBlack) {
+							if (pbrMaterial->landscapeDisplacementTextures[textureIndex] != nullptr && pbrMaterial->landscapeDisplacementTextures[textureIndex] != graphicsState->GetRuntimeData().defaultTextureBlack) {
 								flags |= (1 << (BSLightingShaderMaterialPBRLandscape::NumTiles + textureIndex));
 							}
 							if (pbrMaterial->glintParameters[textureIndex].enabled) {
@@ -903,7 +907,7 @@ struct BSLightingShader_SetupMaterial
 					shadowState->SetPSConstant(PBRProjectedUVParams2, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.ParallaxOccData);
 				}
 
-				const bool hasEmissive = pbrMaterial->emissiveTexture != nullptr && pbrMaterial->emissiveTexture != RE::BSGraphics::State::GetSingleton()->GetRuntimeData().defaultTextureBlack;
+				const bool hasEmissive = pbrMaterial->emissiveTexture != nullptr && pbrMaterial->emissiveTexture != graphicsState->GetRuntimeData().defaultTextureBlack;
 				if (hasEmissive) {
 					shadowState->SetPSTexture(6, pbrMaterial->emissiveTexture->rendererTexture);
 					shadowState->SetPSTextureAddressMode(6, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
@@ -912,7 +916,7 @@ struct BSLightingShader_SetupMaterial
 					shaderFlags.set(PBRShaderFlags::HasEmissive);
 				}
 
-				const bool hasDisplacement = pbrMaterial->displacementTexture != nullptr && pbrMaterial->displacementTexture != RE::BSGraphics::State::GetSingleton()->GetRuntimeData().defaultTextureBlack;
+				const bool hasDisplacement = pbrMaterial->displacementTexture != nullptr && pbrMaterial->displacementTexture != graphicsState->GetRuntimeData().defaultTextureBlack;
 				if (hasDisplacement) {
 					shadowState->SetPSTexture(4, pbrMaterial->displacementTexture->rendererTexture);
 					shadowState->SetPSTextureAddressMode(4, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
@@ -921,7 +925,7 @@ struct BSLightingShader_SetupMaterial
 					shaderFlags.set(PBRShaderFlags::HasDisplacement);
 				}
 
-				const bool hasFeaturesTexture0 = pbrMaterial->featuresTexture0 != nullptr && pbrMaterial->featuresTexture0 != RE::BSGraphics::State::GetSingleton()->GetRuntimeData().defaultTextureWhite;
+				const bool hasFeaturesTexture0 = pbrMaterial->featuresTexture0 != nullptr && pbrMaterial->featuresTexture0 != graphicsState->GetRuntimeData().defaultTextureWhite;
 				if (hasFeaturesTexture0) {
 					shadowState->SetPSTexture(12, pbrMaterial->featuresTexture0->rendererTexture);
 					shadowState->SetPSTextureAddressMode(12, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
@@ -930,7 +934,7 @@ struct BSLightingShader_SetupMaterial
 					shaderFlags.set(PBRShaderFlags::HasFeaturesTexture0);
 				}
 
-				const bool hasFeaturesTexture1 = pbrMaterial->featuresTexture1 != nullptr && pbrMaterial->featuresTexture1 != RE::BSGraphics::State::GetSingleton()->GetRuntimeData().defaultTextureWhite;
+				const bool hasFeaturesTexture1 = pbrMaterial->featuresTexture1 != nullptr && pbrMaterial->featuresTexture1 != graphicsState->GetRuntimeData().defaultTextureWhite;
 				if (hasFeaturesTexture1) {
 					shadowState->SetPSTexture(9, pbrMaterial->featuresTexture1->rendererTexture);
 					shadowState->SetPSTextureAddressMode(9, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
@@ -953,7 +957,7 @@ struct BSLightingShader_SetupMaterial
 			}
 
 			{
-				const uint32_t bufferIndex = RE::BSShaderManager::State::GetSingleton().textureTransformCurrentBuffer;
+				const uint32_t bufferIndex = smState->textureTransformCurrentBuffer;
 
 				std::array<float, 4> texCoordOffsetScale;
 				texCoordOffsetScale[0] = material->texCoordOffset[bufferIndex].x;
@@ -971,10 +975,9 @@ struct BSLightingShader_SetupMaterial
 					shadowState->SetPSTextureAddressMode(11, RE::BSGraphics::TextureAddressMode::kClampSClampT);
 				}
 
-				const auto& smState = RE::BSShaderManager::State::GetSingleton();
 				std::array<float, 4> characterLightParams;
-				if (smState.characterLightEnabled) {
-					std::copy_n(smState.characterLightParams, 4, characterLightParams.data());
+				if (smState->characterLightEnabled) {
+					std::copy_n(smState->characterLightParams, 4, characterLightParams.data());
 				} else {
 					std::fill_n(characterLightParams.data(), 4, 0.f);
 				}
@@ -1048,7 +1051,8 @@ void SetupLandscapeTexture(BSLightingShaderMaterialPBRLandscape& material, RE::T
 		return;
 	}
 
-	auto* textureSetData = TruePBR::GetSingleton()->GetPBRTextureSetData(landTexture.textureSet);
+	auto truePBR = VariableCache::GetSingleton()->truePBR;
+	auto* textureSetData = truePBR->GetPBRTextureSetData(landTexture.textureSet);
 	const bool isPbr = textureSetData != nullptr;
 
 	textureSets[textureIndex] = textureSetData;
@@ -1078,7 +1082,8 @@ struct TESObjectLAND_SetupMaterial
 {
 	static bool thunk(RE::TESObjectLAND* land)
 	{
-		auto* singleton = TruePBR::GetSingleton();
+		auto variableCache = VariableCache::GetSingleton();
+		auto singleton = variableCache->truePBR;
 
 		bool isPbr = false;
 		if (land->loadedData != nullptr) {
@@ -1106,14 +1111,10 @@ struct TESObjectLAND_SetupMaterial
 			return func(land);
 		}
 
-		static const auto settings = RE::INISettingCollection::GetSingleton();
-		static const bool bEnableLandFade = settings->GetSetting("bEnableLandFade:Display");
-		static const bool bDrawLandShadows = settings->GetSetting("bDrawLandShadows:Display");
-
 		if (land->loadedData != nullptr && land->loadedData->mesh[0] != nullptr) {
 			land->data.flags.set(static_cast<RE::OBJ_LAND::Flag>(8));
 			for (uint32_t quadIndex = 0; quadIndex < 4; ++quadIndex) {
-				auto shaderProperty = static_cast<RE::BSLightingShaderProperty*>(RE::MemoryManager::GetSingleton()->Allocate(REL::Module::IsVR() ? 0x178 : sizeof(RE::BSLightingShaderProperty), 0, false));
+				auto shaderProperty = static_cast<RE::BSLightingShaderProperty*>(variableCache->memoryManager->Allocate(REL::Module::IsVR() ? 0x178 : sizeof(RE::BSLightingShaderProperty), 0, false));
 				shaderProperty->Ctor();
 
 				{
@@ -1122,7 +1123,7 @@ struct TESObjectLAND_SetupMaterial
 				}
 
 				auto material = static_cast<BSLightingShaderMaterialPBRLandscape*>(shaderProperty->material);
-				const auto& stateData = RE::BSGraphics::State::GetSingleton()->GetRuntimeData();
+				const auto& stateData = variableCache->graphicsState->GetRuntimeData();
 
 				for (uint32_t textureIndex = 0; textureIndex < BSLightingShaderMaterialPBRLandscape::NumTiles; ++textureIndex) {
 					material->landscapeBaseColorTextures[textureIndex] = stateData.defaultTextureBlack;
@@ -1144,12 +1145,12 @@ struct TESObjectLAND_SetupMaterial
 					}
 				}
 
-				if (bEnableLandFade) {
+				if (variableCache->bEnableLandFade->GetBool()) {
 					shaderProperty->unk108 = false;
 				}
 
 				bool noLODLandBlend = false;
-				auto tes = RE::TES::GetSingleton();
+				auto tes = variableCache->tes;
 				auto worldSpace = tes->GetRuntimeData2().worldSpace;
 				if (worldSpace != nullptr) {
 					if (auto terrainManager = worldSpace->GetTerrainManager()) {
@@ -1158,7 +1159,7 @@ struct TESObjectLAND_SetupMaterial
 				}
 				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kMultiTextureLandscape, true);
 				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kReceiveShadows, true);
-				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kCastShadows, bDrawLandShadows);
+				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kCastShadows, variableCache->bDrawLandShadows->GetBool());
 				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kNoLODLandBlend, noLODLandBlend);
 
 				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kVertexLighting, true);
@@ -1170,7 +1171,7 @@ struct TESObjectLAND_SetupMaterial
 					geometry->GetGeometryRuntimeData().properties[1] = RE::NiPointer(shaderProperty);
 				}
 
-				RE::BSShaderManager::State::GetSingleton().shadowSceneNode[0]->AttachObject(geometry);
+				variableCache->smState->shadowSceneNode[0]->AttachObject(geometry);
 			}
 
 			return true;
@@ -1185,7 +1186,7 @@ struct TESForm_GetFormEditorID
 {
 	static const char* thunk(const RE::TESForm* form)
 	{
-		auto* singleton = TruePBR::GetSingleton();
+		auto* singleton = VariableCache::GetSingleton()->truePBR;
 		auto it = singleton->editorIDs.find(form->GetFormID());
 		if (it == singleton->editorIDs.cend()) {
 			return "";
@@ -1199,7 +1200,7 @@ struct TESForm_SetFormEditorID
 {
 	static bool thunk(RE::TESForm* form, const char* editorId)
 	{
-		auto* singleton = TruePBR::GetSingleton();
+		auto* singleton = VariableCache::GetSingleton()->truePBR;
 		singleton->editorIDs[form->GetFormID()] = editorId;
 		return true;
 	}
@@ -1211,7 +1212,8 @@ struct SetPerFrameBuffers
 	static void thunk(void* renderer)
 	{
 		func(renderer);
-		TruePBR::GetSingleton()->SetupFrame();
+		auto* singleton = VariableCache::GetSingleton()->truePBR;
+		singleton->SetupFrame();
 	}
 	static inline REL::Relocation<decltype(thunk)> func;
 };
@@ -1221,9 +1223,10 @@ struct BSTempEffectSimpleDecal_SetupGeometry
 	static void thunk(RE::BSTempEffectSimpleDecal* decal, RE::BSGeometry* geometry, RE::BGSTextureSet* textureSet, bool blended)
 	{
 		func(decal, geometry, textureSet, blended);
+		auto* singleton = VariableCache::GetSingleton()->truePBR;
 
 		if (auto* shaderProperty = netimmerse_cast<RE::BSLightingShaderProperty*>(geometry->GetGeometryRuntimeData().properties[1].get());
-			shaderProperty != nullptr && TruePBR::GetSingleton()->IsPBRTextureSet(textureSet)) {
+			shaderProperty != nullptr && singleton->IsPBRTextureSet(textureSet)) {
 			{
 				BSLightingShaderMaterialPBR srcMaterial;
 				shaderProperty->LinkMaterial(&srcMaterial, true);
@@ -1257,8 +1260,9 @@ struct BSTempEffectGeometryDecal_Initialize
 	static void thunk(RE::BSTempEffectGeometryDecal* decal)
 	{
 		func(decal);
+		auto* singleton = VariableCache::GetSingleton()->truePBR;
 
-		if (decal->decal != nullptr && TruePBR::GetSingleton()->IsPBRTextureSet(decal->texSet)) {
+		if (decal->decal != nullptr && singleton->IsPBRTextureSet(decal->texSet)) {
 			auto shaderProperty = static_cast<RE::BSLightingShaderProperty*>(RE::MemoryManager::GetSingleton()->Allocate(sizeof(RE::BSLightingShaderProperty), 0, false));
 			shaderProperty->Ctor();
 
@@ -1365,9 +1369,11 @@ struct BSGrassShader_SetupTechnique
 	static bool thunk(RE::BSShader* shader, uint32_t globalTechnique)
 	{
 		if (globalTechnique == 0x5C000042) {
-			auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
-			auto* graphicsState = RE::BSGraphics::State::GetSingleton();
-			auto* renderer = RE::BSGraphics::Renderer::GetSingleton();
+			auto variableCache = VariableCache::GetSingleton();
+
+			auto shadowState = variableCache->shadowState;
+			auto graphicsState = variableCache->graphicsState;
+			auto renderer = variableCache->renderer;
 
 			const uint32_t localTechnique = static_cast<uint32_t>(SIE::ShaderCache::GrassShaderTechniques::TruePbr);
 			uint32_t shaderDescriptor = localTechnique;
@@ -1383,17 +1389,14 @@ struct BSGrassShader_SetupTechnique
 			static auto fogMethod = REL::Relocation<void (*)()>(REL::RelocationID(100000, 106707));
 			fogMethod();
 
-			static auto* bShadowsOnGrass = RE::GetINISetting("bShadowsOnGrass:Display");
-			if (!bShadowsOnGrass->GetBool()) {
+			if (!variableCache->bShadowsOnGrass->GetBool()) {
 				shadowState->SetPSTexture(1, graphicsState->GetRuntimeData().defaultTextureWhite->rendererTexture);
 				shadowState->SetPSTextureAddressMode(1, RE::BSGraphics::TextureAddressMode::kClampSClampT);
 				shadowState->SetPSTextureFilterMode(1, RE::BSGraphics::TextureFilterMode::kNearest);
 			} else {
 				shadowState->SetPSTexture(1, renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGET::kSHADOW_MASK]);
 				shadowState->SetPSTextureAddressMode(1, RE::BSGraphics::TextureAddressMode::kClampSClampT);
-
-				static auto* shadowMaskQuarter = RE::GetINISetting("iShadowMaskQuarter:Display");
-				shadowState->SetPSTextureFilterMode(1, shadowMaskQuarter->GetSInt() != 4 ? RE::BSGraphics::TextureFilterMode::kBilinear : RE::BSGraphics::TextureFilterMode::kNearest);
+				shadowState->SetPSTextureFilterMode(1, variableCache->shadowMaskQuarter->GetSInt() != 4 ? RE::BSGraphics::TextureFilterMode::kBilinear : RE::BSGraphics::TextureFilterMode::kNearest);
 			}
 
 			return true;
@@ -1408,13 +1411,14 @@ struct BSGrassShader_SetupMaterial
 {
 	static void thunk(RE::BSShader* shader, RE::BSLightingShaderMaterialBase const* material)
 	{
-		const auto& state = State::GetSingleton();
+		auto variableCache = VariableCache::GetSingleton();
+		const auto& state = variableCache->state;
 		const auto technique = static_cast<SIE::ShaderCache::GrassShaderTechniques>(state->currentPixelDescriptor & 0b1111);
 
 		const auto& grassPSConstants = ShaderConstants::GrassPS::Get();
 
 		if (technique == SIE::ShaderCache::GrassShaderTechniques::TruePbr) {
-			auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
+			auto shadowState = variableCache->shadowState;
 
 			RE::BSGraphics::Renderer::PreparePSConstantGroup(RE::BSGraphics::ConstantGroupLevel::PerMaterial);
 
@@ -1436,7 +1440,7 @@ struct BSGrassShader_SetupMaterial
 				shaderFlags.set(PBRShaderFlags::Subsurface);
 			}
 
-			const bool hasSubsurface = pbrMaterial->featuresTexture0 != nullptr && pbrMaterial->featuresTexture0 != RE::BSGraphics::State::GetSingleton()->GetRuntimeData().defaultTextureWhite;
+			const bool hasSubsurface = pbrMaterial->featuresTexture0 != nullptr && pbrMaterial->featuresTexture0 != variableCache->graphicsState->GetRuntimeData().defaultTextureWhite;
 			if (hasSubsurface) {
 				shadowState->SetPSTexture(4, pbrMaterial->featuresTexture0->rendererTexture);
 				shadowState->SetPSTextureAddressMode(4, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
@@ -1478,11 +1482,13 @@ struct TESBoundObject_Clone3D
 {
 	static RE::NiAVObject* thunk(RE::TESBoundObject* object, RE::TESObjectREFR* ref, bool arg3)
 	{
+		auto variableCache = VariableCache::GetSingleton();
+		auto truePBR = variableCache->truePBR;
 		auto* result = func(object, ref, arg3);
 		if (result != nullptr && ref != nullptr && ref->data.objectReference != nullptr && ref->data.objectReference->formType == RE::FormType::Static) {
 			auto* stat = static_cast<RE::TESObjectSTAT*>(ref->data.objectReference);
 			if (stat->data.materialObj != nullptr && stat->data.materialObj->directionalData.singlePass) {
-				if (auto* pbrData = TruePBR::GetSingleton()->GetPBRMaterialObjectData(stat->data.materialObj)) {
+				if (auto* pbrData = truePBR->GetPBRMaterialObjectData(stat->data.materialObj)) {
 					RE::BSVisit::TraverseScenegraphGeometries(result, [pbrData](RE::BSGeometry* geometry) {
 						if (auto* shaderProperty = static_cast<RE::BSShaderProperty*>(geometry->GetGeometryRuntimeData().properties[1].get())) {
 							if (shaderProperty->GetMaterialType() == RE::BSShaderMaterial::Type::kLighting &&
@@ -1507,8 +1513,9 @@ struct TESBoundObject_Clone3D
 struct BGSTextureSet_ToShaderTextureSet
 {
 	static RE::BSShaderTextureSet* thunk(RE::BGSTextureSet* textureSet)
-	{
-		TruePBR::GetSingleton()->currentTextureSet = textureSet;
+	{			
+		auto truePBR = VariableCache::GetSingleton()->truePBR;
+		truePBR->currentTextureSet = textureSet;
 
 		return func(textureSet);
 	}
@@ -1521,7 +1528,8 @@ struct BSLightingShaderProperty_OnLoadTextureSet
 	{
 		func(property, a2);
 
-		TruePBR::GetSingleton()->currentTextureSet = nullptr;
+		auto truePBR = VariableCache::GetSingleton()->truePBR;
+		truePBR->currentTextureSet = nullptr;
 	}
 	static inline REL::Relocation<decltype(thunk)> func;
 };

--- a/src/TruePBR.h
+++ b/src/TruePBR.h
@@ -28,7 +28,7 @@ public:
 	void PostPostLoad();
 	void DataLoaded();
 
-	void SetShaderResouces();
+	void SetShaderResouces(ID3D11DeviceContext* a_context);
 	void GenerateShaderPermutations(RE::BSShader* shader);
 
 	void SetupGlintsTexture();

--- a/src/VariableCache.cpp
+++ b/src/VariableCache.cpp
@@ -1,0 +1,24 @@
+#include "VariableCache.h"
+
+#define GET_INSTANCE_MEMBER_PTR(a_value, a_source) \
+	&(!REL::Module::IsVR() ? a_source->GetRuntimeData().a_value : a_source->GetVRRuntimeData().a_value);
+
+void VariableCache::InitializeVariables()
+{
+	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
+
+	context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
+	
+	auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
+
+	currentPixelShader = GET_INSTANCE_MEMBER_PTR(currentPixelShader, shadowState);
+	currentVertexShader = GET_INSTANCE_MEMBER_PTR(currentVertexShader, shadowState);
+	stateUpdateFlags = GET_INSTANCE_MEMBER_PTR(stateUpdateFlags, shadowState);
+
+	state = State::GetSingleton();
+	shaderCache = &SIE::ShaderCache::Instance();
+	rendererShadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
+	deferred = Deferred::GetSingleton();
+	terrainBlending = TerrainBlending::GetSingleton();
+	cloudShadows = CloudShadows::GetSingleton();
+}

--- a/src/VariableCache.cpp
+++ b/src/VariableCache.cpp
@@ -24,6 +24,7 @@ void VariableCache::OnInit()
 	cloudShadows = CloudShadows::GetSingleton();
 	truePBR = TruePBR::GetSingleton();
 	lightLimitFix = LightLimitFix::GetSingleton();
+	grassCollision = GrassCollision::GetSingleton();
 
 	particleLights = ParticleLights::GetSingleton();
 

--- a/src/VariableCache.cpp
+++ b/src/VariableCache.cpp
@@ -21,4 +21,5 @@ void VariableCache::InitializeVariables()
 	deferred = Deferred::GetSingleton();
 	terrainBlending = TerrainBlending::GetSingleton();
 	cloudShadows = CloudShadows::GetSingleton();
+	truePBR = TruePBR::GetSingleton();
 }

--- a/src/VariableCache.cpp
+++ b/src/VariableCache.cpp
@@ -17,6 +17,7 @@ void VariableCache::OnInit()
 	stateUpdateFlags = GET_INSTANCE_MEMBER_PTR(stateUpdateFlags, shadowState);
 
 	state = State::GetSingleton();
+	menu = Menu::GetSingleton();
 	shaderCache = &SIE::ShaderCache::Instance();
 	deferred = Deferred::GetSingleton();
 

--- a/src/VariableCache.cpp
+++ b/src/VariableCache.cpp
@@ -8,7 +8,7 @@ void VariableCache::InitializeVariables()
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
 
 	context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
-	
+
 	auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
 
 	currentPixelShader = GET_INSTANCE_MEMBER_PTR(currentPixelShader, shadowState);

--- a/src/VariableCache.cpp
+++ b/src/VariableCache.cpp
@@ -3,7 +3,7 @@
 #define GET_INSTANCE_MEMBER_PTR(a_value, a_source) \
 	&(!REL::Module::IsVR() ? a_source->GetRuntimeData().a_value : a_source->GetVRRuntimeData().a_value);
 
-void VariableCache::InitializeVariables()
+void VariableCache::OnInit()
 {
 	renderer = RE::BSGraphics::Renderer::GetSingleton();
 
@@ -24,13 +24,16 @@ void VariableCache::InitializeVariables()
 	truePBR = TruePBR::GetSingleton();
 	graphicsState = RE::BSGraphics::State::GetSingleton();
 	smState = &RE::BSShaderManager::State::GetSingleton();
-	tes = RE::TES::GetSingleton();
 	isVR = REL::Module::IsVR();
 	memoryManager = RE::MemoryManager::GetSingleton();
-
 	iniSettingCollection = RE::INISettingCollection::GetSingleton();
+}
+
+void VariableCache::OnDataLoaded()
+{
+	tes = RE::TES::GetSingleton();
+
 	bEnableLandFade = iniSettingCollection->GetSetting("bEnableLandFade:Display");
-	bDrawLandShadows = iniSettingCollection->GetSetting("bDrawLandShadows:Display");
 
 	bShadowsOnGrass = RE::GetINISetting("bShadowsOnGrass:Display");
 	shadowMaskQuarter = RE::GetINISetting("iShadowMaskQuarter:Display");

--- a/src/VariableCache.cpp
+++ b/src/VariableCache.cpp
@@ -19,9 +19,17 @@ void VariableCache::OnInit()
 	state = State::GetSingleton();
 	shaderCache = &SIE::ShaderCache::Instance();
 	deferred = Deferred::GetSingleton();
+
 	terrainBlending = TerrainBlending::GetSingleton();
 	cloudShadows = CloudShadows::GetSingleton();
 	truePBR = TruePBR::GetSingleton();
+	lightLimitFix = LightLimitFix::GetSingleton();
+
+	particleLights = ParticleLights::GetSingleton();
+
+	cameraNear = (float*)(REL::RelocationID(517032, 403540).address() + 0x40);
+	cameraFar = (float*)(REL::RelocationID(517032, 403540).address() + 0x44);
+
 	graphicsState = RE::BSGraphics::State::GetSingleton();
 	smState = &RE::BSShaderManager::State::GetSingleton();
 	isVR = REL::Module::IsVR();

--- a/src/VariableCache.cpp
+++ b/src/VariableCache.cpp
@@ -5,11 +5,12 @@
 
 void VariableCache::InitializeVariables()
 {
-	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
+	renderer = RE::BSGraphics::Renderer::GetSingleton();
 
+	device = reinterpret_cast<ID3D11Device*>(renderer->GetRuntimeData().forwarder);
 	context = reinterpret_cast<ID3D11DeviceContext*>(renderer->GetRuntimeData().context);
 
-	auto shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
+	shadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
 
 	currentPixelShader = GET_INSTANCE_MEMBER_PTR(currentPixelShader, shadowState);
 	currentVertexShader = GET_INSTANCE_MEMBER_PTR(currentVertexShader, shadowState);
@@ -17,9 +18,20 @@ void VariableCache::InitializeVariables()
 
 	state = State::GetSingleton();
 	shaderCache = &SIE::ShaderCache::Instance();
-	rendererShadowState = RE::BSGraphics::RendererShadowState::GetSingleton();
 	deferred = Deferred::GetSingleton();
 	terrainBlending = TerrainBlending::GetSingleton();
 	cloudShadows = CloudShadows::GetSingleton();
 	truePBR = TruePBR::GetSingleton();
+	graphicsState = RE::BSGraphics::State::GetSingleton();
+	smState = &RE::BSShaderManager::State::GetSingleton();
+	tes = RE::TES::GetSingleton();
+	isVR = REL::Module::IsVR();
+	memoryManager = RE::MemoryManager::GetSingleton();
+
+	iniSettingCollection = RE::INISettingCollection::GetSingleton();
+	bEnableLandFade = iniSettingCollection->GetSetting("bEnableLandFade:Display");
+	bDrawLandShadows = iniSettingCollection->GetSetting("bDrawLandShadows:Display");
+
+	bShadowsOnGrass = RE::GetINISetting("bShadowsOnGrass:Display");
+	shadowMaskQuarter = RE::GetINISetting("iShadowMaskQuarter:Display");
 }

--- a/src/VariableCache.h
+++ b/src/VariableCache.h
@@ -7,6 +7,8 @@
 #include "Features/CloudShadows.h"
 #include "Features/TerrainBlending.h"
 
+#include "TruePBR.h"
+
 class VariableCache
 {
 	static VariableCache instance;
@@ -24,6 +26,7 @@ public:
 	Deferred* deferred = nullptr;
 	TerrainBlending* terrainBlending = nullptr;
 	CloudShadows* cloudShadows = nullptr;
+	TruePBR* truePBR = nullptr;
 
 	void InitializeVariables();
 };

--- a/src/VariableCache.h
+++ b/src/VariableCache.h
@@ -5,11 +5,11 @@
 #include "State.h"
 
 #include "Features/CloudShadows.h"
-#include "Features/TerrainBlending.h"
 #include "Features/LightLimitFix.h"
+#include "Features/TerrainBlending.h"
 
-#include "TruePBR.h"
 #include "Features/LightLimitFix/ParticleLights.h"
+#include "TruePBR.h"
 
 class VariableCache
 {

--- a/src/VariableCache.h
+++ b/src/VariableCache.h
@@ -7,6 +7,7 @@
 #include "Features/CloudShadows.h"
 #include "Features/TerrainBlending.h"
 #include "Features/LightLimitFix.h"
+#include "Features/GrassCollision.h"
 
 #include "TruePBR.h"
 #include "Features/LightLimitFix/ParticleLights.h"
@@ -34,6 +35,7 @@ public:
 	TruePBR* truePBR = nullptr;
 	LightLimitFix* lightLimitFix = nullptr;
 	ParticleLights* particleLights = nullptr;
+	GrassCollision* grassCollision = nullptr;
 
 	float* cameraNear = nullptr;
 	float* cameraFar = nullptr;

--- a/src/VariableCache.h
+++ b/src/VariableCache.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include "Deferred.h"
+#include "Menu.h"
 #include "ShaderCache.h"
 #include "State.h"
-#include "Menu.h"
 
 #include "Features/CloudShadows.h"
-#include "Features/LightLimitFix.h"
 #include "Features/GrassCollision.h"
+#include "Features/LightLimitFix.h"
 #include "Features/TerrainBlending.h"
 
 #include "Features/LightLimitFix/ParticleLights.h"

--- a/src/VariableCache.h
+++ b/src/VariableCache.h
@@ -3,6 +3,7 @@
 #include "Deferred.h"
 #include "ShaderCache.h"
 #include "State.h"
+#include "Menu.h"
 
 #include "Features/CloudShadows.h"
 #include "Features/TerrainBlending.h"
@@ -25,6 +26,7 @@ public:
 	RE::BSGraphics::VertexShader** currentVertexShader = nullptr;
 	stl::enumeration<RE::BSGraphics::ShaderFlags, uint32_t>* stateUpdateFlags = nullptr;
 	State* state = nullptr;
+	Menu* menu = nullptr;
 	SIE::ShaderCache* shaderCache = nullptr;
 	RE::BSGraphics::RendererShadowState* shadowState = nullptr;
 

--- a/src/VariableCache.h
+++ b/src/VariableCache.h
@@ -6,8 +6,10 @@
 
 #include "Features/CloudShadows.h"
 #include "Features/TerrainBlending.h"
+#include "Features/LightLimitFix.h"
 
 #include "TruePBR.h"
+#include "Features/LightLimitFix/ParticleLights.h"
 
 class VariableCache
 {
@@ -24,10 +26,18 @@ public:
 	State* state = nullptr;
 	SIE::ShaderCache* shaderCache = nullptr;
 	RE::BSGraphics::RendererShadowState* shadowState = nullptr;
+
 	Deferred* deferred = nullptr;
+
 	TerrainBlending* terrainBlending = nullptr;
 	CloudShadows* cloudShadows = nullptr;
 	TruePBR* truePBR = nullptr;
+	LightLimitFix* lightLimitFix = nullptr;
+	ParticleLights* particleLights = nullptr;
+
+	float* cameraNear = nullptr;
+	float* cameraFar = nullptr;
+
 	RE::BSGraphics::State* graphicsState = nullptr;
 	RE::BSGraphics::Renderer* renderer = nullptr;
 	RE::BSShaderManager::State* smState = nullptr;

--- a/src/VariableCache.h
+++ b/src/VariableCache.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "State.h"
-#include "ShaderCache.h"
 #include "Deferred.h"
+#include "ShaderCache.h"
+#include "State.h"
 
-#include "Features/TerrainBlending.h"
 #include "Features/CloudShadows.h"
+#include "Features/TerrainBlending.h"
 
 class VariableCache
 {
@@ -13,7 +13,6 @@ class VariableCache
 
 public:
 	static VariableCache* GetSingleton() { return &instance; };
-
 
 	ID3D11DeviceContext* context = nullptr;
 	RE::BSGraphics::PixelShader** currentPixelShader = nullptr;

--- a/src/VariableCache.h
+++ b/src/VariableCache.h
@@ -36,11 +36,11 @@ public:
 	RE::MemoryManager* memoryManager = nullptr;
 	RE::INISettingCollection* iniSettingCollection = nullptr;
 	RE::Setting* bEnableLandFade = nullptr;
-	RE::Setting* bDrawLandShadows = nullptr;
 	RE::Setting* bShadowsOnGrass = nullptr;
 	RE::Setting* shadowMaskQuarter = nullptr;
 
-	void InitializeVariables();
+	void OnInit();
+	void OnDataLoaded();
 };
 
 inline constinit VariableCache VariableCache::instance;

--- a/src/VariableCache.h
+++ b/src/VariableCache.h
@@ -16,17 +16,29 @@ class VariableCache
 public:
 	static VariableCache* GetSingleton() { return &instance; };
 
+	ID3D11Device* device = nullptr;
 	ID3D11DeviceContext* context = nullptr;
 	RE::BSGraphics::PixelShader** currentPixelShader = nullptr;
 	RE::BSGraphics::VertexShader** currentVertexShader = nullptr;
 	stl::enumeration<RE::BSGraphics::ShaderFlags, uint32_t>* stateUpdateFlags = nullptr;
 	State* state = nullptr;
 	SIE::ShaderCache* shaderCache = nullptr;
-	RE::BSGraphics::RendererShadowState* rendererShadowState = nullptr;
+	RE::BSGraphics::RendererShadowState* shadowState = nullptr;
 	Deferred* deferred = nullptr;
 	TerrainBlending* terrainBlending = nullptr;
 	CloudShadows* cloudShadows = nullptr;
 	TruePBR* truePBR = nullptr;
+	RE::BSGraphics::State* graphicsState = nullptr;
+	RE::BSGraphics::Renderer* renderer = nullptr;
+	RE::BSShaderManager::State* smState = nullptr;
+	RE::TES* tes = nullptr;
+	bool isVR = false;
+	RE::MemoryManager* memoryManager = nullptr;
+	RE::INISettingCollection* iniSettingCollection = nullptr;
+	RE::Setting* bEnableLandFade = nullptr;
+	RE::Setting* bDrawLandShadows = nullptr;
+	RE::Setting* bShadowsOnGrass = nullptr;
+	RE::Setting* shadowMaskQuarter = nullptr;
 
 	void InitializeVariables();
 };

--- a/src/VariableCache.h
+++ b/src/VariableCache.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "State.h"
+#include "ShaderCache.h"
+#include "Deferred.h"
+
+#include "Features/TerrainBlending.h"
+#include "Features/CloudShadows.h"
+
+class VariableCache
+{
+	static VariableCache instance;
+
+public:
+	static VariableCache* GetSingleton() { return &instance; };
+
+
+	ID3D11DeviceContext* context = nullptr;
+	RE::BSGraphics::PixelShader** currentPixelShader = nullptr;
+	RE::BSGraphics::VertexShader** currentVertexShader = nullptr;
+	stl::enumeration<RE::BSGraphics::ShaderFlags, uint32_t>* stateUpdateFlags = nullptr;
+	State* state = nullptr;
+	SIE::ShaderCache* shaderCache = nullptr;
+	RE::BSGraphics::RendererShadowState* rendererShadowState = nullptr;
+	Deferred* deferred = nullptr;
+	TerrainBlending* terrainBlending = nullptr;
+	CloudShadows* cloudShadows = nullptr;
+
+	void InitializeVariables();
+};
+
+inline constinit VariableCache VariableCache::instance;

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -8,6 +8,7 @@
 #include "State.h"
 #include "TruePBR.h"
 #include "Upscaling.h"
+#include "VariableCache.h"
 
 #include "ENB/ENBSeriesAPI.h"
 
@@ -113,6 +114,7 @@ void MessageHandler(SKSE::MessagingInterface::Message* message)
 			}
 
 			if (errors.empty()) {
+				VariableCache::GetSingleton()->OnDataLoaded();
 				FrameAnnotations::OnDataLoaded();
 
 				auto& shaderCache = SIE::ShaderCache::Instance();


### PR DESCRIPTION
Modifies hot points in CPU code to be much faster by removing GetSingleton(), accessing a static cache of variables/pointers instead. This significantly reduces CPU bottlenecks and the impact having CS installed on the framerate.
Also probably gives shadows to TruePBR landscape since it seems to use a variable that doesn't exist, and used it wrong.