### PR TITLE
fix: human profile judging when skin alpha is not fully 1

### DIFF
--- a/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSSCS.hlsl
+++ b/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSSCS.hlsl
@@ -27,7 +27,7 @@ cbuffer PerFrameSSS : register(b1)
 #if defined(HORIZONTAL)
 
 	float sssAmount = MaskTexture[DTid.xy].x;
-	bool humanProfile = MaskTexture[DTid.xy].y == sssAmount;
+	bool humanProfile = MaskTexture[DTid.xy].y > 0.0;
 
 	float4 color = SSSSBlurCS(DTid.xy, texCoord, float2(1.0, 0.0), sssAmount, humanProfile);
 	SSSRW[DTid.xy] = max(0, color);
@@ -37,7 +37,7 @@ cbuffer PerFrameSSS : register(b1)
 	float sssAmount = MaskTexture[DTid.xy].x;
 
 	if (sssAmount > 0.0) {
-		bool humanProfile = MaskTexture[DTid.xy].y == sssAmount;
+		bool humanProfile = MaskTexture[DTid.xy].y > 0.0;
 
 		float4 color = SSSSBlurCS(DTid.xy, texCoord, float2(0.0, 1.0), sssAmount, humanProfile);
 		color.rgb = Color::LinearToGamma(color.rgb);


### PR DESCRIPTION
fix sss causing artifacts when skin texture has an alpha channel which is not strictly 1
(happens for some trending mod skins)