### PR TITLE
fix: using unused cell flag to toggle ISS

### DIFF
--- a/src/Features/InteriorSunShadows.cpp
+++ b/src/Features/InteriorSunShadows.cpp
@@ -46,7 +46,7 @@ void InteriorSunShadows::EarlyPrepass()
 
 inline bool InteriorSunShadows::IsInteriorWithSun(const RE::TESObjectCELL* cell)
 {
-	return cell && cell->cellFlags.all(RE::TESObjectCELL::Flag::kIsInteriorCell, RE::TESObjectCELL::Flag::kShowSky, RE::TESObjectCELL::Flag::kUseSkyLighting);
+	return cell && cell->cellFlags.all(RE::TESObjectCELL::Flag::kIsInteriorCell, RE::TESObjectCELL::Flag::kShowSky, RE::TESObjectCELL::Flag::kUseSkyLighting, static_cast<RE::TESObjectCELL::Flag>(CellFlagExt::kSunlightShadows));
 }
 
 RE::TESWorldSpace* InteriorSunShadows::GetWorldSpace::thunk(RE::TES* tes)

--- a/src/Features/InteriorSunShadows.h
+++ b/src/Features/InteriorSunShadows.h
@@ -51,7 +51,14 @@ struct InteriorSunShadows : Feature
 		}
 	}
 
+	static bool IsInteriorWithSun(const RE::TESObjectCELL* cell);
+
 private:
+	enum class CellFlagExt : uint16_t
+	{
+		kSunlightShadows = 1 << 15,
+	};
+
 	float* gShadowDistance = nullptr;
 	uint32_t* rasterStateCullMode = nullptr;
 
@@ -68,8 +75,6 @@ private:
 	void ClearArrays();
 
 	void InitialiseOnNewCell(const RE::NiPointer<RE::BSPortalGraph>& portalGraph);
-
-	static bool IsInteriorWithSun(const RE::TESObjectCELL* cell);
 
 	bool IsInSunDirectionAndWithinShadowDistance(const RE::NiPointer<RE::NiAVObject>& object, const RE::NiPoint3& lightDir, const RE::NiPoint3& playerPos) const;
 

--- a/src/Features/VolumetricLighting.cpp
+++ b/src/Features/VolumetricLighting.cpp
@@ -1,5 +1,6 @@
 #include "VolumetricLighting.h"
 
+#include "InteriorSunShadows.h"
 #include "ShaderCache.h"
 #include "State.h"
 
@@ -189,7 +190,7 @@ void VolumetricLighting::EarlyPrepass()
 
 	initialised = true;
 	inInterior = currentlyInInterior;
-	inInteriorWithSunShadows = interiorCell && interiorCell->cellFlags.all(RE::TESObjectCELL::Flag::kIsInteriorCell, RE::TESObjectCELL::Flag::kShowSky, RE::TESObjectCELL::Flag::kUseSkyLighting);
+	inInteriorWithSunShadows = InteriorSunShadows::IsInteriorWithSun(interiorCell);
 	SetupVL();
 }
 


### PR DESCRIPTION
* Enabling Interior Sun Shadows now requires setting unused bit 15 on the interior cell in xEdit
* Allows for mods to use interior weathers without enabling ISS
* RE shows bit 15 _appears_ unused, testing in-game shows no bits above 9 were set - cannot be 100% certain on this but highly likely it is fine

The required flags including bit 15 can be set in on the cell in xEdit as below:

![SSEEdit_DA7OwYd4Kh](https://github.com/user-attachments/assets/999f2ce7-2973-47ae-a5d7-2e18f5dec3d3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved detection for interiors with sunlight by refining the criteria used to identify such spaces.
  - Made the interior sunlight detection method accessible for use in other features.

- **Refactor**
  - Unified and streamlined the logic for determining interiors with sunlight across relevant features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->