### PR TITLE
feat: Add UI elements for unloaded features

### DIFF
--- a/src/Feature.h
+++ b/src/Feature.h
@@ -8,6 +8,7 @@ struct Feature
 
 	virtual std::string GetName() = 0;
 	virtual std::string GetShortName() = 0;
+	virtual std::string GetFeatureModLink() { return ""; }
 	virtual std::string_view GetShaderDefineName() { return ""; }
 	virtual std::vector<std::pair<std::string_view, std::string_view>> GetShaderDefineOptions() { return {}; }
 
@@ -36,6 +37,7 @@ struct Feature
 	virtual void Reset() {}
 
 	virtual void DrawSettings() {}
+	virtual void DrawUnloadedUI() {}
 
 	virtual void ReflectionsPrepass(){};
 	virtual void Prepass() {}

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -33,6 +33,11 @@ struct Feature
 	 */
 	virtual bool IsInMenu() const { return true; }
 
+	/**
+	 * Whether to print the INI version missing message when this feature is unloaded
+	 */
+	virtual bool PrintFailLoadMessage() { return true; }
+
 	virtual void SetupResources() {}
 	virtual void Reset() {}
 

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -36,7 +36,7 @@ struct Feature
 	/**
 	 * Whether to print the INI version missing message when this feature is unloaded
 	 */
-	virtual bool PrintFailLoadMessage() { return true; }
+	virtual bool DrawFailLoadMessage() const { return true; }
 
 	virtual void SetupResources() {}
 	virtual void Reset() {}

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -472,9 +472,25 @@ void Menu::DrawSettings()
 						ImGui::TextColored(themeSettings.StatusPalette.Error, feat->failedLoadedMessage.c_str());
 					}
 
-					if (!isDisabled && isLoaded) {
+					if (!isDisabled) {
 						if (ImGui::BeginChild("##FeatureConfigFrame", { 0, 0 }, true)) {
-							feat->DrawSettings();
+							if (isLoaded) {
+								// draw settings for loaded feature
+								feat->DrawSettings();
+							} else {
+								// draw any unloaded UI elements like help text about the feature
+								feat->DrawUnloadedUI();
+
+								// draw download link if available
+								if (!feat->GetFeatureModLink().empty()) {
+									// print feature download info
+									ImGui::Spacing();
+									const auto downloadText = fmt::format("Click here to download this feature ({})", feat->GetFeatureModLink());
+									if (ImGui::Selectable(downloadText.c_str())) {
+										ShellExecuteA(NULL, "open", feat->GetFeatureModLink().c_str(), NULL, NULL, SW_SHOWNORMAL);
+									}
+								}
+							}
 						}
 						ImGui::EndChild();
 					}

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -468,7 +468,7 @@ void Menu::DrawSettings()
 						ImGui::EndTable();
 					}
 
-					if (hasFailedMessage && feat->PrintFailLoadMessage()) {
+					if (hasFailedMessage && feat->DrawFailLoadMessage()) {
 						ImGui::TextColored(themeSettings.StatusPalette.Error, feat->failedLoadedMessage.c_str());
 					}
 

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -468,7 +468,7 @@ void Menu::DrawSettings()
 						ImGui::EndTable();
 					}
 
-					if (hasFailedMessage) {
+					if (hasFailedMessage && feat->PrintFailLoadMessage()) {
 						ImGui::TextColored(themeSettings.StatusPalette.Error, feat->failedLoadedMessage.c_str());
 					}
 


### PR DESCRIPTION
This PR adds 2 things:
* A new `DrawUnloadedUI()` virtual which will draw anything in the panel when the feature is unloaded (intended for help text or for some text about why you might want / not want this feature)
* A new `GetFeatureModLink()` virtual which, when a non-empty string, will be printed on unloaded features and is clickable. Clicking it opens the defined link in your browser.
* A new `DrawFailLoadMessage()` virtual which, when false, will not print red error for unloaded messages

Test cases:
* Unloaded feature that uses both these functions
* Unloaded feature that does not use these functions
* Loaded feature that does not use these functions