### PR TITLE
ci: generate pr notes based off base version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,30 +110,15 @@ jobs:
           BASE_TAG="v${{ needs.build.outputs.version }}"
           PR_URL="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
 
-          # Create temporary tag and release to generate notes
-          gh release create "$TAG-temp" \
-            --repo "$GITHUB_REPOSITORY" \
-            --notes-start-tag "$BASE_TAG" \
-            --generate-notes \
-            --title "Temporary for notes only" \
-            --draft
+          echo "🔍 Comparing $BASE_SHA...$HEAD_SHA"
 
-          # Extract body
-          gh release view "$TAG-temp" \
-            --repo "$GITHUB_REPOSITORY" \
-            --json body \
-            --jq .body > release-notes.md
+          NOTES=$(gh api repos/$REPO/compare/$BASE_SHA...$HEAD_SHA | jq -r '
+            .commits[] | "- \(.commit.message | split("\n")[0]) by @\(.author.login // $author)"
+          ')
 
-          # Append PR link
-          {
-            echo ""
-            echo "---"
-            echo "[View Pull Request]($PR_URL)"
-          } >> release-notes.md
-
-          # Clean up temporary tag
-          gh release delete "$TAG-temp" --repo "$GITHUB_REPOSITORY" --yes
-          git tag -d "$TAG-temp" || true  # Local delete if created
+          echo "$NOTES" > release-notes.md
+          echo -e "\n[View Pull Request](https://github.com/$REPO/pull/$PR_NUMBER)" >> release-notes.md
+          echo "bodyfile=release-notes.md" >> "$GITHUB_OUTPUT"
 
       - name: Upload prerelease
         uses: ncipollo/release-action@v1
@@ -143,6 +128,7 @@ jobs:
           prerelease: true
           artifacts: "${{ github.workspace }}/dist/CommunityShaders_AIO-*.7z"
           bodyFile: release-notes.md
+          generateReleaseNotes: false
           allowUpdates: true
           replacesArtifacts: true
           removeArtifacts: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -100,6 +100,41 @@ jobs:
           name: dist-artifacts
           path: dist/
 
+      - name: Generate release notes comparing against base version tag
+        id: gen_notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          TAG="v${{ needs.build.outputs.version }}-pr${{ github.event.pull_request.number }}"
+          BASE_TAG="v${{ needs.build.outputs.version }}"
+          PR_URL="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+
+          # Create temporary tag and release to generate notes
+          gh release create "$TAG-temp" \
+            --repo "$GITHUB_REPOSITORY" \
+            --notes-start-tag "$BASE_TAG" \
+            --generate-notes \
+            --title "Temporary for notes only" \
+            --draft
+
+          # Extract body
+          gh release view "$TAG-temp" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json body \
+            --jq .body > release-notes.md
+
+          # Append PR link
+          {
+            echo ""
+            echo "---"
+            echo "[View Pull Request]($PR_URL)"
+          } >> release-notes.md
+
+          # Clean up temporary tag
+          gh release delete "$TAG-temp" --repo "$GITHUB_REPOSITORY" --yes
+          git tag -d "$TAG-temp" || true  # Local delete if created
+
       - name: Upload prerelease
         uses: ncipollo/release-action@v1
         with:
@@ -107,7 +142,7 @@ jobs:
           tag: v${{ needs.build.outputs.version }}-pr${{ github.event.pull_request.number }}
           prerelease: true
           artifacts: "${{ github.workspace }}/dist/CommunityShaders_AIO-*.7z"
-          generateReleaseNotes: true
+          bodyFile: release-notes.md
           allowUpdates: true
           replacesArtifacts: true
           removeArtifacts: true


### PR DESCRIPTION
Multiple PRs could result in incomplete change logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved the prerelease workflow to generate and customize release notes before uploading, providing more explicit control over the release notes content for prereleases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->