### PR TITLE
feat: add a strength slider for vanilla character light

### DIFF
--- a/src/Features/SubsurfaceScattering.cpp
+++ b/src/Features/SubsurfaceScattering.cpp
@@ -11,6 +11,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(SubsurfaceScattering::DiffusionP
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	SubsurfaceScattering::Settings,
 	EnableCharacterLighting,
+	CharacterLightingStrength,
 	BaseProfile,
 	HumanProfile)
 
@@ -20,6 +21,9 @@ void SubsurfaceScattering::DrawSettings()
 		ImGui::Checkbox("Enable Character Lighting", (bool*)&settings.EnableCharacterLighting);
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Vanilla feature, not recommended.");
+		}
+		if (settings.EnableCharacterLighting) {
+			ImGui::SliderFloat("Strength", &settings.CharacterLightingStrength, 0, 5, "%.2f");
 		}
 
 		if (ImGui::TreeNodeEx("Base Profile", ImGuiTreeNodeFlags_DefaultOpen)) {
@@ -279,6 +283,12 @@ void SubsurfaceScattering::Reset()
 	auto shaderManager = globals::game::smState;
 	auto shaderCache = globals::shaderCache;
 	shaderManager->characterLightEnabled = shaderCache->IsEnabled() ? settings.EnableCharacterLighting : true;
+	if (shaderManager->characterLightEnabled) {
+		if (CharacterLightingStrengthOriginal == -1.0f) {
+			CharacterLightingStrengthOriginal = shaderManager->characterLightParams[2];
+		}
+		shaderManager->characterLightParams[2] = settings.CharacterLightingStrength * CharacterLightingStrengthOriginal;
+	}
 
 	if (updateKernels) {
 		updateKernels = false;

--- a/src/Features/SubsurfaceScattering.h
+++ b/src/Features/SubsurfaceScattering.h
@@ -22,11 +22,14 @@ public:
 	struct Settings
 	{
 		uint EnableCharacterLighting = false;
+		float CharacterLightingStrength = 1.0f;
 		DiffusionProfile BaseProfile{ 0.5f, 1.0f, { 0.48f, 0.41f, 0.28f }, { 0.56f, 0.56f, 0.56f } };
 		DiffusionProfile HumanProfile{ 1.0f, 1.0f, { 0.48f, 0.41f, 0.28f }, { 1.0f, 0.37f, 0.3f } };
 	};
 
 	Settings settings;
+
+	float CharacterLightingStrengthOriginal = -1.0f;
 
 	struct alignas(16) Kernel
 	{


### PR DESCRIPTION
add a strength slider for vanilla character light, asked by some users
pretty harmless