### PR TITLE
chore: move truepbr hooks

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -2,6 +2,7 @@
 
 #include "ShaderTools/BSShaderHooks.h"
 
+#include "Globals.h"
 #include "Menu.h"
 #include "ShaderCache.h"
 #include "State.h"
@@ -719,6 +720,40 @@ namespace Hooks
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
+	struct TESObjectLAND_SetupMaterial
+	{
+		static bool thunk(RE::TESObjectLAND* land)
+		{
+			// setup material for PBR
+			auto TruePBRSingleton = globals::truePBR;
+			if (TruePBRSingleton->TESObjectLAND_SetupMaterial(land)) {
+				// if PBR, we are done
+				return true;
+			}
+
+			bool vanillaResult = func(land);
+			return vanillaResult;
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	struct BSLightingShader_SetupMaterial
+	{
+		static void thunk(RE::BSLightingShader* shader, RE::BSLightingShaderMaterialBase const* material)
+		{
+			// setup material for PBR
+			auto TruePBRSingleton = globals::truePBR;
+			if (TruePBRSingleton->BSLightingShader_SetupMaterial(shader, material)) {
+				// if PBR, we are done
+				return;
+			}
+
+			// vanilla
+			func(shader, material);
+		};
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
 #ifdef TRACY_ENABLE
 	struct Main_Update
 	{
@@ -894,6 +929,12 @@ namespace Hooks
 		logger::info("Hooking BSEffectShader");
 		stl::write_vfunc<0x6, EffectExtensions::BSEffectShader_SetupGeometry>(RE::VTABLE_BSEffectShader[0]);
 		stl::write_vfunc<0x6, LightingExtensions::BSLightingShader_SetupGeometry>(RE::VTABLE_BSLightingShader[0]);
+
+		logger::info("Hooking TESObjectLAND");
+		stl::detour_thunk<TESObjectLAND_SetupMaterial>(REL::RelocationID(18368, 18791));
+
+		logger::info("Hooking BSLightingShader");
+		stl::write_vfunc<0x4, BSLightingShader_SetupMaterial>(RE::VTABLE_BSLightingShader[0]);
 
 		const auto renderPassCacheCtor = REL::VariantID(100720, 107500, 0x1340330);
 		const int32_t passCount = 4194240;

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -712,297 +712,292 @@ struct BSLightingShaderProperty_GetRenderPasses
 	static inline REL::Relocation<decltype(thunk)> func;
 };
 
-struct BSLightingShader_SetupMaterial
+bool TruePBR::BSLightingShader_SetupMaterial(RE::BSLightingShader* shader, RE::BSLightingShaderMaterialBase const* material)
 {
-	static void thunk(RE::BSLightingShader* shader, RE::BSLightingShaderMaterialBase const* material)
-	{
-		using enum SIE::ShaderCache::LightingShaderTechniques;
+	using enum SIE::ShaderCache::LightingShaderTechniques;
 
-		const auto& lightingPSConstants = ShaderConstants::LightingPS::Get();
+	const auto& lightingPSConstants = ShaderConstants::LightingPS::Get();
 
-		auto lightingFlags = shader->currentRawTechnique & ~(~0u << 24);
-		auto lightingType = static_cast<SIE::ShaderCache::LightingShaderTechniques>((shader->currentRawTechnique >> 24) & 0x3F);
-		if (!(lightingType == LODLand || lightingType == LODLandNoise) && (lightingFlags & static_cast<uint32_t>(SIE::ShaderCache::LightingShaderFlags::TruePbr))) {
-			auto shadowState = globals::game::shadowState;
-			auto renderer = globals::game::renderer;
-			auto graphicsState = globals::game::graphicsState;
-			auto smState = globals::game::smState;
+	auto lightingFlags = shader->currentRawTechnique & ~(~0u << 24);
+	auto lightingType = static_cast<SIE::ShaderCache::LightingShaderTechniques>((shader->currentRawTechnique >> 24) & 0x3F);
+	if (!(lightingType == LODLand || lightingType == LODLandNoise) && (lightingFlags & static_cast<uint32_t>(SIE::ShaderCache::LightingShaderFlags::TruePbr))) {
+		auto shadowState = globals::game::shadowState;
+		auto renderer = globals::game::renderer;
+		auto graphicsState = globals::game::graphicsState;
+		auto smState = globals::game::smState;
 
-			RE::BSGraphics::Renderer::PrepareVSConstantGroup(RE::BSGraphics::ConstantGroupLevel::PerMaterial);
-			RE::BSGraphics::Renderer::PreparePSConstantGroup(RE::BSGraphics::ConstantGroupLevel::PerMaterial);
+		RE::BSGraphics::Renderer::PrepareVSConstantGroup(RE::BSGraphics::ConstantGroupLevel::PerMaterial);
+		RE::BSGraphics::Renderer::PreparePSConstantGroup(RE::BSGraphics::ConstantGroupLevel::PerMaterial);
 
-			if (lightingType == MTLand || lightingType == MTLandLODBlend) {
-				auto* pbrMaterial = static_cast<const BSLightingShaderMaterialPBRLandscape*>(material);
+		if (lightingType == MTLand || lightingType == MTLandLODBlend) {
+			auto* pbrMaterial = static_cast<const BSLightingShaderMaterialPBRLandscape*>(material);
 
-				constexpr size_t NormalStartIndex = 7;
+			constexpr size_t NormalStartIndex = 7;
+
+			for (uint32_t textureIndex = 0; textureIndex < BSLightingShaderMaterialPBRLandscape::NumTiles; ++textureIndex) {
+				if (pbrMaterial->landscapeBaseColorTextures[textureIndex] != nullptr) {
+					shadowState->SetPSTexture(textureIndex, pbrMaterial->landscapeBaseColorTextures[textureIndex]->rendererTexture);
+					shadowState->SetPSTextureAddressMode(textureIndex, RE::BSGraphics::TextureAddressMode::kWrapSWrapT);
+					shadowState->SetPSTextureFilterMode(textureIndex, RE::BSGraphics::TextureFilterMode::kAnisotropic);
+				}
+				if (pbrMaterial->landscapeNormalTextures[textureIndex] != nullptr) {
+					const uint32_t normalTextureIndex = NormalStartIndex + textureIndex;
+					shadowState->SetPSTexture(normalTextureIndex, pbrMaterial->landscapeNormalTextures[textureIndex]->rendererTexture);
+					shadowState->SetPSTextureAddressMode(normalTextureIndex, RE::BSGraphics::TextureAddressMode::kWrapSWrapT);
+					shadowState->SetPSTextureFilterMode(normalTextureIndex, RE::BSGraphics::TextureFilterMode::kAnisotropic);
+				}
+				if (pbrMaterial->landscapeDisplacementTextures[textureIndex] != nullptr) {
+					extendedRendererState.SetPSTexture(textureIndex, pbrMaterial->landscapeDisplacementTextures[textureIndex]->rendererTexture);
+				}
+				if (pbrMaterial->landscapeRMAOSTextures[textureIndex] != nullptr) {
+					extendedRendererState.SetPSTexture(BSLightingShaderMaterialPBRLandscape::NumTiles + textureIndex, pbrMaterial->landscapeRMAOSTextures[textureIndex]->rendererTexture);
+				}
+			}
+
+			if (pbrMaterial->terrainOverlayTexture != nullptr) {
+				shadowState->SetPSTexture(13, pbrMaterial->terrainOverlayTexture->rendererTexture);
+				shadowState->SetPSTextureAddressMode(13, RE::BSGraphics::TextureAddressMode::kClampSClampT);
+				shadowState->SetPSTextureFilterMode(13, RE::BSGraphics::TextureFilterMode::kAnisotropic);
+			}
+
+			if (pbrMaterial->terrainNoiseTexture != nullptr) {
+				shadowState->SetPSTexture(15, pbrMaterial->terrainNoiseTexture->rendererTexture);
+				shadowState->SetPSTextureAddressMode(15, RE::BSGraphics::TextureAddressMode::kWrapSWrapT);
+				shadowState->SetPSTextureFilterMode(15, RE::BSGraphics::TextureFilterMode::kBilinear);
+			}
+
+			{
+				uint32_t flags = 0;
+				for (uint32_t textureIndex = 0; textureIndex < BSLightingShaderMaterialPBRLandscape::NumTiles; ++textureIndex) {
+					if (pbrMaterial->isPbr[textureIndex]) {
+						flags |= (1 << textureIndex);
+						if (pbrMaterial->landscapeDisplacementTextures[textureIndex] != nullptr && pbrMaterial->landscapeDisplacementTextures[textureIndex] != graphicsState->GetRuntimeData().defaultTextureBlack) {
+							flags |= (1 << (BSLightingShaderMaterialPBRLandscape::NumTiles + textureIndex));
+						}
+						if (pbrMaterial->glintParameters[textureIndex].enabled) {
+							flags |= (1 << (2 * BSLightingShaderMaterialPBRLandscape::NumTiles + textureIndex));
+						}
+					}
+				}
+				shadowState->SetPSConstant(flags, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.PBRFlags);
+			}
+
+			{
+				const size_t PBRParamsStartIndex = lightingPSConstants.PBRParams1;
+				const size_t GlintParametersStartIndex = lightingPSConstants.LandscapeTexture1GlintParameters;
 
 				for (uint32_t textureIndex = 0; textureIndex < BSLightingShaderMaterialPBRLandscape::NumTiles; ++textureIndex) {
-					if (pbrMaterial->landscapeBaseColorTextures[textureIndex] != nullptr) {
-						shadowState->SetPSTexture(textureIndex, pbrMaterial->landscapeBaseColorTextures[textureIndex]->rendererTexture);
-						shadowState->SetPSTextureAddressMode(textureIndex, RE::BSGraphics::TextureAddressMode::kWrapSWrapT);
-						shadowState->SetPSTextureFilterMode(textureIndex, RE::BSGraphics::TextureFilterMode::kAnisotropic);
-					}
-					if (pbrMaterial->landscapeNormalTextures[textureIndex] != nullptr) {
-						const uint32_t normalTextureIndex = NormalStartIndex + textureIndex;
-						shadowState->SetPSTexture(normalTextureIndex, pbrMaterial->landscapeNormalTextures[textureIndex]->rendererTexture);
-						shadowState->SetPSTextureAddressMode(normalTextureIndex, RE::BSGraphics::TextureAddressMode::kWrapSWrapT);
-						shadowState->SetPSTextureFilterMode(normalTextureIndex, RE::BSGraphics::TextureFilterMode::kAnisotropic);
-					}
-					if (pbrMaterial->landscapeDisplacementTextures[textureIndex] != nullptr) {
-						extendedRendererState.SetPSTexture(textureIndex, pbrMaterial->landscapeDisplacementTextures[textureIndex]->rendererTexture);
-					}
-					if (pbrMaterial->landscapeRMAOSTextures[textureIndex] != nullptr) {
-						extendedRendererState.SetPSTexture(BSLightingShaderMaterialPBRLandscape::NumTiles + textureIndex, pbrMaterial->landscapeRMAOSTextures[textureIndex]->rendererTexture);
-					}
-				}
+					std::array<float, 3> PBRParams;
+					PBRParams[0] = pbrMaterial->roughnessScales[textureIndex];
+					PBRParams[1] = pbrMaterial->displacementScales[textureIndex];
+					PBRParams[2] = pbrMaterial->specularLevels[textureIndex];
+					shadowState->SetPSConstant(PBRParams, RE::BSGraphics::ConstantGroupLevel::PerMaterial, PBRParamsStartIndex + textureIndex);
 
-				if (pbrMaterial->terrainOverlayTexture != nullptr) {
-					shadowState->SetPSTexture(13, pbrMaterial->terrainOverlayTexture->rendererTexture);
-					shadowState->SetPSTextureAddressMode(13, RE::BSGraphics::TextureAddressMode::kClampSClampT);
-					shadowState->SetPSTextureFilterMode(13, RE::BSGraphics::TextureFilterMode::kAnisotropic);
-				}
-
-				if (pbrMaterial->terrainNoiseTexture != nullptr) {
-					shadowState->SetPSTexture(15, pbrMaterial->terrainNoiseTexture->rendererTexture);
-					shadowState->SetPSTextureAddressMode(15, RE::BSGraphics::TextureAddressMode::kWrapSWrapT);
-					shadowState->SetPSTextureFilterMode(15, RE::BSGraphics::TextureFilterMode::kBilinear);
-				}
-
-				{
-					uint32_t flags = 0;
-					for (uint32_t textureIndex = 0; textureIndex < BSLightingShaderMaterialPBRLandscape::NumTiles; ++textureIndex) {
-						if (pbrMaterial->isPbr[textureIndex]) {
-							flags |= (1 << textureIndex);
-							if (pbrMaterial->landscapeDisplacementTextures[textureIndex] != nullptr && pbrMaterial->landscapeDisplacementTextures[textureIndex] != graphicsState->GetRuntimeData().defaultTextureBlack) {
-								flags |= (1 << (BSLightingShaderMaterialPBRLandscape::NumTiles + textureIndex));
-							}
-							if (pbrMaterial->glintParameters[textureIndex].enabled) {
-								flags |= (1 << (2 * BSLightingShaderMaterialPBRLandscape::NumTiles + textureIndex));
-							}
-						}
-					}
-					shadowState->SetPSConstant(flags, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.PBRFlags);
-				}
-
-				{
-					const size_t PBRParamsStartIndex = lightingPSConstants.PBRParams1;
-					const size_t GlintParametersStartIndex = lightingPSConstants.LandscapeTexture1GlintParameters;
-
-					for (uint32_t textureIndex = 0; textureIndex < BSLightingShaderMaterialPBRLandscape::NumTiles; ++textureIndex) {
-						std::array<float, 3> PBRParams;
-						PBRParams[0] = pbrMaterial->roughnessScales[textureIndex];
-						PBRParams[1] = pbrMaterial->displacementScales[textureIndex];
-						PBRParams[2] = pbrMaterial->specularLevels[textureIndex];
-						shadowState->SetPSConstant(PBRParams, RE::BSGraphics::ConstantGroupLevel::PerMaterial, PBRParamsStartIndex + textureIndex);
-
-						std::array<float, 4> glintParameters;
-						glintParameters[0] = pbrMaterial->glintParameters[textureIndex].screenSpaceScale;
-						glintParameters[1] = 40.f - pbrMaterial->glintParameters[textureIndex].logMicrofacetDensity;
-						glintParameters[2] = pbrMaterial->glintParameters[textureIndex].microfacetRoughness;
-						glintParameters[3] = pbrMaterial->glintParameters[textureIndex].densityRandomization;
-						shadowState->SetPSConstant(glintParameters, RE::BSGraphics::ConstantGroupLevel::PerMaterial, GlintParametersStartIndex + textureIndex);
-					}
-				}
-
-				{
-					std::array<float, 4> lodTexParams;
-					lodTexParams[0] = pbrMaterial->terrainTexOffsetX;
-					lodTexParams[1] = pbrMaterial->terrainTexOffsetY;
-					lodTexParams[2] = 1.f;
-					lodTexParams[3] = pbrMaterial->terrainTexFade;
-					shadowState->SetPSConstant(lodTexParams, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.LODTexParams);
-				}
-			} else if (lightingType == None || lightingType == TreeAnim) {
-				auto* pbrMaterial = static_cast<const BSLightingShaderMaterialPBR*>(material);
-				CHECK_PBR_TEXTURE(diffuseTexture);
-				CHECK_PBR_TEXTURE(normalTexture);
-				CHECK_PBR_TEXTURE(rmaosTexture);
-				if (pbrMaterial->diffuseRenderTargetSourceIndex != -1) {
-					shadowState->SetPSTexture(0, renderer->GetRuntimeData().renderTargets[pbrMaterial->diffuseRenderTargetSourceIndex]);
-				} else {
-					shadowState->SetPSTexture(0, pbrMaterial->diffuseTexture->rendererTexture);
-				}
-				shadowState->SetPSTextureAddressMode(0, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
-				shadowState->SetPSTextureFilterMode(0, RE::BSGraphics::TextureFilterMode::kAnisotropic);
-
-				shadowState->SetPSTexture(1, pbrMaterial->normalTexture->rendererTexture);
-				shadowState->SetPSTextureAddressMode(1, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
-				shadowState->SetPSTextureFilterMode(1, RE::BSGraphics::TextureFilterMode::kAnisotropic);
-
-				shadowState->SetPSTexture(5, pbrMaterial->rmaosTexture->rendererTexture);
-				shadowState->SetPSTextureAddressMode(5, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
-				shadowState->SetPSTextureFilterMode(5, RE::BSGraphics::TextureFilterMode::kAnisotropic);
-
-				stl::enumeration<PBRShaderFlags> shaderFlags;
-				if (pbrMaterial->pbrFlags.any(PBRFlags::TwoLayer)) {
-					shaderFlags.set(PBRShaderFlags::TwoLayer);
-					if (pbrMaterial->pbrFlags.any(PBRFlags::InterlayerParallax)) {
-						shaderFlags.set(PBRShaderFlags::InterlayerParallax);
-					}
-					if (pbrMaterial->pbrFlags.any(PBRFlags::CoatNormal)) {
-						shaderFlags.set(PBRShaderFlags::CoatNormal);
-					}
-					if (pbrMaterial->pbrFlags.any(PBRFlags::ColoredCoat)) {
-						shaderFlags.set(PBRShaderFlags::ColoredCoat);
-					}
-
-					std::array<float, 4> PBRParams2;
-					PBRParams2[0] = pbrMaterial->GetCoatColor().red;
-					PBRParams2[1] = pbrMaterial->GetCoatColor().green;
-					PBRParams2[2] = pbrMaterial->GetCoatColor().blue;
-					PBRParams2[3] = pbrMaterial->GetCoatStrength();
-					shadowState->SetPSConstant(PBRParams2, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.PBRParams2);
-
-					std::array<float, 4> PBRParams3;
-					PBRParams3[0] = pbrMaterial->GetCoatRoughness();
-					PBRParams3[1] = pbrMaterial->GetCoatSpecularLevel();
-					shadowState->SetPSConstant(PBRParams3, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.MultiLayerParallaxData);
-				} else if (pbrMaterial->pbrFlags.any(PBRFlags::HairMarschner)) {
-					shaderFlags.set(PBRShaderFlags::HairMarschner);
-				} else {
-					if (pbrMaterial->pbrFlags.any(PBRFlags::Subsurface)) {
-						shaderFlags.set(PBRShaderFlags::Subsurface);
-
-						std::array<float, 4> PBRParams2;
-						PBRParams2[0] = pbrMaterial->GetSubsurfaceColor().red;
-						PBRParams2[1] = pbrMaterial->GetSubsurfaceColor().green;
-						PBRParams2[2] = pbrMaterial->GetSubsurfaceColor().blue;
-						PBRParams2[3] = pbrMaterial->GetSubsurfaceOpacity();
-						shadowState->SetPSConstant(PBRParams2, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.PBRParams2);
-					}
-					if (pbrMaterial->pbrFlags.any(PBRFlags::Fuzz)) {
-						shaderFlags.set(PBRShaderFlags::Fuzz);
-
-						std::array<float, 4> PBRParams3;
-						PBRParams3[0] = pbrMaterial->GetFuzzColor().red;
-						PBRParams3[1] = pbrMaterial->GetFuzzColor().green;
-						PBRParams3[2] = pbrMaterial->GetFuzzColor().blue;
-						PBRParams3[3] = pbrMaterial->GetFuzzWeight();
-						shadowState->SetPSConstant(PBRParams3, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.MultiLayerParallaxData);
-					} else {
-						if (pbrMaterial->GetGlintParameters().enabled) {
-							shaderFlags.set(PBRShaderFlags::Glint);
-
-							std::array<float, 4> GlintParameters;
-							GlintParameters[0] = pbrMaterial->GetGlintParameters().screenSpaceScale;
-							GlintParameters[1] = 40.f - pbrMaterial->GetGlintParameters().logMicrofacetDensity;
-							GlintParameters[2] = pbrMaterial->GetGlintParameters().microfacetRoughness;
-							GlintParameters[3] = pbrMaterial->GetGlintParameters().densityRandomization;
-							shadowState->SetPSConstant(GlintParameters, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.MultiLayerParallaxData);
-						}
-						if ((lightingFlags & static_cast<uint32_t>(SIE::ShaderCache::LightingShaderFlags::ProjectedUV)) != 0 && pbrMaterial->GetProjectedMaterialGlintParameters().enabled) {
-							shaderFlags.set(PBRShaderFlags::ProjectedGlint);
-
-							std::array<float, 4> ProjectedGlintParameters;
-							ProjectedGlintParameters[0] = pbrMaterial->GetProjectedMaterialGlintParameters().screenSpaceScale;
-							ProjectedGlintParameters[1] = 40.f - pbrMaterial->GetProjectedMaterialGlintParameters().logMicrofacetDensity;
-							ProjectedGlintParameters[2] = pbrMaterial->GetProjectedMaterialGlintParameters().microfacetRoughness;
-							ProjectedGlintParameters[3] = pbrMaterial->GetProjectedMaterialGlintParameters().densityRandomization;
-							shadowState->SetPSConstant(ProjectedGlintParameters, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.SparkleParams);
-						}
-					}
-				}
-
-				{
-					std::array<float, 4> PBRProjectedUVParams1;
-					PBRProjectedUVParams1[0] = pbrMaterial->GetProjectedMaterialBaseColorScale()[0];
-					PBRProjectedUVParams1[1] = pbrMaterial->GetProjectedMaterialBaseColorScale()[1];
-					PBRProjectedUVParams1[2] = pbrMaterial->GetProjectedMaterialBaseColorScale()[2];
-					shadowState->SetPSConstant(PBRProjectedUVParams1, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.EnvmapData);
-
-					std::array<float, 4> PBRProjectedUVParams2;
-					PBRProjectedUVParams2[0] = pbrMaterial->GetProjectedMaterialRoughness();
-					PBRProjectedUVParams2[1] = pbrMaterial->GetProjectedMaterialSpecularLevel();
-					shadowState->SetPSConstant(PBRProjectedUVParams2, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.ParallaxOccData);
-				}
-
-				const bool hasEmissive = pbrMaterial->emissiveTexture != nullptr && pbrMaterial->emissiveTexture != graphicsState->GetRuntimeData().defaultTextureBlack;
-				if (hasEmissive) {
-					shadowState->SetPSTexture(6, pbrMaterial->emissiveTexture->rendererTexture);
-					shadowState->SetPSTextureAddressMode(6, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
-					shadowState->SetPSTextureFilterMode(6, RE::BSGraphics::TextureFilterMode::kAnisotropic);
-
-					shaderFlags.set(PBRShaderFlags::HasEmissive);
-				}
-
-				const bool hasDisplacement = pbrMaterial->displacementTexture != nullptr && pbrMaterial->displacementTexture != graphicsState->GetRuntimeData().defaultTextureBlack;
-				if (hasDisplacement) {
-					shadowState->SetPSTexture(4, pbrMaterial->displacementTexture->rendererTexture);
-					shadowState->SetPSTextureAddressMode(4, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
-					shadowState->SetPSTextureFilterMode(4, RE::BSGraphics::TextureFilterMode::kAnisotropic);
-
-					shaderFlags.set(PBRShaderFlags::HasDisplacement);
-				}
-
-				const bool hasFeaturesTexture0 = pbrMaterial->featuresTexture0 != nullptr && pbrMaterial->featuresTexture0 != graphicsState->GetRuntimeData().defaultTextureWhite;
-				if (hasFeaturesTexture0) {
-					shadowState->SetPSTexture(12, pbrMaterial->featuresTexture0->rendererTexture);
-					shadowState->SetPSTextureAddressMode(12, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
-					shadowState->SetPSTextureFilterMode(12, RE::BSGraphics::TextureFilterMode::kAnisotropic);
-
-					shaderFlags.set(PBRShaderFlags::HasFeaturesTexture0);
-				}
-
-				const bool hasFeaturesTexture1 = pbrMaterial->featuresTexture1 != nullptr && pbrMaterial->featuresTexture1 != graphicsState->GetRuntimeData().defaultTextureWhite;
-				if (hasFeaturesTexture1) {
-					shadowState->SetPSTexture(9, pbrMaterial->featuresTexture1->rendererTexture);
-					shadowState->SetPSTextureAddressMode(9, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
-					shadowState->SetPSTextureFilterMode(9, RE::BSGraphics::TextureFilterMode::kAnisotropic);
-
-					shaderFlags.set(PBRShaderFlags::HasFeaturesTexture1);
-				}
-
-				{
-					shadowState->SetPSConstant(shaderFlags, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.PBRFlags);
-				}
-
-				{
-					std::array<float, 3> PBRParams1;
-					PBRParams1[0] = pbrMaterial->GetRoughnessScale();
-					PBRParams1[1] = pbrMaterial->GetDisplacementScale();
-					PBRParams1[2] = pbrMaterial->GetSpecularLevel();
-					shadowState->SetPSConstant(PBRParams1, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.PBRParams1);
+					std::array<float, 4> glintParameters;
+					glintParameters[0] = pbrMaterial->glintParameters[textureIndex].screenSpaceScale;
+					glintParameters[1] = 40.f - pbrMaterial->glintParameters[textureIndex].logMicrofacetDensity;
+					glintParameters[2] = pbrMaterial->glintParameters[textureIndex].microfacetRoughness;
+					glintParameters[3] = pbrMaterial->glintParameters[textureIndex].densityRandomization;
+					shadowState->SetPSConstant(glintParameters, RE::BSGraphics::ConstantGroupLevel::PerMaterial, GlintParametersStartIndex + textureIndex);
 				}
 			}
 
 			{
-				const uint32_t bufferIndex = smState->textureTransformCurrentBuffer;
-
-				std::array<float, 4> texCoordOffsetScale;
-				texCoordOffsetScale[0] = material->texCoordOffset[bufferIndex].x;
-				texCoordOffsetScale[1] = material->texCoordOffset[bufferIndex].y;
-				texCoordOffsetScale[2] = material->texCoordScale[bufferIndex].x;
-				texCoordOffsetScale[3] = material->texCoordScale[bufferIndex].y;
-				shadowState->SetVSConstant(texCoordOffsetScale, RE::BSGraphics::ConstantGroupLevel::PerMaterial, 11);
+				std::array<float, 4> lodTexParams;
+				lodTexParams[0] = pbrMaterial->terrainTexOffsetX;
+				lodTexParams[1] = pbrMaterial->terrainTexOffsetY;
+				lodTexParams[2] = 1.f;
+				lodTexParams[3] = pbrMaterial->terrainTexFade;
+				shadowState->SetPSConstant(lodTexParams, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.LODTexParams);
 			}
+		} else if (lightingType == None || lightingType == TreeAnim) {
+			auto* pbrMaterial = static_cast<const BSLightingShaderMaterialPBR*>(material);
+			if (pbrMaterial->diffuseRenderTargetSourceIndex != -1) {
+				shadowState->SetPSTexture(0, renderer->GetRuntimeData().renderTargets[pbrMaterial->diffuseRenderTargetSourceIndex]);
+			} else {
+				shadowState->SetPSTexture(0, pbrMaterial->diffuseTexture->rendererTexture);
+			}
+			shadowState->SetPSTextureAddressMode(0, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
+			shadowState->SetPSTextureFilterMode(0, RE::BSGraphics::TextureFilterMode::kAnisotropic);
 
-			if (lightingFlags & static_cast<uint32_t>(SIE::ShaderCache::LightingShaderFlags::CharacterLight)) {
-				static const REL::Relocation<RE::ImageSpaceTexture*> characterLightTexture{ RELOCATION_ID(513464, 391302) };
+			shadowState->SetPSTexture(1, pbrMaterial->normalTexture->rendererTexture);
+			shadowState->SetPSTextureAddressMode(1, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
+			shadowState->SetPSTextureFilterMode(1, RE::BSGraphics::TextureFilterMode::kAnisotropic);
 
-				if (characterLightTexture->renderTarget >= RE::RENDER_TARGET::kFRAMEBUFFER) {
-					shadowState->SetPSTexture(11, renderer->GetRuntimeData().renderTargets[characterLightTexture->renderTarget]);
-					shadowState->SetPSTextureAddressMode(11, RE::BSGraphics::TextureAddressMode::kClampSClampT);
+			shadowState->SetPSTexture(5, pbrMaterial->rmaosTexture->rendererTexture);
+			shadowState->SetPSTextureAddressMode(5, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
+			shadowState->SetPSTextureFilterMode(5, RE::BSGraphics::TextureFilterMode::kAnisotropic);
+
+			stl::enumeration<PBRShaderFlags> shaderFlags;
+			if (pbrMaterial->pbrFlags.any(PBRFlags::TwoLayer)) {
+				shaderFlags.set(PBRShaderFlags::TwoLayer);
+				if (pbrMaterial->pbrFlags.any(PBRFlags::InterlayerParallax)) {
+					shaderFlags.set(PBRShaderFlags::InterlayerParallax);
+				}
+				if (pbrMaterial->pbrFlags.any(PBRFlags::CoatNormal)) {
+					shaderFlags.set(PBRShaderFlags::CoatNormal);
+				}
+				if (pbrMaterial->pbrFlags.any(PBRFlags::ColoredCoat)) {
+					shaderFlags.set(PBRShaderFlags::ColoredCoat);
 				}
 
-				std::array<float, 4> characterLightParams;
-				if (smState->characterLightEnabled) {
-					std::copy_n(smState->characterLightParams, 4, characterLightParams.data());
+				std::array<float, 4> PBRParams2;
+				PBRParams2[0] = pbrMaterial->GetCoatColor().red;
+				PBRParams2[1] = pbrMaterial->GetCoatColor().green;
+				PBRParams2[2] = pbrMaterial->GetCoatColor().blue;
+				PBRParams2[3] = pbrMaterial->GetCoatStrength();
+				shadowState->SetPSConstant(PBRParams2, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.PBRParams2);
+
+				std::array<float, 4> PBRParams3;
+				PBRParams3[0] = pbrMaterial->GetCoatRoughness();
+				PBRParams3[1] = pbrMaterial->GetCoatSpecularLevel();
+				shadowState->SetPSConstant(PBRParams3, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.MultiLayerParallaxData);
+			} else if (pbrMaterial->pbrFlags.any(PBRFlags::HairMarschner)) {
+				shaderFlags.set(PBRShaderFlags::HairMarschner);
+			} else {
+				if (pbrMaterial->pbrFlags.any(PBRFlags::Subsurface)) {
+					shaderFlags.set(PBRShaderFlags::Subsurface);
+
+					std::array<float, 4> PBRParams2;
+					PBRParams2[0] = pbrMaterial->GetSubsurfaceColor().red;
+					PBRParams2[1] = pbrMaterial->GetSubsurfaceColor().green;
+					PBRParams2[2] = pbrMaterial->GetSubsurfaceColor().blue;
+					PBRParams2[3] = pbrMaterial->GetSubsurfaceOpacity();
+					shadowState->SetPSConstant(PBRParams2, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.PBRParams2);
+				}
+				if (pbrMaterial->pbrFlags.any(PBRFlags::Fuzz)) {
+					shaderFlags.set(PBRShaderFlags::Fuzz);
+
+					std::array<float, 4> PBRParams3;
+					PBRParams3[0] = pbrMaterial->GetFuzzColor().red;
+					PBRParams3[1] = pbrMaterial->GetFuzzColor().green;
+					PBRParams3[2] = pbrMaterial->GetFuzzColor().blue;
+					PBRParams3[3] = pbrMaterial->GetFuzzWeight();
+					shadowState->SetPSConstant(PBRParams3, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.MultiLayerParallaxData);
 				} else {
-					std::fill_n(characterLightParams.data(), 4, 0.f);
+					if (pbrMaterial->GetGlintParameters().enabled) {
+						shaderFlags.set(PBRShaderFlags::Glint);
+
+						std::array<float, 4> GlintParameters;
+						GlintParameters[0] = pbrMaterial->GetGlintParameters().screenSpaceScale;
+						GlintParameters[1] = 40.f - pbrMaterial->GetGlintParameters().logMicrofacetDensity;
+						GlintParameters[2] = pbrMaterial->GetGlintParameters().microfacetRoughness;
+						GlintParameters[3] = pbrMaterial->GetGlintParameters().densityRandomization;
+						shadowState->SetPSConstant(GlintParameters, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.MultiLayerParallaxData);
+					}
+					if ((lightingFlags & static_cast<uint32_t>(SIE::ShaderCache::LightingShaderFlags::ProjectedUV)) != 0 && pbrMaterial->GetProjectedMaterialGlintParameters().enabled) {
+						shaderFlags.set(PBRShaderFlags::ProjectedGlint);
+
+						std::array<float, 4> ProjectedGlintParameters;
+						ProjectedGlintParameters[0] = pbrMaterial->GetProjectedMaterialGlintParameters().screenSpaceScale;
+						ProjectedGlintParameters[1] = 40.f - pbrMaterial->GetProjectedMaterialGlintParameters().logMicrofacetDensity;
+						ProjectedGlintParameters[2] = pbrMaterial->GetProjectedMaterialGlintParameters().microfacetRoughness;
+						ProjectedGlintParameters[3] = pbrMaterial->GetProjectedMaterialGlintParameters().densityRandomization;
+						shadowState->SetPSConstant(ProjectedGlintParameters, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.SparkleParams);
+					}
 				}
-				shadowState->SetPSConstant(characterLightParams, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.CharacterLightParams);
 			}
 
-			RE::BSGraphics::Renderer::FlushVSConstantGroup(RE::BSGraphics::ConstantGroupLevel::PerMaterial);
-			RE::BSGraphics::Renderer::FlushPSConstantGroup(RE::BSGraphics::ConstantGroupLevel::PerMaterial);
-			RE::BSGraphics::Renderer::ApplyVSConstantGroup(RE::BSGraphics::ConstantGroupLevel::PerMaterial);
-			RE::BSGraphics::Renderer::ApplyPSConstantGroup(RE::BSGraphics::ConstantGroupLevel::PerMaterial);
-		} else {
-			func(shader, material);
+			{
+				std::array<float, 4> PBRProjectedUVParams1;
+				PBRProjectedUVParams1[0] = pbrMaterial->GetProjectedMaterialBaseColorScale()[0];
+				PBRProjectedUVParams1[1] = pbrMaterial->GetProjectedMaterialBaseColorScale()[1];
+				PBRProjectedUVParams1[2] = pbrMaterial->GetProjectedMaterialBaseColorScale()[2];
+				shadowState->SetPSConstant(PBRProjectedUVParams1, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.EnvmapData);
+
+				std::array<float, 4> PBRProjectedUVParams2;
+				PBRProjectedUVParams2[0] = pbrMaterial->GetProjectedMaterialRoughness();
+				PBRProjectedUVParams2[1] = pbrMaterial->GetProjectedMaterialSpecularLevel();
+				shadowState->SetPSConstant(PBRProjectedUVParams2, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.ParallaxOccData);
+			}
+
+			const bool hasEmissive = pbrMaterial->emissiveTexture != nullptr && pbrMaterial->emissiveTexture != graphicsState->GetRuntimeData().defaultTextureBlack;
+			if (hasEmissive) {
+				shadowState->SetPSTexture(6, pbrMaterial->emissiveTexture->rendererTexture);
+				shadowState->SetPSTextureAddressMode(6, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
+				shadowState->SetPSTextureFilterMode(6, RE::BSGraphics::TextureFilterMode::kAnisotropic);
+
+				shaderFlags.set(PBRShaderFlags::HasEmissive);
+			}
+
+			const bool hasDisplacement = pbrMaterial->displacementTexture != nullptr && pbrMaterial->displacementTexture != graphicsState->GetRuntimeData().defaultTextureBlack;
+			if (hasDisplacement) {
+				shadowState->SetPSTexture(4, pbrMaterial->displacementTexture->rendererTexture);
+				shadowState->SetPSTextureAddressMode(4, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
+				shadowState->SetPSTextureFilterMode(4, RE::BSGraphics::TextureFilterMode::kAnisotropic);
+
+				shaderFlags.set(PBRShaderFlags::HasDisplacement);
+			}
+
+			const bool hasFeaturesTexture0 = pbrMaterial->featuresTexture0 != nullptr && pbrMaterial->featuresTexture0 != graphicsState->GetRuntimeData().defaultTextureWhite;
+			if (hasFeaturesTexture0) {
+				shadowState->SetPSTexture(12, pbrMaterial->featuresTexture0->rendererTexture);
+				shadowState->SetPSTextureAddressMode(12, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
+				shadowState->SetPSTextureFilterMode(12, RE::BSGraphics::TextureFilterMode::kAnisotropic);
+
+				shaderFlags.set(PBRShaderFlags::HasFeaturesTexture0);
+			}
+
+			const bool hasFeaturesTexture1 = pbrMaterial->featuresTexture1 != nullptr && pbrMaterial->featuresTexture1 != graphicsState->GetRuntimeData().defaultTextureWhite;
+			if (hasFeaturesTexture1) {
+				shadowState->SetPSTexture(9, pbrMaterial->featuresTexture1->rendererTexture);
+				shadowState->SetPSTextureAddressMode(9, static_cast<RE::BSGraphics::TextureAddressMode>(pbrMaterial->textureClampMode));
+				shadowState->SetPSTextureFilterMode(9, RE::BSGraphics::TextureFilterMode::kAnisotropic);
+
+				shaderFlags.set(PBRShaderFlags::HasFeaturesTexture1);
+			}
+
+			{
+				shadowState->SetPSConstant(shaderFlags, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.PBRFlags);
+			}
+
+			{
+				std::array<float, 3> PBRParams1;
+				PBRParams1[0] = pbrMaterial->GetRoughnessScale();
+				PBRParams1[1] = pbrMaterial->GetDisplacementScale();
+				PBRParams1[2] = pbrMaterial->GetSpecularLevel();
+				shadowState->SetPSConstant(PBRParams1, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.PBRParams1);
+			}
 		}
-	};
-	static inline REL::Relocation<decltype(thunk)> func;
-};
+
+		{
+			const uint32_t bufferIndex = smState->textureTransformCurrentBuffer;
+
+			std::array<float, 4> texCoordOffsetScale;
+			texCoordOffsetScale[0] = material->texCoordOffset[bufferIndex].x;
+			texCoordOffsetScale[1] = material->texCoordOffset[bufferIndex].y;
+			texCoordOffsetScale[2] = material->texCoordScale[bufferIndex].x;
+			texCoordOffsetScale[3] = material->texCoordScale[bufferIndex].y;
+			shadowState->SetVSConstant(texCoordOffsetScale, RE::BSGraphics::ConstantGroupLevel::PerMaterial, 11);
+		}
+
+		if (lightingFlags & static_cast<uint32_t>(SIE::ShaderCache::LightingShaderFlags::CharacterLight)) {
+			static const REL::Relocation<RE::ImageSpaceTexture*> characterLightTexture{ RELOCATION_ID(513464, 391302) };
+
+			if (characterLightTexture->renderTarget >= RE::RENDER_TARGET::kFRAMEBUFFER) {
+				shadowState->SetPSTexture(11, renderer->GetRuntimeData().renderTargets[characterLightTexture->renderTarget]);
+				shadowState->SetPSTextureAddressMode(11, RE::BSGraphics::TextureAddressMode::kClampSClampT);
+			}
+
+			std::array<float, 4> characterLightParams;
+			if (smState->characterLightEnabled) {
+				std::copy_n(smState->characterLightParams, 4, characterLightParams.data());
+			} else {
+				std::fill_n(characterLightParams.data(), 4, 0.f);
+			}
+			shadowState->SetPSConstant(characterLightParams, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.CharacterLightParams);
+		}
+
+		RE::BSGraphics::Renderer::FlushVSConstantGroup(RE::BSGraphics::ConstantGroupLevel::PerMaterial);
+		RE::BSGraphics::Renderer::FlushPSConstantGroup(RE::BSGraphics::ConstantGroupLevel::PerMaterial);
+		RE::BSGraphics::Renderer::ApplyVSConstantGroup(RE::BSGraphics::ConstantGroupLevel::PerMaterial);
+		RE::BSGraphics::Renderer::ApplyPSConstantGroup(RE::BSGraphics::ConstantGroupLevel::PerMaterial);
+
+		return true;
+	}
+
+	return false;
+}
 
 struct BSLightingShader_SetupGeometry
 {
@@ -1087,109 +1082,105 @@ RE::TESLandTexture* GetDefaultLandTexture()
 	return *defaultLandTextureAddress;
 }
 
-struct TESObjectLAND_SetupMaterial
+bool TruePBR::TESObjectLAND_SetupMaterial(RE::TESObjectLAND* land)
 {
-	static bool thunk(RE::TESObjectLAND* land)
-	{
-		auto singleton = globals::truePBR;
+	auto singleton = globals::truePBR;
 
-		bool isPbr = false;
-		if (land->loadedData != nullptr) {
-			for (uint32_t quadIndex = 0; quadIndex < 4; ++quadIndex) {
-				if (land->loadedData->defQuadTextures[quadIndex] != nullptr) {
-					if (singleton->IsPBRTextureSet(land->loadedData->defQuadTextures[quadIndex]->textureSet)) {
+	bool isPbr = false;
+	if (land->loadedData != nullptr) {
+		for (uint32_t quadIndex = 0; quadIndex < 4; ++quadIndex) {
+			if (land->loadedData->defQuadTextures[quadIndex] != nullptr) {
+				if (singleton->IsPBRTextureSet(land->loadedData->defQuadTextures[quadIndex]->textureSet)) {
+					isPbr = true;
+					break;
+				}
+			} else if (singleton->defaultPbrLandTextureSet != nullptr) {
+				isPbr = true;
+			}
+			for (uint32_t textureIndex = 0; textureIndex < 6; ++textureIndex) {
+				if (land->loadedData->quadTextures[quadIndex][textureIndex] != nullptr) {
+					if (singleton->IsPBRTextureSet(land->loadedData->quadTextures[quadIndex][textureIndex]->textureSet)) {
 						isPbr = true;
 						break;
 					}
-				} else if (singleton->defaultPbrLandTextureSet != nullptr) {
-					isPbr = true;
-				}
-				for (uint32_t textureIndex = 0; textureIndex < 6; ++textureIndex) {
-					if (land->loadedData->quadTextures[quadIndex][textureIndex] != nullptr) {
-						if (singleton->IsPBRTextureSet(land->loadedData->quadTextures[quadIndex][textureIndex]->textureSet)) {
-							isPbr = true;
-							break;
-						}
-					}
 				}
 			}
 		}
+	}
 
-		if (!isPbr) {
-			return func(land);
-		}
-
-		if (land->loadedData != nullptr && land->loadedData->mesh[0] != nullptr) {
-			land->data.flags.set(static_cast<RE::OBJ_LAND::Flag>(8));
-			for (uint32_t quadIndex = 0; quadIndex < 4; ++quadIndex) {
-				auto shaderProperty = static_cast<RE::BSLightingShaderProperty*>(globals::game::memoryManager->Allocate(REL::Module::IsVR() ? 0x178 : sizeof(RE::BSLightingShaderProperty), 0, false));
-				shaderProperty->Ctor();
-
-				{
-					BSLightingShaderMaterialPBRLandscape srcMaterial;
-					shaderProperty->LinkMaterial(&srcMaterial, true);
-				}
-
-				auto material = static_cast<BSLightingShaderMaterialPBRLandscape*>(shaderProperty->material);
-				const auto& stateData = globals::game::graphicsState->GetRuntimeData();
-
-				for (uint32_t textureIndex = 0; textureIndex < BSLightingShaderMaterialPBRLandscape::NumTiles; ++textureIndex) {
-					material->landscapeBaseColorTextures[textureIndex] = stateData.defaultTextureBlack;
-					material->landscapeNormalTextures[textureIndex] = stateData.defaultTextureNormalMap;
-					material->landscapeDisplacementTextures[textureIndex] = stateData.defaultTextureBlack;
-					material->landscapeRMAOSTextures[textureIndex] = stateData.defaultTextureWhite;
-				}
-
-				auto& textureSets = BSLightingShaderMaterialPBRLandscape::All[material];
-
-				if (auto defTexture = land->loadedData->defQuadTextures[quadIndex]) {
-					SetupLandscapeTexture(*material, *defTexture, 0, textureSets);
-				} else {
-					SetupLandscapeTexture(*material, *GetDefaultLandTexture(), 0, textureSets);
-				}
-				for (uint32_t textureIndex = 0; textureIndex < BSLightingShaderMaterialPBRLandscape::NumTiles - 1; ++textureIndex) {
-					if (auto landTexture = land->loadedData->quadTextures[quadIndex][textureIndex]) {
-						SetupLandscapeTexture(*material, *landTexture, textureIndex + 1, textureSets);
-					}
-				}
-
-				if (globals::game::bEnableLandFade->GetBool()) {
-					shaderProperty->unk108 = false;
-				}
-
-				bool noLODLandBlend = false;
-				auto tes = globals::game::tes;
-				auto worldSpace = tes->GetRuntimeData2().worldSpace;
-				if (worldSpace != nullptr) {
-					if (auto terrainManager = worldSpace->GetTerrainManager()) {
-						noLODLandBlend = reinterpret_cast<bool*>(terrainManager)[0x36];
-					}
-				}
-				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kMultiTextureLandscape, true);
-				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kReceiveShadows, true);
-
-				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kCastShadows, true);
-				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kNoLODLandBlend, noLODLandBlend);
-
-				shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kVertexLighting, true);
-
-				const auto& children = land->loadedData->mesh[quadIndex]->GetChildren();
-				auto geometry = children.empty() ? nullptr : static_cast<RE::BSGeometry*>(children[0].get());
-				shaderProperty->SetupGeometry(geometry);
-				if (geometry != nullptr) {
-					geometry->GetGeometryRuntimeData().properties[1] = RE::NiPointer(shaderProperty);
-				}
-
-				globals::game::smState->shadowSceneNode[0]->AttachObject(geometry);
-			}
-
-			return true;
-		}
-
+	if (!isPbr) {
 		return false;
 	}
-	static inline REL::Relocation<decltype(thunk)> func;
-};
+
+	if (land->loadedData != nullptr && land->loadedData->mesh[0] != nullptr) {
+		land->data.flags.set(static_cast<RE::OBJ_LAND::Flag>(8));
+		for (uint32_t quadIndex = 0; quadIndex < 4; ++quadIndex) {
+			auto shaderProperty = static_cast<RE::BSLightingShaderProperty*>(globals::game::memoryManager->Allocate(REL::Module::IsVR() ? 0x178 : sizeof(RE::BSLightingShaderProperty), 0, false));
+			shaderProperty->Ctor();
+
+			{
+				BSLightingShaderMaterialPBRLandscape srcMaterial;
+				shaderProperty->LinkMaterial(&srcMaterial, true);
+			}
+
+			auto material = static_cast<BSLightingShaderMaterialPBRLandscape*>(shaderProperty->material);
+			const auto& stateData = globals::game::graphicsState->GetRuntimeData();
+
+			for (uint32_t textureIndex = 0; textureIndex < BSLightingShaderMaterialPBRLandscape::NumTiles; ++textureIndex) {
+				material->landscapeBaseColorTextures[textureIndex] = stateData.defaultTextureBlack;
+				material->landscapeNormalTextures[textureIndex] = stateData.defaultTextureNormalMap;
+				material->landscapeDisplacementTextures[textureIndex] = stateData.defaultTextureBlack;
+				material->landscapeRMAOSTextures[textureIndex] = stateData.defaultTextureWhite;
+			}
+
+			auto& textureSets = BSLightingShaderMaterialPBRLandscape::All[material];
+
+			if (auto defTexture = land->loadedData->defQuadTextures[quadIndex]) {
+				SetupLandscapeTexture(*material, *defTexture, 0, textureSets);
+			} else {
+				SetupLandscapeTexture(*material, *GetDefaultLandTexture(), 0, textureSets);
+			}
+			for (uint32_t textureIndex = 0; textureIndex < BSLightingShaderMaterialPBRLandscape::NumTiles - 1; ++textureIndex) {
+				if (auto landTexture = land->loadedData->quadTextures[quadIndex][textureIndex]) {
+					SetupLandscapeTexture(*material, *landTexture, textureIndex + 1, textureSets);
+				}
+			}
+
+			if (globals::game::bEnableLandFade->GetBool()) {
+				shaderProperty->unk108 = false;
+			}
+
+			bool noLODLandBlend = false;
+			auto tes = globals::game::tes;
+			auto worldSpace = tes->GetRuntimeData2().worldSpace;
+			if (worldSpace != nullptr) {
+				if (auto terrainManager = worldSpace->GetTerrainManager()) {
+					noLODLandBlend = reinterpret_cast<bool*>(terrainManager)[0x36];
+				}
+			}
+			shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kMultiTextureLandscape, true);
+			shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kReceiveShadows, true);
+
+			shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kCastShadows, true);
+			shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kNoLODLandBlend, noLODLandBlend);
+
+			shaderProperty->SetFlags(RE::BSShaderProperty::EShaderPropertyFlag8::kVertexLighting, true);
+
+			const auto& children = land->loadedData->mesh[quadIndex]->GetChildren();
+			auto geometry = children.empty() ? nullptr : static_cast<RE::BSGeometry*>(children[0].get());
+			shaderProperty->SetupGeometry(geometry);
+			if (geometry != nullptr) {
+				geometry->GetGeometryRuntimeData().properties[1] = RE::NiPointer(shaderProperty);
+			}
+
+			globals::game::smState->shadowSceneNode[0]->AttachObject(geometry);
+		}
+
+		return true;
+	}
+
+	return false;
+}
 
 struct TESForm_GetFormEditorID
 {
@@ -1550,12 +1541,8 @@ void TruePBR::PostPostLoad()
 	stl::detour_thunk<BSLightingShaderProperty_OnLoadTextureSet>(REL::RelocationID(99865, 106510));
 
 	logger::info("Hooking BSLightingShader");
-	stl::write_vfunc<0x4, BSLightingShader_SetupMaterial>(RE::VTABLE_BSLightingShader[0]);
 	stl::write_vfunc<0x6, BSLightingShader_SetupGeometry>(RE::VTABLE_BSLightingShader[0]);
 	stl::detour_thunk_ignore_func<BSLightingShader_GetPixelTechnique>(REL::RelocationID(101633, 108700));
-
-	logger::info("Hooking TESObjectLAND");
-	stl::detour_thunk<TESObjectLAND_SetupMaterial>(REL::RelocationID(18368, 18791));
 
 	logger::info("Hooking TESLandTexture");
 	stl::write_vfunc<0x32, TESForm_GetFormEditorID>(RE::VTABLE_TESLandTexture[0]);

--- a/src/TruePBR.h
+++ b/src/TruePBR.h
@@ -25,6 +25,8 @@ public:
 	void PrePass();
 	void PostPostLoad();
 	void DataLoaded();
+	bool TESObjectLAND_SetupMaterial(RE::TESObjectLAND* land);
+	bool BSLightingShader_SetupMaterial(RE::BSLightingShader* shader, RE::BSLightingShaderMaterialBase const* material);
 
 	void SetShaderResouces(ID3D11DeviceContext* a_context);
 	void GenerateShaderPermutations(RE::BSShader* shader);


### PR DESCRIPTION
Moved the hooks for:

BSLightingShader_SetupMaterial
TESObjectLand_SetupMaterial

To `hooks.cpp`. Changed the PBR functions to instance functions called from hooks. This will allow other features to tap into these hooks.

Prereq for https://github.com/doodlum/skyrim-community-shaders/pull/1028