### PR TITLE
chore: better skylighting quality

### DIFF
--- a/features/Skylighting/Shaders/Features/Skylighting.ini
+++ b/features/Skylighting/Shaders/Features/Skylighting.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 1-0-1
+Version = 1-0-2

--- a/features/Skylighting/Shaders/Skylighting/Skylighting.hlsli
+++ b/features/Skylighting/Shaders/Skylighting/Skylighting.hlsli
@@ -11,7 +11,7 @@ namespace Skylighting
 #endif
 
 	const static uint3 ARRAY_DIM = uint3(256, 256, 128);
-	const static float3 ARRAY_SIZE = 4096.f * 3.f * float3(1, 1, 0.5);
+	const static float3 ARRAY_SIZE = 4096.f * 2.5f * float3(1, 1, 0.5);
 	const static float3 CELL_SIZE = ARRAY_SIZE / ARRAY_DIM;
 
 	float getFadeOutFactor(float3 positionMS)

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -456,12 +456,12 @@ void Skylighting::SetViewFrustum::thunk(RE::NiCamera* a_camera, RE::NiFrustum* a
 	if (skylighting->inOcclusion) {
 		uint corner = skylighting->frameCount % 4;
 
-		a_frustum->fBottom = (corner == 0 || corner == 1) ? -5000.0f : 0.0f;
+		float frustumSize = a_frustum->fTop * 0.5f;
 
-		a_frustum->fLeft = (corner == 0 || corner == 2) ? -5000.0f : 0.0f;
-		a_frustum->fRight = (corner == 1 || corner == 3) ? 5000.0f : 0.0f;
-
-		a_frustum->fTop = (corner == 2 || corner == 3) ? 5000.0f : 0.0f;
+		a_frustum->fBottom = (corner == 0 || corner == 1) ? -frustumSize : 0.0f;
+		a_frustum->fLeft = (corner == 0 || corner == 2) ? -frustumSize : 0.0f;
+		a_frustum->fRight = (corner == 1 || corner == 3) ? frustumSize : 0.0f;
+		a_frustum->fTop = (corner == 2 || corner == 3) ? frustumSize : 0.0f;
 	}
 
 	func(a_camera, a_frustum);

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -33,7 +33,6 @@ void Skylighting::ResetSkylighting()
 	auto& context = State::GetSingleton()->context;
 	UINT clr[1] = { 0 };
 	context->ClearUnorderedAccessViewUint(texAccumFramesArray->uav.get(), clr);
-	forceFrames = 255 * 4;
 	queuedResetSkylighting = false;
 }
 
@@ -477,8 +476,10 @@ void Skylighting::RenderOcclusion()
 	auto sky = variableCache->sky;
 
 	if (!shaderCache->IsEnabled()) {
+		state->BeginPerfEvent("Precipitation Mask");
 		Main_Precipitation_RenderOcclusion::func();
 		state->EndPerfEvent();
+		return;
 	}
 
 	if (sky) {
@@ -516,86 +517,79 @@ void Skylighting::RenderOcclusion()
 				if (queuedResetSkylighting)
 					ResetSkylighting();
 
-				std::chrono::time_point<std::chrono::system_clock> currentTimer = std::chrono::system_clock::now();
-				auto timePassed = std::chrono::duration_cast<std::chrono::milliseconds>(currentTimer - lastUpdateTimer).count();
+				frameCount++;
 
-				if (forceFrames || timePassed >= (1000.0f / 30.0f)) {
-					forceFrames = (uint)std::max(0, (int)forceFrames - 1);
-					lastUpdateTimer = currentTimer;
-					frameCount++;
+				auto& precipitation = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kPRECIPITATION_OCCLUSION_MAP];
+				RE::BSGraphics::DepthStencilData precipitationCopy = precipitation;
 
-					auto& precipitation = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kPRECIPITATION_OCCLUSION_MAP];
-					RE::BSGraphics::DepthStencilData precipitationCopy = precipitation;
+				precipitation.depthSRV = texOcclusion->srv.get();
+				precipitation.texture = texOcclusion->resource.get();
+				precipitation.views[0] = texOcclusion->dsv.get();
 
