### PR TITLE
fix: Update README.md with troubleshooting steps for Build with Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 bin/
 dist/
+.idea/
 .vs*/
 CMakeUserPresets.json
 shadertoolsconfig.json

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ docker run -it --rm -v .:C:/skyrim-community-shaders skyrim-community-shaders:la
 4. Retrieve the generated build files from the `build/aio` folder.
 5. In subsequent builds only run the build step (3.)
 
+#### Troubleshooting Build with Docker
+If you run into `Access violation` build errors during step 3, you can try adding [`--isolation=process`](https://learn.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container):
+```pwsh
+docker run -it --rm --isolation=process -v .:C:/skyrim-community-shaders skyrim-community-shaders:latest
+```
+
 ## License
 
 ### Default


### PR DESCRIPTION
Ran into an access violation error when trying to build CS using Docker on my Windows 11 machine. Found a solution via Claude and it was basically swapping the default isolation mode from `Hyper-V` to `process` when running the build. Posted about it in the Discord and mnkl said it wouldn't hurt to add the steps to the README in case someone ran into it down the road.

- Adds troubleshooting step for Build with Docker to README
- Adds IntelliJ IDE project files to .gitignore


[Original context in the discord](https://discord.com/channels/1080142797870485606/1082470343119216751/1334050215107498098)