### PR TITLE
fix: clamp weights to avoid line artifacts

### DIFF
--- a/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
+++ b/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
@@ -122,7 +122,7 @@ namespace ExtendedMaterials
 		}
 		[unroll] for (int i = 0; i < 6; i++)
 		{
-			weights[i] = pow(weights[i], heightBlend);
+			weights[i] = min(100, pow(weights[i], heightBlend));
 		}
 		float wsum = 0;
 		[unroll] for (int i = 0; i < 6; i++)
@@ -181,7 +181,7 @@ namespace ExtendedMaterials
 		}
 		[unroll] for (int i = 0; i < 6; i++)
 		{
-			weights[i] = pow(weights[i], heightBlend);
+			weights[i] = min(100, pow(weights[i], heightBlend));
 		}
 		float wsum = 0;
 		[unroll] for (int i = 0; i < 6; i++)


### PR DESCRIPTION
I tracked the lines appearing on terrain between triangles to this piece of code. Dunno exactly why the values are exploding here, but meh, it just works.