### PR TITLE
fix(iss): fix cell change detection logic

### DIFF
--- a/src/Features/InteriorSunShadows.cpp
+++ b/src/Features/InteriorSunShadows.cpp
@@ -12,9 +12,24 @@ void InteriorSunShadows::DrawSettings()
 	ImGui::Checkbox("Force Double-Sided Rendering", &settings.ForceDoubleSidedRendering);
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text(
-			"Forces double-sided vertices during sun shadowmap rendering on interiors. "
+			"Disables backface culling during sun shadowmap rendering in interiors. "
 			"Will prevent most light leaking through unmasked/unprepared interiors at a small performance cost. ");
 	}
+}
+
+void InteriorSunShadows::LoadSettings(json& o_json)
+{
+	settings = o_json;
+}
+
+void InteriorSunShadows::SaveSettings(json& o_json)
+{
+	o_json = settings;
+}
+
+void InteriorSunShadows::RestoreDefaultSettings()
+{
+	settings = {};
 }
 
 void InteriorSunShadows::PostPostLoad()
@@ -74,14 +89,18 @@ void InteriorSunShadows::DirShadowLightCulling::thunk(RE::BSShadowDirectionalLig
 	const auto cell = globals::game::tes->interiorCell;
 	auto* passedJobArrays = &jobArrays;
 
-	if (!cell) {
-		singleton->ClearArrays();
-	} else {
-		const auto portalGraph = cell->GetRuntimeData().loadedData->portalGraph;
-		if (singleton->isInteriorWithSun && portalGraph) {
+	if (cell && singleton->isInteriorWithSun) {
+		const auto* loadedData = cell->GetRuntimeData().loadedData;
+		const auto portalGraph = loadedData ? loadedData->portalGraph : nullptr;
+		if (portalGraph) {
 			singleton->PopulateReplacementJobArrays(cell, portalGraph, dirLight, jobArrays);
 			passedJobArrays = &singleton->replacementJobArrays;
-		}
+		} else
+			singleton->currentCell = nullptr;
+	} else {
+		if (!singleton->arraysCleared)
+			singleton->ClearArrays();
+		singleton->currentCell = nullptr;
 	}
 
 	func(dirLight, *passedJobArrays, nodes);
@@ -89,9 +108,6 @@ void InteriorSunShadows::DirShadowLightCulling::thunk(RE::BSShadowDirectionalLig
 
 void InteriorSunShadows::ClearArrays()
 {
-	if (arraysCleared)
-		return;
-
 	currentCellRoomsAndPortals.clear();
 
 	for (auto& jobArray : replacementJobArrays)

--- a/src/Features/InteriorSunShadows.h
+++ b/src/Features/InteriorSunShadows.h
@@ -43,7 +43,8 @@ struct InteriorSunShadows : Feature
 	void UpdateRasterStateCullMode(const RE::BSRenderPass* pass, const uint32_t technique) const
 	{
 		if (isInteriorWithSun && settings.ForceDoubleSidedRendering && technique & static_cast<uint32_t>(SIE::ShaderCache::UtilityShaderFlags::RenderShadowmap)) {
-			const auto renderTwoSided = pass->shaderProperty->flags.none(RE::BSShaderProperty::EShaderPropertyFlag::kAssumeShadowmask, RE::BSShaderProperty::EShaderPropertyFlag::kSkinned);
+			const auto flags = pass->shaderProperty->flags;
+			const auto renderTwoSided = flags.all(RE::BSShaderProperty::EShaderPropertyFlag::kTwoSided) || flags.none(RE::BSShaderProperty::EShaderPropertyFlag::kAssumeShadowmask, RE::BSShaderProperty::EShaderPropertyFlag::kSkinned);
 			if (renderTwoSided && *rasterStateCullMode != 0) {
 				*rasterStateCullMode = 0;
 				globals::game::stateUpdateFlags->set(RE::BSGraphics::DIRTY_RASTER_CULL_MODE);

--- a/src/Features/InteriorSunShadows.h
+++ b/src/Features/InteriorSunShadows.h
@@ -12,6 +12,9 @@ struct InteriorSunShadows : Feature
 	virtual inline std::string GetName() override { return "Interior Sun Shadows"; }
 	virtual inline std::string GetShortName() override { return "InteriorSunShadows"; }
 	virtual void DrawSettings() override;
+	virtual void LoadSettings(json& o_json) override;
+	virtual void SaveSettings(json& o_json) override;
+	virtual void RestoreDefaultSettings() override;
 	virtual bool SupportsVR() override { return true; }
 	virtual void PostPostLoad() override;
 	virtual void EarlyPrepass() override;
@@ -40,7 +43,7 @@ struct InteriorSunShadows : Feature
 	void UpdateRasterStateCullMode(const RE::BSRenderPass* pass, const uint32_t technique) const
 	{
 		if (isInteriorWithSun && settings.ForceDoubleSidedRendering && technique & static_cast<uint32_t>(SIE::ShaderCache::UtilityShaderFlags::RenderShadowmap)) {
-			const auto renderTwoSided = pass->shaderProperty->flags.none(RE::BSShaderProperty::EShaderPropertyFlag::kAssumeShadowmask);
+			const auto renderTwoSided = pass->shaderProperty->flags.none(RE::BSShaderProperty::EShaderPropertyFlag::kAssumeShadowmask, RE::BSShaderProperty::EShaderPropertyFlag::kSkinned);
 			if (renderTwoSided && *rasterStateCullMode != 0) {
 				*rasterStateCullMode = 0;
 				globals::game::stateUpdateFlags->set(RE::BSGraphics::DIRTY_RASTER_CULL_MODE);


### PR DESCRIPTION
* Fixes issue where detection of cell change was not functioning correctly and it would revert to broken vanilla culling behaviour when leaving and re-entering the same interior cell
* Skinned meshes are now ignored when forcing double sided rendering interiors, saving performance and fixing shadowing issues on actors
* Settings are now savable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added options to load, save, and restore default settings for interior sun shadows.
- **Improvements**
  - Clarified the tooltip for the "Force Double-Sided Rendering" option to better explain its effect.
  - Enhanced the logic for determining when to use two-sided rendering for shadows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->