### PR TITLE
feat: VR depth buffer culling fix

### DIFF
--- a/features/VR/Shaders/Features/VR.ini
+++ b/features/VR/Shaders/Features/VR.ini
@@ -1,0 +1,2 @@
+[Info]
+Version = 1-0-0

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -18,6 +18,7 @@
 #include "Features/TerrainBlending.h"
 #include "Features/TerrainHelper.h"
 #include "Features/TerrainShadows.h"
+#include "Features/VR.h"
 #include "Features/VolumetricLighting.h"
 #include "Features/WaterEffects.h"
 #include "Features/WetnessEffects.h"
@@ -149,10 +150,13 @@ const std::vector<Feature*>& Feature::GetFeatureList()
 		globals::features::hairSpecular
 	};
 
-	static std::vector<Feature*> featuresVR(features);
-	std::erase_if(featuresVR, [](Feature* a) {
-		return !a->SupportsVR();
-	});
+	static std::vector<Feature*> featuresVR = [] {
+		auto v = features;
+		v.push_back(globals::features::vr);
+		std::erase_if(v, [](Feature* a) { return !a->SupportsVR(); });
+		return v;
+	}();
+
 	return (REL::Module::IsVR() && !globals::state->IsDeveloperMode()) ? featuresVR : features;
 }
 

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -1,0 +1,60 @@
+﻿#include "VR.h"
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+	VR::Settings,
+	EnableDepthBufferCulling,
+	MinOccludeeBoxExtent)
+
+void VR::DrawSettings()
+{
+	if (ImGui::Checkbox("Enable Depth Buffer Culling", &settings.EnableDepthBufferCulling))
+		*gDepthBufferCulling = settings.EnableDepthBufferCulling;
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text(
+			"Enables a depth buffer culling solution that checks object bounds against the depth buffer before rendering. "
+			"Provides a significant performance boost and includes fixes for game engine bugs. ");
+	}
+
+	if (settings.EnableDepthBufferCulling) {
+		if (ImGui::SliderFloat("Min Occludee Box Extent", &settings.MinOccludeeBoxExtent, 0.1f, 500.0f, "%.1f"))
+			*gMinOccludeeBoxExtent = settings.MinOccludeeBoxExtent;
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text(
+				"Sets the minimum bounding box size to use for objects when testing them against the depth buffer. "
+				"Helps prevent small objects from flickering due to precision issues. "
+				"Lower values will give better performance. ");
+		}
+	}
+}
+
+void VR::LoadSettings(json& o_json)
+{
+	settings = o_json;
+}
+
+void VR::SaveSettings(json& o_json)
+{
+	o_json = settings;
+}
+
+void VR::RestoreDefaultSettings()
+{
+	settings = {};
+}
+
+void VR::PostPostLoad()
+{
+	gDepthBufferCulling = reinterpret_cast<bool*>(REL::Offset(0x1EC6B88).address());
+	gMinOccludeeBoxExtent = reinterpret_cast<float*>(REL::Offset(0x1ED64E8).address());
+
+	// Patches BSGeometry::CopyTransformAndBounds to copy the model-bound translation across correctly instead of overwriting it with the bounding sphere centre
+	REL::safe_write(REL::RelocationID(0, 0, 69528).address() + REL::Relocate(0, 0, 0xD9) + 0x2, 0x148);
+	REL::safe_write(REL::RelocationID(0, 0, 69528).address() + REL::Relocate(0, 0, 0xE5) + 0x2, 0x14C);
+	REL::safe_write(REL::RelocationID(0, 0, 69528).address() + REL::Relocate(0, 0, 0xF1) + 0x2, 0x150);
+}
+
+void VR::DataLoaded()
+{
+	*gDepthBufferCulling = settings.EnableDepthBufferCulling;
+	*gMinOccludeeBoxExtent = settings.MinOccludeeBoxExtent;
+}

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -1,0 +1,37 @@
+#pragma once
+
+struct VR : Feature
+{
+	static VR* GetSingleton()
+	{
+		static VR singleton;
+		return &singleton;
+	}
+
+	virtual inline std::string GetName() override { return "VR"; }
+	virtual inline std::string GetShortName() override { return "VR"; }
+
+	struct Settings
+	{
+		bool EnableDepthBufferCulling = true;
+		float MinOccludeeBoxExtent = 10.0f;
+	};
+
+	Settings settings;
+
+	virtual void DrawSettings() override;
+
+	virtual void LoadSettings(json& o_json) override;
+	virtual void SaveSettings(json& o_json) override;
+
+	virtual void RestoreDefaultSettings() override;
+
+	virtual bool SupportsVR() override { return true; }
+	virtual bool IsCore() const override { return true; }
+
+	virtual void PostPostLoad() override;
+	virtual void DataLoaded() override;
+
+	bool* gDepthBufferCulling = nullptr;
+	float* gMinOccludeeBoxExtent = nullptr;
+};

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -28,6 +28,7 @@
 #include "Features/TerrainBlending.h"
 #include "Features/TerrainHelper.h"
 #include "Features/TerrainShadows.h"
+#include "Features/VR.h"
 #include "Features/VolumetricLighting.h"
 #include "Features/WaterEffects.h"
 #include "Features/WetnessEffects.h"
@@ -65,6 +66,7 @@ namespace globals
 		TerrainHelper* terrainHelper = nullptr;
 		TerrainShadows* terrainShadows = nullptr;
 		VolumetricLighting* volumetricLighting = nullptr;
+		VR* vr = nullptr;
 		WaterEffects* waterEffects = nullptr;
 		WetnessEffects* wetnessEffects = nullptr;
 
@@ -144,6 +146,7 @@ namespace globals
 		features::terrainHelper = TerrainHelper::GetSingleton();
 		features::terrainShadows = TerrainShadows::GetSingleton();
 		features::volumetricLighting = VolumetricLighting::GetSingleton();
+		features::vr = VR::GetSingleton();
 		features::waterEffects = WaterEffects::GetSingleton();
 		features::wetnessEffects = WetnessEffects::GetSingleton();
 

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -18,6 +18,7 @@ struct TerrainBlending;
 struct TerrainHelper;
 struct TerrainShadows;
 struct VolumetricLighting;
+struct VR;
 struct WaterEffects;
 struct WetnessEffects;
 
@@ -66,6 +67,7 @@ namespace globals
 		extern TerrainHelper* terrainHelper;
 		extern TerrainShadows* terrainShadows;
 		extern VolumetricLighting* volumetricLighting;
+		extern VR* vr;
 		extern WaterEffects* waterEffects;
 		extern WetnessEffects* wetnessEffects;
 


### PR DESCRIPTION
* Fixes VR game engine bug with bDepthBufferCulling enabled that caused erroneous culling. When geometry is first loaded from disk its extents are calculated and the center of those extents are stored on the geom. When that geom is later cloned the extent center is clobbered with the center of the bounding sphere defined in the nif. If the bounding sphere isn't exactly at the extent center this caused flickering or incorrect culling.
* Options added to configure depth buffer culling
* Fix added under new VR core feature
* Change VR features vector to initialise once and added VR core feature directly