### PR TITLE
fix: consistent grass collision

### DIFF
--- a/features/Grass Collision/Shaders/Features/GrassCollision.ini
+++ b/features/Grass Collision/Shaders/Features/GrassCollision.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 2-0-0
+Version = 2-0-1

--- a/features/Grass Collision/Shaders/GrassCollision/GrassCollision.hlsli
+++ b/features/Grass Collision/Shaders/GrassCollision/GrassCollision.hlsli
@@ -14,8 +14,8 @@ namespace GrassCollision
 	void ClampDisplacement(inout float3 displacement, float maxLength)
 	{
 		float lengthSq = displacement.x * displacement.x +
-						displacement.y * displacement.y +
-						displacement.z * displacement.z;
+		                 displacement.y * displacement.y +
+		                 displacement.z * displacement.z;
 
 		if (lengthSq > maxLength * maxLength)  // Compare squared values for performance
 		{

--- a/features/Grass Collision/Shaders/GrassCollision/GrassCollision.hlsli
+++ b/features/Grass Collision/Shaders/GrassCollision/GrassCollision.hlsli
@@ -11,23 +11,40 @@ namespace GrassCollision
 		uint numCollisions;
 	}
 
+	void ClampDisplacement(inout float3 displacement, float maxLength)
+	{
+		float lengthSq = displacement.x * displacement.x +
+						displacement.y * displacement.y +
+						displacement.z * displacement.z;
+
+		if (lengthSq > maxLength * maxLength)  // Compare squared values for performance
+		{
+			float length = sqrt(lengthSq);
+			float scale = maxLength / length;
+
+			displacement.x *= scale;
+			displacement.y *= scale;
+			displacement.z *= scale;
+		}
+	}
+
 	float3 GetDisplacedPosition(float3 position, float alpha, uint eyeIndex = 0)
 	{
 		float3 worldPosition = mul(World[eyeIndex], float4(position, 1.0)).xyz;
 
-		if (length(worldPosition) < 1024.0 && alpha > 0.0) {
+		if (length(worldPosition) < 2048.0 && alpha > 0.0) {
 			float3 displacement = 0.0;
 
 			for (uint i = 0; i < numCollisions; i++) {
 				float dist = distance(collisionData[i].centre[eyeIndex].xyz, worldPosition);
 				float power = 1.0 - saturate(dist / collisionData[i].centre[0].w);
 				float3 direction = worldPosition - collisionData[i].centre[eyeIndex].xyz;
-				float3 shift = power * direction;
+				float3 shift = power * power * direction;
 				displacement += shift;
-				displacement.z -= length(shift.xy);
 			}
 
-			return displacement * alpha;
+			ClampDisplacement(displacement, 20);
+			return displacement * saturate(alpha * 10);
 		}
 
 		return 0.0;


### PR DESCRIPTION
restricts grass to only the physics shape from the NPC skeleton. no more collisions from weapons, gear etc. that do not match the size of it.
dynamic culling by distance of colliders.
tweaked collisions so that mammoths do not have weird/broken collisions
