### PR TITLE
fix: Performance Overlay menu width

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1192,6 +1192,13 @@ void Menu::DrawPerfOverlay()
 		ImGui::SetNextWindowPos(settings.PerfOverlay.Position, ImGuiCond_FirstUseEver);
 	}
 
+	// Set window size based on whether graphs are shown, was rapidly changing size based on text
+	bool hasGraphs = settings.PerfOverlay.ShowPreFGFrameTimeGraph || settings.PerfOverlay.ShowPostFGFrameTimeGraph;
+	if (!hasGraphs) {
+		float fixedWidth = 325.0f * textScale;
+		ImGui::SetNextWindowSize(ImVec2(fixedWidth, 0), ImGuiCond_Always);
+	}
+
 	// Create the window
 	ImGui::Begin("Performance Overlay", NULL, windowFlags);
 


### PR DESCRIPTION
Sets a fixed width for the perf overlay menu as it would rapidly change when graphs were disabled with the background enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the stability of the performance overlay window size, preventing rapid resizing when only textual performance data is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->