### PR TITLE
feat: add Interior Sun Shadows

### DIFF
--- a/features/Interior Sun Shadows/Shaders/Features/InteriorSunShadows.ini
+++ b/features/Interior Sun Shadows/Shaders/Features/InteriorSunShadows.ini
@@ -1,0 +1,2 @@
+[Info]
+Version = 1-0-0

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -7,6 +7,7 @@
 #include "Features/GrassCollision.h"
 #include "Features/GrassLighting.h"
 #include "Features/HairSpecular.h"
+#include "Features/InteriorSunShadows.h"
 #include "Features/InverseSquareLighting.h"
 #include "Features/LODBlending.h"
 #include "Features/LightLimitFix.h"
@@ -147,7 +148,8 @@ const std::vector<Feature*>& Feature::GetFeatureList()
 		globals::features::volumetricLighting,
 		globals::features::lodBlending,
 		globals::features::inverseSquareLighting,
-		globals::features::hairSpecular
+		globals::features::hairSpecular,
+		globals::features::interiorSunShadows
 	};
 
 	static std::vector<Feature*> featuresVR = [] {

--- a/src/Features/InteriorSunShadows.cpp
+++ b/src/Features/InteriorSunShadows.cpp
@@ -1,0 +1,172 @@
+﻿#include "InteriorSunShadows.h"
+#include "State.h"
+
+#include <numbers>
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+	InteriorSunShadows::Settings,
+	ForceDoubleSidedRendering)
+
+void InteriorSunShadows::DrawSettings()
+{
+	ImGui::Checkbox("Force Double-Sided Rendering", &settings.ForceDoubleSidedRendering);
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text(
+			"Forces double-sided vertices during sun shadowmap rendering on interiors. "
+			"Will prevent most light leaking through unmasked/unprepared interiors at a small performance cost. ");
+	}
+}
+
+void InteriorSunShadows::PostPostLoad()
+{
+	// Hooks and patch to enable directional lighting for interiors
+	stl::write_thunk_call<GetWorldSpace>(REL::RelocationID(35562, 36561).address() + REL::Relocate(0x399, 0x37D, 0x639));
+	stl::write_thunk_call<GetWorldSpace>(REL::RelocationID(35562, 36561).address() + REL::Relocate(0x3AE, 0x392, 0x64E));
+	REL::safe_fill(REL::RelocationID(35562, 36561).address() + REL::Relocate(0x397, 0x37B, 0x637), 0x90, 2);
+
+	// Hook for overriding the rooms and portals passed to the directional light culling step to fix light leaking through unrendered geometry
+	stl::detour_thunk<DirShadowLightCulling>(REL::RelocationID(101498, 108492));
+
+	gShadowDistance = reinterpret_cast<float*>(REL::RelocationID(528314, 415263).address());
+
+	// Patches BSShadowDirectionalLight::SetFrameCamera to read the correct shadow distance value in interior cells
+	const std::uintptr_t address = REL::RelocationID(101499, 108496).address() + REL::Relocate(0xD62, 0xE6C, 0xE72);
+	const std::int32_t displacement = static_cast<std::int32_t>(reinterpret_cast<std::uintptr_t>(gShadowDistance) - (address + 8));
+	REL::safe_write(address + 4, &displacement, sizeof(displacement));
+
+	rasterStateCullMode = globals::game::isVR ? &globals::game::shadowState->GetVRRuntimeData().rasterStateCullMode : &globals::game::shadowState->GetRuntimeData().rasterStateCullMode;
+
+	logger::info("[Interior Sun Shadows] Installed hooks");
+}
+
+void InteriorSunShadows::EarlyPrepass()
+{
+	isInteriorWithSun = IsInteriorWithSun(globals::game::tes->interiorCell);
+}
+
+inline bool InteriorSunShadows::IsInteriorWithSun(const RE::TESObjectCELL* cell)
+{
+	return cell && cell->cellFlags.all(RE::TESObjectCELL::Flag::kIsInteriorCell, RE::TESObjectCELL::Flag::kShowSky, RE::TESObjectCELL::Flag::kUseSkyLighting);
+}
+
+RE::TESWorldSpace* InteriorSunShadows::GetWorldSpace::thunk(RE::TES* tes)
+{
+	if (const auto cell = tes->interiorCell)
+		return IsInteriorWithSun(cell) ? enableInteriorSunShadows : disableInteriorSunShadows;
+	return func(tes);
+}
+
+RE::TESWorldSpace* InteriorSunShadows::enableInteriorSunShadows = [] {
+	alignas(RE::TESWorldSpace) static char buffer[sizeof(RE::TESWorldSpace)]{};
+	return reinterpret_cast<RE::TESWorldSpace*>(buffer);
+}();
+
+RE::TESWorldSpace* InteriorSunShadows::disableInteriorSunShadows = [] {
+	alignas(RE::TESWorldSpace) static char buffer[sizeof(RE::TESWorldSpace)] = {};
+	const auto noShadows = reinterpret_cast<RE::TESWorldSpace*>(buffer);
+	noShadows->flags.set(RE::TESWorldSpace::Flag::kNoSky, RE::TESWorldSpace::Flag::kFixedDimensions);
+	return noShadows;
+}();
+
+void InteriorSunShadows::DirShadowLightCulling::thunk(RE::BSShadowDirectionalLight* dirLight, RE::BSTArray<RE::BSTArray<RE::NiPointer<RE::NiAVObject>>>& jobArrays, RE::BSTArray<RE::NiPointer<RE::NiAVObject>>& nodes)
+{
+	auto* singleton = GetSingleton();
+	const auto cell = globals::game::tes->interiorCell;
+	auto* passedJobArrays = &jobArrays;
+
+	if (!cell) {
+		singleton->ClearArrays();
+	} else {
+		const auto portalGraph = cell->GetRuntimeData().loadedData->portalGraph;
+		if (singleton->isInteriorWithSun && portalGraph) {
+			singleton->PopulateReplacementJobArrays(cell, portalGraph, dirLight, jobArrays);
+			passedJobArrays = &singleton->replacementJobArrays;
+		}
+	}
+
+	func(dirLight, *passedJobArrays, nodes);
+}
+
+void InteriorSunShadows::ClearArrays()
+{
+	if (arraysCleared)
+		return;
+	
+	currentCellRoomsAndPortals.clear();
+
+	for (auto& jobArray : replacementJobArrays)
+		jobArray.clear();
+
+	arraysCleared = true;
+}
+
+namespace RE
+{
+	class BSMultiBoundRoom : public NiNode
+	{};
+}
+
+void InteriorSunShadows::PopulateReplacementJobArrays(RE::TESObjectCELL* cell, const RE::NiPointer<RE::BSPortalGraph>& portalGraph, const RE::BSShadowDirectionalLight* dirLight, RE::BSTArray<RE::BSTArray<RE::NiPointer<RE::NiAVObject>>>& jobArrays)
+{
+	if (cell != currentCell) {
+		InitialiseOnNewCell(portalGraph);
+		currentCell = cell;
+	}
+
+	const auto jobArraySize = jobArrays.size();
+
+	if (replacementJobArrays.size() != jobArraySize)
+		replacementJobArrays.resize(jobArraySize);
+
+	for (auto& jobArray : replacementJobArrays)
+		jobArray.clear();
+
+	addedSet.clear();
+
+	// Copy the original job arrays contents into the replacement job arrays
+	uint32_t count = 0;
+	for (uint32_t i = 0; i < jobArraySize; ++i) {
+		for (const auto& object : jobArrays[i]) {
+			replacementJobArrays[i].push_back(object);
+			addedSet.insert(object.get());
+			count++;
+		}
+	}
+
+	const auto playerPos = RE::PlayerCharacter::GetSingleton()->GetPosition();
+	auto lightDir = -dirLight->GetShadowDirectionalLightRuntimeData().lightDirection;
+	lightDir.Unitize();
+
+	// Add extra rooms and portals that are in the direction of the sun
+	for (const auto& object : currentCellRoomsAndPortals) {
+		if (addedSet.find(object.get()) != addedSet.end() || !IsInSunDirectionAndWithinShadowDistance(object, lightDir, playerPos))
+			continue;
+
+		addedSet.insert(object.get());
+		replacementJobArrays[count++ % jobArraySize].push_back(object);
+	}
+
+	arraysCleared = false;
+}
+
+void InteriorSunShadows::InitialiseOnNewCell(const RE::NiPointer<RE::BSPortalGraph>& portalGraph)
+{
+	currentCellRoomsAndPortals.clear();
+
+	if (const auto portalSharedNode = portalGraph->portalSharedNode) {
+		for (const auto room : portalGraph->rooms)
+			currentCellRoomsAndPortals.push_back(room);
+
+		for (auto child : portalGraph->portalSharedNode->GetChildren())
+			currentCellRoomsAndPortals.push_back(child);
+	}
+}
+
+bool InteriorSunShadows::IsInSunDirectionAndWithinShadowDistance(const RE::NiPointer<RE::NiAVObject>& object, const RE::NiPoint3& lightDir, const RE::NiPoint3& playerPos) const
+{
+	const float radius = object->worldBound.radius;
+	const auto diff = object->worldBound.center - playerPos;
+	const float distance = diff.Length();
+	const float projection = lightDir.Dot(diff);
+	return projection >= -radius && (distance - radius) <= *gShadowDistance;
+}

