### PR TITLE
fix(terrainhelper): add thread safety for extended slots

### DIFF
--- a/src/Features/TerrainHelper.cpp
+++ b/src/Features/TerrainHelper.cpp
@@ -52,13 +52,6 @@ bool TerrainHelper::TESObjectLAND_SetupMaterial(RE::TESObjectLAND* land)
 			continue;
 		}
 
-		{
-			const std::lock_guard<std::mutex> lock(extendedSlotsMutex);
-			if (!extendedSlots.contains(hashKey)) {
-				extendedSlots[hashKey] = {};
-			}
-		}
-
 		// Create array of texture sets (6 tiles)
 		std::array<RE::BGSTextureSet*, 6> textureSets;
 		auto defTexture = land->loadedData->defQuadTextures[quadI];
@@ -84,15 +77,19 @@ bool TerrainHelper::TESObjectLAND_SetupMaterial(RE::TESObjectLAND* land)
 		}
 
 		// Assign textures to material
-		for (uint32_t textureI = 0; textureI < 6; ++textureI) {
-			if (textureSets[textureI] == nullptr) {
-				continue;
-			}
+		{
+			const std::unique_lock lock(extendedSlotsMutex);
+			auto& slot = extendedSlots.try_emplace(hashKey).first->second;
 
-			auto txSet = textureSets[textureI];
-			if (txSet->GetTexturePath(static_cast<RE::BSTextureSet::Texture>(3)) != nullptr) {
-				const std::lock_guard<std::mutex> lock(extendedSlotsMutex);
-				txSet->SetTexture(static_cast<RE::BSTextureSet::Texture>(3), extendedSlots[hashKey].parallax[textureI]);
+			for (uint32_t textureI = 0; textureI < 6; ++textureI) {
+				if (textureSets[textureI] == nullptr) {
+					continue;
+				}
+
+				auto txSet = textureSets[textureI];
+				if (txSet->GetTexturePath(static_cast<RE::BSTextureSet::Texture>(3)) != nullptr) {
+					txSet->SetTexture(static_cast<RE::BSTextureSet::Texture>(3), slot.parallax[textureI]);
+				}
 			}
 		}
 	}
@@ -140,7 +137,7 @@ void TerrainHelper::BSLightingShader_SetupMaterial(RE::BSLightingShaderMaterialB
 
 	ExtendedSlots materialBase;
 	{
-		const std::lock_guard<std::mutex> lock(extendedSlotsMutex);
+		const std::shared_lock lock(extendedSlotsMutex);
 
 		if (!extendedSlots.contains(material->hashKey)) {
 			// hash does not exists

--- a/src/Features/TerrainHelper.cpp
+++ b/src/Features/TerrainHelper.cpp
@@ -52,8 +52,11 @@ bool TerrainHelper::TESObjectLAND_SetupMaterial(RE::TESObjectLAND* land)
 			continue;
 		}
 
-		if (!extendedSlots.contains(hashKey)) {
-			extendedSlots[hashKey] = {};
+		{
+			const std::lock_guard<std::mutex> lock(extendedSlotsMutex);
+			if (!extendedSlots.contains(hashKey)) {
+				extendedSlots[hashKey] = {};
+			}
 		}
 
 		// Create array of texture sets (6 tiles)
@@ -88,6 +91,7 @@ bool TerrainHelper::TESObjectLAND_SetupMaterial(RE::TESObjectLAND* land)
 
 			auto txSet = textureSets[textureI];
 			if (txSet->GetTexturePath(static_cast<RE::BSTextureSet::Texture>(3)) != nullptr) {
+				const std::lock_guard<std::mutex> lock(extendedSlotsMutex);
 				txSet->SetTexture(static_cast<RE::BSTextureSet::Texture>(3), extendedSlots[hashKey].parallax[textureI]);
 			}
 		}
@@ -134,12 +138,17 @@ void TerrainHelper::BSLightingShader_SetupMaterial(RE::BSLightingShaderMaterialB
 		return;
 	}
 
-	if (!extendedSlots.contains(material->hashKey)) {
-		// hash does not exists
-		return;
+	ExtendedSlots materialBase;
+	{
+		const std::lock_guard<std::mutex> lock(extendedSlotsMutex);
+
+		if (!extendedSlots.contains(material->hashKey)) {
+			// hash does not exists
+			return;
+		}
+		materialBase = extendedSlots[material->hashKey];
 	}
 
-	const auto materialBase = extendedSlots[material->hashKey];
 	const auto state = globals::state;
 	const auto& stateData = globals::game::graphicsState->GetRuntimeData();
 

--- a/src/Features/TerrainHelper.h
+++ b/src/Features/TerrainHelper.h
@@ -21,7 +21,7 @@ struct TerrainHelper : Feature
 		std::array<RE::NiSourceTexturePtr, 6> parallax;
 	};
 
-	std::mutex extendedSlotsMutex;
+	std::shared_mutex extendedSlotsMutex;
 	std::unordered_map<uint32_t, ExtendedSlots> extendedSlots;
 	RE::BGSTextureSet* defaultLandTexture;
 

--- a/src/Features/TerrainHelper.h
+++ b/src/Features/TerrainHelper.h
@@ -21,6 +21,7 @@ struct TerrainHelper : Feature
 		std::array<RE::NiSourceTexturePtr, 6> parallax;
 	};
 
+	std::mutex extendedSlotsMutex;
 	std::unordered_map<uint32_t, ExtendedSlots> extendedSlots;
 	RE::BGSTextureSet* defaultLandTexture;
 


### PR DESCRIPTION
Missed this in my original PR

This PR simply adds mutex locking for operations on the global extended slots map which is used to store the extended height textures.