### PR TITLE
chore: include shader paths for IDE code completion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,11 +52,25 @@ target_compile_definitions(
 	"$<$<BOOL:${TRACY_SUPPORT}>:TRACY_SUPPORT>"
 )
 
+file(GLOB FEATURE_SHADER_DIRS
+    RELATIVE "${CMAKE_SOURCE_DIR}"
+    "${CMAKE_SOURCE_DIR}/features/*/Shaders"
+)
+
+foreach(_dir IN LISTS FEATURE_SHADER_DIRS)
+    target_include_directories(
+        ${PROJECT_NAME}
+        PRIVATE
+          "${CMAKE_SOURCE_DIR}/${_dir}"
+    )
+endforeach()
+
 target_include_directories(
 	${PROJECT_NAME}
 	PRIVATE
 	${BSHOSHANY_THREAD_POOL_INCLUDE_DIRS}
 	${CLIB_UTIL_INCLUDE_DIRS}
+	"${CMAKE_SOURCE_DIR}/package/Shaders"
 )
 
 target_link_libraries(


### PR DESCRIPTION
* Adds feature shaders and the root shaders folder to the project includes to allow for code completion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build configuration to automatically include shader directories from feature subfolders and explicitly include the package shader directory. No changes to application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->