### PR TITLE
fix: light flags bitcasting

### DIFF
--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -326,7 +326,7 @@ void LightLimitFix::BSLightingShader_SetupGeometry_GeometrySetupConstantPointLig
 
 		SetLightPosition(light, niLight->world.translate, inWorld);
 
-		light.lightFlags = std::bit_cast<stl::enumeration<LightFlags>>(runtimeData.ambient.red);
+		light.lightFlags = std::bit_cast<LightFlags>(runtimeData.ambient.red);
 
 		if (bsLight->IsShadowLight()) {
 			auto* shadowLight = static_cast<RE::BSShadowLight*>(bsLight);
@@ -770,7 +770,7 @@ void LightLimitFix::UpdateLights()
 
 					light.radius = runtimeData.radius.x;
 
-					light.lightFlags = std::bit_cast<stl::enumeration<LightFlags>>(runtimeData.ambient.red);
+					light.lightFlags = std::bit_cast<LightFlags>(runtimeData.ambient.red);
 
 					if (!IsGlobalLight(bsLight)) {
 						// List of BSMultiBoundRooms affected by a light

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -326,7 +326,7 @@ void LightLimitFix::BSLightingShader_SetupGeometry_GeometrySetupConstantPointLig
 
 		SetLightPosition(light, niLight->world.translate, inWorld);
 
-		light.lightFlags = static_cast<LightFlags>(runtimeData.ambient.red);
+		light.lightFlags = std::bit_cast<stl::enumeration<LightFlags>>(runtimeData.ambient.red);
 
 		if (bsLight->IsShadowLight()) {
 			auto* shadowLight = static_cast<RE::BSShadowLight*>(bsLight);
@@ -770,7 +770,7 @@ void LightLimitFix::UpdateLights()
 
 					light.radius = runtimeData.radius.x;
 
-					light.lightFlags = static_cast<LightFlags>(runtimeData.ambient.red);
+					light.lightFlags = std::bit_cast<stl::enumeration<LightFlags>>(runtimeData.ambient.red);
 
 					if (!IsGlobalLight(bsLight)) {
 						// List of BSMultiBoundRooms affected by a light


### PR DESCRIPTION
Using bit_cast instead of static_casting from float to preserve bit pattern