### PR TITLE
fix: sss human profile judging, using diffuse irradiance to calculate sss 

### DIFF
--- a/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSS.hlsli
+++ b/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSS.hlsli
@@ -103,6 +103,7 @@ float4 SSSSBlurCS(
 
 #if defined(HORIZONTAL)
 	colorM.rgb = Color::GammaToTrueLinear(colorM.rgb);
+	colorM.rgb = colorM.rgb / max(AlbedoTexture[DTid.xy].rgb, 0.0001);
 #endif
 
 	if (sssAmount == 0)
@@ -160,13 +161,14 @@ float4 SSSSBlurCS(
 
 #if defined(HORIZONTAL)
 		color.rgb = Color::GammaToTrueLinear(color.rgb);
+		color.rgb = color.rgb / max(AlbedoTexture[coords].rgb, 0.0001);
 #endif
 
 		float depth = DepthTexture[coords].r;
 		depth = SharedData::GetScreenDepth(depth);
 
 		// If the difference in depth is huge, we lerp color back to "colorM":
-		float s = saturate(profile.y * distanceToProjectionWindow * abs(depthM - depth));
+		float s = saturate(max(profile.y, 0.0001) * distanceToProjectionWindow * abs(depthM - depth));
 		color = lerp(color, colorM.rgb, s * s);
 
 		// Accumulate:

--- a/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSSCS.hlsl
+++ b/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSSCS.hlsl
@@ -3,6 +3,7 @@ RWTexture2D<float4> SSSRW : register(u0);
 Texture2D<float4> ColorTexture : register(t0);
 Texture2D<float4> DepthTexture : register(t1);
 Texture2D<float4> MaskTexture : register(t2);
+Texture2D<float4> AlbedoTexture : register(t3);
 
 #define SSSS_N_SAMPLES 21
 
@@ -40,6 +41,7 @@ cbuffer PerFrameSSS : register(b1)
 		bool humanProfile = MaskTexture[DTid.xy].y > 0.0;
 
 		float4 color = SSSSBlurCS(DTid.xy, texCoord, float2(0.0, 1.0), sssAmount, humanProfile);
+		color.rgb *= AlbedoTexture[DTid.xy].rgb;
 		color.rgb = Color::TrueLinearToGamma(color.rgb);
 		SSSRW[DTid.xy] = float4(color.rgb, 1.0);
 	}

--- a/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSSCS.hlsl
+++ b/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSSCS.hlsl
@@ -27,7 +27,7 @@ cbuffer PerFrameSSS : register(b1)
 #if defined(HORIZONTAL)
 
 	float sssAmount = MaskTexture[DTid.xy].x;
-	bool humanProfile = MaskTexture[DTid.xy].y == sssAmount;
+	bool humanProfile = MaskTexture[DTid.xy].y > 0.0;
 
 	float4 color = SSSSBlurCS(DTid.xy, texCoord, float2(1.0, 0.0), sssAmount, humanProfile);
 	SSSRW[DTid.xy] = max(0, color);
@@ -37,7 +37,7 @@ cbuffer PerFrameSSS : register(b1)
 	float sssAmount = MaskTexture[DTid.xy].x;
 
 	if (sssAmount > 0.0) {
-		bool humanProfile = MaskTexture[DTid.xy].y == sssAmount;
+		bool humanProfile = MaskTexture[DTid.xy].y > 0.0;
 
 		float4 color = SSSSBlurCS(DTid.xy, texCoord, float2(0.0, 1.0), sssAmount, humanProfile);
 		color.rgb = Color::TrueLinearToGamma(color.rgb);

--- a/src/Features/SubsurfaceScattering.cpp
+++ b/src/Features/SubsurfaceScattering.cpp
@@ -190,18 +190,20 @@ void SubsurfaceScattering::DrawSSS()
 
 		auto depth = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kPOST_ZPREPASS_COPY];
 		auto mask = renderer->GetRuntimeData().renderTargets[MASKS];
+		auto albedo = renderer->GetRuntimeData().renderTargets[ALBEDO];
 
 		ID3D11UnorderedAccessView* uav = blurHorizontalTemp->uav.get();
 		context->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
 
 		auto terrainBlending = globals::features::terrainBlending;
 
-		ID3D11ShaderResourceView* views[3];
+		ID3D11ShaderResourceView* views[4];
 		views[0] = main.SRV;
 		views[1] = terrainBlending->loaded ? terrainBlending->blendedDepthTexture16->srv.get() : depth.depthSRV,
 		views[2] = mask.SRV;
+		views[3] = albedo.SRV;
 
-		context->CSSetShaderResources(0, 3, views);
+		context->CSSetShaderResources(0, 4, views);
 
 		// Horizontal pass to temporary texture
 		{
@@ -221,7 +223,8 @@ void SubsurfaceScattering::DrawSSS()
 			TracyD3D11Zone(globals::state->tracyCtx, "Subsurface Scattering - Vertical");
 
 			views[0] = blurHorizontalTemp->srv.get();
-			context->CSSetShaderResources(0, 1, views);
+			views[3] = albedo.SRV;
+			context->CSSetShaderResources(0, 4, views);
 
 			ID3D11UnorderedAccessView* uavs[1] = { main.UAV };
 			context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
@@ -236,8 +239,8 @@ void SubsurfaceScattering::DrawSSS()
 	ID3D11Buffer* buffer = nullptr;
 	context->CSSetConstantBuffers(1, 1, &buffer);
 
-	ID3D11ShaderResourceView* views[3]{ nullptr, nullptr, nullptr };
-	context->CSSetShaderResources(0, 3, views);
+	ID3D11ShaderResourceView* views[4]{ nullptr, nullptr, nullptr, nullptr };
+	context->CSSetShaderResources(0, 4, views);
 
 	ID3D11UnorderedAccessView* uavs[1]{ nullptr };
 	context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);


### PR DESCRIPTION
two fixes:
1. prevent artifacts if human skin texture has a noisy alpha channel (which is common in mod skins)
2. using diffuse irradiance instead of diffuse light to calculate sss, by dividing albedo before then multiply it after.