### PR TITLE
fix: load default settings for feature if no saved settings

### DIFF
--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -32,6 +32,9 @@ void Feature::Load(json& o_json)
 			logger::warn("Invalid settings for {}, using default.", GetName());
 			RestoreDefaultSettings();
 		}
+	} else {
+		logger::info("Loading default settings for {}", GetName());
+		RestoreDefaultSettings();
 	}
 
 	// Convert string to wstring


### PR DESCRIPTION
for now, features with a customized `RestoreDefaultSettings()` (when it's not just `settings = {};`) will not load default settings when initialized. this should fix it.
it may not affect current features, but might work for future features.