-					precipitation.depthSRV = texOcclusion->srv.get();
-					precipitation.texture = texOcclusion->resource.get();
-					precipitation.views[0] = texOcclusion->dsv.get();
+				static float& PrecipitationShaderCubeSize = (*(float*)REL::RelocationID(515451, 401590).address());
+				float originalPrecipitationShaderCubeSize = PrecipitationShaderCubeSize;
 
-					static float& PrecipitationShaderCubeSize = (*(float*)REL::RelocationID(515451, 401590).address());
-					float originalPrecipitationShaderCubeSize = PrecipitationShaderCubeSize;
+				static RE::NiPoint3& PrecipitationShaderDirection = (*(RE::NiPoint3*)REL::RelocationID(515509, 401648).address());
+				RE::NiPoint3 originalParticleShaderDirection = PrecipitationShaderDirection;
 
-					static RE::NiPoint3& PrecipitationShaderDirection = (*(RE::NiPoint3*)REL::RelocationID(515509, 401648).address());
-					RE::NiPoint3 originalParticleShaderDirection = PrecipitationShaderDirection;
+				inOcclusion = true;
+				PrecipitationShaderCubeSize = occlusionDistance;
 
-					inOcclusion = true;
-					PrecipitationShaderCubeSize = occlusionDistance;
+				float originaLastCubeSize = precip->lastCubeSize;
+				precip->lastCubeSize = PrecipitationShaderCubeSize;
 
