### PR TITLE
fix: Terrain Variation MipMap Bug

### DIFF
--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -67,7 +67,7 @@ inline float4 StochasticEffect(float rnd, float mipLevel, Texture2D tex, Sampler
 {
 	// If feature is disabled, return standard sample
 	if (!SharedData::terrainVariationSettings.enableTilingFix)
-		return tex.SampleLevel(samp, uv, mipLevel);
+		return tex.SampleGrad(samp, uv, dx, dy);
 
 	// Calculate distance factor (0 when close, 1 when far)
 	float distanceFactor = ComputeDistanceFactor(distance);


### PR DESCRIPTION
When parallax & TV is disabled, mipmap errors occured. this is a hotfix for this issue.
![ScreenShot0](https://github.com/user-attachments/assets/5747f705-a81f-41a6-bbf2-7f97681f558a)
![ScreenShot1](https://github.com/user-attachments/assets/70b6c30a-c422-4605-93b5-feac4ad1f4fe)

Working on better mipmap solution currently and this is a temp fix but important for users who do not wish to have either terrain variation or parallax enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved texture sampling behavior for terrain variation when the tiling fix feature is disabled, resulting in more consistent visual quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->