### PR TITLE
chore(wetness): make pbr consistent, reduce overall glossiness

### DIFF
--- a/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
+++ b/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
@@ -166,7 +166,6 @@ namespace WetnessEffects
 
 	float3 GetWetnessSpecular(float3 N, float3 L, float3 V, float3 lightColor, float roughness)
 	{
-		lightColor *= 0.01;
-		return LightingFuncGGX_OPT3(N, V, L, roughness, 1.0 - roughness) * lightColor;
+		return LightingFuncGGX_OPT3(N, V, L, roughness, 0.02) * lightColor;
 	}
 }

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1866,7 +1866,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	}
 
 	puddle *= nearFactor;
-	puddle *= saturate(dot(worldSpaceNormal, float3(0, 0, 1)));
 
 	float3 wetnessSpecular = 0.0;
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1866,6 +1866,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	}
 
 	puddle *= nearFactor;
+	puddle *= saturate(dot(worldSpaceNormal, float3(0, 0, 1)));
 
 	float3 wetnessSpecular = 0.0;
 
@@ -2415,7 +2416,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	baseColor.xyz = lerp(baseColor.xyz, pow(baseColor.xyz, 1.0 + wetnessDarkeningAmount), 0.8);
 #		endif
 
-	float3 wetnessReflectance = WetnessEffects::GetWetnessAmbientSpecular(screenUV, wetnessNormal, worldSpaceVertexNormal, worldSpaceViewDirection, 1.0 - wetnessGlossinessSpecular) * wetnessGlossinessSpecular;
+	float3 wetnessReflectance = WetnessEffects::GetWetnessAmbientSpecular(screenUV, wetnessNormal, worldSpaceVertexNormal, worldSpaceViewDirection, waterRoughnessSpecular) * wetnessGlossinessSpecular;
 
 #		if !defined(DEFERRED)
 	wetnessSpecular += wetnessReflectance;
@@ -2706,14 +2707,19 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 #		endif
 	psout.Albedo = float4(outputAlbedo, psout.Diffuse.w);
 
+	const float wetnessGlossinessGain = 0.65;
 	float outGlossiness = saturate(glossiness * SSRParams.w);
 
 #		if defined(TRUE_PBR)
 	psout.Reflectance = float4(indirectSpecularLobeWeight, psout.Diffuse.w);
+#			if defined(WETNESS_EFFECTS)
+	psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), lerp(pbrGlossiness, saturate(pbrGlossiness + wetnessGlossinessGain), wetnessGlossinessSpecular), psout.Diffuse.w);
+#			else
 	psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), pbrGlossiness, psout.Diffuse.w);
+#			endif
 #		elif defined(WETNESS_EFFECTS)
 	psout.Reflectance = float4(wetnessReflectance, psout.Diffuse.w);
-	psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), lerp(outGlossiness, 1.0, wetnessGlossinessSpecular), psout.Diffuse.w);
+	psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), lerp(outGlossiness, saturate(outGlossiness + wetnessGlossinessGain), wetnessGlossinessSpecular), psout.Diffuse.w);
 #		else
 	psout.Reflectance = float4(0.0.xxx, psout.Diffuse.w);
 	psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), outGlossiness, psout.Diffuse.w);
@@ -2732,7 +2738,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 	if (dynamicCubemap) {
 #				if defined(WETNESS_EFFECTS)
 		psout.Reflectance.xyz = max(envColor, wetnessReflectance);
-		psout.NormalGlossiness.z = lerp(1.0 - envRoughness, 1.0, wetnessGlossinessSpecular);
+		psout.NormalGlossiness.z = lerp(1.0 - envRoughness, saturate(1.0 - envRoughness + wetnessGlossinessGain), wetnessGlossinessSpecular);
 #				else
 		psout.Reflectance.xyz = envColor;
 		psout.NormalGlossiness.z = 1.0 - envRoughness;


### PR DESCRIPTION
PBR now also uses glossiness from wetness (duh). Removed suspicious wetness code (trust). 

Made wetness add glossiness instead of going to full glossy. This reduces the overall reflections at least until we have better ssr or raytracing. Though it's arguably incorrect, it makes rougher materials feel as if they absorbed water but are not fully coated in it, so all materials don't look the same.