### PR TITLE
fix(VR): fix volumetric lighting movement

### DIFF
--- a/src/Features/VolumetricLighting.cpp
+++ b/src/Features/VolumetricLighting.cpp
@@ -18,7 +18,6 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	InteriorQuality,
 	InteriorCustomSize);
 
-
 void VolumetricLighting::DrawSettings()
 {
 	if (ImGui::TreeNodeEx("Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
@@ -33,7 +32,7 @@ void VolumetricLighting::DrawSettings()
 
 		if (settings.InteriorEnabled)
 			DrawVolumetricLightingSettings(settings.InteriorQuality, settings.InteriorCustomSize, true, inInterior);
-		
+
 		ImGui::Spacing();
 		ImGui::TreePop();
 	}
@@ -42,7 +41,7 @@ void VolumetricLighting::DrawSettings()
 void VolumetricLighting::DrawVolumetricLightingSettings(int32_t& quality, TextureSize& customSize, const bool isInterior, const bool inLocationType)
 {
 	auto& [Width, Height, Depth] = FetchCurrentSizeInUnits(isInterior);
-	
+
 	if (ImGui::SliderInt(isInterior ? "Interior Quality" : "Exterior Quality", &quality, 0, static_cast<uint8_t>(Quality::Count) - 1, QualityNames[quality])) {
 		if (inLocationType)
 			SetupVL();
@@ -74,7 +73,8 @@ void VolumetricLighting::DrawVolumetricLightingSettings(int32_t& quality, Textur
 		ImGui::EndDisabled();
 }
 
-inline const char* VolumetricLighting::FromUnits(const int32_t value, const int32_t unitScale) {
+inline const char* VolumetricLighting::FromUnits(const int32_t value, const int32_t unitScale)
+{
 	static std::string s;
 	s = std::to_string(value * unitScale);
 	return s.c_str();
@@ -165,11 +165,11 @@ void VolumetricLighting::PostPostLoad()
 		logger::info("[{}] Hooking CopyResource at {:x}", GetName(), address);
 		REL::safe_fill(address, REL::NOP, 7);
 		stl::write_thunk_call<CopyResource>(address);
-		
+
 		// Skip volumetric lighting rendering
 		REL::safe_write(REL::RelocationID(35560, 0).address() + REL::Relocate(0x254, 0), &REL::JMP8, 1);
 		// Move it to render after depth to ensure camera matches rest of scene
-		stl::write_thunk_call<RenderDepth>(REL::RelocationID(35560, 0).address() + REL::Relocate(0x2EE, 0));	
+		stl::write_thunk_call<RenderDepth>(REL::RelocationID(35560, 0).address() + REL::Relocate(0x2EE, 0));
 	}
 
 	bEnableVolumetricLighting = reinterpret_cast<bool*>(REL::VariantOffset(0x3232EF0, 0x338C544, 0x3485362).address());
@@ -202,8 +202,7 @@ void VolumetricLighting::SetupVL()
 			*bEnableVolumetricLighting = settings.InteriorEnabled && inInteriorWithSunShadows;
 		*gVolumetricLightingSizeHigh = static_cast<Quality>(settings.InteriorQuality) == Quality::Custom ? settings.InteriorCustomSize : defaultSizeHigh;
 		SetVLQuality(GetVLDescriptor(), settings.InteriorQuality);
-	}
-	else {
+	} else {
 		if (globals::game::isVR)
 			SetBooleanSettings(hiddenVRSettings, GetName(), settings.ExteriorEnabled);
 		else

--- a/src/Features/VolumetricLighting.cpp
+++ b/src/Features/VolumetricLighting.cpp
@@ -172,16 +172,16 @@ void VolumetricLighting::PostPostLoad()
 		stl::write_thunk_call<RenderDepth>(REL::RelocationID(35560, 0).address() + REL::Relocate(0x2EE, 0));
 	}
 
-	bEnableVolumetricLighting = reinterpret_cast<bool*>(REL::VariantOffset(0x3232EF0, 0x338C544, 0x3485362).address());
-	gVolumetricLightingSizeLow = reinterpret_cast<TextureSize*>(REL::VariantOffset(0x3233090, 0x338C550, 0x3485630).address());
-	gVolumetricLightingSizeMedium = reinterpret_cast<TextureSize*>(REL::VariantOffset(0x323309C, 0x338C55C, 0x348563C).address());
-	gVolumetricLightingSizeHigh = reinterpret_cast<TextureSize*>(REL::VariantOffset(0x32330A8, 0x338C568, 0x3485648).address());
+	bEnableVolumetricLighting = reinterpret_cast<bool*>(REL::RelocationID(527940, 414913).address());
+	gVolumetricLightingSizeLow = reinterpret_cast<TextureSize*>(REL::RelocationID(527970, 414916).address());
+	gVolumetricLightingSizeMedium = reinterpret_cast<TextureSize*>(REL::RelocationID(527973, 414919).address());
+	gVolumetricLightingSizeHigh = reinterpret_cast<TextureSize*>(REL::RelocationID(527976, 414922).address());
 	defaultSizeHigh = *gVolumetricLightingSizeHigh;
 }
 
 void VolumetricLighting::EarlyPrepass()
 {
-	const auto interiorCell = RE::TES::GetSingleton()->interiorCell;
+	const auto interiorCell = globals::game::tes->interiorCell;
 	const bool currentlyInInterior = interiorCell != nullptr;
 
 	if (initialised && currentlyInInterior == inInterior)

--- a/src/Features/VolumetricLighting.cpp
+++ b/src/Features/VolumetricLighting.cpp
@@ -1,53 +1,146 @@
 #include "VolumetricLighting.h"
 
 #include "ShaderCache.h"
+#include "State.h"
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+	VolumetricLighting::TextureSize,
+	Width,
+	Height,
+	Depth);
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	VolumetricLighting::Settings,
-	EnabledVL);
+	ExteriorEnabled,
+	ExteriorQuality,
+	ExteriorCustomSize,
+	InteriorEnabled,
+	InteriorQuality,
+	InteriorCustomSize);
+
 
 void VolumetricLighting::DrawSettings()
 {
 	if (ImGui::TreeNodeEx("Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
-		if (globals::game::isVR) {
-			if (ImGui::Checkbox("Enable Volumetric Lighting in VR", reinterpret_cast<bool*>(&settings.EnabledVL))) {
-				if (auto _tt = Util::HoverTooltipWrapper()) {
-					ImGui::Text("Enable Volumetric Lighting in VR");
-				}
-				SetBooleanSettings(hiddenVRSettings, GetName(), settings.EnabledVL);
-			}
-			if (settings.EnabledVL) {
-				RenderImGuiSettingsTree(VLSettings, "Skyrim Settings");
-			}
-		}
+		if (ImGui::Checkbox("Enable Volumetric Lighting in Exteriors", &settings.ExteriorEnabled))
+			SetupVL();
+
+		if (settings.ExteriorEnabled)
+			DrawVolumetricLightingSettings(settings.ExteriorQuality, settings.ExteriorCustomSize, false, !inInterior);
+
+		if (ImGui::Checkbox("Enable Volumetric Lighting in Interiors", &settings.InteriorEnabled))
+			SetupVL();
+
+		if (settings.InteriorEnabled)
+			DrawVolumetricLightingSettings(settings.InteriorQuality, settings.InteriorCustomSize, true, inInterior);
+		
 		ImGui::Spacing();
 		ImGui::TreePop();
 	}
 }
 
+void VolumetricLighting::DrawVolumetricLightingSettings(int32_t& quality, TextureSize& customSize, const bool isInterior, const bool inLocationType)
+{
+	auto& [Width, Height, Depth] = FetchCurrentSizeInUnits(isInterior);
+	
+	if (ImGui::SliderInt(isInterior ? "Interior Quality" : "Exterior Quality", &quality, 0, static_cast<uint8_t>(Quality::Count) - 1, QualityNames[quality])) {
+		if (inLocationType)
+			SetupVL();
+	}
+
+	const bool isCustomQuality = static_cast<Quality>(quality) == Quality::Custom;
+	if (!isCustomQuality)
+		ImGui::BeginDisabled();
+
+	if (ImGui::SliderInt(isInterior ? "Interior Width" : "Exterior Width", &Width, 1, 20, FromUnits(Width, 32), ImGuiSliderFlags_AlwaysClamp | ImGuiSliderFlags_NoInput)) {
+		customSize.Width = Width * 32;
+		if (inLocationType)
+			SetupVL();
+	}
+
+	if (ImGui::SliderInt(isInterior ? "Interior Height" : "Exterior Height", &Height, 1, 20, FromUnits(Height, 32), ImGuiSliderFlags_AlwaysClamp | ImGuiSliderFlags_NoInput)) {
+		customSize.Height = Height * 32;
+		if (inLocationType)
+			SetupVL();
+	}
+
+	if (ImGui::SliderInt(isInterior ? "Interior Depth" : "Exterior Depth", &Depth, 1, 64, FromUnits(Depth, 10), ImGuiSliderFlags_AlwaysClamp | ImGuiSliderFlags_NoInput)) {
+		customSize.Depth = Depth * 10;
+		if (inLocationType)
+			SetupVL();
+	}
+
+	if (!isCustomQuality)
+		ImGui::EndDisabled();
+}
+
+inline const char* VolumetricLighting::FromUnits(const int32_t value, const int32_t unitScale) {
+	static std::string s;
+	s = std::to_string(value * unitScale);
+	return s.c_str();
+}
+
+VolumetricLighting::TextureSize& VolumetricLighting::FetchCurrentSizeInUnits(const bool interior)
+{
+	auto& size = interior ? interiorSizeInUnits : exteriorSizeInUnits;
+	if (interior) {
+		switch (static_cast<Quality>(settings.InteriorQuality)) {
+		case Quality::Low:
+			size = *gVolumetricLightingSizeLow;
+			break;
+		case Quality::Medium:
+			size = *gVolumetricLightingSizeMedium;
+			break;
+		case Quality::High:
+			size = defaultSizeHigh;
+			break;
+		case Quality::Custom:
+			size = settings.InteriorCustomSize;
+			break;
+		default:
+			break;
+		}
+	} else {
+		switch (static_cast<Quality>(settings.ExteriorQuality)) {
+		case Quality::Low:
+			size = *gVolumetricLightingSizeLow;
+			break;
+		case Quality::Medium:
+			size = *gVolumetricLightingSizeMedium;
+			break;
+		case Quality::High:
+			size = defaultSizeHigh;
+			break;
+		case Quality::Custom:
+			size = settings.ExteriorCustomSize;
+			break;
+		default:
+			break;
+		}
+	}
+
+	size.Height /= 32;
+	size.Width /= 32;
+	size.Depth /= 10;
+
+	return size;
+}
+
 void VolumetricLighting::LoadSettings(json& o_json)
 {
 	settings = o_json;
-	if (globals::game::isVR) {
-		Util::LoadGameSettings(VLSettings);
-	}
 }
 
 void VolumetricLighting::SaveSettings(json& o_json)
 {
 	o_json = settings;
-	if (globals::game::isVR) {
-		Util::SaveGameSettings(VLSettings);
-	}
 }
 
 void VolumetricLighting::RestoreDefaultSettings()
 {
 	settings = {};
-	if (globals::game::isVR) {
-		Util::ResetGameSettingsToDefaults(VLSettings);
+	if (globals::game::isVR)
 		Util::ResetGameSettingsToDefaults(hiddenVRSettings);
-	}
 }
 
 void VolumetricLighting::DataLoaded()
@@ -66,15 +159,84 @@ void VolumetricLighting::DataLoaded()
 void VolumetricLighting::PostPostLoad()
 {
 	if (REL::Module::IsVR()) {
-		if (settings.EnabledVL)
+		if (settings.ExteriorEnabled || settings.InteriorEnabled)
 			EnableBooleanSettings(hiddenVRSettings, GetName());
 		auto address = REL::RelocationID(100475, 0).address() + 0x45b;  // AE not needed, VR only hook
 		logger::info("[{}] Hooking CopyResource at {:x}", GetName(), address);
 		REL::safe_fill(address, REL::NOP, 7);
 		stl::write_thunk_call<CopyResource>(address);
+		
+		// Skip volumetric lighting rendering
+		REL::safe_write(REL::RelocationID(35560, 0).address() + REL::Relocate(0x254, 0), &REL::JMP8, 1);
+		// Move it to render after depth to ensure camera matches rest of scene
+		stl::write_thunk_call<RenderDepth>(REL::RelocationID(35560, 0).address() + REL::Relocate(0x2EE, 0));	
+	}
+
+	bEnableVolumetricLighting = reinterpret_cast<bool*>(REL::VariantOffset(0x3232EF0, 0x338C544, 0x3485362).address());
+	gVolumetricLightingSizeLow = reinterpret_cast<TextureSize*>(REL::VariantOffset(0x3233090, 0x338C550, 0x3485630).address());
+	gVolumetricLightingSizeMedium = reinterpret_cast<TextureSize*>(REL::VariantOffset(0x323309C, 0x338C55C, 0x348563C).address());
+	gVolumetricLightingSizeHigh = reinterpret_cast<TextureSize*>(REL::VariantOffset(0x32330A8, 0x338C568, 0x3485648).address());
+	defaultSizeHigh = *gVolumetricLightingSizeHigh;
+}
+
+void VolumetricLighting::EarlyPrepass()
+{
+	const auto interiorCell = RE::TES::GetSingleton()->interiorCell;
+	const bool currentlyInInterior = interiorCell != nullptr;
+
+	if (initialised && currentlyInInterior == inInterior)
+		return;
+
+	initialised = true;
+	inInterior = currentlyInInterior;
+	inInteriorWithSunShadows = interiorCell && interiorCell->cellFlags.all(RE::TESObjectCELL::Flag::kIsInteriorCell, RE::TESObjectCELL::Flag::kShowSky, RE::TESObjectCELL::Flag::kUseSkyLighting);
+	SetupVL();
+}
+
+void VolumetricLighting::SetupVL()
+{
+	if (inInterior) {
+		if (globals::game::isVR)
+			SetBooleanSettings(hiddenVRSettings, GetName(), settings.InteriorEnabled && inInteriorWithSunShadows);
+		else
+			*bEnableVolumetricLighting = settings.InteriorEnabled && inInteriorWithSunShadows;
+		*gVolumetricLightingSizeHigh = static_cast<Quality>(settings.InteriorQuality) == Quality::Custom ? settings.InteriorCustomSize : defaultSizeHigh;
+		SetVLQuality(GetVLDescriptor(), settings.InteriorQuality);
+	}
+	else {
+		if (globals::game::isVR)
+			SetBooleanSettings(hiddenVRSettings, GetName(), settings.ExteriorEnabled);
+		else
+			*bEnableVolumetricLighting = settings.ExteriorEnabled;
+		*gVolumetricLightingSizeHigh = static_cast<Quality>(settings.ExteriorQuality) == Quality::Custom ? settings.ExteriorCustomSize : defaultSizeHigh;
+		SetVLQuality(GetVLDescriptor(), settings.ExteriorQuality);
 	}
 }
 
-void VolumetricLighting::Reset()
+VolumetricLighting::VolumetricLightingDescriptor& VolumetricLighting::GetVLDescriptor()
 {
+	using func_t = decltype(&VolumetricLighting::GetVLDescriptor);
+	static REL::Relocation<func_t> func{ REL::RelocationID(100297, 107014) };
+	return func();
+}
+
+void VolumetricLighting::SetVLQuality(VolumetricLightingDescriptor& descriptor, const uint32_t quality)
+{
+	using func_t = decltype(&VolumetricLighting::SetVLQuality);
+	static REL::Relocation<func_t> func{ REL::RelocationID(100299, 107016).address() };
+	func(descriptor, std::clamp<uint32_t>(quality, 0, 2));
+}
+
+void VolumetricLighting::RenderVolumetricLighting(VolumetricLightingDescriptor* descriptor, RE::NiCamera* camera, bool flag)
+{
+	using func_t = decltype(&VolumetricLighting::RenderVolumetricLighting);
+	static REL::Relocation<func_t> func{ REL::RelocationID(100306, 0) };
+	func(descriptor, camera, flag);
+}
+
+void VolumetricLighting::RenderDepth::thunk()
+{
+	func();
+	if (*GetSingleton()->bEnableVolumetricLighting)
+		RenderVolumetricLighting(&GetVLDescriptor(), RE::Main::WorldRootCamera(), false);
 }

--- a/src/Features/VolumetricLighting.h
+++ b/src/Features/VolumetricLighting.h
@@ -89,9 +89,10 @@ public:
 		static void thunk();
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
-	
+
 private:
-	struct VolumetricLightingDescriptor {};
+	struct VolumetricLightingDescriptor
+	{};
 
 	static const char* FromUnits(int32_t value, int32_t unitScale);
 	static VolumetricLightingDescriptor& GetVLDescriptor();

--- a/src/Features/VolumetricLighting.h
+++ b/src/Features/VolumetricLighting.h
@@ -11,9 +11,9 @@ public:
 
 	struct TextureSize
 	{
-		std::int32_t Width = 320;
-		std::int32_t Height = 192;
-		std::int32_t Depth = 90;
+		int32_t Width = 320;
+		int32_t Height = 192;
+		int32_t Depth = 90;
 	};
 
 	struct Settings

--- a/src/Features/VolumetricLighting.h
+++ b/src/Features/VolumetricLighting.h
@@ -9,9 +9,21 @@ public:
 		return &singleton;
 	}
 
+	struct TextureSize
+	{
+		std::int32_t Width = 320;
+		std::int32_t Height = 192;
+		std::int32_t Depth = 90;
+	};
+
 	struct Settings
 	{
-		uint EnabledVL = true;
+		bool ExteriorEnabled = true;
+		int32_t ExteriorQuality = 2;
+		TextureSize ExteriorCustomSize;
+		bool InteriorEnabled = true;
+		int32_t InteriorQuality = 2;
+		TextureSize InteriorCustomSize;
 	};
 
 	Settings settings;
@@ -21,18 +33,13 @@ public:
 	virtual inline std::string GetName() override { return "Volumetric Lighting"; }
 	virtual inline std::string GetShortName() override { return "VolumetricLighting"; }
 
-	virtual void Reset() override;
-
 	virtual void SaveSettings(json&) override;
 	virtual void LoadSettings(json&) override;
 	virtual void RestoreDefaultSettings() override;
 	virtual void DrawSettings() override;
 	virtual void DataLoaded() override;
 	virtual void PostPostLoad() override;
-
-	std::map<std::string, Util::GameSetting> VLSettings{
-		{ "iVolumetricLightingQuality:Display", { "Lighting Quality", "Adjusts the quality of volumetric lighting. [-1,-2] (off, low, mid, high).", REL::Relocate<uintptr_t>(0, 0, 0x1ed4030), 1, -1, 2 } },
-	};
+	virtual void EarlyPrepass() override;
 
 	std::map<std::string, Util::GameSetting> hiddenVRSettings{
 		{ "bEnableVolumetricLighting:Display", { "Enable VL Shaders (INI) ",
@@ -70,10 +77,52 @@ public:
 			// used in the next frame.
 
 			auto* singleton = GetSingleton();
-			if (singleton && !(Util::IsDynamicResolution() && singleton->settings.EnabledVL)) {
+			if (singleton && !(Util::IsDynamicResolution() && *singleton->bEnableVolumetricLighting)) {
 				a_this->CopyResource(a_renderTarget, a_renderTargetSource);
 			}
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
+
+	struct RenderDepth
+	{
+		static void thunk();
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+	
+private:
+	struct VolumetricLightingDescriptor {};
+
+	static const char* FromUnits(int32_t value, int32_t unitScale);
+	static VolumetricLightingDescriptor& GetVLDescriptor();
+	static void SetVLQuality(VolumetricLightingDescriptor& descriptor, std::uint32_t quality);
+	static void RenderVolumetricLighting(VolumetricLightingDescriptor* descriptor, RE::NiCamera* camera, bool flag);
+
+	void DrawVolumetricLightingSettings(int32_t& quality, TextureSize& customSize, bool isInterior, bool inLocationType);
+	TextureSize& FetchCurrentSizeInUnits(bool interior);
+	void SetupVL();
+
+	enum class Quality : uint8_t
+	{
+		Low,
+		Medium,
+		High,
+		Custom,
+		Count
+	};
+
+	const char* QualityNames[static_cast<uint8_t>(Quality::Count)] = { "Low", "Medium", "High", "Custom" };
+
+	TextureSize exteriorSizeInUnits;
+	TextureSize interiorSizeInUnits;
+	TextureSize defaultSizeHigh;
+
+	bool* bEnableVolumetricLighting = nullptr;
+	TextureSize* gVolumetricLightingSizeHigh = nullptr;
+	TextureSize* gVolumetricLightingSizeMedium = nullptr;
+	TextureSize* gVolumetricLightingSizeLow = nullptr;
+
+	bool initialised = false;
+	bool inInterior = false;
+	bool inInteriorWithSunShadows = false;
 };


### PR DESCRIPTION
* Fixes VL appearing to follow camera movement in VR, shifted just after depth rendering to ensure updated camera matrices are used
* Fixes issues with adjusting VL quality in VR
* VR executable cannot read VL ini settings, added ability to select between default low/medium/high quality presets as well as specifying custom dimensions
* VL is toggleable for interiors/exteriors separately each with their own settings
* Setting adjustments ported to SE/AE too
