### PR TITLE
ci: add pr release cleanup job

### DIFF
--- a/.github/workflows/cleanup-pr-releases.yaml
+++ b/.github/workflows/cleanup-pr-releases.yaml
@@ -15,6 +15,11 @@ jobs:
   cleanup-prereleases:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
       - name: Delete closed PR prereleases
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cleanup-pr-releases.yaml
+++ b/.github/workflows/cleanup-pr-releases.yaml
@@ -38,7 +38,7 @@ jobs:
                 # Remove release and cleanup the Git tag (requires GH CLI ≥2.3.0)
                 gh release delete "$tag" --yes --cleanup-tag \
                   || git push --delete origin "$tag"
-                gh tag delete "$tag"
+                git tag -d "$tag" || true
               else
                 echo "PR #$pr_number is still open. Keeping tag $tag"
               fi

--- a/.github/workflows/cleanup-pr-releases.yaml
+++ b/.github/workflows/cleanup-pr-releases.yaml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   cleanup-prereleases:
@@ -27,10 +28,11 @@ jobs:
               echo "Checking PR #$pr_number for tag $tag"
 
               pr_status=$(gh pr view "$pr_number" --json state --jq .state 2>/dev/null || echo "NOT_FOUND")
-
               if [[ "$pr_status" != "OPEN" ]]; then
                 echo "Deleting prerelease with tag $tag (PR #$pr_number is $pr_status)"
-                gh release delete "$tag" --yes
+                # Remove release and cleanup the Git tag (requires GH CLI ≥2.3.0)
+                gh release delete "$tag" --yes --cleanup-tag \
+                  || git push --delete origin "$tag"
                 gh tag delete "$tag"
               else
                 echo "PR #$pr_number is still open. Keeping tag $tag"

--- a/.github/workflows/cleanup-pr-releases.yaml
+++ b/.github/workflows/cleanup-pr-releases.yaml
@@ -1,0 +1,41 @@
+name: Cleanup Closed PR Releases
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'  # Optional: runs daily at 2am UTC
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup-prereleases:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete closed PR prereleases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Fetching all prereleases..."
+          releases=$(gh release list --limit 1000 --json tagName,isPrerelease --jq '.[] | select(.isPrerelease) | .tagName')
+
+          for tag in $releases; do
+            if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-pr([0-9]+)$ ]]; then
+              pr_number="${BASH_REMATCH[1]}"
+              echo "Checking PR #$pr_number for tag $tag"
+
+              pr_status=$(gh pr view "$pr_number" --json state --jq .state 2>/dev/null || echo "NOT_FOUND")
+
+              if [[ "$pr_status" != "OPEN" ]]; then
+                echo "Deleting prerelease with tag $tag (PR #$pr_number is $pr_status)"
+                gh release delete "$tag" --yes
+                gh tag delete "$tag"
+              else
+                echo "PR #$pr_number is still open. Keeping tag $tag"
+              fi
+            else
+              echo "Skipping non-PR tag $tag"
+            fi
+          done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced an automated workflow to regularly clean up prereleases associated with closed pull requests, helping to keep the repository organized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->