### PR TITLE
fix: add cpu-side padding to terrain variation

### DIFF
--- a/src/Features/TerrainVariation.cpp
+++ b/src/Features/TerrainVariation.cpp
@@ -1,8 +1,9 @@
-#include "TerrainVariation.h"
 #include "../FeatureBuffer.h"
 #include "../Globals.h"
 #include "../State.h"
 #include "../Util.h"
+#include "TerrainVariation.h"
+
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	TerrainVariation::Settings,
@@ -16,8 +17,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 void TerrainVariation::DrawSettings()
 {
 	bool oldEnabled = settings.enableTilingFix;
-	ImGui::Checkbox("Enable Terrain Tiling Fix", &settings.enableTilingFix);
-	if (oldEnabled != settings.enableTilingFix) {
+	ImGui::Checkbox("Enable Terrain Tiling Fix", (bool*)&settings.enableTilingFix);
+	if (oldEnabled != (bool)settings.enableTilingFix) {
 		// Update the shader settings when the checkbox is toggled
 		UpdateShaderSettings();
 		logger::info("TerrainVariation setting changed to: {}", settings.enableTilingFix);

--- a/src/Features/TerrainVariation.cpp
+++ b/src/Features/TerrainVariation.cpp
@@ -1,9 +1,8 @@
+#include "TerrainVariation.h"
 #include "../FeatureBuffer.h"
 #include "../Globals.h"
 #include "../State.h"
 #include "../Util.h"
-#include "TerrainVariation.h"
-
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	TerrainVariation::Settings,

--- a/src/Features/TerrainVariation.h
+++ b/src/Features/TerrainVariation.h
@@ -18,13 +18,14 @@ struct TerrainVariation : Feature
 
 	struct Settings
 	{
-		bool enableTilingFix = true;
+		uint enableTilingFix = true;
 		float startDistance = 200.0f;           // No offset will be applied under this distance
 		float maxDistance = 2000.0f;            // Maximum distance that the terrain will blend the stochastic effect to
 		float invDistanceRange = 0.00056f;      // Precalculated 1.0f / (maxDistance - startDistance) for shader optimization
 		float heightCompensationFactor = 1.0f;  // Compensation for terrain parallax when enabled
 		float shadowRayDirFactor = 1.0f;        // Shadow ray direction multiplier for parallax shadows
 		int hashQuality = 1;                    // 0 = Low quality hash, 1 = High quality hash
+		float pad;
 	};
 
 	Settings settings;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reliability of the "Enable Tiling Fix" checkbox in terrain settings.

- **Chores**
  - Minor adjustments to internal settings structure for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->