### PR TITLE
fix(VR): add VR address for renderPassCacheCtor

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -770,7 +770,7 @@ namespace Hooks
 		stl::write_vfunc<0x6, EffectExtensions::BSEffectShader_SetupGeometry>(RE::VTABLE_BSEffectShader[0]);
 
 		{
-			const auto renderPassCacheCtor = REL::RelocationID(100720, 107500);
+			const auto renderPassCacheCtor = REL::VariantID(100720, 107500, 0x1340330);
 			const int32_t passCount = 4194240;
 			const int32_t passCountSE = 4194240 * 16;
 


### PR DESCRIPTION
Add VR address for renderPassCacheCtor to update render, added it manually as a test. Can update vr-address-library later if it's needed for VR

**not tested in VR yet**