-					float originaLastCubeSize = precip->lastCubeSize;
-					precip->lastCubeSize = PrecipitationShaderCubeSize;
+				float2 vPoint;
+				{
+					constexpr float rcpRandMax = 1.f / RAND_MAX;
+					static int randSeed = std::rand();
+					static uint randFrameCount = 0;
 
-					float2 vPoint;
-					{
-						constexpr float rcpRandMax = 1.f / RAND_MAX;
-						static int randSeed = std::rand();
-						static uint randFrameCount = 0;
+					// r2 sequence
+					vPoint = float2(randSeed * rcpRandMax) + (float)randFrameCount * float2(0.245122333753f, 0.430159709002f);
+					vPoint.x -= static_cast<unsigned long long>(vPoint.x);
+					vPoint.y -= static_cast<unsigned long long>(vPoint.y);
 
-						// r2 sequence
-						vPoint = float2(randSeed * rcpRandMax) + (float)randFrameCount * float2(0.245122333753f, 0.430159709002f);
-						vPoint.x -= static_cast<unsigned long long>(vPoint.x);
-						vPoint.y -= static_cast<unsigned long long>(vPoint.y);
-
-						randFrameCount++;
-						if (randFrameCount == 1000) {
-							randFrameCount = 0;
-							randSeed = std::rand();
-						}
-
-						// disc transformation
-						vPoint.x = sqrt(vPoint.x * sin(settings.MaxZenith));
-						vPoint.y *= 6.28318530718f;
-
-						vPoint = { vPoint.x * cos(vPoint.y), vPoint.x * sin(vPoint.y) };
+					randFrameCount++;
+					if (randFrameCount == 1000) {
+						randFrameCount = 0;
+						randSeed = std::rand();
 					}
 
-					float3 PrecipitationShaderDirectionF = -float3{ vPoint.x, vPoint.y, sqrt(1 - vPoint.LengthSquared()) };
-					PrecipitationShaderDirectionF.Normalize();
+					// disc transformation
+					vPoint.x = sqrt(vPoint.x * sin(settings.MaxZenith));
+					vPoint.y *= 6.28318530718f;
 
-					PrecipitationShaderDirection = { PrecipitationShaderDirectionF.x, PrecipitationShaderDirectionF.y, PrecipitationShaderDirectionF.z };
-
-					precip->SetupMask();
-					precip->SetupMask();  // Calling setup twice fixes an issue when it is raining
-
-					BSParticleShaderRainEmitter* rain = new BSParticleShaderRainEmitter;
-					{
-						TracyD3D11Zone(state->tracyCtx, "Skylighting - Render Height Map");
-						precip->RenderMask((RE::BSParticleShaderRainEmitter*)rain);
-					}
-					inOcclusion = false;
-
-					OcclusionDir = -float4{ PrecipitationShaderDirectionF.x, PrecipitationShaderDirectionF.y, PrecipitationShaderDirectionF.z, 0 };
-					OcclusionTransform = ((RE::BSParticleShaderRainEmitter*)rain)->occlusionProjection;
-
-					delete rain;
-
-					PrecipitationShaderCubeSize = originalPrecipitationShaderCubeSize;
-					precip->lastCubeSize = originaLastCubeSize;
-
-					PrecipitationShaderDirection = originalParticleShaderDirection;
-
-					precipitation = precipitationCopy;
-
-					state->EndPerfEvent();
+					vPoint = { vPoint.x * cos(vPoint.y), vPoint.x * sin(vPoint.y) };
 				}
+
+				float3 PrecipitationShaderDirectionF = -float3{ vPoint.x, vPoint.y, sqrt(1 - vPoint.LengthSquared()) };
+				PrecipitationShaderDirectionF.Normalize();
+
+				PrecipitationShaderDirection = { PrecipitationShaderDirectionF.x, PrecipitationShaderDirectionF.y, PrecipitationShaderDirectionF.z };
+
+				precip->SetupMask();
+				precip->SetupMask();  // Calling setup twice fixes an issue when it is raining
+
+				BSParticleShaderRainEmitter* rain = new BSParticleShaderRainEmitter;
+				{
+					TracyD3D11Zone(state->tracyCtx, "Skylighting - Render Height Map");
+					precip->RenderMask((RE::BSParticleShaderRainEmitter*)rain);
+				}
+				inOcclusion = false;
+
+				OcclusionDir = -float4{ PrecipitationShaderDirectionF.x, PrecipitationShaderDirectionF.y, PrecipitationShaderDirectionF.z, 0 };
+				OcclusionTransform = ((RE::BSParticleShaderRainEmitter*)rain)->occlusionProjection;
+
+				delete rain;
+
+				PrecipitationShaderCubeSize = originalPrecipitationShaderCubeSize;
+				precip->lastCubeSize = originaLastCubeSize;
+
+				PrecipitationShaderDirection = originalParticleShaderDirection;
+
+				precipitation = precipitationCopy;
+
+				state->EndPerfEvent();
 			}
 		}
 	}

--- a/src/Features/Skylighting.h
+++ b/src/Features/Skylighting.h
@@ -74,14 +74,13 @@ struct Skylighting : Feature
 
 	// misc parameters
 	uint probeArrayDims[3] = { 256, 256, 128 };
-	float occlusionDistance = 4096.f * 3.f;  // 3 cells
+	float occlusionDistance = 4096.f * 2.5f;  // 5 ugrids
 
 	// cached variables
 	bool queuedResetSkylighting = true;
 	bool inOcclusion = false;
 	REX::W32::XMFLOAT4X4 OcclusionTransform;
 	float4 OcclusionDir;
-	uint forceFrames = 255 * 4;
 	uint frameCount = 0;
 
 	void ResetSkylighting();


### PR DESCRIPTION
removes forceFrames, timers etc. because it did not improve performance.
performance with skylighting vs no skylighting feature is negligible, ~0.2ms
reduced the cached size to be 5 ugrids. beyond that is LOD.
now every update adds new information to skylighting, making it significantly higher quality in areas you move into 
