### PR TITLE
chore(frame generation): extra device checks

### DIFF
--- a/src/DX12SwapChain.cpp
+++ b/src/DX12SwapChain.cpp
@@ -9,7 +9,29 @@
 
 void DX12SwapChain::CreateD3D12Device(IDXGIAdapter* a_adapter)
 {
-	DX::ThrowIfFailed(D3D12CreateDevice(a_adapter, D3D_FEATURE_LEVEL_12_0, IID_PPV_ARGS(&d3d12Device)));
+	// Define feature levels in descending order (highest to lowest)
+	D3D_FEATURE_LEVEL featureLevels[] = {
+		D3D_FEATURE_LEVEL_12_2,
+		D3D_FEATURE_LEVEL_12_1,
+		D3D_FEATURE_LEVEL_12_0
+	};
+
+	// Store the supported feature level
+	D3D_FEATURE_LEVEL supportedFeatureLevel;
+
+	// Try to create the device with the highest feature level
+	for (const auto& level : featureLevels) {
+		HRESULT hr = D3D12CreateDevice(a_adapter, level, IID_PPV_ARGS(&d3d12Device));
+		if (SUCCEEDED(hr)) {
+			supportedFeatureLevel = level;
+			break;
+		}
+	}
+
+	// Ensure we actually created a device
+	if (!d3d12Device) {
+		throw std::runtime_error("[Frame Generation] Failed to create Direct3D 12 device");
+	}
 
 	D3D12_COMMAND_QUEUE_DESC queueDesc = {};
 	queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -373,6 +373,12 @@ HRESULT WINAPI hk_D3D11CreateDeviceAndSwapChain(
 			streamline->PostDevice();
 			streamline->InstallHooks(*ppImmediateContext);
 
+			IDXGIFactory* factory = nullptr;
+			if (SUCCEEDED((*ppSwapChain)->GetParent(IID_PPV_ARGS(&factory)))) {
+				factory->MakeWindowAssociation(pSwapChainDesc->OutputWindow, DXGI_MWA_NO_WINDOW_CHANGES);
+				factory->Release();
+			}
+
 			return ret;
 
 		} else {
@@ -407,6 +413,12 @@ HRESULT WINAPI hk_D3D11CreateDeviceAndSwapChain(
 				if (streamline->initialized) {
 					streamline->slSetD3DDevice(*ppDevice);
 					streamline->PostDevice();
+				}
+
+				IDXGIFactory* factory = nullptr;
+				if (SUCCEEDED((*ppSwapChain)->GetParent(IID_PPV_ARGS(&factory)))) {
+					factory->MakeWindowAssociation(pSwapChainDesc->OutputWindow, DXGI_MWA_NO_WINDOW_CHANGES);
+					factory->Release();
 				}
 
 				return S_OK;


### PR DESCRIPTION
Tries to set the window association which is a requirement for FG.
Uses the highest level DX12 version that is compatible, to improve FG performance.