### PR TITLE
fix: grass typo

### DIFF
--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -777,7 +777,7 @@ PS_OUTPUT main(PS_INPUT input)
 	float4 baseColor = TexBaseSampler.SampleBias(SampBaseSampler, input.TexCoord.xy, SharedData::MipBias);
 
 #		if defined(RENDER_DEPTH)
-	float diffuseAlpha = input.DiffuseColor.w * baseColor.w;
+	float diffuseAlpha = input.VertexColor.w * baseColor.w;
 
 	if ((diffuseAlpha - AlphaTestRefRS) < 0) {
 		discard;


### PR DESCRIPTION
Fixed forgotten rename of a variable that did a compile error without grass lighting.