### PR TITLE
fix: interior check 2

### DIFF
--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -386,8 +386,11 @@ void Deferred::DeferredPasses()
 	auto motionVectors = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMOTION_VECTOR];
 
 	bool interior = true;
-	if (auto sky = globals::game::sky)
-		interior = sky->mode.get() != RE::Sky::Mode::kFull;
+	if (auto player = RE::PlayerCharacter::GetSingleton()) {
+		if (auto parentCell = player->GetParentCell()) {
+			interior = parentCell->IsInteriorCell();
+		}
+	}
 
 	auto skylighting = globals::features::skylighting;
 


### PR DESCRIPTION
Changes the interior test in Deferred.cpp to match #1013. Fixes the INTERIOR flag not being set for cubemapping causing objects to be too bright.