### PR TITLE
Refactor ProcessCompilationSet to utilize stop token.

### DIFF
--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -2469,8 +2469,13 @@ namespace SIE
 
 	void ShaderCache::ProcessCompilationSet(std::stop_token stoken, SIE::ShaderCompilationTask task)
 	{
+		if (stoken.stop_requested()) { return; }
+		
 		SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_BELOW_NORMAL);
 		task.Perform();
+
+		if (stoken.stop_requested()) { return; }
+		
 		compilationSet.Complete(task);
 	}
 

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -2469,13 +2469,17 @@ namespace SIE
 
 	void ShaderCache::ProcessCompilationSet(std::stop_token stoken, SIE::ShaderCompilationTask task)
 	{
-		if (stoken.stop_requested()) { return; }
-		
+		if (stoken.stop_requested()) {
+			return;
+		}
+
 		SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_BELOW_NORMAL);
 		task.Perform();
 
-		if (stoken.stop_requested()) { return; }
-		
+		if (stoken.stop_requested()) {
+			return;
+		}
+
 		compilationSet.Complete(task);
 	}
 


### PR DESCRIPTION
This gave me compile error because "stoken" was not being used at all in this function. I added a simple check before the task and after to see if we should not proceed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of cancellation requests during shader compilation, ensuring that processing stops promptly when a stop is requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->