--- a/src/Features/InteriorSunShadows.cpp
+++ b/src/Features/InteriorSunShadows.cpp
@@ -91,7 +91,7 @@ void InteriorSunShadows::ClearArrays()
 {
 	if (arraysCleared)
 		return;
-	
+
 	currentCellRoomsAndPortals.clear();
 
 	for (auto& jobArray : replacementJobArrays)

--- a/src/Features/InteriorSunShadows.h
+++ b/src/Features/InteriorSunShadows.h
@@ -54,7 +54,7 @@ struct InteriorSunShadows : Feature
 private:
 	float* gShadowDistance = nullptr;
 	uint32_t* rasterStateCullMode = nullptr;
-	
+
 	RE::TESObjectCELL* currentCell = nullptr;
 
 	bool arraysCleared = true;
@@ -66,12 +66,12 @@ private:
 	static RE::TESWorldSpace* disableInteriorSunShadows;
 
 	void ClearArrays();
-	
+
 	void InitialiseOnNewCell(const RE::NiPointer<RE::BSPortalGraph>& portalGraph);
-	
+
 	static bool IsInteriorWithSun(const RE::TESObjectCELL* cell);
-	
+
 	bool IsInSunDirectionAndWithinShadowDistance(const RE::NiPointer<RE::NiAVObject>& object, const RE::NiPoint3& lightDir, const RE::NiPoint3& playerPos) const;
-	
+
 	void PopulateReplacementJobArrays(RE::TESObjectCELL* cell, const RE::NiPointer<RE::BSPortalGraph>& portalGraph, const RE::BSShadowDirectionalLight* dirLight, RE::BSTArray<RE::BSTArray<RE::NiPointer<RE::NiAVObject>>>& jobArrays);
 };

--- a/src/Features/InteriorSunShadows.h
+++ b/src/Features/InteriorSunShadows.h
@@ -1,0 +1,77 @@
+﻿#pragma once
+#include "ShaderCache.h"
+
+struct InteriorSunShadows : Feature
+{
+	static InteriorSunShadows* GetSingleton()
+	{
+		static InteriorSunShadows singleton;
+		return &singleton;
+	}
+
+	virtual inline std::string GetName() override { return "Interior Sun Shadows"; }
+	virtual inline std::string GetShortName() override { return "InteriorSunShadows"; }
+	virtual void DrawSettings() override;
+	virtual bool SupportsVR() override { return true; }
+	virtual void PostPostLoad() override;
+	virtual void EarlyPrepass() override;
+
+	struct Settings
+	{
+		bool ForceDoubleSidedRendering = true;
+	};
+
+	Settings settings;
+
+	bool isInteriorWithSun = false;
+
+	struct GetWorldSpace
+	{
+		static RE::TESWorldSpace* thunk(RE::TES* tes);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	struct DirShadowLightCulling
+	{
+		static void thunk(RE::BSShadowDirectionalLight* dirLight, RE::BSTArray<RE::BSTArray<RE::NiPointer<RE::NiAVObject>>>& jobArrays, RE::BSTArray<RE::NiPointer<RE::NiAVObject>>& nodes);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	void BSBatchRenderer_RenderPassImmediately2(const RE::BSRenderPass* pass, const uint32_t technique) const
+	{
+		if (isInteriorWithSun && settings.ForceDoubleSidedRendering && technique & static_cast<uint32_t>(SIE::ShaderCache::UtilityShaderFlags::RenderShadowmap)) {
+			const auto renderTwoSided = pass->shaderProperty->flags.none(RE::BSShaderProperty::EShaderPropertyFlag::kAssumeShadowmask);
+			if (renderTwoSided && *rasterStateCullMode != 0) {
+				*rasterStateCullMode = 0;
+				globals::game::stateUpdateFlags->set(RE::BSGraphics::DIRTY_RASTER_CULL_MODE);
+			} else if (!renderTwoSided && *rasterStateCullMode != RE::BSGraphics::RasterStateCullMode::RASTER_STATE_CULL_MODE_BACK) {
+				*rasterStateCullMode = RE::BSGraphics::RasterStateCullMode::RASTER_STATE_CULL_MODE_BACK;
+				globals::game::stateUpdateFlags->set(RE::BSGraphics::DIRTY_RASTER_CULL_MODE);
+			}
+		}
+	}
+
+private:
+	float* gShadowDistance = nullptr;
+	uint32_t* rasterStateCullMode = nullptr;
+	
+	RE::TESObjectCELL* currentCell = nullptr;
+
+	bool arraysCleared = true;
+	RE::BSTArray<RE::NiPointer<RE::NiAVObject>> currentCellRoomsAndPortals = {};
+	RE::BSTArray<RE::BSTArray<RE::NiPointer<RE::NiAVObject>>> replacementJobArrays = {};
+	eastl::hash_set<RE::NiAVObject*> addedSet = {};
+
+	static RE::TESWorldSpace* enableInteriorSunShadows;
+	static RE::TESWorldSpace* disableInteriorSunShadows;
+
+	void ClearArrays();
+	
+	void InitialiseOnNewCell(const RE::NiPointer<RE::BSPortalGraph>& portalGraph);
+	
+	static bool IsInteriorWithSun(const RE::TESObjectCELL* cell);
+	
+	bool IsInSunDirectionAndWithinShadowDistance(const RE::NiPointer<RE::NiAVObject>& object, const RE::NiPoint3& lightDir, const RE::NiPoint3& playerPos) const;
+	
+	void PopulateReplacementJobArrays(RE::TESObjectCELL* cell, const RE::NiPointer<RE::BSPortalGraph>& portalGraph, const RE::BSShadowDirectionalLight* dirLight, RE::BSTArray<RE::BSTArray<RE::NiPointer<RE::NiAVObject>>>& jobArrays);
+};

--- a/src/Features/InteriorSunShadows.h
+++ b/src/Features/InteriorSunShadows.h
@@ -37,7 +37,7 @@ struct InteriorSunShadows : Feature
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
-	void BSBatchRenderer_RenderPassImmediately2(const RE::BSRenderPass* pass, const uint32_t technique) const
+	void UpdateRasterStateCullMode(const RE::BSRenderPass* pass, const uint32_t technique) const
 	{
 		if (isInteriorWithSun && settings.ForceDoubleSidedRendering && technique & static_cast<uint32_t>(SIE::ShaderCache::UtilityShaderFlags::RenderShadowmap)) {
 			const auto renderTwoSided = pass->shaderProperty->flags.none(RE::BSShaderProperty::EShaderPropertyFlag::kAssumeShadowmask);

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -1028,10 +1028,9 @@ void LightLimitFix::UpdateLights()
 	context->CSSetUnorderedAccessViews(0, 3, null_uavs, nullptr);
 }
 
-void LightLimitFix::Hooks::BSBatchRenderer_RenderPassImmediately::thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags)
+bool LightLimitFix::BSBatchRenderer_RenderPassImmediately(RE::BSRenderPass* pass, uint32_t technique)
 {
-	if (globals::features::lightLimitFix->CheckParticleLights(Pass, Technique))
-		func(Pass, Technique, AlphaTest, RenderFlags);
+	return CheckParticleLights(pass, technique);
 }
 
 void LightLimitFix::Hooks::BSLightingShader_SetupGeometry::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -1028,11 +1028,6 @@ void LightLimitFix::UpdateLights()
 	context->CSSetUnorderedAccessViews(0, 3, null_uavs, nullptr);
 }
 
-bool LightLimitFix::BSBatchRenderer_RenderPassImmediately(RE::BSRenderPass* pass, uint32_t technique)
-{
-	return CheckParticleLights(pass, technique);
-}
-
 void LightLimitFix::Hooks::BSLightingShader_SetupGeometry::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
 {
 	auto singleton = globals::features::lightLimitFix;

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -203,6 +203,7 @@ public:
 	bool CheckParticleLights(RE::BSRenderPass* a_pass, uint32_t a_technique);
 
 	void BSLightingShader_SetupGeometry_Before(RE::BSRenderPass* a_pass);
+	bool BSBatchRenderer_RenderPassImmediately(RE::BSRenderPass* pass, uint32_t technique);
 
 	enum class Space
 	{
@@ -224,12 +225,6 @@ public:
 
 	struct Hooks
 	{
-		struct BSBatchRenderer_RenderPassImmediately
-		{
-			static void thunk(RE::BSRenderPass* Pass, uint32_t Technique, bool AlphaTest, uint32_t RenderFlags);
-			static inline REL::Relocation<decltype(thunk)> func;
-		};
-
 		struct BSLightingShader_SetupGeometry
 		{
 			static void thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags);
@@ -268,10 +263,6 @@ public:
 
 		static void Install()
 		{
-			stl::write_thunk_call<BSBatchRenderer_RenderPassImmediately>(REL::RelocationID(100877, 107673).address() + REL::Relocate(0x1E5, 0x1EE));
-			stl::write_thunk_call<BSBatchRenderer_RenderPassImmediately>(REL::RelocationID(100852, 107642).address() + REL::Relocate(0x29E, 0x28F));
-			stl::write_thunk_call<BSBatchRenderer_RenderPassImmediately>(REL::RelocationID(100871, 107667).address() + REL::Relocate(0xEE, 0xED));
-
 			stl::write_thunk_call<AIProcess_CalculateLightValue_GetLuminance>(REL::RelocationID(38900, 39946).address() + REL::Relocate(0x1C9, 0x1D3));
 
 			stl::write_vfunc<0x6, BSLightingShader_SetupGeometry>(RE::VTABLE_BSLightingShader[0]);

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -203,7 +203,6 @@ public:
 	bool CheckParticleLights(RE::BSRenderPass* a_pass, uint32_t a_technique);
 
 	void BSLightingShader_SetupGeometry_Before(RE::BSRenderPass* a_pass);
-	bool BSBatchRenderer_RenderPassImmediately(RE::BSRenderPass* pass, uint32_t technique);
 
 	enum class Space
 	{

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -17,6 +17,7 @@
 #include "Features/GrassCollision.h"
 #include "Features/GrassLighting.h"
 #include "Features/HairSpecular.h"
+#include "Features/InteriorSunShadows.h"
 #include "Features/InverseSquareLighting.h"
 #include "Features/LODBlending.h"
 #include "Features/LightLimitFix.h"
@@ -56,6 +57,7 @@ namespace globals
 		LightLimitFix* lightLimitFix = nullptr;
 		LODBlending* lodBlending = nullptr;
 		HairSpecular* hairSpecular = nullptr;
+		InteriorSunShadows* interiorSunShadows = nullptr;
 		InverseSquareLighting* inverseSquareLighting = nullptr;
 		ScreenSpaceGI* screenSpaceGI = nullptr;
 		ScreenSpaceShadows* screenSpaceShadows = nullptr;
@@ -136,6 +138,7 @@ namespace globals
 		features::hairSpecular = HairSpecular::GetSingleton();
 		features::lightLimitFix = LightLimitFix::GetSingleton();
 		features::lodBlending = LODBlending::GetSingleton();
+		features::interiorSunShadows = InteriorSunShadows::GetSingleton();
 		features::inverseSquareLighting = InverseSquareLighting::GetSingleton();
 		features::screenSpaceGI = ScreenSpaceGI::GetSingleton();
 		features::screenSpaceShadows = ScreenSpaceShadows::GetSingleton();

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -8,6 +8,7 @@ struct GrassLighting;
 struct HairSpecular;
 struct LightLimitFix;
 struct LODBlending;
+struct InteriorSunShadows;
 struct InverseSquareLighting;
 struct ScreenSpaceGI;
 struct ScreenSpaceShadows;
@@ -57,6 +58,7 @@ namespace globals
 		extern HairSpecular* hairSpecular;
 		extern LightLimitFix* lightLimitFix;
 		extern LODBlending* lodBlending;
+		extern InteriorSunShadows* interiorSunShadows;
 		extern InverseSquareLighting* inverseSquareLighting;
 		extern ScreenSpaceGI* screenSpaceGI;
 		extern ScreenSpaceShadows* screenSpaceShadows;

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -804,7 +804,7 @@ namespace Hooks
 		{
 			if (globals::features::lightLimitFix->loaded && !globals::features::lightLimitFix->BSBatchRenderer_RenderPassImmediately(pass, technique))
 				return;
-			
+
 			func(pass, technique, alphaTest, renderFlags);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -9,6 +9,8 @@
 #include "TruePBR.h"
 #include "Util.h"
 
+#include "Features/InteriorSunShadows.h"
+#include "Features/LightLimitFix.h"
 #include "Features/TerrainHelper.h"
 
 #include "ShaderTools/BSShaderHooks.h"
@@ -769,6 +771,45 @@ namespace Hooks
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
+	struct BSBatchRenderer_RenderPassImmediately1
+	{
+		static void thunk(RE::BSRenderPass* pass, uint32_t technique, bool alphaTest, uint32_t renderFlags)
+		{
+			if (globals::features::lightLimitFix->loaded && !globals::features::lightLimitFix->BSBatchRenderer_RenderPassImmediately(pass, technique))
+				return;
+
+			func(pass, technique, alphaTest, renderFlags);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	struct BSBatchRenderer_RenderPassImmediately2
+	{
+		static void thunk(RE::BSRenderPass* pass, uint32_t technique, bool alphaTest, uint32_t renderFlags)
+		{
+			if (globals::features::lightLimitFix->loaded && !globals::features::lightLimitFix->BSBatchRenderer_RenderPassImmediately(pass, technique))
+				return;
+
+			if (globals::features::interiorSunShadows->loaded)
+				globals::features::interiorSunShadows->BSBatchRenderer_RenderPassImmediately2(pass, technique);
+
+			func(pass, technique, alphaTest, renderFlags);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	struct BSBatchRenderer_RenderPassImmediately3
+	{
+		static void thunk(RE::BSRenderPass* pass, uint32_t technique, bool alphaTest, uint32_t renderFlags)
+		{
+			if (globals::features::lightLimitFix->loaded && !globals::features::lightLimitFix->BSBatchRenderer_RenderPassImmediately(pass, technique))
+				return;
+			
+			func(pass, technique, alphaTest, renderFlags);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
 #ifdef TRACY_ENABLE
 	struct Main_Update
 	{
@@ -950,6 +991,11 @@ namespace Hooks
 
 		logger::info("Hooking BSLightingShader");
 		stl::write_vfunc<0x4, BSLightingShader_SetupMaterial>(RE::VTABLE_BSLightingShader[0]);
+
+		logger::info("Hooking BSBatchRenderer::RenderPassImmediately");
+		stl::write_thunk_call<BSBatchRenderer_RenderPassImmediately1>(REL::RelocationID(100877, 107673).address() + REL::Relocate(0x1E5, 0x1EE));
+		stl::write_thunk_call<BSBatchRenderer_RenderPassImmediately2>(REL::RelocationID(100852, 107642).address() + REL::Relocate(0x29E, 0x28F));
+		stl::write_thunk_call<BSBatchRenderer_RenderPassImmediately3>(REL::RelocationID(100871, 107667).address() + REL::Relocate(0xEE, 0xED));
 
 		const auto renderPassCacheCtor = REL::VariantID(100720, 107500, 0x1340330);
 		const int32_t passCount = 4194240;

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -791,7 +791,7 @@ namespace Hooks
 				return;
 
 			if (globals::features::interiorSunShadows->loaded)
-				globals::features::interiorSunShadows->BSBatchRenderer_RenderPassImmediately2(pass, technique);
+				globals::features::interiorSunShadows->UpdateRasterStateCullMode(pass, technique);
 
 			func(pass, technique, alphaTest, renderFlags);
 		}

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -775,7 +775,7 @@ namespace Hooks
 	{
 		static void thunk(RE::BSRenderPass* pass, uint32_t technique, bool alphaTest, uint32_t renderFlags)
 		{
-			if (globals::features::lightLimitFix->loaded && !globals::features::lightLimitFix->BSBatchRenderer_RenderPassImmediately(pass, technique))
+			if (globals::features::lightLimitFix->loaded && !globals::features::lightLimitFix->CheckParticleLights(pass, technique))
 				return;
 
 			func(pass, technique, alphaTest, renderFlags);
@@ -787,7 +787,7 @@ namespace Hooks
 	{
 		static void thunk(RE::BSRenderPass* pass, uint32_t technique, bool alphaTest, uint32_t renderFlags)
 		{
-			if (globals::features::lightLimitFix->loaded && !globals::features::lightLimitFix->BSBatchRenderer_RenderPassImmediately(pass, technique))
+			if (globals::features::lightLimitFix->loaded && !globals::features::lightLimitFix->CheckParticleLights(pass, technique))
 				return;
 
 			if (globals::features::interiorSunShadows->loaded)
@@ -802,7 +802,7 @@ namespace Hooks
 	{
 		static void thunk(RE::BSRenderPass* pass, uint32_t technique, bool alphaTest, uint32_t renderFlags)
 		{
-			if (globals::features::lightLimitFix->loaded && !globals::features::lightLimitFix->BSBatchRenderer_RenderPassImmediately(pass, technique))
+			if (globals::features::lightLimitFix->loaded && !globals::features::lightLimitFix->CheckParticleLights(pass, technique))
 				return;
 
 			func(pass, technique, alphaTest, renderFlags);

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -3,6 +3,7 @@
 #include "TruePBR/BSLightingShaderMaterialPBR.h"
 #include "TruePBR/BSLightingShaderMaterialPBRLandscape.h"
 
+#include "Features/InteriorSunShadows.h"
 #include "Hooks.h"
 #include "ShaderCache.h"
 #include "State.h"
@@ -666,6 +667,8 @@ struct BSLightingShaderProperty_GetRenderPasses
 			return renderPasses;
 		}
 
+		const auto issEnabledAndInteriorWithSun = globals::features::interiorSunShadows->loaded && globals::features::interiorSunShadows->isInteriorWithSun;
+
 		bool isPbr = false;
 
 		if (property->flags.any(RE::BSShaderProperty::EShaderPropertyFlag::kVertexLighting) && (property->material->GetFeature() == RE::BSShaderMaterial::Feature::kDefault || property->material->GetFeature() == RE::BSShaderMaterial::Feature::kMultiTexLandLODBlend)) {
@@ -695,6 +698,10 @@ struct BSLightingShaderProperty_GetRenderPasses
 						}
 					}
 				}
+				
+				if (issEnabledAndInteriorWithSun)
+					lightingFlags |= static_cast<uint32_t>(SIE::ShaderCache::LightingShaderFlags::ShadowDir) | static_cast<uint32_t>(SIE::ShaderCache::LightingShaderFlags::DefShadow);
+				
 				lightingTechnique = (static_cast<uint32_t>(lightingType) << 24) | lightingFlags;
 				currentPass->passEnum = lightingTechnique + LightingTechniqueStart;
 

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -698,10 +698,10 @@ struct BSLightingShaderProperty_GetRenderPasses
 						}
 					}
 				}
-				
+
 				if (issEnabledAndInteriorWithSun)
 					lightingFlags |= static_cast<uint32_t>(SIE::ShaderCache::LightingShaderFlags::ShadowDir) | static_cast<uint32_t>(SIE::ShaderCache::LightingShaderFlags::DefShadow);
-				
+
 				lightingTechnique = (static_cast<uint32_t>(lightingType) << 24) | lightingFlags;
 				currentPass->passEnum = lightingTechnique + LightingTechniqueStart;
 

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -153,7 +153,7 @@ bool Load()
 	}
 
 	if (REL::Module::IsVR()) {
-		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.175.0", true);
+		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.178.0", true);
 	}
 
 	auto privateProfileRedirectorVersion = Util::GetDllVersion(L"Data/SKSE/Plugins/PrivateProfileRedirector.dll");


### PR DESCRIPTION
* Enables sun/moon shadow casting in interiors
* Patches the shadow distance value used in interiors to use the values derived from fInteriorShadowDistance
* Hooks prior to the room/portal culling process to inject extra rooms/portals in the direction of the sun to prevent geometry disappearing based on view angle and letting light through
* Shifts the BSBatchRenderer_RenderPassImmediately hooks in LightLimitFix to Hooks.cpp, one of these hooks are used by ISS to optionally force the double sided flag during shadowmap rendering
* Any mesh with the hijacked kAssumeShadowmask flag set will not be forced double sided, this can be used for window panes so they allow light through
* Sets the ShadowDir and DefShadow lighting flags on the lighting shader if a sun enabled interior is detected
* Requires an interior with the IsInteriorCell, ShowSky, and UseSkyLighting flags and a weather set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an "Interior Sun Shadows" feature, enhancing sun shadow rendering within interior environments that have sunlight.
  - Added a user setting to force double-sided rendering for improved shadow accuracy in interiors.

- **Improvements**
  - Interior sun shadows now dynamically adjust rendering techniques and lighting flags for more realistic lighting effects.
  - Enhanced compatibility with VR environments for interior shadow rendering.

- **Bug Fixes**
  - Refined light limit checks and rendering pass hooks to provide more reliable lighting behavior, especially for particle lights.

- **Chores**
  - Updated the minimum required version of the VR address library to 0.178.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->