### PR TITLE
Related issue #1110 - Performance Overlay refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 project(
 	CommunityShaders
-	VERSION 1.2.1
+	VERSION 0.8.7
 	LANGUAGES CXX
 )
 
@@ -15,11 +15,9 @@ message("Options:")
 option(AUTO_PLUGIN_DEPLOYMENT "Copy the build output and addons to env:CommunityShadersOutputDir." OFF)
 option(ZIP_TO_DIST "Zip the base mod and addons to their own 7z file in dist." ON)
 option(AIO_ZIP_TO_DIST "Zip the base mod and addons to a AIO 7z file in dist." ON)
-option(TRACY_SUPPORT "Enable support for tracy profiler" OFF)
 message("\tAuto plugin deployment: ${AUTO_PLUGIN_DEPLOYMENT}")
 message("\tZip to dist: ${ZIP_TO_DIST}")
 message("\tAIO Zip to dist: ${AIO_ZIP_TO_DIST}")
-message("\tTracy profiler: ${TRACY_SUPPORT}")
 
 # #######################################################################################################################
 # # Add CMake features
@@ -42,36 +40,11 @@ find_package(pystring CONFIG REQUIRED)
 find_package(cppwinrt CONFIG REQUIRED)
 find_package(unordered_dense CONFIG REQUIRED)
 find_package(efsw CONFIG REQUIRED)
-find_package(Tracy CONFIG REQUIRED)
-add_subdirectory(${CMAKE_SOURCE_DIR}/cmake/Streamline)
-include(FidelityFX-SDK)
-include(DXRHelpers)
-
-target_compile_definitions(
-	${PROJECT_NAME}
-	PRIVATE
-	"$<$<BOOL:${TRACY_SUPPORT}>:TRACY_SUPPORT>"
-)
-
-file(GLOB FEATURE_SHADER_DIRS
-    RELATIVE "${CMAKE_SOURCE_DIR}"
-    "${CMAKE_SOURCE_DIR}/features/*/Shaders"
-)
-
-foreach(_dir IN LISTS FEATURE_SHADER_DIRS)
-    target_include_directories(
-        ${PROJECT_NAME}
-        PRIVATE
-          "${CMAKE_SOURCE_DIR}/${_dir}"
-    )
-endforeach()
-
 target_include_directories(
 	${PROJECT_NAME}
 	PRIVATE
 	${BSHOSHANY_THREAD_POOL_INCLUDE_DIRS}
 	${CLIB_UTIL_INCLUDE_DIRS}
-	"${CMAKE_SOURCE_DIR}/package/Shaders"
 )
 
 target_link_libraries(
@@ -90,9 +63,6 @@ target_link_libraries(
 	pystring::pystring
 	unordered_dense::unordered_dense
 	efsw::efsw
-	Tracy::TracyClient
-	Streamline
-	d3d12.lib
 )
 
 # https://gitlab.kitware.com/cmake/cmake/-/issues/24922#note_1371990
@@ -151,18 +121,6 @@ target_sources(
 )
 
 # #######################################################################################################################
-# # clang-format
-# #######################################################################################################################
-
-find_program(CLANG_FORMAT_PATH clang-format)
-if(CLANG_FORMAT_PATH)
-	add_custom_target(FORMAT_CODE
-		COMMAND ${CLANG_FORMAT_PATH} -i -style=file ${CPP_SOURCES};${HLSL_FILES}
-		COMMENT "Running clang format for cpp and hlsl files"
-	)
-endif()
-
-# #######################################################################################################################
 # # Automatic deployment
 # #######################################################################################################################
 file(GLOB FEATURE_PATHS LIST_DIRECTORIES true ${CMAKE_SOURCE_DIR}/features/*)
@@ -172,23 +130,16 @@ if(AUTO_PLUGIN_DEPLOYMENT OR AIO_ZIP_TO_DIST)
 	set(AIO_DIR "${CMAKE_CURRENT_BINARY_DIR}/aio")
 	message("Copying package folder with dll/pdb with all features to ${AIO_DIR}")
 	add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E remove_directory "${AIO_DIR}"
-		COMMAND ${CMAKE_COMMAND} -E make_directory "${AIO_DIR}/SKSE/Plugins"
 		COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/package "${AIO_DIR}"
-		COMMAND ${CMAKE_COMMAND} -E copy_directory ${FEATURE_PATHS} "${AIO_DIR}"
 		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${PROJECT_NAME}> "${AIO_DIR}/SKSE/Plugins/"
 		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_PDB_FILE:${PROJECT_NAME}> "${AIO_DIR}/SKSE/Plugins/"
-		COMMAND ${CMAKE_COMMAND} -E remove "${AIO_DIR}/CORE"
 	)
 
-	add_custom_command(
-		OUTPUT copy_shaders.stamp
-		COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/package "${AIO_DIR}"
-		COMMAND ${CMAKE_COMMAND} -E copy_directory ${FEATURE_PATHS} "${AIO_DIR}"
-		COMMAND ${CMAKE_COMMAND} -E touch copy_shaders.stamp
-		DEPENDS ${HLSL_FILES}
-	)
-
+	foreach(FEATURE_PATH ${FEATURE_PATHS})
+		add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy_directory ${FEATURE_PATH} "${AIO_DIR}"
+		)
+	endforeach()
 endif()
 
 # Automatic deployment to CommunityShaders output directory.
@@ -198,25 +149,7 @@ if(AUTO_PLUGIN_DEPLOYMENT)
 		add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
 			COMMAND ${CMAKE_COMMAND} -E copy_directory ${AIO_DIR} "${DEPLOY_TARGET}"
 		)
-
-		string(MD5 DEPLOY_TARGET_HASH ${DEPLOY_TARGET})
-
-		add_custom_command(
-			OUTPUT ${DEPLOY_TARGET_HASH}.stamp
-			COMMAND ${CMAKE_COMMAND} -E copy_directory "${AIO_DIR}/Shaders" "${DEPLOY_TARGET}/Shaders"
-			COMMAND ${CMAKE_COMMAND} -E touch ${DEPLOY_TARGET_HASH}.stamp
-			DEPENDS copy_shaders.stamp
-		)
-
-		list(APPEND DEPLOY_TARGET_HASHES ${DEPLOY_TARGET_HASH}.stamp)
-
 	endforeach()
-
-	add_custom_target(COPY_SHADERS ALL
-		DEPENDS
-			copy_shaders.stamp
-			${DEPLOY_TARGET_HASHES}
-	)
 
 	if(NOT DEFINED ENV{CommunityShadersOutputDir})
 		message("When using AUTO_PLUGIN_DEPLOYMENT option, you need to set environment variable 'CommunityShadersOutputDir'")
@@ -226,36 +159,26 @@ endif()
 # Zip base CommunityShaders and all addons as their own 7z in dist folder
 if(ZIP_TO_DIST)
 	set(ZIP_DIR "${CMAKE_CURRENT_BINARY_DIR}/zip")
+	add_custom_target(build-time-make-directory ALL
+		COMMAND ${CMAKE_COMMAND} -E remove_directory "${ZIP_DIR}" ${CMAKE_SOURCE_DIR}/dist
+		COMMAND ${CMAKE_COMMAND} -E make_directory "${ZIP_DIR}" ${CMAKE_SOURCE_DIR}/dist
+	)
+
 	message("Copying base CommunityShader into ${ZIP_DIR}.")
 	add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E remove_directory "${ZIP_DIR}" ${CMAKE_SOURCE_DIR}/dist
-		COMMAND ${CMAKE_COMMAND} -E make_directory "${ZIP_DIR}/SKSE/Plugins" ${CMAKE_SOURCE_DIR}/dist
 		COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/package "${ZIP_DIR}"
 		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${PROJECT_NAME}> "${ZIP_DIR}/SKSE/Plugins/"
 		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_PDB_FILE:${PROJECT_NAME}> "${ZIP_DIR}/SKSE/Plugins/"
 	)
-	foreach(FEATURE_PATH ${FEATURE_PATHS})
-		if (EXISTS "${FEATURE_PATH}/CORE")
-			add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-				COMMAND ${CMAKE_COMMAND} -E copy_directory ${FEATURE_PATH} "${ZIP_DIR}"
-			)
-		endif()
-	endforeach()
-	add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E remove "${ZIP_DIR}/CORE"
-	)
 
 	set(TARGET_ZIP "${PROJECT_NAME}-${UTC_NOW}.7z")
 	message("Zipping ${ZIP_DIR} to ${CMAKE_SOURCE_DIR}/dist/${TARGET_ZIP}")
-	add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+	ADD_CUSTOM_COMMAND(TARGET ${PROJECT_NAME} POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E tar cf ${CMAKE_SOURCE_DIR}/dist/${TARGET_ZIP} --format=7zip -- .
 		WORKING_DIRECTORY ${ZIP_DIR}
 	)
 
 	foreach(FEATURE_PATH ${FEATURE_PATHS})
-		if (EXISTS "${FEATURE_PATH}/CORE")
-			continue()
-		endif()
 		get_filename_component(FEATURE ${FEATURE_PATH} NAME)
 		message("Zipping ${FEATURE_PATH} to ${CMAKE_SOURCE_DIR}/dist/${FEATURE}-${UTC_NOW}.7z")
 		add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
@@ -268,15 +191,15 @@ endif()
 # Create a AIO zip for easier testing
 if(AIO_ZIP_TO_DIST)
 	if(NOT ZIP_TO_DIST)
-		add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-			COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_SOURCE_DIR}/dist
-			COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_SOURCE_DIR}/dist
+		add_custom_target(build-time-make-directory ALL
+			COMMAND ${CMAKE_COMMAND} -E remove_directory "${ZIP_DIR}" ${CMAKE_SOURCE_DIR}/dist
+			COMMAND ${CMAKE_COMMAND} -E make_directory "${ZIP_DIR}" ${CMAKE_SOURCE_DIR}/dist
 		)
 	endif()
 
 	set(TARGET_AIO_ZIP "${PROJECT_NAME}_AIO-${UTC_NOW}.7z")
 	message("Zipping ${AIO_DIR} to ${CMAKE_SOURCE_DIR}/dist/${TARGET_AIO_ZIP}")
-	add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+	ADD_CUSTOM_COMMAND(TARGET ${PROJECT_NAME} POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E tar cf ${CMAKE_SOURCE_DIR}/dist/${TARGET_AIO_ZIP} --format=7zip -- .
 		WORKING_DIRECTORY ${AIO_DIR}
 	)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ find_package(efsw CONFIG REQUIRED)
 find_package(Tracy CONFIG REQUIRED)
 add_subdirectory(${CMAKE_SOURCE_DIR}/cmake/Streamline)
 include(FidelityFX-SDK)
+include(DXRHelpers)
 
 target_compile_definitions(
 	${PROJECT_NAME}

--- a/extern/DXRHelpers/DXRHelper.h
+++ b/extern/DXRHelpers/DXRHelper.h
@@ -1,0 +1,308 @@
+/******************************************************************************
+ * Copyright 1998-2018 NVIDIA Corp. All Rights Reserved.
+ *****************************************************************************/
+
+#pragma once
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <d3d12.h>
+#include "DXSampleHelper.h"
+#include <dxcapi.h>
+
+#include <vector>
+
+namespace nv_helpers_dx12
+{
+
+//--------------------------------------------------------------------------------------------------
+//
+//
+inline ID3D12Resource* CreateBuffer(ID3D12Device* m_device, uint64_t size,
+                                    D3D12_RESOURCE_FLAGS flags, D3D12_RESOURCE_STATES initState,
+                                    const D3D12_HEAP_PROPERTIES& heapProps)
+{
+  D3D12_RESOURCE_DESC bufDesc = {};
+  bufDesc.Alignment = 0;
+  bufDesc.DepthOrArraySize = 1;
+  bufDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+  bufDesc.Flags = flags;
+  bufDesc.Format = DXGI_FORMAT_UNKNOWN;
+  bufDesc.Height = 1;
+  bufDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+  bufDesc.MipLevels = 1;
+  bufDesc.SampleDesc.Count = 1;
+  bufDesc.SampleDesc.Quality = 0;
+  bufDesc.Width = size;
+
+  ID3D12Resource* pBuffer;
+  ThrowIfFailed(m_device->CreateCommittedResource(&heapProps, D3D12_HEAP_FLAG_NONE, &bufDesc,
+                                                  initState, nullptr, IID_PPV_ARGS(&pBuffer)));
+  return pBuffer;
+}
+
+#ifndef ROUND_UP
+#define ROUND_UP(v, powerOf2Alignment) (((v) + (powerOf2Alignment)-1) & ~((powerOf2Alignment)-1))
+#endif
+
+// Specifies a heap used for uploading. This heap type has CPU access optimized
+// for uploading to the GPU.
+static const D3D12_HEAP_PROPERTIES kUploadHeapProps = {
+    D3D12_HEAP_TYPE_UPLOAD, D3D12_CPU_PAGE_PROPERTY_UNKNOWN, D3D12_MEMORY_POOL_UNKNOWN, 0, 0};
+
+// Specifies the default heap. This heap type experiences the most bandwidth for
+// the GPU, but cannot provide CPU access.
+static const D3D12_HEAP_PROPERTIES kDefaultHeapProps = {
+    D3D12_HEAP_TYPE_DEFAULT, D3D12_CPU_PAGE_PROPERTY_UNKNOWN, D3D12_MEMORY_POOL_UNKNOWN, 0, 0};
+
+//--------------------------------------------------------------------------------------------------
+// Compile a HLSL file into a DXIL library
+//
+IDxcBlob* CompileShaderLibrary(LPCWSTR fileName)
+{
+  static IDxcCompiler* pCompiler = nullptr;
+  static IDxcLibrary* pLibrary = nullptr;
+  static IDxcIncludeHandler* dxcIncludeHandler;
+
+  HRESULT hr;
+
+  // Initialize the DXC compiler and compiler helper
+  if (!pCompiler)
+  {
+    ThrowIfFailed(DxcCreateInstance(CLSID_DxcCompiler, __uuidof(IDxcCompiler), (void **)&pCompiler));
+    ThrowIfFailed(DxcCreateInstance(CLSID_DxcLibrary, __uuidof(IDxcLibrary), (void **)&pLibrary));
+    ThrowIfFailed(pLibrary->CreateIncludeHandler(&dxcIncludeHandler));
+  }
+  // Open and read the file
+  std::ifstream shaderFile(fileName);
+  if (shaderFile.good() == false)
+  {
+    throw std::logic_error("Cannot find shader file");
+  }
+  std::stringstream strStream;
+  strStream << shaderFile.rdbuf();
+  std::string sShader = strStream.str();
+
+  // Create blob from the string
+  IDxcBlobEncoding* pTextBlob;
+  ThrowIfFailed(pLibrary->CreateBlobWithEncodingFromPinned(
+      (LPBYTE)sShader.c_str(), (uint32_t)sShader.size(), 0, &pTextBlob));
+
+  // Compile
+  IDxcOperationResult* pResult;
+  ThrowIfFailed(pCompiler->Compile(pTextBlob, fileName, L"", L"lib_6_3", nullptr, 0, nullptr, 0,
+                                   dxcIncludeHandler, &pResult));
+
+  // Verify the result
+  HRESULT resultCode;
+  ThrowIfFailed(pResult->GetStatus(&resultCode));
+  if (FAILED(resultCode))
+  {
+    IDxcBlobEncoding* pError;
+    hr = pResult->GetErrorBuffer(&pError);
+    if (FAILED(hr))
+    {
+      throw std::logic_error("Failed to get shader compiler error");
+    }
+
+    // Convert error blob to a string
+    std::vector<char> infoLog(pError->GetBufferSize() + 1);
+    memcpy(infoLog.data(), pError->GetBufferPointer(), pError->GetBufferSize());
+    infoLog[pError->GetBufferSize()] = 0;
+
+    std::string errorMsg = "Shader Compiler Error:\n";
+    errorMsg.append(infoLog.data());
+
+    MessageBoxA(nullptr, errorMsg.c_str(), "Error!", MB_OK);
+    throw std::logic_error("Failed compile shader");
+  }
+
+  IDxcBlob* pBlob;
+  ThrowIfFailed(pResult->GetResult(&pBlob));
+  return pBlob;
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+//
+ID3D12DescriptorHeap* CreateDescriptorHeap(ID3D12Device* device, uint32_t count,
+                                           D3D12_DESCRIPTOR_HEAP_TYPE type, bool shaderVisible)
+{
+  D3D12_DESCRIPTOR_HEAP_DESC desc = {};
+  desc.NumDescriptors = count;
+  desc.Type = type;
+  desc.Flags =
+      shaderVisible ? D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE : D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+
+  ID3D12DescriptorHeap* pHeap;
+  ThrowIfFailed(device->CreateDescriptorHeap(&desc, IID_PPV_ARGS(&pHeap)));
+  return pHeap;
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+//
+template <class Vertex>
+void GenerateMengerSponge(int32_t level, float probability, std::vector<Vertex>& outputVertices,
+                          std::vector<UINT>& outputIndices)
+{
+  struct Cube
+  {
+    Cube(const XMVECTOR& tlf, float s) : m_topLeftFront(tlf), m_size(s)
+    {
+    }
+    XMVECTOR m_topLeftFront;
+    float m_size;
+
+    void enqueueQuad(std::vector<Vertex>& vertices, std::vector<UINT>& indices,
+                     const XMVECTOR& bottomLeft4, const XMVECTOR& dx, const XMVECTOR& dy, bool flip)
+    {
+      UINT currentIndex = static_cast<UINT>(vertices.size());
+      XMFLOAT3 bottomLeft(bottomLeft4.m128_f32);
+      XMVECTOR normal = XMVector3Cross(XMVector3Normalize(dy), XMVector3Normalize(dx));
+      if (flip)
+      {
+        normal = -normal;
+
+        indices.push_back(currentIndex + 0);
+        indices.push_back(currentIndex + 2);
+        indices.push_back(currentIndex + 1);
+
+        indices.push_back(currentIndex + 3);
+        indices.push_back(currentIndex + 1);
+        indices.push_back(currentIndex + 2);
+      }
+      else
+      {
+
+        indices.push_back(currentIndex + 0);
+        indices.push_back(currentIndex + 1);
+        indices.push_back(currentIndex + 2);
+
+        indices.push_back(currentIndex + 2);
+        indices.push_back(currentIndex + 1);
+        indices.push_back(currentIndex + 3);
+      }
+
+      const DirectX::XMFLOAT4 n = {normal.m128_f32[0], normal.m128_f32[1], normal.m128_f32[2], 0.f};
+      vertices.push_back(
+          {{bottomLeft.x, bottomLeft.y, bottomLeft.z, 1.f}, n, {1.f, 0.f, 0.f, 1.f}});
+      vertices.push_back({{bottomLeft.x + dx.m128_f32[0], bottomLeft.y + dx.m128_f32[1],
+                           bottomLeft.z + dx.m128_f32[2], 1.f},
+                          n,
+                          {0.5f, 1.f, 0.f, 1.f}});
+      vertices.push_back({{bottomLeft.x + dy.m128_f32[0], bottomLeft.y + dy.m128_f32[1],
+                           bottomLeft.z + dy.m128_f32[2], 1.f},
+                          n,
+                          {0.5f, 0.f, 1.f, 1.f}});
+
+      vertices.push_back({{bottomLeft.x + dx.m128_f32[0] + dy.m128_f32[0],
+                           bottomLeft.y + dx.m128_f32[1] + dy.m128_f32[1],
+                           bottomLeft.z + dx.m128_f32[2] + dy.m128_f32[2], 1.f},
+                          n,
+                          {0.f, 1.f, 0.f, 1.f}});
+    }
+    void enqueueVertices(std::vector<Vertex>& vertices, std::vector<UINT>& indices)
+    {
+
+      XMVECTOR current = m_topLeftFront;
+      enqueueQuad(vertices, indices, current, {m_size, 0, 0}, {0, m_size, 0}, false);
+      enqueueQuad(vertices, indices, current, {m_size, 0, 0}, {0, 0, m_size}, true);
+      enqueueQuad(vertices, indices, current, {0, m_size, 0}, {0, 0, m_size}, false);
+
+      current.m128_f32[0] += m_size;
+      current.m128_f32[1] += m_size;
+      current.m128_f32[2] += m_size;
+      enqueueQuad(vertices, indices, current, {-m_size, 0, 0}, {0, -m_size, 0}, true);
+      enqueueQuad(vertices, indices, current, {-m_size, 0, 0}, {0, 0, -m_size}, false);
+      enqueueQuad(vertices, indices, current, {0, -m_size, 0}, {0, 0, -m_size}, true);
+    }
+    void split(std::vector<Cube>& cubes)
+    {
+      float size = m_size / 3.f;
+      XMVECTOR topLeftFront = m_topLeftFront;
+      for (int x = 0; x < 3; x++)
+      {
+        topLeftFront.m128_f32[0] = m_topLeftFront.m128_f32[0] + static_cast<float>(x) * size;
+        for (int y = 0; y < 3; y++)
+        {
+          if (x == 1 && y == 1)
+            continue;
+          topLeftFront.m128_f32[1] = m_topLeftFront.m128_f32[1] + static_cast<float>(y) * size;
+          for (int z = 0; z < 3; z++)
+          {
+            if (x == 1 && z == 1)
+              continue;
+            if (y == 1 && z == 1)
+              continue;
+
+            topLeftFront.m128_f32[2] = m_topLeftFront.m128_f32[2] + static_cast<float>(z) * size;
+            cubes.push_back({topLeftFront, size});
+          }
+        }
+      }
+    }
+
+    void splitProb(std::vector<Cube>& cubes, float prob)
+    {
+
+      float size = m_size / 3.f;
+      XMVECTOR topLeftFront = m_topLeftFront;
+      for (int x = 0; x < 3; x++)
+      {
+        topLeftFront.m128_f32[0] = m_topLeftFront.m128_f32[0] + static_cast<float>(x) * size;
+        for (int y = 0; y < 3; y++)
+        {
+          topLeftFront.m128_f32[1] = m_topLeftFront.m128_f32[1] + static_cast<float>(y) * size;
+          for (int z = 0; z < 3; z++)
+          {
+            float sample = rand() / static_cast<float>(RAND_MAX);
+            if (sample > prob)
+              continue;
+            topLeftFront.m128_f32[2] = m_topLeftFront.m128_f32[2] + static_cast<float>(z) * size;
+            cubes.push_back({topLeftFront, size});
+          }
+        }
+      }
+    }
+  };
+
+  XMVECTOR orig;
+  orig.m128_f32[0] = -0.5f;
+  orig.m128_f32[1] = -0.5f;
+  orig.m128_f32[2] = -0.5f;
+  orig.m128_f32[3] = 1.f;
+
+  Cube cube(orig, 1.f);
+
+  std::vector<Cube> cubes1 = {cube};
+  std::vector<Cube> cubes2 = {};
+
+  auto previous = &cubes1;
+  auto next = &cubes2;
+
+  for (int i = 0; i < level; i++)
+  {
+    for (Cube& c : *previous)
+    {
+      if (probability < 0.f)
+        c.split(*next);
+      else
+        c.splitProb(*next, 20.f / 27.f);
+    }
+    auto temp = previous;
+    previous = next;
+    next = temp;
+    next->clear();
+  }
+
+  outputVertices.reserve(24 * previous->size());
+  outputIndices.reserve(24 * previous->size());
+  for (Cube& c : *previous)
+  {
+    c.enqueueVertices(outputVertices, outputIndices);
+  }
+}
+
+} // namespace nv_helpers_dx12

--- a/extern/DXRHelpers/nv_helpers_dx12/BottomLevelASGenerator.cpp
+++ b/extern/DXRHelpers/nv_helpers_dx12/BottomLevelASGenerator.cpp
@@ -1,0 +1,246 @@
+/*-----------------------------------------------------------------------
+Copyright (c) 2014-2018, NVIDIA. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Neither the name of its contributors may be used to endorse
+or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-----------------------------------------------------------------------*/
+
+/*
+Contacts for feedback:
+- pgautron@nvidia.com (Pascal Gautron)
+- mlefrancois@nvidia.com (Martin-Karl Lefrancois)
+*/
+
+#include "BottomLevelASGenerator.h"
+
+// Helper to compute aligned buffer sizes
+#ifndef ROUND_UP
+#define ROUND_UP(v, powerOf2Alignment)                                         \
+  (((v) + (powerOf2Alignment)-1) & ~((powerOf2Alignment)-1))
+#endif
+
+namespace nv_helpers_dx12 {
+
+//--------------------------------------------------------------------------------------------------
+// Add a vertex buffer in GPU memory into the acceleration structure. The
+// vertices are supposed to be represented by 3 float32 value
+void BottomLevelASGenerator::AddVertexBuffer(
+    ID3D12Resource *vertexBuffer, // Buffer containing the vertex coordinates,
+                                  // possibly interleaved with other vertex data
+    UINT64
+        vertexOffsetInBytes, // Offset of the first vertex in the vertex buffer
+    uint32_t vertexCount,    // Number of vertices to consider in the buffer
+    UINT vertexSizeInBytes,  // Size of a vertex including all its other data,
+                             // used to stride in the buffer
+    ID3D12Resource *transformBuffer, // Buffer containing a 4x4 transform matrix
+                                     // in GPU memory, to be applied to the
+                                     // vertices. This buffer cannot be nullptr
+    UINT64 transformOffsetInBytes,   // Offset of the transform matrix in the
+                                     // transform buffer
+    bool isOpaque /* = true */ // If true, the geometry is considered opaque,
+                               // optimizing the search for a closest hit
+) {
+  AddVertexBuffer(vertexBuffer, vertexOffsetInBytes, vertexCount,
+                  vertexSizeInBytes, nullptr, 0, 0, transformBuffer,
+                  transformOffsetInBytes, isOpaque);
+}
+
+//--------------------------------------------------------------------------------------------------
+// Add a vertex buffer along with its index buffer in GPU memory into the
+// acceleration structure. The vertices are supposed to be represented by 3
+// float32 value. This implementation limits the original flexibility of the
+// API:
+//   - triangles (no custom intersector support)
+//   - 3xfloat32 format
+//   - 32-bit indices
+void BottomLevelASGenerator::AddVertexBuffer(
+    ID3D12Resource *vertexBuffer, // Buffer containing the vertex coordinates,
+                                  // possibly interleaved with other vertex data
+    UINT64
+        vertexOffsetInBytes, // Offset of the first vertex in the vertex buffer
+    uint32_t vertexCount,    // Number of vertices to consider in the buffer
+    UINT vertexSizeInBytes,  // Size of a vertex including all its other data,
+                             // used to stride in the buffer
+    ID3D12Resource *indexBuffer, // Buffer containing the vertex indices
+                                 // describing the triangles
+    UINT64 indexOffsetInBytes, // Offset of the first index in the index buffer
+    uint32_t indexCount,       // Number of indices to consider in the buffer
+    ID3D12Resource *transformBuffer, // Buffer containing a 4x4 transform matrix
+                                     // in GPU memory, to be applied to the
+                                     // vertices. This buffer cannot be nullptr
+    UINT64 transformOffsetInBytes,   // Offset of the transform matrix in the
+                                     // transform buffer
+    bool isOpaque /* = true */ // If true, the geometry is considered opaque,
+                               // optimizing the search for a closest hit
+) {
+  // Create the DX12 descriptor representing the input data, assumed to be
+  // opaque triangles, with 3xf32 vertex coordinates and 32-bit indices
+  D3D12_RAYTRACING_GEOMETRY_DESC descriptor = {};
+  descriptor.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES;
+  descriptor.Triangles.VertexBuffer.StartAddress =
+      vertexBuffer->GetGPUVirtualAddress() + vertexOffsetInBytes;
+  descriptor.Triangles.VertexBuffer.StrideInBytes = vertexSizeInBytes;
+  descriptor.Triangles.VertexCount = vertexCount;
+  descriptor.Triangles.VertexFormat = DXGI_FORMAT_R32G32B32_FLOAT;
+  descriptor.Triangles.IndexBuffer =
+      indexBuffer ? (indexBuffer->GetGPUVirtualAddress() + indexOffsetInBytes)
+                  : 0;
+  descriptor.Triangles.IndexFormat =
+      indexBuffer ? DXGI_FORMAT_R32_UINT : DXGI_FORMAT_UNKNOWN;
+  descriptor.Triangles.IndexCount = indexCount;
+  descriptor.Triangles.Transform3x4 =
+      transformBuffer
+          ? (transformBuffer->GetGPUVirtualAddress() + transformOffsetInBytes)
+          : 0;
+  descriptor.Flags = isOpaque ? D3D12_RAYTRACING_GEOMETRY_FLAG_OPAQUE
+                              : D3D12_RAYTRACING_GEOMETRY_FLAG_NONE;
+
+  m_vertexBuffers.push_back(descriptor);
+}
+
+//--------------------------------------------------------------------------------------------------
+// Compute the size of the scratch space required to build the acceleration
+// structure, as well as the size of the resulting structure. The allocation of
+// the buffers is then left to the application
+void BottomLevelASGenerator::ComputeASBufferSizes(
+    ID3D12Device5 *device, // Device on which the build will be performed
+    bool allowUpdate,     // If true, the resulting acceleration structure will
+                          // allow iterative updates
+    UINT64 *scratchSizeInBytes, // Required scratch memory on the GPU to build
+                                // the acceleration structure
+    UINT64 *resultSizeInBytes   // Required GPU memory to store the acceleration
+                                // structure
+) {
+  // The generated AS can support iterative updates. This may change the final
+  // size of the AS as well as the temporary memory requirements, and hence has
+  // to be set before the actual build
+  m_flags =
+      allowUpdate
+          ? D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE
+          : D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_NONE;
+
+  // Describe the work being requested, in this case the construction of a
+  // (possibly dynamic) bottom-level hierarchy, with the given vertex buffers
+  
+  D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS prebuildDesc;
+  prebuildDesc.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+  prebuildDesc.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+  prebuildDesc.NumDescs = static_cast<UINT>(m_vertexBuffers.size());
+  prebuildDesc.pGeometryDescs = m_vertexBuffers.data();
+  prebuildDesc.Flags = m_flags;
+
+  // This structure is used to hold the sizes of the required scratch memory and
+  // resulting AS
+  D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO info = {};
+
+  // Building the acceleration structure (AS) requires some scratch space, as
+  // well as space to store the resulting structure This function computes a
+  // conservative estimate of the memory requirements for both, based on the
+  // geometry size.
+  device->GetRaytracingAccelerationStructurePrebuildInfo(&prebuildDesc, &info);
+
+  // Buffer sizes need to be 256-byte-aligned
+  *scratchSizeInBytes =
+      ROUND_UP(info.ScratchDataSizeInBytes,
+               D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
+  *resultSizeInBytes = ROUND_UP(info.ResultDataMaxSizeInBytes,
+                                D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
+
+  // Store the memory requirements for use during build
+  m_scratchSizeInBytes = *scratchSizeInBytes;
+  m_resultSizeInBytes = *resultSizeInBytes;
+}
+
+//--------------------------------------------------------------------------------------------------
+// Enqueue the construction of the acceleration structure on a command list,
+// using application-provided buffers and possibly a pointer to the previous
+// acceleration structure in case of iterative updates. Note that the update can
+// be done in place: the result and previousResult pointers can be the same.
+void BottomLevelASGenerator::Generate(
+    ID3D12GraphicsCommandList4
+        *commandList, // Command list on which the build will be enqueued
+    ID3D12Resource *scratchBuffer, // Scratch buffer used by the builder to
+                                   // store temporary data
+    ID3D12Resource
+        *resultBuffer, // Result buffer storing the acceleration structure
+    bool updateOnly,   // If true, simply refit the existing
+                       // acceleration structure
+    ID3D12Resource *previousResult // Optional previous acceleration
+                                   // structure, used if an iterative update
+                                   // is requested
+) {
+
+  D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS flags = m_flags;
+  // The stored flags represent whether the AS has been built for updates or
+  // not. If yes and an update is requested, the builder is told to only update
+  // the AS instead of fully rebuilding it
+  if (flags ==
+          D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE &&
+      updateOnly) {
+    flags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE;
+  }
+
+  // Sanity checks
+  if (m_flags !=
+          D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE &&
+      updateOnly) {
+    throw std::logic_error(
+        "Cannot update a bottom-level AS not originally built for updates");
+  }
+  if (updateOnly && previousResult == nullptr) {
+    throw std::logic_error(
+        "Bottom-level hierarchy update requires the previous hierarchy");
+  }
+
+  if (m_resultSizeInBytes == 0 || m_scratchSizeInBytes == 0) {
+    throw std::logic_error(
+        "Invalid scratch and result buffer sizes - ComputeASBufferSizes needs "
+        "to be called before Build");
+  }
+  // Create a descriptor of the requested builder work, to generate a
+  // bottom-level AS from the input parameters
+  D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC buildDesc;
+  buildDesc.Inputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+  buildDesc.Inputs.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+  buildDesc.Inputs.NumDescs = static_cast<UINT>(m_vertexBuffers.size());
+  buildDesc.Inputs.pGeometryDescs = m_vertexBuffers.data();
+  buildDesc.DestAccelerationStructureData = {
+      resultBuffer->GetGPUVirtualAddress()};
+  buildDesc.ScratchAccelerationStructureData = {
+      scratchBuffer->GetGPUVirtualAddress()};
+  buildDesc.SourceAccelerationStructureData =
+      previousResult ? previousResult->GetGPUVirtualAddress() : 0;
+  buildDesc.Inputs.Flags = flags;
+
+  // Build the AS
+  commandList->BuildRaytracingAccelerationStructure(&buildDesc, 0, nullptr);
+
+  // Wait for the builder to complete by setting a barrier on the resulting
+  // buffer. This is particularly important as the construction of the top-level
+  // hierarchy may be called right afterwards, before executing the command
+  // list.
+  D3D12_RESOURCE_BARRIER uavBarrier;
+  uavBarrier.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
+  uavBarrier.UAV.pResource = resultBuffer;
+  uavBarrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+  commandList->ResourceBarrier(1, &uavBarrier);
+}
+} // namespace nv_helpers_dx12

--- a/extern/DXRHelpers/nv_helpers_dx12/BottomLevelASGenerator.cpp
+++ b/extern/DXRHelpers/nv_helpers_dx12/BottomLevelASGenerator.cpp
@@ -139,7 +139,7 @@ void BottomLevelASGenerator::ComputeASBufferSizes(
 
   // Describe the work being requested, in this case the construction of a
   // (possibly dynamic) bottom-level hierarchy, with the given vertex buffers
-  
+
   D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS prebuildDesc;
   prebuildDesc.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
   prebuildDesc.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;

--- a/extern/DXRHelpers/nv_helpers_dx12/BottomLevelASGenerator.h
+++ b/extern/DXRHelpers/nv_helpers_dx12/BottomLevelASGenerator.h
@@ -1,0 +1,171 @@
+/*-----------------------------------------------------------------------
+Copyright (c) 2014-2018, NVIDIA. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Neither the name of its contributors may be used to endorse
+or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-----------------------------------------------------------------------*/
+
+/*
+Contacts for feedback:
+- pgautron@nvidia.com (Pascal Gautron)
+- mlefrancois@nvidia.com (Martin-Karl Lefrancois)
+
+The bottom-level hierarchy is used to store the triangle data in a way suitable
+for fast ray-triangle intersection at runtime. To be built, this data structure
+requires some scratch space which has to be allocated by the application.
+Similarly, the resulting data structure is stored in an application-controlled
+buffer.
+
+To be used, the application must first add all the vertex buffers to be
+contained in the final structure, using AddVertexBuffer. After all buffers have
+been added, ComputeASBufferSizes will prepare the build, and provide the
+required sizes for the scratch data and the final result. The Build call will
+finally compute the acceleration structure and store it in the result buffer.
+
+Note that the build is enqueued in the command list, meaning that the scratch
+buffer needs to be kept until the command list execution is finished.
+
+
+Example:
+
+BottomLevelASGenerator bottomLevelAS;
+bottomLevelAS.AddVertexBuffer(vertexBuffer, 0, vertexCount, sizeof(Vertex),
+identityMat.Get(), 0); bottomLevelAS.AddVertexBuffer(vertexBuffer2, 0,
+vertexCount2, sizeof(Vertex), identityMat.Get(), 0);
+...
+UINT64 scratchSizeInBytes = 0;
+UINT64 resultSizeInBytes = 0;
+bottomLevelAS.ComputeASBufferSizes(GetRTDevice(), false, &scratchSizeInBytes,
+&resultSizeInBytes); AccelerationStructureBuffers buffers; buffers.pScratch =
+nv_helpers_dx12::CreateBuffer(..., scratchSizeInBytes, ...); buffers.pResult =
+nv_helpers_dx12::CreateBuffer(..., resultSizeInBytes, ...);
+
+bottomLevelAS.Generate(m_commandList.Get(), rtCmdList, buffers.pScratch.Get(),
+buffers.pResult.Get(), false, nullptr);
+
+return buffers;
+
+*/
+
+#pragma once
+
+#include "d3d12.h"
+
+#include <vector>
+
+namespace nv_helpers_dx12
+{
+
+/// Helper class to generate bottom-level acceleration structures for raytracing
+class BottomLevelASGenerator
+{
+public:
+  /// Add a vertex buffer in GPU memory into the acceleration structure. The
+  /// vertices are supposed to be represented by 3 float32 value. Indices are
+  /// implicit.
+  void AddVertexBuffer(ID3D12Resource* vertexBuffer, /// Buffer containing the vertex coordinates,
+                                                     /// possibly interleaved with other vertex data
+                       UINT64 vertexOffsetInBytes,   /// Offset of the first vertex in the vertex
+                                                     /// buffer
+                       uint32_t vertexCount,         /// Number of vertices to consider
+                                                     /// in the buffer
+                       UINT vertexSizeInBytes,       /// Size of a vertex including all
+                                                     /// its other data, used to stride
+                                                     /// in the buffer
+                       ID3D12Resource* transformBuffer, /// Buffer containing a 4x4 transform
+                                                        /// matrix in GPU memory, to be applied
+                                                        /// to the vertices. This buffer cannot
+                                                        /// be nullptr
+                       UINT64 transformOffsetInBytes,   /// Offset of the transform matrix in the
+                                                        /// transform buffer
+                       bool isOpaque = true /// If true, the geometry is considered opaque,
+                                            /// optimizing the search for a closest hit
+  );
+
+  /// Add a vertex buffer along with its index buffer in GPU memory into the acceleration structure.
+  /// The vertices are supposed to be represented by 3 float32 value, and the indices are 32-bit
+  /// unsigned ints
+  void AddVertexBuffer(ID3D12Resource* vertexBuffer, /// Buffer containing the vertex coordinates,
+                                                     /// possibly interleaved with other vertex data
+                       UINT64 vertexOffsetInBytes,   /// Offset of the first vertex in the vertex
+                                                     /// buffer
+                       uint32_t vertexCount,         /// Number of vertices to consider
+                                                     /// in the buffer
+                       UINT vertexSizeInBytes,       /// Size of a vertex including
+                                                     /// all its other data,
+                                                     /// used to stride in the buffer
+                       ID3D12Resource* indexBuffer,  /// Buffer containing the vertex indices
+                                                     /// describing the triangles
+                       UINT64 indexOffsetInBytes,    /// Offset of the first index in
+                                                     /// the index buffer
+                       uint32_t indexCount,          /// Number of indices to consider in the buffer
+                       ID3D12Resource* transformBuffer, /// Buffer containing a 4x4 transform
+                                                        /// matrix in GPU memory, to be applied
+                                                        /// to the vertices. This buffer cannot
+                                                        /// be nullptr
+                       UINT64 transformOffsetInBytes,   /// Offset of the transform matrix in the
+                                                        /// transform buffer
+                       bool isOpaque = true /// If true, the geometry is considered opaque,
+                                            /// optimizing the search for a closest hit
+  );
+
+  /// Compute the size of the scratch space required to build the acceleration structure, as well as
+  /// the size of the resulting structure. The allocation of the buffers is then left to the
+  /// application
+  void ComputeASBufferSizes(
+      ID3D12Device5* device, /// Device on which the build will be performed
+      bool allowUpdate,           /// If true, the resulting acceleration structure will
+                                  /// allow iterative updates
+      UINT64* scratchSizeInBytes, /// Required scratch memory on the GPU to
+                                  /// build the acceleration structure
+      UINT64* resultSizeInBytes   /// Required GPU memory to store the
+                                  /// acceleration structure
+  );
+
+  /// Enqueue the construction of the acceleration structure on a command list, using
+  /// application-provided buffers and possibly a pointer to the previous acceleration structure in
+  /// case of iterative updates. Note that the update can be done in place: the result and
+  /// previousResult pointers can be the same.
+  void Generate(
+      ID3D12GraphicsCommandList4* commandList, /// Command list on which the build will be enqueued
+      ID3D12Resource* scratchBuffer, /// Scratch buffer used by the builder to
+                                     /// store temporary data
+      ID3D12Resource* resultBuffer,  /// Result buffer storing the acceleration structure
+      bool updateOnly = false,       /// If true, simply refit the existing acceleration structure
+      ID3D12Resource* previousResult = nullptr /// Optional previous acceleration structure, used
+                                               /// if an iterative update is requested
+  );
+
+private:
+  /// Vertex buffer descriptors used to generate the AS
+  std::vector<D3D12_RAYTRACING_GEOMETRY_DESC> m_vertexBuffers = {};
+
+  /// Amount of temporary memory required by the builder
+  UINT64 m_scratchSizeInBytes = 0;
+
+  /// Amount of memory required to store the AS
+  UINT64 m_resultSizeInBytes = 0;
+
+  /// Flags for the builder, specifying whether to allow iterative updates, or
+  /// when to perform an update
+  D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS m_flags;
+};
+} // namespace nv_helpers_dx12

--- a/extern/DXRHelpers/nv_helpers_dx12/RaytracingPipelineGenerator.cpp
+++ b/extern/DXRHelpers/nv_helpers_dx12/RaytracingPipelineGenerator.cpp
@@ -1,0 +1,522 @@
+/*-----------------------------------------------------------------------
+Copyright (c) 2014-2018, NVIDIA. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Neither the name of its contributors may be used to endorse
+or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-----------------------------------------------------------------------*/
+
+/*
+Contacts for feedback:
+- pgautron@nvidia.com (Pascal Gautron)
+- mlefrancois@nvidia.com (Martin-Karl Lefrancois)
+
+The raytracing pipeline combines the raytracing shaders into a state object,
+that can be thought of as an executable GPU program. For that, it requires the
+shaders compiled as DXIL libraries, where each library exports symbols in a way
+similar to DLLs. Those symbols are then used to refer to these shaders libraries
+when creating hit groups, associating the shaders to their root signatures and
+declaring the steps of the pipeline. All the calls to this helper class can be
+done in arbitrary order. Some basic sanity checks are also performed when
+compiling in debug mode.
+
+*/
+
+#include "RaytracingPipelineGenerator.h"
+
+#include "dxcapi.h"
+#include <unordered_set>
+
+namespace nv_helpers_dx12
+{
+
+//--------------------------------------------------------------------------------------------------
+// The pipeline helper requires access to the device, as well as the
+// raytracing device prior to Windows 10 RS5.
+RayTracingPipelineGenerator::RayTracingPipelineGenerator(ID3D12Device5* device)
+    : m_device(device)
+{
+  // The pipeline creation requires having at least one empty global and local root signatures, so
+  // we systematically create both, as this does not incur any overhead
+  CreateDummyRootSignatures();
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Add a DXIL library to the pipeline. Note that this library has to be
+// compiled with dxc, using a lib_6_3 target. The exported symbols must correspond exactly to the
+// names of the shaders declared in the library, although unused ones can be omitted.
+void RayTracingPipelineGenerator::AddLibrary(IDxcBlob* dxilLibrary,
+                                             const std::vector<std::wstring>& symbolExports)
+{
+  m_libraries.emplace_back(Library(dxilLibrary, symbolExports));
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// In DXR the hit-related shaders are grouped into hit groups. Such shaders are:
+// - The intersection shader, which can be used to intersect custom geometry, and is called upon
+//   hitting the bounding box the the object. A default one exists to intersect triangles
+// - The any hit shader, called on each intersection, which can be used to perform early
+//   alpha-testing and allow the ray to continue if needed. Default is a pass-through.
+// - The closest hit shader, invoked on the hit point closest to the ray start.
+// The shaders in a hit group share the same root signature, and are only referred to by the
+// hit group name in other places of the program.
+void RayTracingPipelineGenerator::AddHitGroup(const std::wstring& hitGroupName,
+                                              const std::wstring& closestHitSymbol,
+                                              const std::wstring& anyHitSymbol /*= L""*/,
+                                              const std::wstring& intersectionSymbol /*= L""*/)
+{
+  m_hitGroups.emplace_back(
+      HitGroup(hitGroupName, closestHitSymbol, anyHitSymbol, intersectionSymbol));
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// The shaders and hit groups may have various root signatures. This call associates a root
+// signature to one or more symbols. All imported symbols must be associated to one root
+// signature.
+void RayTracingPipelineGenerator::AddRootSignatureAssociation(
+    ID3D12RootSignature* rootSignature, const std::vector<std::wstring>& symbols)
+{
+  m_rootSignatureAssociations.emplace_back(RootSignatureAssociation(rootSignature, symbols));
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// The payload is the way hit or miss shaders can exchange data with the shader that called
+// TraceRay. When several ray types are used (e.g. primary and shadow rays), this value must be
+// the largest possible payload size. Note that to optimize performance, this size must be kept
+// as low as possible.
+void RayTracingPipelineGenerator::SetMaxPayloadSize(UINT sizeInBytes)
+{
+  m_maxPayLoadSizeInBytes = sizeInBytes;
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// When hitting geometry, a number of surface attributes can be generated by the intersector.
+// Using the built-in triangle intersector the attributes are the barycentric coordinates, with a
+// size 2*sizeof(float).
+void RayTracingPipelineGenerator::SetMaxAttributeSize(UINT sizeInBytes)
+{
+  m_maxAttributeSizeInBytes = sizeInBytes;
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Upon hitting a surface, a closest hit shader can issue a new TraceRay call. This parameter
+// indicates the maximum level of recursion. Note that this depth should be kept as low as
+// possible, typically 2, to allow hit shaders to trace shadow rays. Recursive ray tracing
+// algorithms must be flattened to a loop in the ray generation program for best performance.
+void RayTracingPipelineGenerator::SetMaxRecursionDepth(UINT maxDepth)
+{
+  m_maxRecursionDepth = maxDepth;
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Compiles the raytracing state object
+ID3D12StateObject* RayTracingPipelineGenerator::Generate()
+{
+  // The pipeline is made of a set of sub-objects, representing the DXIL libraries, hit group
+  // declarations, root signature associations, plus some configuration objects
+  UINT64 subobjectCount =
+      m_libraries.size() +                     // DXIL libraries
+      m_hitGroups.size() +                     // Hit group declarations
+      1 +                                      // Shader configuration
+      1 +                                      // Shader payload
+      2 * m_rootSignatureAssociations.size() + // Root signature declaration + association
+      2 +                                      // Empty global and local root signatures
+      1;                                       // Final pipeline subobject
+
+  // Initialize a vector with the target object count. It is necessary to make the allocation before
+  // adding subobjects as some subobjects reference other subobjects by pointer. Using push_back may
+  // reallocate the array and invalidate those pointers.
+  std::vector<D3D12_STATE_SUBOBJECT> subobjects(subobjectCount);
+
+  UINT currentIndex = 0;
+
+  // Add all the DXIL libraries
+  for (const Library& lib : m_libraries)
+  {
+    D3D12_STATE_SUBOBJECT libSubobject = {};
+    libSubobject.Type = D3D12_STATE_SUBOBJECT_TYPE_DXIL_LIBRARY;
+    libSubobject.pDesc = &lib.m_libDesc;
+
+    subobjects[currentIndex++] = libSubobject;
+  }
+
+  // Add all the hit group declarations
+  for (const HitGroup& group : m_hitGroups)
+  {
+    D3D12_STATE_SUBOBJECT hitGroup = {};
+    hitGroup.Type = D3D12_STATE_SUBOBJECT_TYPE_HIT_GROUP;
+    hitGroup.pDesc = &group.m_desc;
+
+    subobjects[currentIndex++] = hitGroup;
+  }
+
+  // Add a subobject for the shader payload configuration
+  D3D12_RAYTRACING_SHADER_CONFIG shaderDesc = {};
+  shaderDesc.MaxPayloadSizeInBytes = m_maxPayLoadSizeInBytes;
+  shaderDesc.MaxAttributeSizeInBytes = m_maxAttributeSizeInBytes;
+
+  D3D12_STATE_SUBOBJECT shaderConfigObject = {};
+  shaderConfigObject.Type = D3D12_STATE_SUBOBJECT_TYPE_RAYTRACING_SHADER_CONFIG;
+  shaderConfigObject.pDesc = &shaderDesc;
+
+  subobjects[currentIndex++] = shaderConfigObject;
+
+  // Build a list of all the symbols for ray generation, miss and hit groups
+  // Those shaders have to be associated with the payload definition
+  std::vector<std::wstring> exportedSymbols = {};
+  std::vector<LPCWSTR> exportedSymbolPointers = {};
+  BuildShaderExportList(exportedSymbols);
+
+  // Build an array of the string pointers
+  exportedSymbolPointers.reserve(exportedSymbols.size());
+  for (const auto& name : exportedSymbols)
+  {
+    exportedSymbolPointers.push_back(name.c_str());
+  }
+  const WCHAR** shaderExports = exportedSymbolPointers.data();
+
+  // Add a subobject for the association between shaders and the payload
+  D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION shaderPayloadAssociation = {};
+  shaderPayloadAssociation.NumExports = static_cast<UINT>(exportedSymbols.size());
+  shaderPayloadAssociation.pExports = shaderExports;
+
+  // Associate the set of shaders with the payload defined in the previous subobject
+  shaderPayloadAssociation.pSubobjectToAssociate = &subobjects[(currentIndex - 1)];
+
+  // Create and store the payload association object
+  D3D12_STATE_SUBOBJECT shaderPayloadAssociationObject = {};
+  shaderPayloadAssociationObject.Type = D3D12_STATE_SUBOBJECT_TYPE_SUBOBJECT_TO_EXPORTS_ASSOCIATION;
+  shaderPayloadAssociationObject.pDesc = &shaderPayloadAssociation;
+  subobjects[currentIndex++] = shaderPayloadAssociationObject;
+
+  // The root signature association requires two objects for each: one to declare the root
+  // signature, and another to associate that root signature to a set of symbols
+  for (RootSignatureAssociation& assoc : m_rootSignatureAssociations)
+  {
+
+    // Add a subobject to declare the root signature
+    D3D12_STATE_SUBOBJECT rootSigObject = {};
+    rootSigObject.Type = D3D12_STATE_SUBOBJECT_TYPE_LOCAL_ROOT_SIGNATURE;
+    rootSigObject.pDesc = &assoc.m_rootSignature;
+
+    subobjects[currentIndex++] = rootSigObject;
+
+    // Add a subobject for the association between the exported shader symbols and the root
+    // signature
+    assoc.m_association.NumExports = static_cast<UINT>(assoc.m_symbolPointers.size());
+    assoc.m_association.pExports = assoc.m_symbolPointers.data();
+    assoc.m_association.pSubobjectToAssociate = &subobjects[(currentIndex - 1)];
+
+    D3D12_STATE_SUBOBJECT rootSigAssociationObject = {};
+    rootSigAssociationObject.Type = D3D12_STATE_SUBOBJECT_TYPE_SUBOBJECT_TO_EXPORTS_ASSOCIATION;
+    rootSigAssociationObject.pDesc = &assoc.m_association;
+
+    subobjects[currentIndex++] = rootSigAssociationObject;
+  }
+
+  // The pipeline construction always requires an empty global root signature
+  D3D12_STATE_SUBOBJECT globalRootSig;
+  globalRootSig.Type = D3D12_STATE_SUBOBJECT_TYPE_GLOBAL_ROOT_SIGNATURE;
+  ID3D12RootSignature* dgSig = m_dummyGlobalRootSignature;
+  globalRootSig.pDesc = &dgSig;
+
+  subobjects[currentIndex++] = globalRootSig;
+
+  // The pipeline construction always requires an empty local root signature
+  D3D12_STATE_SUBOBJECT dummyLocalRootSig;
+  dummyLocalRootSig.Type = D3D12_STATE_SUBOBJECT_TYPE_LOCAL_ROOT_SIGNATURE;
+  ID3D12RootSignature* dlSig = m_dummyLocalRootSignature;
+  dummyLocalRootSig.pDesc = &dlSig;
+  subobjects[currentIndex++] = dummyLocalRootSig;
+
+  // Add a subobject for the ray tracing pipeline configuration
+  D3D12_RAYTRACING_PIPELINE_CONFIG pipelineConfig = {};
+  pipelineConfig.MaxTraceRecursionDepth = m_maxRecursionDepth;
+
+  D3D12_STATE_SUBOBJECT pipelineConfigObject = {};
+  pipelineConfigObject.Type = D3D12_STATE_SUBOBJECT_TYPE_RAYTRACING_PIPELINE_CONFIG;
+  pipelineConfigObject.pDesc = &pipelineConfig;
+
+  subobjects[currentIndex++] = pipelineConfigObject;
+
+  // Describe the ray tracing pipeline state object
+  D3D12_STATE_OBJECT_DESC pipelineDesc = {};
+  pipelineDesc.Type = D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE;
+  pipelineDesc.NumSubobjects = currentIndex; // static_cast<UINT>(subobjects.size());
+  pipelineDesc.pSubobjects = subobjects.data();
+
+  ID3D12StateObject* rtStateObject = nullptr;
+
+  // Create the state object
+  HRESULT hr = m_device->CreateStateObject(&pipelineDesc, IID_PPV_ARGS(&rtStateObject));
+  if (FAILED(hr))
+  {
+    throw std::logic_error("Could not create the raytracing state object");
+  }
+  return rtStateObject;
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// The pipeline creation requires having at least one empty global and local root signatures, so
+// we systematically create both
+void RayTracingPipelineGenerator::CreateDummyRootSignatures()
+{
+  // Creation of the global root signature
+  D3D12_ROOT_SIGNATURE_DESC rootDesc = {};
+  rootDesc.NumParameters = 0;
+  rootDesc.pParameters = nullptr;
+  // A global root signature is the default, hence this flag
+  rootDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
+
+  HRESULT hr = 0;
+
+  ID3DBlob* serializedRootSignature;
+  ID3DBlob* error;
+
+  // Create the empty global root signature
+  hr = D3D12SerializeRootSignature(&rootDesc, D3D_ROOT_SIGNATURE_VERSION_1,
+                                   &serializedRootSignature, &error);
+  if (FAILED(hr))
+  {
+    throw std::logic_error("Could not serialize the global root signature");
+  }
+  hr = m_device->CreateRootSignature(0, serializedRootSignature->GetBufferPointer(),
+                                     serializedRootSignature->GetBufferSize(),
+                                     IID_PPV_ARGS(&m_dummyGlobalRootSignature));
+
+  serializedRootSignature->Release();
+  if (FAILED(hr))
+  {
+    throw std::logic_error("Could not create the global root signature");
+  }
+
+  // Create the local root signature, reusing the same descriptor but altering the creation flag
+  rootDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_LOCAL_ROOT_SIGNATURE;
+  hr = D3D12SerializeRootSignature(&rootDesc, D3D_ROOT_SIGNATURE_VERSION_1,
+                                   &serializedRootSignature, &error);
+  if (FAILED(hr))
+  {
+    throw std::logic_error("Could not serialize the local root signature");
+  }
+  hr = m_device->CreateRootSignature(0, serializedRootSignature->GetBufferPointer(),
+                                     serializedRootSignature->GetBufferSize(),
+                                     IID_PPV_ARGS(&m_dummyLocalRootSignature));
+
+  serializedRootSignature->Release();
+  if (FAILED(hr))
+  {
+    throw std::logic_error("Could not create the local root signature");
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Build a list containing the export symbols for the ray generation shaders, miss shaders, and
+// hit group names
+void RayTracingPipelineGenerator::BuildShaderExportList(std::vector<std::wstring>& exportedSymbols)
+{
+  // Get all names from libraries
+  // Get names associated to hit groups
+  // Return list of libraries+hit group names - shaders in hit groups
+
+  std::unordered_set<std::wstring> exports;
+
+  // Add all the symbols exported by the libraries
+  for (const Library& lib : m_libraries)
+  {
+    for (const auto& exportName : lib.m_exportedSymbols)
+    {
+#ifdef _DEBUG
+      // Sanity check in debug mode: check that no name is exported more than once
+      if (exports.find(exportName) != exports.end())
+      {
+        throw std::logic_error("Multiple definition of a symbol in the imported DXIL libraries");
+      }
+#endif
+      exports.insert(exportName);
+    }
+  }
+
+#ifdef _DEBUG
+  // Sanity check in debug mode: verify that the hit groups do not reference an unknown shader name
+  std::unordered_set<std::wstring> all_exports = exports;
+
+  for (const auto& hitGroup : m_hitGroups)
+  {
+    if (!hitGroup.m_anyHitSymbol.empty() && exports.find(hitGroup.m_anyHitSymbol) == exports.end())
+    {
+      throw std::logic_error("Any hit symbol not found in the imported DXIL libraries");
+    }
+
+    if (!hitGroup.m_closestHitSymbol.empty() &&
+        exports.find(hitGroup.m_closestHitSymbol) == exports.end())
+    {
+      throw std::logic_error("Closest hit symbol not found in the imported DXIL libraries");
+    }
+
+    if (!hitGroup.m_intersectionSymbol.empty() &&
+        exports.find(hitGroup.m_intersectionSymbol) == exports.end())
+    {
+      throw std::logic_error("Intersection symbol not found in the imported DXIL libraries");
+    }
+
+    all_exports.insert(hitGroup.m_hitGroupName);
+  }
+
+  // Sanity check in debug mode: verify that the root signature associations do not reference an
+  // unknown shader or hit group name
+  for (const auto& assoc : m_rootSignatureAssociations)
+  {
+    for (const auto& symb : assoc.m_symbols)
+    {
+      if (!symb.empty() && all_exports.find(symb) == all_exports.end())
+      {
+        throw std::logic_error("Root association symbol not found in the "
+                               "imported DXIL libraries and hit group names");
+      }
+    }
+  }
+#endif
+
+  // Go through all hit groups and remove the symbols corresponding to intersection, any hit and
+  // closest hit shaders from the symbol set
+  for (const auto& hitGroup : m_hitGroups)
+  {
+    if (!hitGroup.m_anyHitSymbol.empty())
+    {
+      exports.erase(hitGroup.m_anyHitSymbol);
+    }
+    if (!hitGroup.m_closestHitSymbol.empty())
+    {
+      exports.erase(hitGroup.m_closestHitSymbol);
+    }
+    if (!hitGroup.m_intersectionSymbol.empty())
+    {
+      exports.erase(hitGroup.m_intersectionSymbol);
+    }
+    exports.insert(hitGroup.m_hitGroupName);
+  }
+
+  // Finally build a vector containing ray generation and miss shaders, plus the hit group names
+  for (const auto& name : exports)
+  {
+    exportedSymbols.push_back(name);
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Store data related to a DXIL library: the library itself, the exported symbols, and the
+// associated descriptors
+RayTracingPipelineGenerator::Library::Library(IDxcBlob* dxil,
+                                              const std::vector<std::wstring>& exportedSymbols)
+    : m_dxil(dxil), m_exportedSymbols(exportedSymbols), m_exports(exportedSymbols.size())
+{
+  // Create one export descriptor per symbol
+  for (size_t i = 0; i < m_exportedSymbols.size(); i++)
+  {
+    m_exports[i] = {};
+    m_exports[i].Name = m_exportedSymbols[i].c_str();
+    m_exports[i].ExportToRename = nullptr;
+    m_exports[i].Flags = D3D12_EXPORT_FLAG_NONE;
+  }
+
+  // Create a library descriptor combining the DXIL code and the export names
+  m_libDesc.DXILLibrary.BytecodeLength = dxil->GetBufferSize();
+  m_libDesc.DXILLibrary.pShaderBytecode = dxil->GetBufferPointer();
+  m_libDesc.NumExports = static_cast<UINT>(m_exportedSymbols.size());
+  m_libDesc.pExports = m_exports.data();
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// This copy constructor has to be defined so that the export descriptors are set correctly. Using
+// the default constructor would copy the string pointers of the symbols into the descriptors, which
+// would cause issues when the original Library object gets out of scope
+RayTracingPipelineGenerator::Library::Library(const Library& source)
+    : Library(source.m_dxil, source.m_exportedSymbols)
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Create a hit group descriptor from the input hit group name and shader symbols
+RayTracingPipelineGenerator::HitGroup::HitGroup(std::wstring hitGroupName,
+                                                std::wstring closestHitSymbol,
+                                                std::wstring anyHitSymbol /*= L""*/,
+                                                std::wstring intersectionSymbol /*= L""*/)
+    : m_hitGroupName(std::move(hitGroupName)), m_closestHitSymbol(std::move(closestHitSymbol)),
+      m_anyHitSymbol(std::move(anyHitSymbol)), m_intersectionSymbol(std::move(intersectionSymbol))
+{
+  // Indicate which shader program is used for closest hit, leave the other
+  // ones undefined (default behavior), export the name of the group
+  m_desc.HitGroupExport = m_hitGroupName.c_str();
+  m_desc.ClosestHitShaderImport = m_closestHitSymbol.empty() ? nullptr : m_closestHitSymbol.c_str();
+  m_desc.AnyHitShaderImport = m_anyHitSymbol.empty() ? nullptr : m_anyHitSymbol.c_str();
+  m_desc.IntersectionShaderImport =
+      m_intersectionSymbol.empty() ? nullptr : m_intersectionSymbol.c_str();
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// This copy constructor has to be defined so that the export descriptors are set correctly. Using
+// the default constructor would copy the string pointers of the symbols into the descriptors, which
+// would cause issues when the original HitGroup object gets out of scope
+RayTracingPipelineGenerator::HitGroup::HitGroup(const HitGroup& source)
+    : HitGroup(source.m_hitGroupName, source.m_closestHitSymbol, source.m_anyHitSymbol,
+               source.m_intersectionSymbol)
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Store the association between a set of symbols and a root signature. The associated descriptors
+// will be built when compiling the pipeline. We store the symbol pointers directly so that they can
+// be used without processing during compilation.
+RayTracingPipelineGenerator::RootSignatureAssociation::RootSignatureAssociation(
+    ID3D12RootSignature* rootSignature, const std::vector<std::wstring>& symbols)
+    : m_rootSignature(rootSignature), m_symbols(symbols), m_symbolPointers(symbols.size())
+{
+  for (size_t i = 0; i < m_symbols.size(); i++)
+  {
+    m_symbolPointers[i] = m_symbols[i].c_str();
+  }
+  m_rootSignaturePointer = m_rootSignature;
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// This copy constructor has to be defined so that the export descriptors are set correctly. Using
+// the default constructor would copy the string pointers of the symbols into the descriptors, which
+// would cause issues when the original RootSignatureAssociation object gets out of scope
+RayTracingPipelineGenerator::RootSignatureAssociation::RootSignatureAssociation(
+    const RootSignatureAssociation& source)
+    : RootSignatureAssociation(source.m_rootSignature, source.m_symbols)
+{
+}
+} // namespace nv_helpers_dx12

--- a/extern/DXRHelpers/nv_helpers_dx12/RaytracingPipelineGenerator.h
+++ b/extern/DXRHelpers/nv_helpers_dx12/RaytracingPipelineGenerator.h
@@ -1,0 +1,197 @@
+/*-----------------------------------------------------------------------
+Copyright (c) 2014-2018, NVIDIA. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Neither the name of its contributors may be used to endorse
+or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-----------------------------------------------------------------------*/
+
+/*
+Contacts for feedback:
+- pgautron@nvidia.com (Pascal Gautron)
+- mlefrancois@nvidia.com (Martin-Karl Lefrancois)
+
+The raytracing pipeline combines the raytracing shaders into a state object,
+that can be thought of as an executable GPU program. For that, it requires the
+shaders compiled as DXIL libraries, where each library exports symbols in a way
+similar to DLLs. Those symbols are then used to refer to these shaders libraries
+when creating hit groups, associating the shaders to their root signatures and
+declaring the steps of the pipeline. All the calls to this helper class can be
+done in arbitrary order. Some basic sanity checks are also performed when
+compiling in debug mode.
+
+Simple usage of this class:
+
+pipeline.AddLibrary(m_rayGenLibrary.Get(), {L"RayGen"});
+pipeline.AddLibrary(m_missLibrary.Get(), {L"Miss"});
+pipeline.AddLibrary(m_hitLibrary.Get(), {L"ClosestHit"});
+
+pipeline.AddHitGroup(L"HitGroup", L"ClosestHit");
+
+pipeline.AddRootSignatureAssociation(m_rayGenSignature.Get(), {L"RayGen"});
+pipeline.AddRootSignatureAssociation(m_missSignature.Get(), {L"Miss"});
+pipeline.AddRootSignatureAssociation(m_hitSignature.Get(), {L"HitGroup"});
+
+pipeline.SetMaxPayloadSize(4 * sizeof(float)); // RGB + distance
+
+pipeline.SetMaxAttributeSize(2 * sizeof(float)); // barycentric coordinates
+
+pipeline.SetMaxRecursionDepth(1);
+
+rtStateObject = pipeline.Generate();
+
+*/
+
+#pragma once
+
+#include "d3d12.h"
+
+#include <dxcapi.h>
+
+#include <string>
+#include <vector>
+
+namespace nv_helpers_dx12
+{
+
+/// Helper class to create raytracing pipelines
+class RayTracingPipelineGenerator
+{
+public:
+  /// The pipeline helper requires access to the device, as well as the
+  /// raytracing device prior to Windows 10 RS5.
+  RayTracingPipelineGenerator(ID3D12Device5* device);
+
+  /// Add a DXIL library to the pipeline. Note that this library has to be
+  /// compiled with dxc, using a lib_6_3 target. The exported symbols must correspond exactly to the
+  /// names of the shaders declared in the library, although unused ones can be omitted.
+  void AddLibrary(IDxcBlob* dxilLibrary, const std::vector<std::wstring>& symbolExports);
+
+  /// In DXR the hit-related shaders are grouped into hit groups. Such shaders are:
+  /// - The intersection shader, which can be used to intersect custom geometry, and is called upon
+  ///   hitting the bounding box the the object. A default one exists to intersect triangles
+  /// - The any hit shader, called on each intersection, which can be used to perform early
+  ///   alpha-testing and allow the ray to continue if needed. Default is a pass-through.
+  /// - The closest hit shader, invoked on the hit point closest to the ray start.
+  /// The shaders in a hit group share the same root signature, and are only referred to by the
+  /// hit group name in other places of the program.
+  void AddHitGroup(const std::wstring& hitGroupName, const std::wstring& closestHitSymbol,
+                   const std::wstring& anyHitSymbol = L"",
+                   const std::wstring& intersectionSymbol = L"");
+
+  /// The shaders and hit groups may have various root signatures. This call associates a root
+  /// signature to one or more symbols. All imported symbols must be associated to one root
+  /// signature.
+  void AddRootSignatureAssociation(ID3D12RootSignature* rootSignature,
+                                   const std::vector<std::wstring>& symbols);
+
+  /// The payload is the way hit or miss shaders can exchange data with the shader that called
+  /// TraceRay. When several ray types are used (e.g. primary and shadow rays), this value must be
+  /// the largest possible payload size. Note that to optimize performance, this size must be kept
+  /// as low as possible.
+  void SetMaxPayloadSize(UINT sizeInBytes);
+
+  /// When hitting geometry, a number of surface attributes can be generated by the intersector.
+  /// Using the built-in triangle intersector the attributes are the barycentric coordinates, with a
+  /// size 2*sizeof(float).
+  void SetMaxAttributeSize(UINT sizeInBytes);
+
+  /// Upon hitting a surface, a closest hit shader can issue a new TraceRay call. This parameter
+  /// indicates the maximum level of recursion. Note that this depth should be kept as low as
+  /// possible, typically 2, to allow hit shaders to trace shadow rays. Recursive ray tracing
+  /// algorithms must be flattened to a loop in the ray generation program for best performance.
+  void SetMaxRecursionDepth(UINT maxDepth);
+
+  /// Compiles the raytracing state object
+  ID3D12StateObject* Generate();
+
+private:
+  /// Storage for DXIL libraries and their exported symbols
+  struct Library
+  {
+    Library(IDxcBlob* dxil, const std::vector<std::wstring>& exportedSymbols);
+
+    Library(const Library& source);
+
+    IDxcBlob* m_dxil;
+    const std::vector<std::wstring> m_exportedSymbols;
+
+    std::vector<D3D12_EXPORT_DESC> m_exports;
+    D3D12_DXIL_LIBRARY_DESC m_libDesc;
+  };
+
+  /// Storage for the hit groups, binding the hit group name with the underlying intersection, any
+  /// hit and closest hit symbols
+  struct HitGroup
+  {
+    HitGroup(std::wstring hitGroupName, std::wstring closestHitSymbol,
+             std::wstring anyHitSymbol = L"", std::wstring intersectionSymbol = L"");
+
+    HitGroup(const HitGroup& source);
+
+    std::wstring m_hitGroupName;
+    std::wstring m_closestHitSymbol;
+    std::wstring m_anyHitSymbol;
+    std::wstring m_intersectionSymbol;
+    D3D12_HIT_GROUP_DESC m_desc = {};
+  };
+
+  /// Storage for the association between shaders and root signatures
+  struct RootSignatureAssociation
+  {
+    RootSignatureAssociation(ID3D12RootSignature* rootSignature,
+                             const std::vector<std::wstring>& symbols);
+
+    RootSignatureAssociation(const RootSignatureAssociation& source);
+
+    ID3D12RootSignature* m_rootSignature;
+    ID3D12RootSignature* m_rootSignaturePointer;
+    std::vector<std::wstring> m_symbols;
+    std::vector<LPCWSTR> m_symbolPointers;
+    D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION m_association = {};
+  };
+
+  /// The pipeline creation requires having at least one empty global and local root signatures, so
+  /// we systematically create both
+  void CreateDummyRootSignatures();
+
+  /// Build a list containing the export symbols for the ray generation shaders, miss shaders, and
+  /// hit group names
+  void BuildShaderExportList(std::vector<std::wstring>& exportedSymbols);
+
+  std::vector<Library> m_libraries = {};
+  std::vector<HitGroup> m_hitGroups = {};
+  std::vector<RootSignatureAssociation> m_rootSignatureAssociations = {};
+
+  UINT m_maxPayLoadSizeInBytes = 0;
+  /// Attribute size, initialized to 2 for the barycentric coordinates used by the built-in triangle
+  /// intersection shader
+  UINT m_maxAttributeSizeInBytes = 2 * sizeof(float);
+  /// Maximum recursion depth, initialized to 1 to at least allow tracing primary rays
+  UINT m_maxRecursionDepth = 1;
+
+  ID3D12Device5* m_device;
+  ID3D12RootSignature* m_dummyLocalRootSignature;
+  ID3D12RootSignature* m_dummyGlobalRootSignature;
+
+  
+};
+
+} // namespace nv_helpers_dx12

--- a/extern/DXRHelpers/nv_helpers_dx12/RaytracingPipelineGenerator.h
+++ b/extern/DXRHelpers/nv_helpers_dx12/RaytracingPipelineGenerator.h
@@ -191,7 +191,7 @@ private:
   ID3D12RootSignature* m_dummyLocalRootSignature;
   ID3D12RootSignature* m_dummyGlobalRootSignature;
 
-  
+
 };
 
 } // namespace nv_helpers_dx12

--- a/extern/DXRHelpers/nv_helpers_dx12/RootSignatureGenerator.cpp
+++ b/extern/DXRHelpers/nv_helpers_dx12/RootSignatureGenerator.cpp
@@ -1,0 +1,195 @@
+/*-----------------------------------------------------------------------
+Copyright (c) 2014-2018, NVIDIA. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Neither the name of its contributors may be used to endorse
+or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-----------------------------------------------------------------------*/
+
+/*
+Contacts for feedback:
+- pgautron@nvidia.com (Pascal Gautron)
+- mlefrancois@nvidia.com (Martin-Karl Lefrancois)
+
+
+Utility class to create root signatures. The order in which the addition methods are called is
+important as it will define the slots of the heap or of the Shader Binding Table to which buffer
+pointers will be bound.
+
+*/
+
+#include "RootSignatureGenerator.h"
+
+namespace nv_helpers_dx12
+{
+
+//--------------------------------------------------------------------------------------------------
+//
+// Add a set of heap range descriptors as a parameter of the root signature.
+void RootSignatureGenerator::AddHeapRangesParameter(
+    const std::vector<D3D12_DESCRIPTOR_RANGE>& ranges)
+{
+  m_ranges.push_back(ranges);
+
+  // A set of ranges on the heap is a descriptor table parameter
+  D3D12_ROOT_PARAMETER param = {};
+  param.ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+  param.DescriptorTable.NumDescriptorRanges = static_cast<UINT>(ranges.size());
+  // The range pointer is kept null here, and will be resolved when generating the root signature
+  // (see explanation of m_rangeLocations below)
+  param.DescriptorTable.pDescriptorRanges = nullptr;
+
+  // All parameters (heap ranges and root parameters) are added to the same parameter list to
+  // preserve order
+  m_parameters.push_back(param);
+
+  // The descriptor table descriptor ranges require a pointer to the descriptor ranges. Since new
+  // ranges can be dynamically added in the vector, we separately store the index of the range set.
+  // The actual address will be solved when generating the actual root signature
+  m_rangeLocations.push_back(static_cast<UINT>(m_ranges.size() - 1));
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Add a set of heap ranges as a parameter of the root signature. Each range
+// is defined as follows:
+// - UINT BaseShaderRegister: the first register index in the range, e.g. the
+// register of a UAV with BaseShaderRegister==0 is defined in the HLSL code
+// as register(u0)
+// - UINT NumDescriptors: number of descriptors in the range. Those will be
+// mapped to BaseShaderRegister, BaseShaderRegister+1 etc. UINT
+// RegisterSpace: Allows using the same register numbers multiple times by
+// specifying a space where they are defined, similarly to a namespace. For
+// example, a UAV with BaseShaderRegister==0 and RegisterSpace==1 is accessed
+// in HLSL using the syntax register(u0, space1)
+// - D3D12_DESCRIPTOR_RANGE_TYPE RangeType: The range type, such as
+// D3D12_DESCRIPTOR_RANGE_TYPE_CBV for a constant buffer
+// - UINT OffsetInDescriptorsFromTableStart: The first slot in the heap
+// corresponding to the buffers mapped by the root signature. This can either
+// be explicit, or implicit using D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND. In
+// this case the index in the heap is the one directly following the last
+// parameter range (or 0 if it's the first)
+void RootSignatureGenerator::AddHeapRangesParameter(
+    std::vector<std::tuple<UINT, /* BaseShaderRegister, */ UINT, /* NumDescriptors */ UINT,
+                           /* RegisterSpace */ D3D12_DESCRIPTOR_RANGE_TYPE,
+                           /* RangeType */ UINT /* OffsetInDescriptorsFromTableStart */>>
+        ranges)
+{
+  // Build and store the set of descriptors for the ranges
+  std::vector<D3D12_DESCRIPTOR_RANGE> rangeStorage;
+  for (const auto& input : ranges)
+  {
+    D3D12_DESCRIPTOR_RANGE r = {};
+    r.BaseShaderRegister = std::get<RSC_BASE_SHADER_REGISTER>(input);
+    r.NumDescriptors = std::get<RSC_NUM_DESCRIPTORS>(input);
+    r.RegisterSpace = std::get<RSC_REGISTER_SPACE>(input);
+    r.RangeType = std::get<RSC_RANGE_TYPE>(input);
+    r.OffsetInDescriptorsFromTableStart =
+        std::get<RSC_OFFSET_IN_DESCRIPTORS_FROM_TABLE_START>(input);
+    rangeStorage.push_back(r);
+  }
+
+  // Add those ranges to the heap parameters
+  AddHeapRangesParameter(rangeStorage);
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Add a root parameter to the shader, defined by its type: constant buffer (CBV), shader
+// resource (SRV), unordered access (UAV), or root constant (CBV, directly defined by its value
+// instead of a buffer). The shaderRegister and registerSpace indicate how to access the
+// parameter in the HLSL code, e.g a SRV with shaderRegister==1 and registerSpace==0 is
+// accessible via register(t1, space0).
+// In case of a root constant, the last parameter indicates how many successive 32-bit constants
+// will be bound.
+void RootSignatureGenerator::AddRootParameter(D3D12_ROOT_PARAMETER_TYPE type,
+                                              UINT shaderRegister /*= 0*/,
+                                              UINT registerSpace /*= 0*/,
+                                              UINT numRootConstants /*= 1*/)
+{
+  D3D12_ROOT_PARAMETER param = {};
+  param.ParameterType = type;
+  // The descriptor is an union, so specific values need to be set in case the parameter is a
+  // constant instead of a buffer.
+  if (type == D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS)
+  {
+    param.Constants.Num32BitValues = numRootConstants;
+    param.Constants.RegisterSpace = registerSpace;
+    param.Constants.ShaderRegister = shaderRegister;
+  }
+  else
+  {
+    param.Descriptor.RegisterSpace = registerSpace;
+    param.Descriptor.ShaderRegister = shaderRegister;
+  }
+
+  // We default the visibility to all shaders
+  param.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+
+  // Add the root parameter to the set of parameters,
+  m_parameters.push_back(param);
+  // and indicate that there will be no range
+  // location to indicate since this parameter is not part of the heap
+  m_rangeLocations.push_back(~0u);
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Create the root signature from the set of parameters, in the order of the addition calls
+ID3D12RootSignature* RootSignatureGenerator::Generate(ID3D12Device* device, bool isLocal)
+{
+  // Go through all the parameters, and set the actual addresses of the heap range descriptors based
+  // on their indices in the range set array
+  for (size_t i = 0; i < m_parameters.size(); i++)
+  {
+    if (m_parameters[i].ParameterType == D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
+    {
+      m_parameters[i].DescriptorTable.pDescriptorRanges = m_ranges[m_rangeLocations[i]].data();
+    }
+  }
+  // Specify the root signature with its set of parameters
+  D3D12_ROOT_SIGNATURE_DESC rootDesc = {};
+  rootDesc.NumParameters = static_cast<UINT>(m_parameters.size());
+  rootDesc.pParameters = m_parameters.data();
+  // Set the flags of the signature. By default root signatures are global, for example for vertex
+  // and pixel shaders. For raytracing shaders the root signatures are local.
+  rootDesc.Flags =
+      isLocal ? D3D12_ROOT_SIGNATURE_FLAG_LOCAL_ROOT_SIGNATURE : D3D12_ROOT_SIGNATURE_FLAG_NONE;
+
+  // Create the root signature from its descriptor
+  ID3DBlob* pSigBlob;
+  ID3DBlob* pErrorBlob;
+  HRESULT hr = D3D12SerializeRootSignature(&rootDesc, D3D_ROOT_SIGNATURE_VERSION_1_0, &pSigBlob,
+                                           &pErrorBlob);
+  if (FAILED(hr))
+  {
+    throw std::logic_error("Cannot serialize root signature");
+  }
+  ID3D12RootSignature* pRootSig;
+  hr = device->CreateRootSignature(0, pSigBlob->GetBufferPointer(), pSigBlob->GetBufferSize(),
+                                   IID_PPV_ARGS(&pRootSig));
+  if (FAILED(hr))
+  {
+    throw std::logic_error("Cannot create root signature");
+  }
+  return pRootSig;
+}
+
+} // namespace nv_helpers_dx12

--- a/extern/DXRHelpers/nv_helpers_dx12/RootSignatureGenerator.h
+++ b/extern/DXRHelpers/nv_helpers_dx12/RootSignatureGenerator.h
@@ -1,0 +1,127 @@
+/*-----------------------------------------------------------------------
+Copyright (c) 2014-2018, NVIDIA. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Neither the name of its contributors may be used to endorse
+or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-----------------------------------------------------------------------*/
+
+/*
+Contacts for feedback:
+- pgautron@nvidia.com (Pascal Gautron)
+- mlefrancois@nvidia.com (Martin-Karl Lefrancois)
+
+Utility class to create root signatures. The order in which the addition methods are called is
+important as it will define the slots of the heap or of the Shader Binding Table to which buffer
+pointers will be bound.
+
+Example to create an empty root signature:
+nv_helpers_dx12::RootSignatureGenerator rsc;
+return rsc.Generate(m_device.Get(), true);
+
+Example to create a signature with one constant buffer:
+nv_helpers_dx12::RootSignatureGenerator rsc;
+rsc.AddRootParameter(D3D12_ROOT_PARAMETER_TYPE_CBV);
+return rsc.Generate(m_device.Get(), true);
+
+More advance root signature:
+nv_helpers_dx12::RootSignatureGenerator rsc;
+rsc.AddRangeParameter({{0,1,0, D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 0},
+{0,1,0, D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1},
+{0,1,0, D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 2}});
+return rsc.Generate(m_device.Get(), true);
+
+*/
+
+#pragma once
+
+#include "d3d12.h"
+
+#include <tuple>
+#include <vector>
+
+namespace nv_helpers_dx12
+{
+
+class RootSignatureGenerator
+{
+public:
+  /// Add a set of heap range descriptors as a parameter of the root signature.
+  void AddHeapRangesParameter(const std::vector<D3D12_DESCRIPTOR_RANGE>& ranges);
+
+  /// Add a set of heap ranges as a parameter of the root signature. Each range
+  /// is defined as follows:
+  /// - UINT BaseShaderRegister: the first register index in the range, e.g. the
+  /// register of a UAV with BaseShaderRegister==0 is defined in the HLSL code
+  /// as register(u0)
+  /// - UINT NumDescriptors: number of descriptors in the range. Those will be
+  /// mapped to BaseShaderRegister, BaseShaderRegister+1 etc. UINT
+  /// RegisterSpace: Allows using the same register numbers multiple times by
+  /// specifying a space where they are defined, similarly to a namespace. For
+  /// example, a UAV with BaseShaderRegister==0 and RegisterSpace==1 is accessed
+  /// in HLSL using the syntax register(u0, space1)
+  /// - D3D12_DESCRIPTOR_RANGE_TYPE RangeType: The range type, such as
+  /// D3D12_DESCRIPTOR_RANGE_TYPE_CBV for a constant buffer
+  /// - UINT OffsetInDescriptorsFromTableStart: The first slot in the heap
+  /// corresponding to the buffers mapped by the root signature. This can either
+  /// be explicit, or implicit using D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND. In
+  /// this case the index in the heap is the one directly following the last
+  /// parameter range (or 0 if it's the first)
+  void AddHeapRangesParameter(std::vector<std::tuple<UINT, // BaseShaderRegister,
+                                                     UINT, // NumDescriptors
+                                                     UINT, // RegisterSpace
+                                                     D3D12_DESCRIPTOR_RANGE_TYPE, // RangeType
+                                                     UINT // OffsetInDescriptorsFromTableStart
+                                                     >>
+                                  ranges);
+
+  /// Add a root parameter to the shader, defined by its type: constant buffer (CBV), shader
+  /// resource (SRV), unordered access (UAV), or root constant (CBV, directly defined by its value
+  /// instead of a buffer). The shaderRegister and registerSpace indicate how to access the
+  /// parameter in the HLSL code, e.g a SRV with shaderRegister==1 and registerSpace==0 is
+  /// accessible via register(t1, space0).
+  /// In case of a root constant, the last parameter indicates how many successive 32-bit constants
+  /// will be bound.
+  void AddRootParameter(D3D12_ROOT_PARAMETER_TYPE type, UINT shaderRegister = 0,
+                        UINT registerSpace = 0, UINT numRootConstants = 1);
+
+  /// Create the root signature from the set of parameters, in the order of the addition calls
+  ID3D12RootSignature* Generate(ID3D12Device* device, bool isLocal);
+
+private:
+  /// Heap range descriptors
+  std::vector<std::vector<D3D12_DESCRIPTOR_RANGE>> m_ranges;
+  /// Root parameter descriptors
+  std::vector<D3D12_ROOT_PARAMETER> m_parameters;
+
+  /// For each entry of m_parameter, indicate the index of the range array in m_ranges, and ~0u if
+  /// the parameter is not a heap range descriptor
+  std::vector<UINT> m_rangeLocations;
+
+  enum
+  {
+    RSC_BASE_SHADER_REGISTER = 0,
+    RSC_NUM_DESCRIPTORS = 1,
+    RSC_REGISTER_SPACE = 2,
+    RSC_RANGE_TYPE = 3,
+    RSC_OFFSET_IN_DESCRIPTORS_FROM_TABLE_START = 4
+  };
+};
+} // namespace nv_helpers_dx12

--- a/extern/DXRHelpers/nv_helpers_dx12/ShaderBindingTableGenerator.cpp
+++ b/extern/DXRHelpers/nv_helpers_dx12/ShaderBindingTableGenerator.cpp
@@ -1,0 +1,258 @@
+/*-----------------------------------------------------------------------
+Copyright (c) 2014-2018, NVIDIA. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Neither the name of its contributors may be used to endorse
+or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-----------------------------------------------------------------------*/
+
+/*
+Contacts for feedback:
+- pgautron@nvidia.com (Pascal Gautron)
+- mlefrancois@nvidia.com (Martin-Karl Lefrancois)
+
+The ShaderBindingTable is a helper to construct the SBT. It helps to maintain the
+proper offsets of each element, required when constructing the SBT, but also when filling the
+dispatch rays description.
+
+*/
+
+#include "ShaderBindingTableGenerator.h"
+
+// Helper to compute aligned buffer sizes
+#ifndef ROUND_UP
+#define ROUND_UP(v, powerOf2Alignment) (((v) + (powerOf2Alignment)-1) & ~((powerOf2Alignment)-1))
+#endif
+
+namespace nv_helpers_dx12
+{
+
+//--------------------------------------------------------------------------------------------------
+//
+// Add a ray generation program by name, with its list of data pointers or values according to
+// the layout of its root signature
+void ShaderBindingTableGenerator::AddRayGenerationProgram(const std::wstring& entryPoint,
+                                                          const std::vector<void*>& inputData)
+{
+  m_rayGen.emplace_back(SBTEntry(entryPoint, inputData));
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Add a miss program by name, with its list of data pointers or values according to
+// the layout of its root signature
+void ShaderBindingTableGenerator::AddMissProgram(const std::wstring& entryPoint,
+                                                 const std::vector<void*>& inputData)
+{
+  m_miss.emplace_back(SBTEntry(entryPoint, inputData));
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Add a hit group by name, with its list of data pointers or values according to
+// the layout of its root signature
+void ShaderBindingTableGenerator::AddHitGroup(const std::wstring& entryPoint,
+                                              const std::vector<void*>& inputData)
+{
+  m_hitGroup.emplace_back(SBTEntry(entryPoint, inputData));
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Compute the size of the SBT based on the set of programs and hit groups it contains
+uint32_t ShaderBindingTableGenerator::ComputeSBTSize()
+{
+  // Size of a program identifier
+  m_progIdSize = D3D12_RAYTRACING_SHADER_RECORD_BYTE_ALIGNMENT;
+  // Compute the entry size of each program type depending on the maximum number of parameters in
+  // each category
+  m_rayGenEntrySize = GetEntrySize(m_rayGen);
+  m_missEntrySize = GetEntrySize(m_miss);
+  m_hitGroupEntrySize = GetEntrySize(m_hitGroup);
+
+  // The total SBT size is the sum of the entries for ray generation, miss and hit groups, aligned
+  // on 256 bytes
+  uint32_t sbtSize = ROUND_UP(m_rayGenEntrySize * static_cast<UINT>(m_rayGen.size()) +
+                                  m_missEntrySize * static_cast<UINT>(m_miss.size()) +
+                                  m_hitGroupEntrySize * static_cast<UINT>(m_hitGroup.size()),
+                              256);
+  return sbtSize;
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Build the SBT and store it into sbtBuffer, which has to be pre-allocated on the upload heap.
+// Access to the raytracing pipeline object is required to fetch program identifiers using their
+// names
+void ShaderBindingTableGenerator::Generate(ID3D12Resource* sbtBuffer,
+                                           ID3D12StateObjectProperties* raytracingPipeline)
+{
+  // Map the SBT
+  uint8_t* pData;
+  HRESULT hr = sbtBuffer->Map(0, nullptr, reinterpret_cast<void**>(&pData));
+  if (FAILED(hr))
+  {
+    throw std::logic_error("Could not map the shader binding table");
+  }
+  // Copy the shader identifiers followed by their resource pointers or root constants: first the
+  // ray generation, then the miss shaders, and finally the set of hit groups
+  uint32_t offset = 0;
+
+  offset = CopyShaderData(raytracingPipeline, pData, m_rayGen, m_rayGenEntrySize);
+  pData += offset;
+
+  offset = CopyShaderData(raytracingPipeline, pData, m_miss, m_missEntrySize);
+  pData += offset;
+
+  offset = CopyShaderData(raytracingPipeline, pData, m_hitGroup, m_hitGroupEntrySize);
+
+  // Unmap the SBT
+  sbtBuffer->Unmap(0, nullptr);
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Reset the sets of programs and hit groups
+void ShaderBindingTableGenerator::Reset()
+{
+  m_rayGen.clear();
+  m_miss.clear();
+  m_hitGroup.clear();
+
+  m_rayGenEntrySize = 0;
+  m_missEntrySize = 0;
+  m_hitGroupEntrySize = 0;
+  m_progIdSize = 0;
+}
+
+//--------------------------------------------------------------------------------------------------
+// The following getters are used to simplify the call to DispatchRays where the offsets of the
+// shader programs must be exactly following the SBT layout
+
+//--------------------------------------------------------------------------------------------------
+//
+// Get the size in bytes of the SBT section dedicated to ray generation programs
+UINT ShaderBindingTableGenerator::GetRayGenSectionSize() const
+{
+  return m_rayGenEntrySize * static_cast<UINT>(m_rayGen.size());
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Get the size in bytes of one ray generation program entry in the SBT
+UINT ShaderBindingTableGenerator::GetRayGenEntrySize() const
+{
+  return m_rayGenEntrySize;
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Get the size in bytes of the SBT section dedicated to miss programs
+UINT ShaderBindingTableGenerator::GetMissSectionSize() const
+{
+  return m_missEntrySize * static_cast<UINT>(m_miss.size());
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Get the size in bytes of one miss program entry in the SBT
+UINT ShaderBindingTableGenerator::GetMissEntrySize()
+{
+  return m_missEntrySize;
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Get the size in bytes of the SBT section dedicated to hit groups
+UINT ShaderBindingTableGenerator::GetHitGroupSectionSize() const
+{
+  return m_hitGroupEntrySize * static_cast<UINT>(m_hitGroup.size());
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Get the size in bytes of one hit group entry in the SBT
+UINT ShaderBindingTableGenerator::GetHitGroupEntrySize() const
+{
+  return m_hitGroupEntrySize;
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// For each entry, copy the shader identifier followed by its resource pointers and/or root
+// constants in outputData, with a stride in bytes of entrySize, and returns the size in bytes
+// actually written to outputData.
+uint32_t ShaderBindingTableGenerator::CopyShaderData(
+    ID3D12StateObjectProperties* raytracingPipeline, uint8_t* outputData,
+    const std::vector<SBTEntry>& shaders, uint32_t entrySize)
+{
+  uint8_t* pData = outputData;
+  for (const auto& shader : shaders)
+  {
+    // Get the shader identifier, and check whether that identifier is known
+    void* id = raytracingPipeline->GetShaderIdentifier(shader.m_entryPoint.c_str());
+    if (!id)
+    {
+      std::wstring errMsg(std::wstring(L"Unknown shader identifier used in the SBT: ") +
+                          shader.m_entryPoint);
+      throw std::logic_error(std::string(errMsg.begin(), errMsg.end()));
+    }
+    // Copy the shader identifier
+    memcpy(pData, id, m_progIdSize);
+    // Copy all its resources pointers or values in bulk
+    memcpy(pData + m_progIdSize, shader.m_inputData.data(), shader.m_inputData.size() * 8);
+
+    pData += entrySize;
+  }
+  // Return the number of bytes actually written to the output buffer
+  return static_cast<uint32_t>(shaders.size()) * entrySize;
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Compute the size of the SBT entries for a set of entries, which is determined by the maximum
+// number of parameters of their root signature
+uint32_t ShaderBindingTableGenerator::GetEntrySize(const std::vector<SBTEntry>& entries)
+{
+  // Find the maximum number of parameters used by a single entry
+  size_t maxArgs = 0;
+  for (const auto& shader : entries)
+  {
+    maxArgs = max(maxArgs, shader.m_inputData.size());
+  }
+  // A SBT entry is made of a program ID and a set of parameters, taking 8 bytes each. Those
+  // parameters can either be 8-bytes pointers, or 4-bytes constants
+  uint32_t entrySize = m_progIdSize + 8 * static_cast<uint32_t>(maxArgs);
+
+  // The entries of the shader binding table must be 16-bytes-aligned
+  entrySize = ROUND_UP(entrySize, D3D12_RAYTRACING_SHADER_RECORD_BYTE_ALIGNMENT);
+
+  return entrySize;
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+//
+ShaderBindingTableGenerator::SBTEntry::SBTEntry(std::wstring entryPoint,
+                                                std::vector<void*> inputData)
+    : m_entryPoint(std::move(entryPoint)), m_inputData(std::move(inputData))
+{
+}
+} // namespace nv_helpers_dx12

--- a/extern/DXRHelpers/nv_helpers_dx12/ShaderBindingTableGenerator.h
+++ b/extern/DXRHelpers/nv_helpers_dx12/ShaderBindingTableGenerator.h
@@ -1,0 +1,199 @@
+/*-----------------------------------------------------------------------
+Copyright (c) 2014-2018, NVIDIA. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Neither the name of its contributors may be used to endorse
+or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-----------------------------------------------------------------------*/
+
+/*
+Contacts for feedback:
+- pgautron@nvidia.com (Pascal Gautron)
+- mlefrancois@nvidia.com (Martin-Karl Lefrancois)
+
+The ShaderBindingTable is a helper to construct the SBT. It helps to maintain the
+proper offsets of each element, required when constructing the SBT, but also when filling the
+dispatch rays description.
+
+Example:
+
+
+D3D12_GPU_DESCRIPTOR_HANDLE srvUavHeapHandle = m_srvUavHeap->GetGPUDescriptorHandleForHeapStart();
+UINT64* heapPointer = reinterpret_cast< UINT64* >(srvUavHeapHandle.ptr);
+
+m_sbtHelper.AddRayGenerationProgram(L"RayGen", {heapPointer});
+m_sbtHelper.AddMissProgram(L"Miss", {});
+
+m_sbtHelper.AddHitGroup(L"HitGroup",
+{(void*)(m_constantBuffers[i]->GetGPUVirtualAddress())});
+m_sbtHelper.AddHitGroup(L"ShadowHitGroup", {});
+
+
+// Create the SBT on the upload heap
+uint32_t sbtSize = 0;
+m_sbtHelper.ComputeSBTSize(GetRTDevice(), &sbtSize);
+m_sbtStorage = nv_helpers_dx12::CreateBuffer(m_device.Get(), sbtSize,
+D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_GENERIC_READ,
+nv_helpers_dx12::kUploadHeapProps);
+
+m_sbtHelper.Generate(m_sbtStorage.Get(), m_rtStateObjectProps.Get());
+
+
+//--------------------------------------------------------------------
+Then setting the descriptor for the dispatch rays become way easier
+//--------------------------------------------------------------------
+
+D3D12_DISPATCH_RAYS_DESC desc = {};
+// The layout of the SBT is as follows: ray generation shaders, miss shaders,
+hit groups. As
+// described in the CreateShaderBindingTable method, all SBT entries have the
+same size to allow
+// a fixed stride.
+
+// The ray generation shaders are always at the beginning of the SBT. In this
+// example we have only one RG, so the size of this SBT sections is
+m_sbtEntrySize. uint32_t rayGenerationSectionSizeInBytes =
+m_sbtHelper.GetRayGenSectionSize(); desc.RayGenerationShaderRecord.StartAddress
+= m_sbtStorage->GetGPUVirtualAddress();
+desc.RayGenerationShaderRecord.SizeInBytes = rayGenerationSectionSizeInBytes;
+
+// The miss shaders are in the second SBT section, right after the ray
+generation shader. We
+// have one miss shader for the camera rays and one for the shadow rays, so this
+section has a
+// size of 2*m_sbtEntrySize. We also indicate the stride between the two miss
+shaders, which is
+// the size of a SBT entry
+uint32_t missSectionSizeInBytes = m_sbtHelper.GetMissSectionSize();
+desc.MissShaderTable.StartAddress =
+m_sbtStorage->GetGPUVirtualAddress() + rayGenerationSectionSizeInBytes;
+desc.MissShaderTable.SizeInBytes = missSectionSizeInBytes;
+desc.MissShaderTable.StrideInBytes = m_sbtHelper.GetMissEntrySize();
+
+// The hit groups section start after the miss shaders. In this sample we have 4
+hit groups: 2
+// for the triangles (1 used when hitting the geometry from a camera ray, 1 when
+hitting the
+// same geometry from a shadow ray) and 2 for the plane. We also indicate the
+stride between the
+// two miss shaders, which is the size of a SBT entry
+// #Pascal: experiment with different sizes for the SBT entries
+uint32_t hitGroupsSectionSize = m_sbtHelper.GetHitGroupSectionSize();
+desc.HitGroupTable.StartAddress =
+m_sbtStorage->GetGPUVirtualAddress() + rayGenerationSectionSizeInBytes +
+missSectionSizeInBytes; desc.HitGroupTable.SizeInBytes = hitGroupsSectionSize;
+desc.HitGroupTable.StrideInBytes = m_sbtHelper.GetHitGroupEntrySize();
+
+
+
+*/
+
+#pragma once
+
+#include "d3d12.h"
+
+#include <vector>
+
+namespace nv_helpers_dx12
+{
+/// Helper class to create and maintain a Shader Binding Table
+class ShaderBindingTableGenerator
+{
+public:
+  /// Add a ray generation program by name, with its list of data pointers or values according to
+  /// the layout of its root signature
+  void AddRayGenerationProgram(const std::wstring& entryPoint, const std::vector<void*>& inputData);
+
+  /// Add a miss program by name, with its list of data pointers or values according to
+  /// the layout of its root signature
+  void AddMissProgram(const std::wstring& entryPoint, const std::vector<void*>& inputData);
+
+  /// Add a hit group by name, with its list of data pointers or values according to
+  /// the layout of its root signature
+  void AddHitGroup(const std::wstring& entryPoint, const std::vector<void*>& inputData);
+
+  /// Compute the size of the SBT based on the set of programs and hit groups it contains
+  uint32_t ComputeSBTSize();
+
+  /// Build the SBT and store it into sbtBuffer, which has to be pre-allocated on the upload heap.
+  /// Access to the raytracing pipeline object is required to fetch program identifiers using their
+  /// names
+  void Generate(ID3D12Resource* sbtBuffer,
+                ID3D12StateObjectProperties* raytracingPipeline);
+
+  /// Reset the sets of programs and hit groups
+  void Reset();
+
+  /// The following getters are used to simplify the call to DispatchRays where the offsets of the
+  /// shader programs must be exactly following the SBT layout
+
+  /// Get the size in bytes of the SBT section dedicated to ray generation programs
+  UINT GetRayGenSectionSize() const;
+  /// Get the size in bytes of one ray generation program entry in the SBT
+  UINT GetRayGenEntrySize() const;
+
+  /// Get the size in bytes of the SBT section dedicated to miss programs
+  UINT GetMissSectionSize() const;
+  /// Get the size in bytes of one miss program entry in the SBT
+  UINT GetMissEntrySize();
+
+  /// Get the size in bytes of the SBT section dedicated to hit groups
+  UINT GetHitGroupSectionSize() const;
+  /// Get the size in bytes of hit group entry in the SBT
+  UINT GetHitGroupEntrySize() const;
+
+private:
+  /// Wrapper for SBT entries, each consisting of the name of the program and a list of values,
+  /// which can be either pointers or raw 32-bit constants
+  struct SBTEntry
+  {
+    SBTEntry(std::wstring entryPoint, std::vector<void*> inputData);
+
+    const std::wstring m_entryPoint;
+    const std::vector<void*> m_inputData;
+  };
+
+  /// For each entry, copy the shader identifier followed by its resource pointers and/or root
+  /// constants in outputData, with a stride in bytes of entrySize, and returns the size in bytes
+  /// actually written to outputData.
+  uint32_t CopyShaderData(ID3D12StateObjectProperties* raytracingPipeline,
+                          uint8_t* outputData, const std::vector<SBTEntry>& shaders,
+                          uint32_t entrySize);
+
+  /// Compute the size of the SBT entries for a set of entries, which is determined by the maximum
+  /// number of parameters of their root signature
+  uint32_t GetEntrySize(const std::vector<SBTEntry>& entries);
+
+  std::vector<SBTEntry> m_rayGen;
+  std::vector<SBTEntry> m_miss;
+  std::vector<SBTEntry> m_hitGroup;
+
+  /// For each category, the size of an entry in the SBT depends on the maximum number of resources
+  /// used by the shaders in that category.The helper computes those values automatically in
+  /// GetEntrySize()
+  uint32_t m_rayGenEntrySize;
+  uint32_t m_missEntrySize;
+  uint32_t m_hitGroupEntrySize;
+
+  /// The program names are translated into program identifiers.The size in bytes of an identifier
+  /// is provided by the device and is the same for all categories.
+  UINT m_progIdSize;
+};
+} // namespace nv_helpers_dx12

--- a/extern/DXRHelpers/nv_helpers_dx12/TopLevelASGenerator.cpp
+++ b/extern/DXRHelpers/nv_helpers_dx12/TopLevelASGenerator.cpp
@@ -1,0 +1,259 @@
+/*-----------------------------------------------------------------------
+Copyright (c) 2014-2018, NVIDIA. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Neither the name of its contributors may be used to endorse
+or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-----------------------------------------------------------------------*/
+
+/*
+Contacts for feedback:
+- pgautron@nvidia.com (Pascal Gautron)
+- mlefrancois@nvidia.com (Martin-Karl Lefrancois)
+
+The top-level hierarchy is used to store a set of instances represented by
+bottom-level hierarchies in a way suitable for fast intersection at runtime. To
+be built, this data structure requires some scratch space which has to be
+allocated by the application. Similarly, the resulting data structure is stored
+in an application-controlled buffer.
+
+To be used, the application must first add all the instances to be contained in
+the final structure, using AddInstance. After all instances have been added,
+ComputeASBufferSizes will prepare the build, and provide the required sizes for
+the scratch data and the final result. The Build call will finally compute the
+acceleration structure and store it in the result buffer.
+
+Note that the build is enqueued in the command list, meaning that the scratch
+buffer needs to be kept until the command list execution is finished.
+
+*/
+
+#include "TopLevelASGenerator.h"
+
+// Helper to compute aligned buffer sizes
+#ifndef ROUND_UP
+#define ROUND_UP(v, powerOf2Alignment) (((v) + (powerOf2Alignment)-1) & ~((powerOf2Alignment)-1))
+#endif
+
+namespace nv_helpers_dx12
+{
+
+//--------------------------------------------------------------------------------------------------
+//
+// Add an instance to the top-level acceleration structure. The instance is
+// represented by a bottom-level AS, a transform, an instance ID and the index
+// of the hit group indicating which shaders are executed upon hitting any
+// geometry within the instance
+void TopLevelASGenerator::AddInstance(
+    ID3D12Resource* bottomLevelAS,      // Bottom-level acceleration structure containing the
+                                        // actual geometric data of the instance
+    const DirectX::XMMATRIX& transform, // Transform matrix to apply to the instance, allowing the
+                                        // same bottom-level AS to be used at several world-space
+                                        // positions
+    UINT instanceID,                    // Instance ID, which can be used in the shaders to
+                                        // identify this specific instance
+    UINT hitGroupIndex                  // Hit group index, corresponding the the index of the
+                                        // hit group in the Shader Binding Table that will be
+                                        // invocated upon hitting the geometry
+)
+{
+  m_instances.emplace_back(Instance(bottomLevelAS, transform, instanceID, hitGroupIndex));
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Compute the size of the scratch space required to build the acceleration
+// structure, as well as the size of the resulting structure. The allocation of
+// the buffers is then left to the application
+void TopLevelASGenerator::ComputeASBufferSizes(
+    ID3D12Device5* device, // Device on which the build will be performed
+    bool allowUpdate,                        // If true, the resulting acceleration structure will
+                                             // allow iterative updates
+    UINT64* scratchSizeInBytes,              // Required scratch memory on the GPU to build
+                                             // the acceleration structure
+    UINT64* resultSizeInBytes,               // Required GPU memory to store the acceleration
+                                             // structure
+    UINT64* descriptorsSizeInBytes           // Required GPU memory to store instance
+                                             // descriptors, containing the matrices,
+                                             // indices etc.
+)
+{
+  // The generated AS can support iterative updates. This may change the final
+  // size of the AS as well as the temporary memory requirements, and hence has
+  // to be set before the actual build
+  m_flags = allowUpdate ? D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE
+                        : D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_NONE;
+
+  // Describe the work being requested, in this case the construction of a
+  // (possibly dynamic) top-level hierarchy, with the given instance descriptors
+  D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS
+  prebuildDesc = {};
+  prebuildDesc.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL;
+  prebuildDesc.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+  prebuildDesc.NumDescs = static_cast<UINT>(m_instances.size());
+  prebuildDesc.Flags = m_flags;
+
+  // This structure is used to hold the sizes of the required scratch memory and
+  // resulting AS
+  D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO info = {};
+
+  // Building the acceleration structure (AS) requires some scratch space, as
+  // well as space to store the resulting structure This function computes a
+  // conservative estimate of the memory requirements for both, based on the
+  // number of bottom-level instances.
+  device->GetRaytracingAccelerationStructurePrebuildInfo(&prebuildDesc, &info);
+
+  // Buffer sizes need to be 256-byte-aligned
+  info.ResultDataMaxSizeInBytes =
+      ROUND_UP(info.ResultDataMaxSizeInBytes, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
+  info.ScratchDataSizeInBytes =
+      ROUND_UP(info.ScratchDataSizeInBytes, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
+
+  m_resultSizeInBytes = info.ResultDataMaxSizeInBytes;
+  m_scratchSizeInBytes = info.ScratchDataSizeInBytes;
+  // The instance descriptors are stored as-is in GPU memory, so we can deduce
+  // the required size from the instance count
+  m_instanceDescsSizeInBytes =
+      ROUND_UP(sizeof(D3D12_RAYTRACING_INSTANCE_DESC) * static_cast<UINT64>(m_instances.size()),
+               D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
+
+  *scratchSizeInBytes = m_scratchSizeInBytes;
+  *resultSizeInBytes = m_resultSizeInBytes;
+  *descriptorsSizeInBytes = m_instanceDescsSizeInBytes;
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+// Enqueue the construction of the acceleration structure on a command list,
+// using application-provided buffers and possibly a pointer to the previous
+// acceleration structure in case of iterative updates. Note that the update can
+// be done in place: the result and previousResult pointers can be the same.
+void TopLevelASGenerator::Generate(
+    ID3D12GraphicsCommandList4* commandList, // Command list on which the build will be enqueued
+    ID3D12Resource* scratchBuffer,     // Scratch buffer used by the builder to
+                                       // store temporary data
+    ID3D12Resource* resultBuffer,      // Result buffer storing the acceleration structure
+    ID3D12Resource* descriptorsBuffer, // Auxiliary result buffer containing the instance
+                                       // descriptors, has to be in upload heap
+    bool updateOnly /*= false*/,       // If true, simply refit the existing
+                                       // acceleration structure
+    ID3D12Resource* previousResult /*= nullptr*/ // Optional previous acceleration
+                                                 // structure, used if an iterative update
+                                                 // is requested
+)
+{
+  // Copy the descriptors in the target descriptor buffer
+  D3D12_RAYTRACING_INSTANCE_DESC* instanceDescs;
+  descriptorsBuffer->Map(0, nullptr, reinterpret_cast<void**>(&instanceDescs));
+  if (!instanceDescs)
+  {
+    throw std::logic_error("Cannot map the instance descriptor buffer - is it "
+                           "in the upload heap?");
+  }
+
+  auto instanceCount = static_cast<UINT>(m_instances.size());
+
+  // Initialize the memory to zero on the first time only
+  if (!updateOnly)
+  {
+    ZeroMemory(instanceDescs, m_instanceDescsSizeInBytes);
+  }
+
+  // Create the description for each instance
+  for (uint32_t i = 0; i < instanceCount; i++)
+  {
+    // Instance ID visible in the shader in InstanceID()
+    instanceDescs[i].InstanceID = m_instances[i].instanceID;
+    // Index of the hit group invoked upon intersection
+    instanceDescs[i].InstanceContributionToHitGroupIndex = m_instances[i].hitGroupIndex;
+    // Instance flags, including backface culling, winding, etc - TODO: should
+    // be accessible from outside
+    instanceDescs[i].Flags = D3D12_RAYTRACING_INSTANCE_FLAG_NONE;
+    // Instance transform matrix
+    DirectX::XMMATRIX m = XMMatrixTranspose(
+        m_instances[i].transform); // GLM is column major, the INSTANCE_DESC is row major
+    memcpy(instanceDescs[i].Transform, &m, sizeof(instanceDescs[i].Transform));
+    // Get access to the bottom level
+    instanceDescs[i].AccelerationStructure = m_instances[i].bottomLevelAS->GetGPUVirtualAddress();
+    // Visibility mask, always visible here - TODO: should be accessible from
+    // outside
+    instanceDescs[i].InstanceMask = 0xFF;
+  }
+
+  descriptorsBuffer->Unmap(0, nullptr);
+
+  // If this in an update operation we need to provide the source buffer
+  D3D12_GPU_VIRTUAL_ADDRESS pSourceAS = updateOnly ? previousResult->GetGPUVirtualAddress() : 0;
+
+  D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS flags = m_flags;
+  // The stored flags represent whether the AS has been built for updates or
+  // not. If yes and an update is requested, the builder is told to only update
+  // the AS instead of fully rebuilding it
+  if (flags == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE && updateOnly)
+  {
+    flags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE;
+  }
+
+  // Sanity checks
+  if (m_flags != D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE && updateOnly)
+  {
+    throw std::logic_error("Cannot update a top-level AS not originally built for updates");
+  }
+  if (updateOnly && previousResult == nullptr)
+  {
+    throw std::logic_error("Top-level hierarchy update requires the previous hierarchy");
+  }
+
+  // Create a descriptor of the requested builder work, to generate a top-level
+  // AS from the input parameters
+  D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC buildDesc = {};
+  buildDesc.Inputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL;
+  buildDesc.Inputs.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+  buildDesc.Inputs.InstanceDescs = descriptorsBuffer->GetGPUVirtualAddress();
+  buildDesc.Inputs.NumDescs = instanceCount;
+  buildDesc.DestAccelerationStructureData = {resultBuffer->GetGPUVirtualAddress()
+                                             };
+  buildDesc.ScratchAccelerationStructureData = {scratchBuffer->GetGPUVirtualAddress()
+                                                };
+  buildDesc.SourceAccelerationStructureData = pSourceAS;
+  buildDesc.Inputs.Flags = flags;
+
+  // Build the top-level AS
+  commandList->BuildRaytracingAccelerationStructure(&buildDesc, 0, nullptr);
+
+  // Wait for the builder to complete by setting a barrier on the resulting
+  // buffer. This can be important in case the rendering is triggered
+  // immediately afterwards, without executing the command list
+  D3D12_RESOURCE_BARRIER uavBarrier;
+  uavBarrier.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
+  uavBarrier.UAV.pResource = resultBuffer;
+  uavBarrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+  commandList->ResourceBarrier(1, &uavBarrier);
+}
+
+//--------------------------------------------------------------------------------------------------
+//
+//
+TopLevelASGenerator::Instance::Instance(ID3D12Resource* blAS, const DirectX::XMMATRIX& tr, UINT iID,
+                                        UINT hgId)
+    : bottomLevelAS(blAS), transform(tr), instanceID(iID), hitGroupIndex(hgId)
+{
+}
+} // namespace nv_helpers_dx12

--- a/extern/DXRHelpers/nv_helpers_dx12/TopLevelASGenerator.h
+++ b/extern/DXRHelpers/nv_helpers_dx12/TopLevelASGenerator.h
@@ -1,0 +1,161 @@
+/*-----------------------------------------------------------------------
+Copyright (c) 2014-2018, NVIDIA. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Neither the name of its contributors may be used to endorse
+or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-----------------------------------------------------------------------*/
+
+/*
+Contacts for feedback:
+- pgautron@nvidia.com (Pascal Gautron)
+- mlefrancois@nvidia.com (Martin-Karl Lefrancois)
+
+The top-level hierarchy is used to store a set of instances represented by
+bottom-level hierarchies in a way suitable for fast intersection at runtime. To
+be built, this data structure requires some scratch space which has to be
+allocated by the application. Similarly, the resulting data structure is stored
+in an application-controlled buffer.
+
+To be used, the application must first add all the instances to be contained in
+the final structure, using AddInstance. After all instances have been added,
+ComputeASBufferSizes will prepare the build, and provide the required sizes for
+the scratch data and the final result. The Build call will finally compute the
+acceleration structure and store it in the result buffer.
+
+Note that the build is enqueued in the command list, meaning that the scratch
+buffer needs to be kept until the command list execution is finished.
+
+
+
+Example:
+
+TopLevelASGenerator topLevelAS;
+topLevelAS.AddInstance(instances1, matrix1, instanceId1, hitGroupIndex1);
+topLevelAS.AddInstance(instances2, matrix2, instanceId2, hitGroupIndex2);
+...
+UINT64 scratchSize, resultSize, instanceDescsSize;
+topLevelAS.ComputeASBufferSizes(GetRTDevice(), true, &scratchSize, &resultSize,
+&instanceDescsSize); AccelerationStructureBuffers buffers; buffers.pScratch =
+nv_helpers_dx12::CreateBuffer(..., scratchSizeInBytes, ...); buffers.pResult =
+nv_helpers_dx12::CreateBuffer(..., resultSizeInBytes, ...);
+buffers.pInstanceDesc = nv_helpers_dx12::CreateBuffer(..., resultSizeInBytes,
+...); topLevelAS.Generate(m_commandList.Get(), rtCmdList,
+m_topLevelAS.pScratch.Get(), m_topLevelAS.pResult.Get(),
+m_topLevelAS.pInstanceDesc.Get(), updateOnly, updateOnly ?
+m_topLevelAS.pResult.Get() : nullptr);
+
+return buffers;
+
+*/
+
+#pragma once
+
+#include "d3d12.h"
+
+#include <DirectXMath.h>
+
+#include <vector>
+
+namespace nv_helpers_dx12
+{
+
+/// Helper class to generate top-level acceleration structures for raytracing
+class TopLevelASGenerator
+{
+public:
+  /// Add an instance to the top-level acceleration structure. The instance is
+  /// represented by a bottom-level AS, a transform, an instance ID and the
+  /// index of the hit group indicating which shaders are executed upon hitting
+  /// any geometry within the instance
+  void
+  AddInstance(ID3D12Resource* bottomLevelAS, /// Bottom-level acceleration structure containing the
+                                             /// actual geometric data of the instance
+              const DirectX::XMMATRIX& transform, /// Transform matrix to apply to the instance,
+                                                  /// allowing the same bottom-level AS to be used
+                                                  /// at several world-space positions
+              UINT instanceID,   /// Instance ID, which can be used in the shaders to
+                                 /// identify this specific instance
+              UINT hitGroupIndex /// Hit group index, corresponding the the index of the
+                                 /// hit group in the Shader Binding Table that will be
+                                 /// invocated upon hitting the geometry
+  );
+
+  /// Compute the size of the scratch space required to build the acceleration
+  /// structure, as well as the size of the resulting structure. The allocation
+  /// of the buffers is then left to the application
+  void ComputeASBufferSizes(
+      ID3D12Device5* device, /// Device on which the build will be performed
+      bool allowUpdate,              /// If true, the resulting acceleration structure will
+                                     /// allow iterative updates
+      UINT64* scratchSizeInBytes,    /// Required scratch memory on the GPU to
+                                     /// build the acceleration structure
+      UINT64* resultSizeInBytes,     /// Required GPU memory to store the
+                                     /// acceleration structure
+      UINT64* descriptorsSizeInBytes /// Required GPU memory to store instance
+                                     /// descriptors, containing the matrices,
+                                     /// indices etc.
+  );
+
+  /// Enqueue the construction of the acceleration structure on a command list,
+  /// using application-provided buffers and possibly a pointer to the previous
+  /// acceleration structure in case of iterative updates. Note that the update
+  /// can be done in place: the result and previousResult pointers can be the
+  /// same.
+  void Generate(
+      ID3D12GraphicsCommandList4* commandList, /// Command list on which the build will be enqueued
+      ID3D12Resource* scratchBuffer,     /// Scratch buffer used by the builder to
+                                         /// store temporary data
+      ID3D12Resource* resultBuffer,      /// Result buffer storing the acceleration structure
+      ID3D12Resource* descriptorsBuffer, /// Auxiliary result buffer containing the instance
+                                         /// descriptors, has to be in upload heap
+      bool updateOnly = false, /// If true, simply refit the existing acceleration structure
+      ID3D12Resource* previousResult = nullptr /// Optional previous acceleration structure, used
+                                               /// if an iterative update is requested
+  );
+
+private:
+  /// Helper struct storing the instance data
+  struct Instance
+  {
+    Instance(ID3D12Resource* blAS, const DirectX::XMMATRIX& tr, UINT iID, UINT hgId);
+    /// Bottom-level AS
+    ID3D12Resource* bottomLevelAS;
+    /// Transform matrix
+    const DirectX::XMMATRIX& transform;
+    /// Instance ID visible in the shader
+    UINT instanceID;
+    /// Hit group index used to fetch the shaders from the SBT
+    UINT hitGroupIndex;
+  };
+
+  /// Construction flags, indicating whether the AS supports iterative updates
+  D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS m_flags;
+  /// Instances contained in the top-level AS
+  std::vector<Instance> m_instances;
+
+  /// Size of the temporary memory used by the TLAS builder
+  UINT64 m_scratchSizeInBytes;
+  /// Size of the buffer containing the instance descriptors
+  UINT64 m_instanceDescsSizeInBytes;
+  /// Size of the buffer containing the TLAS
+  UINT64 m_resultSizeInBytes;
+};
+} // namespace nv_helpers_dx12

--- a/features/Light Limit Fix/Shaders/LightLimitFix/ClusterCullingCS.hlsl
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/ClusterCullingCS.hlsl
@@ -1,4 +1,4 @@
-#include "LightLimitFix/Common.hlsli"
+#include "Common.hlsli"
 
 cbuffer PerFrame : register(b0)
 {
@@ -9,87 +9,69 @@ cbuffer PerFrame : register(b0)
 //https://github.com/pezcode/Cluster
 
 StructuredBuffer<ClusterAABB> clusters : register(t0);
-StructuredBuffer<Light> lights : register(t1);
+StructuredBuffer<StructuredLight> lights : register(t1);
 
-RWStructuredBuffer<uint> lightIndexCounter : register(u0);
-RWStructuredBuffer<uint> lightIndexList : register(u1);
-RWStructuredBuffer<LightGrid> lightGrid : register(u2);
+RWStructuredBuffer<uint> lightIndexCounter : register(u0);  //1
+RWStructuredBuffer<uint> lightIndexList : register(u1);     //MAX_CLUSTER_LIGHTS * 16^3
+RWStructuredBuffer<LightGrid> lightGrid : register(u2);     //16^3
 
-groupshared Light sharedLights[GROUP_SIZE];
+groupshared StructuredLight sharedLights[GROUP_SIZE];
 
-struct Vector3 {
-	float x, y, z;
-
-	Vector3 operator-(Vector3& other) const {
-		return {x - other.x, y - other.y, z - other.z};
-	} 
-	
-	float dot(const Vector3& other) const {
-		return x * other.x + y * other.y + z * other.z;
-	}
-
-	Vector3 normalize() const {
-		float length = std::sqrt(x * x + y * y + z * z);
-		return {x / length, y / length, z / length};
-	}
-}
-
-bool LightIntersectsCluster(float3 position, float radius, ClusterAABB cluster)
+bool LightIntersectsCluster(StructuredLight light, ClusterAABB cluster, int eyeIndex = 0)
 {
-	float3 closest = max(cluster.minPoint.xyz, min(position, cluster.maxPoint.xyz));
+	float3 closest = max(cluster.minPoint.xyz, min(light.positionVS[eyeIndex].xyz, cluster.maxPoint.xyz));
 
-	float3 dist = closest - position;
-	return dot(dist, dist) <= radius;
+	float3 dist = closest - light.positionVS[eyeIndex].xyz;
+	return dot(dist, dist) <= (light.radius * light.radius);
 }
 
-[numthreads(NUMTHREAD_X, NUMTHREAD_Y, NUMTHREAD_Z)] void main(
-	uint3 groupId
-	: SV_GroupID, uint3 dispatchThreadId
-	: SV_DispatchThreadID, uint3 groupThreadId
-	: SV_GroupThreadID, uint groupIndex
-	: SV_GroupIndex) {
-	if (any(dispatchThreadId >= uint3(CLUSTER_BUILDING_DISPATCH_SIZE_X, CLUSTER_BUILDING_DISPATCH_SIZE_Y, CLUSTER_BUILDING_DISPATCH_SIZE_Z)))
-		return;
+[numthreads(16, 8, 8)] void main(uint3 groupId
+								 : SV_GroupID,
+								 uint3 dispatchThreadId
+								 : SV_DispatchThreadID,
+								 uint3 groupThreadId
+								 : SV_GroupThreadID,
+								 uint groupIndex
+								 : SV_GroupIndex) {
+	if (all(dispatchThreadId == 0)) {
+		lightIndexCounter[0] = 0;
+	}
 
 	uint visibleLightCount = 0;
 	uint visibleLightIndices[MAX_CLUSTER_LIGHTS];
 
-	uint clusterIndex = dispatchThreadId.x +
-	                    dispatchThreadId.y * CLUSTER_BUILDING_DISPATCH_SIZE_X +
-	                    dispatchThreadId.z * (CLUSTER_BUILDING_DISPATCH_SIZE_X * CLUSTER_BUILDING_DISPATCH_SIZE_Y);
+	uint clusterIndex = groupIndex + GROUP_SIZE * groupId.z;
 
 	ClusterAABB cluster = clusters[clusterIndex];
 
-	if (groupIndex < LightCount) {
-		uint lightIndex = groupIndex;
-		Light light = lights[lightIndex];
-		sharedLights[groupIndex] = light;
-	}
+	uint lightOffset = 0;
+	uint lightCount = LightCount;
 
-	GroupMemoryBarrierWithGroupSync();
+	while (lightOffset < lightCount) {
+		uint batchSize = min(GROUP_SIZE, lightCount - lightOffset);
 
-	for (uint i = 0; i < LightCount; i++) {
-		Light light = lights[i];
-
-		float radius = light.radius * light.radius;
-
-#if defined(VR)
-		[branch] if (LightIntersectsCluster(light.positionVS[0].xyz, radius, cluster) || LightIntersectsCluster(light.positionVS[1].xyz, radius, cluster))
-		{
-#else
-		[branch] if (LightIntersectsCluster(light.positionVS[0].xyz, radius, cluster))
-		{
-#endif
-			// The light intersects the cluster area. Check if the light is obstructed.
-			// Draw a line from the light to the center of the cluster and check if it intersects any objects.
-			// If it does, the light is obstructed and should not be rendered within that cluster.
-			// This is a simplified implementation, and a good place to start.
-			
-			visibleLightIndices[visibleLightCount] = i;
-			visibleLightCount++;
-			if (visibleLightCount >= MAX_CLUSTER_LIGHTS)
-				break;
+		if (groupIndex < batchSize) {
+			uint lightIndex = lightOffset + groupIndex;
+			StructuredLight light = lights[lightIndex];
+			sharedLights[groupIndex] = light;
 		}
+
+		GroupMemoryBarrierWithGroupSync();
+
+		for (uint i = 0; i < batchSize; i++) {
+			StructuredLight light = lights[i];
+
+			if (visibleLightCount < MAX_CLUSTER_LIGHTS && (LightIntersectsCluster(light, cluster)
+#ifdef VR
+															  || LightIntersectsCluster(light, cluster, 1)
+#endif  // VR
+																  )) {
+				visibleLightIndices[visibleLightCount] = lightOffset + i;
+				visibleLightCount++;
+			}
+		}
+
+		lightOffset += batchSize;
 	}
 
 	GroupMemoryBarrierWithGroupSync();
@@ -101,11 +83,8 @@ bool LightIntersectsCluster(float3 position, float radius, ClusterAABB cluster)
 		lightIndexList[offset + i] = visibleLightIndices[i];
 	}
 
-	LightGrid output = {
-		offset, visibleLightCount, 0, 0
-	};
-
-	lightGrid[clusterIndex] = output;
+	lightGrid[clusterIndex].offset = offset;
+	lightGrid[clusterIndex].lightCount = visibleLightCount;
 }
 
 //https://www.3dgep.com/forward-plus/#Grid_Frustums_Compute_Shader
@@ -117,22 +96,22 @@ function CullLights( L, C, G, I )
     Input: A list I of global light index list.
     Output: A 2D grid G with the current tiles offset and light count.
     Output: A list I with the current tiles overlapping light indices appended to it.
-
+ 
 1.  let t be the index of the current tile  ; t is the 2D index of the tile.
 2.  let i be a local light index list       ; i is a local light index list.
 3.  let f <- Frustum(t)                     ; f is the frustum for the current tile.
-
+ 
 4.  for l in L                      ; Iterate the lights in the light list.
 5.      if Cull( l, f )             ; Cull the light against the tile frustum.
 6.          AppendLight( l, i )     ; Append the light to the local light index list.
-
-7.  c <- AtomicInc( C, i.count )    ; Atomically increment the current index of the
+                     
+7.  c <- AtomicInc( C, i.count )    ; Atomically increment the current index of the 
                                     ; global light index list by the number of lights
                                     ; overlapping the current tile and store the
                                     ; original index in c.
-
+             
 8.  G(t) <- ( c, i.count )          ; Store the offset and light count in the light grid.
-
-9.  I(c) <- i                       ; Store the local light index list into the global
+         
+9.  I(c) <- i                       ; Store the local light index list into the global 
                                     ; light index list.
 */

--- a/features/Light Limit Fix/Shaders/LightLimitFix/ClusterCullingCS.hlsl
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/ClusterCullingCS.hlsl
@@ -17,6 +17,23 @@ RWStructuredBuffer<LightGrid> lightGrid : register(u2);
 
 groupshared Light sharedLights[GROUP_SIZE];
 
+struct Vector3 {
+	float x, y, z;
+
+	Vector3 operator-(Vector3& other) const {
+		return {x - other.x, y - other.y, z - other.z};
+	} 
+	
+	float dot(const Vector3& other) const {
+		return x * other.x + y * other.y + z * other.z;
+	}
+
+	Vector3 normalize() const {
+		float length = std::sqrt(x * x + y * y + z * z);
+		return {x / length, y / length, z / length};
+	}
+}
+
 bool LightIntersectsCluster(float3 position, float radius, ClusterAABB cluster)
 {
 	float3 closest = max(cluster.minPoint.xyz, min(position, cluster.maxPoint.xyz));
@@ -63,6 +80,11 @@ bool LightIntersectsCluster(float3 position, float radius, ClusterAABB cluster)
 		[branch] if (LightIntersectsCluster(light.positionVS[0].xyz, radius, cluster))
 		{
 #endif
+			// The light intersects the cluster area. Check if the light is obstructed.
+			// Draw a line from the light to the center of the cluster and check if it intersects any objects.
+			// If it does, the light is obstructed and should not be rendered within that cluster.
+			// This is a simplified implementation, and a good place to start.
+			
 			visibleLightIndices[visibleLightCount] = i;
 			visibleLightCount++;
 			if (visibleLightCount >= MAX_CLUSTER_LIGHTS)

--- a/features/Light Limit Fix/Shaders/LightLimitFix/ClusterCullingCS.hlsl
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/ClusterCullingCS.hlsl
@@ -96,22 +96,22 @@ function CullLights( L, C, G, I )
     Input: A list I of global light index list.
     Output: A 2D grid G with the current tiles offset and light count.
     Output: A list I with the current tiles overlapping light indices appended to it.
- 
+
 1.  let t be the index of the current tile  ; t is the 2D index of the tile.
 2.  let i be a local light index list       ; i is a local light index list.
 3.  let f <- Frustum(t)                     ; f is the frustum for the current tile.
- 
+
 4.  for l in L                      ; Iterate the lights in the light list.
 5.      if Cull( l, f )             ; Cull the light against the tile frustum.
 6.          AppendLight( l, i )     ; Append the light to the local light index list.
-                     
-7.  c <- AtomicInc( C, i.count )    ; Atomically increment the current index of the 
+
+7.  c <- AtomicInc( C, i.count )    ; Atomically increment the current index of the
                                     ; global light index list by the number of lights
                                     ; overlapping the current tile and store the
                                     ; original index in c.
-             
+
 8.  G(t) <- ( c, i.count )          ; Store the offset and light count in the light grid.
-         
-9.  I(c) <- i                       ; Store the local light index list into the global 
+
+9.  I(c) <- i                       ; Store the local light index list into the global
                                     ; light index list.
 */

--- a/features/Ray Tracing/Shaders/RayTracing/RayTracing.hlsl
+++ b/features/Ray Tracing/Shaders/RayTracing/RayTracing.hlsl
@@ -33,21 +33,21 @@ void RayGen()
     // Get dispatch dimensions
     uint2 launchIndex = DispatchRaysIndex().xy;
     uint2 launchDim = DispatchRaysDimensions().xy;
-    
+
     // Generate ray
     float2 d = (launchIndex.xy + 0.5f) / launchDim;
     float4 target = mul(projInverseMatrix, float4(d.x * 2 - 1, 1 - d.y * 2, 0, 1));
     target.xyz /= target.w;
-    
+
     RayDesc ray;
     ray.Origin = cameraPosition;
     ray.Direction = normalize(mul(viewInverseMatrix, float4(target.xyz, 0)).xyz);
     ray.TMin = 0.001;
     ray.TMax = 10000.0;
-    
+
     // Initialize payload
     RayPayload payload = { float3(0, 0, 0), -1 };
-    
+
     // Trace ray
     TraceRay(
         SceneBVH,
@@ -58,7 +58,7 @@ void RayGen()
         0,    // Miss shader index
         ray,
         payload);
-    
+
     // Write result
     gOutput[launchIndex] = float4(payload.color, 1.0f);
 }
@@ -69,7 +69,7 @@ void ClosestHit(inout RayPayload payload, in Attributes attrib)
     // Basic diffuse shading
     float3 hitNormal = normalize(HitWorldNormal());
     float3 lightDir = normalize(float3(0.5, 1, 0.25));
-    
+
     float NdotL = saturate(dot(hitNormal, lightDir));
     payload.color = float3(0.8, 0.8, 0.8) * NdotL;
     payload.hitDistance = HitT();

--- a/features/Ray Tracing/Shaders/RayTracing/RayTracing.hlsl
+++ b/features/Ray Tracing/Shaders/RayTracing/RayTracing.hlsl
@@ -1,0 +1,92 @@
+// Ray Tracing Shaders for Skyrim Community Shaders
+
+struct RayPayload
+{
+    float3 color;
+    float hitDistance;
+};
+
+struct Attributes
+{
+    float2 barycentrics;
+};
+
+// Shared constant buffer
+cbuffer GlobalConstants : register(b0)
+{
+    float4x4 viewInverseMatrix;
+    float4x4 projInverseMatrix;
+    float3 cameraPosition;
+    float rayBias;
+    uint frameCount;
+};
+
+// Acceleration structure
+RaytracingAccelerationStructure SceneBVH : register(t0);
+
+// Output texture
+RWTexture2D<float4> gOutput : register(u0);
+
+[shader("raygeneration")]
+void RayGen()
+{
+    // Get dispatch dimensions
+    uint2 launchIndex = DispatchRaysIndex().xy;
+    uint2 launchDim = DispatchRaysDimensions().xy;
+    
+    // Generate ray
+    float2 d = (launchIndex.xy + 0.5f) / launchDim;
+    float4 target = mul(projInverseMatrix, float4(d.x * 2 - 1, 1 - d.y * 2, 0, 1));
+    target.xyz /= target.w;
+    
+    RayDesc ray;
+    ray.Origin = cameraPosition;
+    ray.Direction = normalize(mul(viewInverseMatrix, float4(target.xyz, 0)).xyz);
+    ray.TMin = 0.001;
+    ray.TMax = 10000.0;
+    
+    // Initialize payload
+    RayPayload payload = { float3(0, 0, 0), -1 };
+    
+    // Trace ray
+    TraceRay(
+        SceneBVH,
+        RAY_FLAG_NONE,
+        0xFF, // Instance mask
+        0,    // Ray contribution to hit group index
+        1,    // Multiplier for geometry contribution to hit group index
+        0,    // Miss shader index
+        ray,
+        payload);
+    
+    // Write result
+    gOutput[launchIndex] = float4(payload.color, 1.0f);
+}
+
+[shader("closesthit")]
+void ClosestHit(inout RayPayload payload, in Attributes attrib)
+{
+    // Basic diffuse shading
+    float3 hitNormal = normalize(HitWorldNormal());
+    float3 lightDir = normalize(float3(0.5, 1, 0.25));
+    
+    float NdotL = saturate(dot(hitNormal, lightDir));
+    payload.color = float3(0.8, 0.8, 0.8) * NdotL;
+    payload.hitDistance = HitT();
+}
+
+[shader("anyhit")]
+void AnyHit(inout RayPayload payload, in Attributes attrib)
+{
+    // Simple alpha testing (can be expanded for foliage etc.)
+    if (Opacity() < 0.5)
+        IgnoreHit();
+}
+
+[shader("miss")]
+void Miss(inout RayPayload payload)
+{
+    // Sky gradient
+    float t = saturate(payload.Direction.y * 0.5 + 0.5);
+    payload.color = lerp(float3(0.3, 0.4, 0.7), float3(0.8, 0.9, 1.0), t);
+}

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -12,6 +12,7 @@
 #include "Features/InverseSquareLighting.h"
 #include "Features/LODBlending.h"
 #include "Features/LightLimitFix.h"
+#include "Features/RayTracing.h"
 #include "Features/ScreenSpaceGI.h"
 #include "Features/ScreenSpaceShadows.h"
 #include "Features/SkySync.h"
@@ -25,7 +26,6 @@
 #include "Features/VolumetricLighting.h"
 #include "Features/WaterEffects.h"
 #include "Features/WetnessEffects.h"
-#include "Features/RayTracing.h"
 
 #include "State.h"
 

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -25,6 +25,7 @@
 #include "Features/VolumetricLighting.h"
 #include "Features/WaterEffects.h"
 #include "Features/WetnessEffects.h"
+#include "Features/RayTracing.h"
 
 #include "State.h"
 
@@ -153,7 +154,8 @@ const std::vector<Feature*>& Feature::GetFeatureList()
 		globals::features::hairSpecular,
 		globals::features::interiorSunShadows,
 		globals::features::terrainVariation,
-		globals::features::ibl
+		globals::features::ibl,
+		globals::features::rayTracing
 	};
 
 	static std::vector<Feature*> featuresVR = [] {

--- a/src/Features/RayTracing/RayTracing.cpp
+++ b/src/Features/RayTracing/RayTracing.cpp
@@ -1,0 +1,204 @@
+#include "RayTracing.h"
+
+void RayTracing::SetupResources() {
+    auto device = D3D12::GetDevice();
+    
+    // Initialize pipeline generator
+    m_pipelineGenerator = std::make_unique<nv_helpers_dx12::RayTracingPipelineGenerator>(device);
+    
+    // Create BLAS for all geometry
+    auto& geometries = RE::BSGeometry::GetAllGeometries();
+    
+    m_blasGenerator = nv_helpers_dx12::RayTracingAccelerationStructureGenerator(device);
+    
+    for (auto& geometry : geometries) {
+        if (auto geom = geometry->AsGeometry()) {
+            auto vertexDesc = geom->GetVertexDesc();
+            auto indexDesc = geom->GetIndexDesc();
+            
+            // Add geometry to BLAS generator
+            m_blasGenerator.AddVertexBuffer(
+                vertexDesc->resource.Get(),
+                vertexDesc->offset,
+                vertexDesc->vertexCount,
+                vertexDesc->vertexSize,
+                indexDesc->resource.Get(),
+                indexDesc->offset,
+                indexDesc->indexCount,
+                nullptr, 0, // No transform buffer
+                true // Opaque geometry
+            );
+        }
+    }
+    
+    // Create BLAS
+    UINT64 blasScratchSize, blasResultSize;
+    m_blasGenerator.ComputeASBufferSizes(device, false, &blasScratchSize, &blasResultSize);
+    
+    m_scratchBuffer = D3D12::CreateBuffer(
+        blasScratchSize,
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+        
+    m_blasBuffer = D3D12::CreateBuffer(
+        blasResultSize,
+        D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+    
+    m_blasGenerator.Generate(
+        D3D12::GetCommandList(),
+        m_scratchBuffer.Get(),
+        m_blasBuffer.Get(),
+        false, nullptr);
+    
+    // Create TLAS
+    m_tlasGenerator = nv_helpers_dx12::RayTracingAccelerationStructureGenerator(device);
+    
+    for (auto& geometry : geometries) {
+        if (auto geom = geometry->AsGeometry()) {
+            m_tlasGenerator.AddInstance(
+                m_blasBuffer.Get(),
+                geom->worldTransform,
+                geom->GetFormID(),
+                0 // Default hit group
+            );
+        }
+    }
+    
+    UINT64 tlasScratchSize, tlasResultSize, instanceDescsSize;
+    m_tlasGenerator.ComputeASBufferSizes(device, false, &tlasScratchSize, &tlasResultSize, &instanceDescsSize);
+    
+    m_scratchBuffer = D3D12::CreateBuffer(
+        tlasScratchSize,
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+        
+    m_tlasBuffer = D3D12::CreateBuffer(
+        tlasResultSize,
+        D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+    
+    auto instanceDescs = D3D12::CreateBuffer(
+        instanceDescsSize,
+        D3D12_RESOURCE_STATE_GENERIC_READ,
+        D3D12_RESOURCE_FLAG_NONE);
+    
+    m_tlasGenerator.Generate(
+        D3D12::GetCommandList(),
+        m_scratchBuffer.Get(),
+        m_tlasBuffer.Get(),
+        instanceDescs.Get(),
+        false, nullptr);
+    
+    // Create ray tracing pipeline
+    CreateRayTracingPipeline();
+    
+    // Create shader tables
+    CreateShaderBindingTables();
+}
+
+void RayTracing::Reset() {
+    m_blasBuffer.Reset();
+    m_tlasBuffer.Reset();
+    m_scratchBuffer.Reset();
+    
+    m_shaderTables.rayGen.Reset();
+    m_shaderTables.miss.Reset();
+    m_shaderTables.hitGroup.Reset();
+    
+    m_rtStateObject.Reset();
+    m_pipelineGenerator.reset();
+}
+
+void RayTracing::CreateRayTracingPipeline() {
+    auto device = D3D12::GetDevice();
+    
+    // Load shader libraries (simplified - actual implementation would compile from HLSL)
+    // m_rayGenLibrary = CompileShader(L"RayTracing.hlsl", L"RayGen");
+    // m_missLibrary = CompileShader(L"RayTracing.hlsl", L"Miss");
+    // m_hitLibrary = CompileShader(L"RayTracing.hlsl", L"ClosestHit");
+    
+    // Add shader libraries to pipeline
+    m_pipelineGenerator->AddLibrary(m_rayGenLibrary.Get(), {L"RayGen"});
+    m_pipelineGenerator->AddLibrary(m_missLibrary.Get(), {L"Miss"});
+    m_pipelineGenerator->AddLibrary(m_hitLibrary.Get(), {L"ClosestHit", L"AnyHit"});
+    
+    // Add hit groups
+    m_pipelineGenerator->AddHitGroup(L"HitGroup", L"ClosestHit", L"AnyHit");
+    
+    // Add root signature associations
+    m_pipelineGenerator->AddRootSignatureAssociation(m_rayGenSignature.Get(), {L"RayGen"});
+    m_pipelineGenerator->AddRootSignatureAssociation(m_missSignature.Get(), {L"Miss"});
+    m_pipelineGenerator->AddRootSignatureAssociation(m_hitSignature.Get(), {L"HitGroup"});
+    
+    // Set pipeline parameters
+    m_pipelineGenerator->SetMaxPayloadSize(4 * sizeof(float)); // RGB + distance
+    m_pipelineGenerator->SetMaxAttributeSize(2 * sizeof(float)); // barycentric coordinates
+    m_pipelineGenerator->SetMaxRecursionDepth(2); // Primary + shadow rays
+    
+    // Generate pipeline state object
+    m_rtStateObject = m_pipelineGenerator->Generate();
+    
+    // Get shader identifiers
+    auto GetShaderID = [&](LPCWSTR name) {
+        void* id;
+        ThrowIfFailed(m_rtStateObject->GetShaderIdentifier(name, &id));
+        return id;
+    };
+    
+    m_shaderIDs.rayGen = GetShaderID(L"RayGen");
+    m_shaderIDs.miss = GetShaderID(L"Miss");
+    m_shaderIDs.closestHit = GetShaderID(L"ClosestHit");
+    m_shaderIDs.anyHit = GetShaderID(L"AnyHit");
+}
+
+void RayTracing::CreateShaderBindingTables() {
+    auto device = D3D12::GetDevice();
+    
+    // Get shader identifier size
+    UINT shaderIDSize = D3D12::GetShaderIdentifierSize();
+    
+    // Create shader tables
+    m_shaderTables.rayGenStride = shaderIDSize;
+    m_shaderTables.missStride = shaderIDSize;
+    m_shaderTables.hitGroupStride = shaderIDSize;
+    
+    // RayGen table (1 entry)
+    m_shaderTables.rayGen = D3D12::CreateBuffer(
+        shaderIDSize,
+        D3D12_RESOURCE_STATE_GENERIC_READ,
+        D3D12_RESOURCE_FLAG_NONE);
+    
+    // Miss table (1 entry)
+    m_shaderTables.miss = D3D12::CreateBuffer(
+        shaderIDSize,
+        D3D12_RESOURCE_STATE_GENERIC_READ,
+        D3D12_RESOURCE_FLAG_NONE);
+    
+    // HitGroup table (1 entry per material type)
+    m_shaderTables.hitGroup = D3D12::CreateBuffer(
+        shaderIDSize * 4, // Room for 4 material types
+        D3D12_RESOURCE_STATE_GENERIC_READ,
+        D3D12_RESOURCE_FLAG_NONE);
+    
+    // Map and populate tables
+    {
+        // RayGen
+        void* rayGenData;
+        m_shaderTables.rayGen->Map(0, nullptr, &rayGenData);
+        memcpy(rayGenData, m_shaderIDs.rayGen, shaderIDSize);
+        m_shaderTables.rayGen->Unmap(0, nullptr);
+        
+        // Miss
+        void* missData;
+        m_shaderTables.miss->Map(0, nullptr, &missData);
+        memcpy(missData, m_shaderIDs.miss, shaderIDSize);
+        m_shaderTables.miss->Unmap(0, nullptr);
+        
+        // HitGroup (placeholder - will be filled per-material)
+        void* hitGroupData;
+        m_shaderTables.hitGroup->Map(0, nullptr, &hitGroupData);
+        memset(hitGroupData, 0, shaderIDSize * 4);
+        m_shaderTables.hitGroup->Unmap(0, nullptr);
+    }
+}

--- a/src/Features/RayTracing/RayTracing.cpp
+++ b/src/Features/RayTracing/RayTracing.cpp
@@ -1,204 +1,208 @@
 #include "RayTracing.h"
 
-void RayTracing::SetupResources() {
-    auto device = D3D12::GetDevice();
-    
-    // Initialize pipeline generator
-    m_pipelineGenerator = std::make_unique<nv_helpers_dx12::RayTracingPipelineGenerator>(device);
-    
-    // Create BLAS for all geometry
-    auto& geometries = RE::BSGeometry::GetAllGeometries();
-    
-    m_blasGenerator = nv_helpers_dx12::RayTracingAccelerationStructureGenerator(device);
-    
-    for (auto& geometry : geometries) {
-        if (auto geom = geometry->AsGeometry()) {
-            auto vertexDesc = geom->GetVertexDesc();
-            auto indexDesc = geom->GetIndexDesc();
-            
-            // Add geometry to BLAS generator
-            m_blasGenerator.AddVertexBuffer(
-                vertexDesc->resource.Get(),
-                vertexDesc->offset,
-                vertexDesc->vertexCount,
-                vertexDesc->vertexSize,
-                indexDesc->resource.Get(),
-                indexDesc->offset,
-                indexDesc->indexCount,
-                nullptr, 0, // No transform buffer
-                true // Opaque geometry
-            );
-        }
-    }
-    
-    // Create BLAS
-    UINT64 blasScratchSize, blasResultSize;
-    m_blasGenerator.ComputeASBufferSizes(device, false, &blasScratchSize, &blasResultSize);
-    
-    m_scratchBuffer = D3D12::CreateBuffer(
-        blasScratchSize,
-        D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
-        
-    m_blasBuffer = D3D12::CreateBuffer(
-        blasResultSize,
-        D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE,
-        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
-    
-    m_blasGenerator.Generate(
-        D3D12::GetCommandList(),
-        m_scratchBuffer.Get(),
-        m_blasBuffer.Get(),
-        false, nullptr);
-    
-    // Create TLAS
-    m_tlasGenerator = nv_helpers_dx12::RayTracingAccelerationStructureGenerator(device);
-    
-    for (auto& geometry : geometries) {
-        if (auto geom = geometry->AsGeometry()) {
-            m_tlasGenerator.AddInstance(
-                m_blasBuffer.Get(),
-                geom->worldTransform,
-                geom->GetFormID(),
-                0 // Default hit group
-            );
-        }
-    }
-    
-    UINT64 tlasScratchSize, tlasResultSize, instanceDescsSize;
-    m_tlasGenerator.ComputeASBufferSizes(device, false, &tlasScratchSize, &tlasResultSize, &instanceDescsSize);
-    
-    m_scratchBuffer = D3D12::CreateBuffer(
-        tlasScratchSize,
-        D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
-        
-    m_tlasBuffer = D3D12::CreateBuffer(
-        tlasResultSize,
-        D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE,
-        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
-    
-    auto instanceDescs = D3D12::CreateBuffer(
-        instanceDescsSize,
-        D3D12_RESOURCE_STATE_GENERIC_READ,
-        D3D12_RESOURCE_FLAG_NONE);
-    
-    m_tlasGenerator.Generate(
-        D3D12::GetCommandList(),
-        m_scratchBuffer.Get(),
-        m_tlasBuffer.Get(),
-        instanceDescs.Get(),
-        false, nullptr);
-    
-    // Create ray tracing pipeline
-    CreateRayTracingPipeline();
-    
-    // Create shader tables
-    CreateShaderBindingTables();
+void RayTracing::SetupResources()
+{
+	auto device = D3D12::GetDevice();
+
+	// Initialize pipeline generator
+	m_pipelineGenerator = std::make_unique<nv_helpers_dx12::RayTracingPipelineGenerator>(device);
+
+	// Create BLAS for all geometry
+	auto& geometries = RE::BSGeometry::GetAllGeometries();
+
+	m_blasGenerator = nv_helpers_dx12::RayTracingAccelerationStructureGenerator(device);
+
+	for (auto& geometry : geometries) {
+		if (auto geom = geometry->AsGeometry()) {
+			auto vertexDesc = geom->GetVertexDesc();
+			auto indexDesc = geom->GetIndexDesc();
+
+			// Add geometry to BLAS generator
+			m_blasGenerator.AddVertexBuffer(
+				vertexDesc->resource.Get(),
+				vertexDesc->offset,
+				vertexDesc->vertexCount,
+				vertexDesc->vertexSize,
+				indexDesc->resource.Get(),
+				indexDesc->offset,
+				indexDesc->indexCount,
+				nullptr, 0,  // No transform buffer
+				true         // Opaque geometry
+			);
+		}
+	}
+
+	// Create BLAS
+	UINT64 blasScratchSize, blasResultSize;
+	m_blasGenerator.ComputeASBufferSizes(device, false, &blasScratchSize, &blasResultSize);
+
+	m_scratchBuffer = D3D12::CreateBuffer(
+		blasScratchSize,
+		D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+		D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+
+	m_blasBuffer = D3D12::CreateBuffer(
+		blasResultSize,
+		D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE,
+		D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+
+	m_blasGenerator.Generate(
+		D3D12::GetCommandList(),
+		m_scratchBuffer.Get(),
+		m_blasBuffer.Get(),
+		false, nullptr);
+
+	// Create TLAS
+	m_tlasGenerator = nv_helpers_dx12::RayTracingAccelerationStructureGenerator(device);
+
+	for (auto& geometry : geometries) {
+		if (auto geom = geometry->AsGeometry()) {
+			m_tlasGenerator.AddInstance(
+				m_blasBuffer.Get(),
+				geom->worldTransform,
+				geom->GetFormID(),
+				0  // Default hit group
+			);
+		}
+	}
+
+	UINT64 tlasScratchSize, tlasResultSize, instanceDescsSize;
+	m_tlasGenerator.ComputeASBufferSizes(device, false, &tlasScratchSize, &tlasResultSize, &instanceDescsSize);
+
+	m_scratchBuffer = D3D12::CreateBuffer(
+		tlasScratchSize,
+		D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+		D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+
+	m_tlasBuffer = D3D12::CreateBuffer(
+		tlasResultSize,
+		D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE,
+		D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+
+	auto instanceDescs = D3D12::CreateBuffer(
+		instanceDescsSize,
+		D3D12_RESOURCE_STATE_GENERIC_READ,
+		D3D12_RESOURCE_FLAG_NONE);
+
+	m_tlasGenerator.Generate(
+		D3D12::GetCommandList(),
+		m_scratchBuffer.Get(),
+		m_tlasBuffer.Get(),
+		instanceDescs.Get(),
+		false, nullptr);
+
+	// Create ray tracing pipeline
+	CreateRayTracingPipeline();
+
+	// Create shader tables
+	CreateShaderBindingTables();
 }
 
-void RayTracing::Reset() {
-    m_blasBuffer.Reset();
-    m_tlasBuffer.Reset();
-    m_scratchBuffer.Reset();
-    
-    m_shaderTables.rayGen.Reset();
-    m_shaderTables.miss.Reset();
-    m_shaderTables.hitGroup.Reset();
-    
-    m_rtStateObject.Reset();
-    m_pipelineGenerator.reset();
+void RayTracing::Reset()
+{
+	m_blasBuffer.Reset();
+	m_tlasBuffer.Reset();
+	m_scratchBuffer.Reset();
+
+	m_shaderTables.rayGen.Reset();
+	m_shaderTables.miss.Reset();
+	m_shaderTables.hitGroup.Reset();
+
+	m_rtStateObject.Reset();
+	m_pipelineGenerator.reset();
 }
 
-void RayTracing::CreateRayTracingPipeline() {
-    auto device = D3D12::GetDevice();
-    
-    // Load shader libraries (simplified - actual implementation would compile from HLSL)
-    // m_rayGenLibrary = CompileShader(L"RayTracing.hlsl", L"RayGen");
-    // m_missLibrary = CompileShader(L"RayTracing.hlsl", L"Miss");
-    // m_hitLibrary = CompileShader(L"RayTracing.hlsl", L"ClosestHit");
-    
-    // Add shader libraries to pipeline
-    m_pipelineGenerator->AddLibrary(m_rayGenLibrary.Get(), {L"RayGen"});
-    m_pipelineGenerator->AddLibrary(m_missLibrary.Get(), {L"Miss"});
-    m_pipelineGenerator->AddLibrary(m_hitLibrary.Get(), {L"ClosestHit", L"AnyHit"});
-    
-    // Add hit groups
-    m_pipelineGenerator->AddHitGroup(L"HitGroup", L"ClosestHit", L"AnyHit");
-    
-    // Add root signature associations
-    m_pipelineGenerator->AddRootSignatureAssociation(m_rayGenSignature.Get(), {L"RayGen"});
-    m_pipelineGenerator->AddRootSignatureAssociation(m_missSignature.Get(), {L"Miss"});
-    m_pipelineGenerator->AddRootSignatureAssociation(m_hitSignature.Get(), {L"HitGroup"});
-    
-    // Set pipeline parameters
-    m_pipelineGenerator->SetMaxPayloadSize(4 * sizeof(float)); // RGB + distance
-    m_pipelineGenerator->SetMaxAttributeSize(2 * sizeof(float)); // barycentric coordinates
-    m_pipelineGenerator->SetMaxRecursionDepth(2); // Primary + shadow rays
-    
-    // Generate pipeline state object
-    m_rtStateObject = m_pipelineGenerator->Generate();
-    
-    // Get shader identifiers
-    auto GetShaderID = [&](LPCWSTR name) {
-        void* id;
-        ThrowIfFailed(m_rtStateObject->GetShaderIdentifier(name, &id));
-        return id;
-    };
-    
-    m_shaderIDs.rayGen = GetShaderID(L"RayGen");
-    m_shaderIDs.miss = GetShaderID(L"Miss");
-    m_shaderIDs.closestHit = GetShaderID(L"ClosestHit");
-    m_shaderIDs.anyHit = GetShaderID(L"AnyHit");
+void RayTracing::CreateRayTracingPipeline()
+{
+	auto device = D3D12::GetDevice();
+
+	// Load shader libraries (simplified - actual implementation would compile from HLSL)
+	// m_rayGenLibrary = CompileShader(L"RayTracing.hlsl", L"RayGen");
+	// m_missLibrary = CompileShader(L"RayTracing.hlsl", L"Miss");
+	// m_hitLibrary = CompileShader(L"RayTracing.hlsl", L"ClosestHit");
+
+	// Add shader libraries to pipeline
+	m_pipelineGenerator->AddLibrary(m_rayGenLibrary.Get(), { L"RayGen" });
+	m_pipelineGenerator->AddLibrary(m_missLibrary.Get(), { L"Miss" });
+	m_pipelineGenerator->AddLibrary(m_hitLibrary.Get(), { L"ClosestHit", L"AnyHit" });
+
+	// Add hit groups
+	m_pipelineGenerator->AddHitGroup(L"HitGroup", L"ClosestHit", L"AnyHit");
+
+	// Add root signature associations
+	m_pipelineGenerator->AddRootSignatureAssociation(m_rayGenSignature.Get(), { L"RayGen" });
+	m_pipelineGenerator->AddRootSignatureAssociation(m_missSignature.Get(), { L"Miss" });
+	m_pipelineGenerator->AddRootSignatureAssociation(m_hitSignature.Get(), { L"HitGroup" });
+
+	// Set pipeline parameters
+	m_pipelineGenerator->SetMaxPayloadSize(4 * sizeof(float));    // RGB + distance
+	m_pipelineGenerator->SetMaxAttributeSize(2 * sizeof(float));  // barycentric coordinates
+	m_pipelineGenerator->SetMaxRecursionDepth(2);                 // Primary + shadow rays
+
+	// Generate pipeline state object
+	m_rtStateObject = m_pipelineGenerator->Generate();
+
+	// Get shader identifiers
+	auto GetShaderID = [&](LPCWSTR name) {
+		void* id;
+		ThrowIfFailed(m_rtStateObject->GetShaderIdentifier(name, &id));
+		return id;
+	};
+
+	m_shaderIDs.rayGen = GetShaderID(L"RayGen");
+	m_shaderIDs.miss = GetShaderID(L"Miss");
+	m_shaderIDs.closestHit = GetShaderID(L"ClosestHit");
+	m_shaderIDs.anyHit = GetShaderID(L"AnyHit");
 }
 
-void RayTracing::CreateShaderBindingTables() {
-    auto device = D3D12::GetDevice();
-    
-    // Get shader identifier size
-    UINT shaderIDSize = D3D12::GetShaderIdentifierSize();
-    
-    // Create shader tables
-    m_shaderTables.rayGenStride = shaderIDSize;
-    m_shaderTables.missStride = shaderIDSize;
-    m_shaderTables.hitGroupStride = shaderIDSize;
-    
-    // RayGen table (1 entry)
-    m_shaderTables.rayGen = D3D12::CreateBuffer(
-        shaderIDSize,
-        D3D12_RESOURCE_STATE_GENERIC_READ,
-        D3D12_RESOURCE_FLAG_NONE);
-    
-    // Miss table (1 entry)
-    m_shaderTables.miss = D3D12::CreateBuffer(
-        shaderIDSize,
-        D3D12_RESOURCE_STATE_GENERIC_READ,
-        D3D12_RESOURCE_FLAG_NONE);
-    
-    // HitGroup table (1 entry per material type)
-    m_shaderTables.hitGroup = D3D12::CreateBuffer(
-        shaderIDSize * 4, // Room for 4 material types
-        D3D12_RESOURCE_STATE_GENERIC_READ,
-        D3D12_RESOURCE_FLAG_NONE);
-    
-    // Map and populate tables
-    {
-        // RayGen
-        void* rayGenData;
-        m_shaderTables.rayGen->Map(0, nullptr, &rayGenData);
-        memcpy(rayGenData, m_shaderIDs.rayGen, shaderIDSize);
-        m_shaderTables.rayGen->Unmap(0, nullptr);
-        
-        // Miss
-        void* missData;
-        m_shaderTables.miss->Map(0, nullptr, &missData);
-        memcpy(missData, m_shaderIDs.miss, shaderIDSize);
-        m_shaderTables.miss->Unmap(0, nullptr);
-        
-        // HitGroup (placeholder - will be filled per-material)
-        void* hitGroupData;
-        m_shaderTables.hitGroup->Map(0, nullptr, &hitGroupData);
-        memset(hitGroupData, 0, shaderIDSize * 4);
-        m_shaderTables.hitGroup->Unmap(0, nullptr);
-    }
+void RayTracing::CreateShaderBindingTables()
+{
+	auto device = D3D12::GetDevice();
+
+	// Get shader identifier size
+	UINT shaderIDSize = D3D12::GetShaderIdentifierSize();
+
+	// Create shader tables
+	m_shaderTables.rayGenStride = shaderIDSize;
+	m_shaderTables.missStride = shaderIDSize;
+	m_shaderTables.hitGroupStride = shaderIDSize;
+
+	// RayGen table (1 entry)
+	m_shaderTables.rayGen = D3D12::CreateBuffer(
+		shaderIDSize,
+		D3D12_RESOURCE_STATE_GENERIC_READ,
+		D3D12_RESOURCE_FLAG_NONE);
+
+	// Miss table (1 entry)
+	m_shaderTables.miss = D3D12::CreateBuffer(
+		shaderIDSize,
+		D3D12_RESOURCE_STATE_GENERIC_READ,
+		D3D12_RESOURCE_FLAG_NONE);
+
+	// HitGroup table (1 entry per material type)
+	m_shaderTables.hitGroup = D3D12::CreateBuffer(
+		shaderIDSize * 4,  // Room for 4 material types
+		D3D12_RESOURCE_STATE_GENERIC_READ,
+		D3D12_RESOURCE_FLAG_NONE);
+
+	// Map and populate tables
+	{
+		// RayGen
+		void* rayGenData;
+		m_shaderTables.rayGen->Map(0, nullptr, &rayGenData);
+		memcpy(rayGenData, m_shaderIDs.rayGen, shaderIDSize);
+		m_shaderTables.rayGen->Unmap(0, nullptr);
+
+		// Miss
+		void* missData;
+		m_shaderTables.miss->Map(0, nullptr, &missData);
+		memcpy(missData, m_shaderIDs.miss, shaderIDSize);
+		m_shaderTables.miss->Unmap(0, nullptr);
+
+		// HitGroup (placeholder - will be filled per-material)
+		void* hitGroupData;
+		m_shaderTables.hitGroup->Map(0, nullptr, &hitGroupData);
+		memset(hitGroupData, 0, shaderIDSize * 4);
+		m_shaderTables.hitGroup->Unmap(0, nullptr);
+	}
 }

--- a/src/Features/RayTracing/RayTracing.h
+++ b/src/Features/RayTracing/RayTracing.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <d3d12.h>
+#include <DXRHelpers>
+
+/* Reference Documenation:
+    1. https://microsoft.github.io/DirectX-Specs/d3d/Raytracing.html
+    2. Source: I made it up.
+*/
+
+/* Ray Tracing Pipeline:
+    1. Acceleration Structures:
+        - BLAS: per-geometry (triangle meshes or AABB primitives)
+        - TLAS: instances of BLAS with transforms
+    2. Shader Tables & Records:
+        - Shader Table: array of Shader Records
+        - Shader Record: shader ID + local root arguments
+    3. Shader Types:
+        - RayGen: generate rays into the scene
+        - Miss: handle rays with no hit (sky/background)
+        - HitGroup: closestHit, anyHit, intersection shaders
+    4. Dispatch:
+        - Use DispatchRays() binding AS and shader tables
+*/
+
+struct RayTracing : Feature {
+    static RayTracing* GetSingleton() {
+        static RayTracing singleton;
+        return &singleton;
+    }
+
+    virtual inline std::string GetName() override { return "Ray Tracing"; }
+    virtual inline std::string GetShortName() override { return "RayTracing"; }
+    virtual inline std::string_view GetShaderDefineName() override { return "RAY_TRACING"; }
+    bool HasShaderDefine(RE::BSShader::Type) override { return true; };
+
+    virtual inline std::vector<std::pair<std::string_view, std::string_view>> GetShaderDefineOptions() override;
+
+    virtual void SetupResources() override;
+    virtual void Reset() override;
+
+	virtual void SaveSettings(json&) override;
+	virtual void LoadSettings(json&) override;
+	virtual void RestoreDefaultSettings() override;
+	virtual void DrawSettings() override;
+
+    struct Settings {
+		uint Enabled = false;
+		uint pad0[3];
+	};
+    Settings settings;
+
+    bool enabledAtBoot = false;
+    virtual bool SupportsVR() override { return false; }; // VR support later
+
+    // Acceleration structures
+    nv_helpers_dx12::BottomLevelASGenerator m_blasGenerator;
+    nv_helpers_dx12::TopLevelASGenerator m_tlasGenerator;
+    Microsoft::WRL::ComPtr<ID3D12Resource> m_blasBuffer;
+    Microsoft::WRL::ComPtr<ID3D12Resource> m_tlasBuffer;
+    Microsoft::WRL::ComPtr<ID3D12Resource> m_scratchBuffer;
+
+    // Pipeline
+    std::unique_ptr<nv_helpers_dx12::RayTracingPipelineGenerator> m_pipelineGenerator;
+    Microsoft::WRL::ComPtr<ID3D12StateObject> m_rtStateObject;
+    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_rayGenSignature;
+    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_hitSignature;
+    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_missSignature;
+
+    // Shader tables
+    struct ShaderTables {
+        Microsoft::WRL::ComPtr<ID3D12Resource> rayGen;
+        Microsoft::WRL::ComPtr<ID3D12Resource> miss;
+        Microsoft::WRL::ComPtr<ID3D12Resource> hitGroup;
+        
+        UINT rayGenStride = 0;
+        UINT missStride = 0;
+        UINT hitGroupStride = 0;
+    };
+    ShaderTables m_shaderTables;
+
+    // Shader identifiers
+    struct ShaderIDs {
+        void* rayGen = nullptr;
+        void* miss = nullptr;
+        void* closestHit = nullptr;
+        void* anyHit = nullptr;
+    };
+    ShaderIDs m_shaderIDs;
+
+    // Pipeline methods
+    void CreateRayTracingPipeline();
+    void CreateShaderBindingTables();
+
+    // Shader resources
+    Microsoft::WRL::ComPtr<IDxcBlob> m_rayGenLibrary;
+    Microsoft::WRL::ComPtr<IDxcBlob> m_missLibrary;
+    Microsoft::WRL::ComPtr<IDxcBlob> m_hitLibrary;
+}

--- a/src/Features/RayTracing/RayTracing.h
+++ b/src/Features/RayTracing/RayTracing.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <d3d12.h>
 #include <DXRHelpers>
+#include <d3d12.h>
 
 /* Reference Documenation:
     1. https://microsoft.github.io/DirectX-Specs/d3d/Raytracing.html
@@ -23,77 +23,82 @@
         - Use DispatchRays() binding AS and shader tables
 */
 
-struct RayTracing : Feature {
-    static RayTracing* GetSingleton() {
-        static RayTracing singleton;
-        return &singleton;
-    }
+struct RayTracing : Feature
+{
+	static RayTracing* GetSingleton()
+	{
+		static RayTracing singleton;
+		return &singleton;
+	}
 
-    virtual inline std::string GetName() override { return "Ray Tracing"; }
-    virtual inline std::string GetShortName() override { return "RayTracing"; }
-    virtual inline std::string_view GetShaderDefineName() override { return "RAY_TRACING"; }
-    bool HasShaderDefine(RE::BSShader::Type) override { return true; };
+	virtual inline std::string GetName() override { return "Ray Tracing"; }
+	virtual inline std::string GetShortName() override { return "RayTracing"; }
+	virtual inline std::string_view GetShaderDefineName() override { return "RAY_TRACING"; }
+	bool HasShaderDefine(RE::BSShader::Type) override { return true; };
 
-    virtual inline std::vector<std::pair<std::string_view, std::string_view>> GetShaderDefineOptions() override;
+	virtual inline std::vector<std::pair<std::string_view, std::string_view>> GetShaderDefineOptions() override;
 
-    virtual void SetupResources() override;
-    virtual void Reset() override;
+	virtual void SetupResources() override;
+	virtual void Reset() override;
 
 	virtual void SaveSettings(json&) override;
 	virtual void LoadSettings(json&) override;
 	virtual void RestoreDefaultSettings() override;
 	virtual void DrawSettings() override;
 
-    struct Settings {
+	struct Settings
+	{
 		uint Enabled = false;
 		uint pad0[3];
 	};
-    Settings settings;
+	Settings settings;
 
-    bool enabledAtBoot = false;
-    virtual bool SupportsVR() override { return false; }; // VR support later
+	bool enabledAtBoot = false;
+	virtual bool SupportsVR() override { return false; };  // VR support later
 
-    // Acceleration structures
-    nv_helpers_dx12::BottomLevelASGenerator m_blasGenerator;
-    nv_helpers_dx12::TopLevelASGenerator m_tlasGenerator;
-    Microsoft::WRL::ComPtr<ID3D12Resource> m_blasBuffer;
-    Microsoft::WRL::ComPtr<ID3D12Resource> m_tlasBuffer;
-    Microsoft::WRL::ComPtr<ID3D12Resource> m_scratchBuffer;
+	// Acceleration structures
+	nv_helpers_dx12::BottomLevelASGenerator m_blasGenerator;
+	nv_helpers_dx12::TopLevelASGenerator m_tlasGenerator;
+	Microsoft::WRL::ComPtr<ID3D12Resource> m_blasBuffer;
+	Microsoft::WRL::ComPtr<ID3D12Resource> m_tlasBuffer;
+	Microsoft::WRL::ComPtr<ID3D12Resource> m_scratchBuffer;
 
-    // Pipeline
-    std::unique_ptr<nv_helpers_dx12::RayTracingPipelineGenerator> m_pipelineGenerator;
-    Microsoft::WRL::ComPtr<ID3D12StateObject> m_rtStateObject;
-    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_rayGenSignature;
-    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_hitSignature;
-    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_missSignature;
+	// Pipeline
+	std::unique_ptr<nv_helpers_dx12::RayTracingPipelineGenerator> m_pipelineGenerator;
+	Microsoft::WRL::ComPtr<ID3D12StateObject> m_rtStateObject;
+	Microsoft::WRL::ComPtr<ID3D12RootSignature> m_rayGenSignature;
+	Microsoft::WRL::ComPtr<ID3D12RootSignature> m_hitSignature;
+	Microsoft::WRL::ComPtr<ID3D12RootSignature> m_missSignature;
 
-    // Shader tables
-    struct ShaderTables {
-        Microsoft::WRL::ComPtr<ID3D12Resource> rayGen;
-        Microsoft::WRL::ComPtr<ID3D12Resource> miss;
-        Microsoft::WRL::ComPtr<ID3D12Resource> hitGroup;
-        
-        UINT rayGenStride = 0;
-        UINT missStride = 0;
-        UINT hitGroupStride = 0;
-    };
-    ShaderTables m_shaderTables;
+	// Shader tables
+	struct ShaderTables
+	{
+		Microsoft::WRL::ComPtr<ID3D12Resource> rayGen;
+		Microsoft::WRL::ComPtr<ID3D12Resource> miss;
+		Microsoft::WRL::ComPtr<ID3D12Resource> hitGroup;
 
-    // Shader identifiers
-    struct ShaderIDs {
-        void* rayGen = nullptr;
-        void* miss = nullptr;
-        void* closestHit = nullptr;
-        void* anyHit = nullptr;
-    };
-    ShaderIDs m_shaderIDs;
+		UINT rayGenStride = 0;
+		UINT missStride = 0;
+		UINT hitGroupStride = 0;
+	};
+	ShaderTables m_shaderTables;
 
-    // Pipeline methods
-    void CreateRayTracingPipeline();
-    void CreateShaderBindingTables();
+	// Shader identifiers
+	struct ShaderIDs
+	{
+		void* rayGen = nullptr;
+		void* miss = nullptr;
+		void* closestHit = nullptr;
+		void* anyHit = nullptr;
+	};
+	ShaderIDs m_shaderIDs;
 
-    // Shader resources
-    Microsoft::WRL::ComPtr<IDxcBlob> m_rayGenLibrary;
-    Microsoft::WRL::ComPtr<IDxcBlob> m_missLibrary;
-    Microsoft::WRL::ComPtr<IDxcBlob> m_hitLibrary;
+	// Pipeline methods
+	void CreateRayTracingPipeline();
+	void CreateShaderBindingTables();
+
+	// Shader resources
+	Microsoft::WRL::ComPtr<IDxcBlob> m_rayGenLibrary;
+	Microsoft::WRL::ComPtr<IDxcBlob> m_missLibrary;
+	Microsoft::WRL::ComPtr<IDxcBlob> m_hitLibrary;
 }

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -45,6 +45,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ShowPostFGFrameTime,
 	ShowPostFGFrameTimeGraph,
 	UpdateInterval,
+	FrameHistorySize,
 	Size,
 	BackgroundOpacity,
 	ShowBorder,
@@ -1231,18 +1232,7 @@ void Menu::DrawPerfOverlay()
 			settings.PerfOverlay.BackgroundOpacity));
 
 	// Set text size based on user preference
-	float textScale = 1.0f;
-	switch (settings.PerfOverlay.Size) {
-	case Settings::PerfOverlaySettings::TextSize::Small:
-		textScale = 0.8f;
-		break;
-	case Settings::PerfOverlaySettings::TextSize::Medium:
-		textScale = 1.0f;
-		break;
-	case Settings::PerfOverlaySettings::TextSize::Large:
-		textScale = 1.2f;
-		break;
-	}
+	perfOverlayState.textScale = perfOverlayState.SetTextScale(settings.PerfOverlay);
 
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, settings.PerfOverlay.ShowBorder ? 1.0f : 0.0f);
 
@@ -1256,9 +1246,9 @@ void Menu::DrawPerfOverlay()
 	}
 
 	// Set window size based on whether graphs are shown, was rapidly changing size based on text
-	bool hasGraphs = settings.PerfOverlay.ShowPreFGFrameTimeGraph || settings.PerfOverlay.ShowPostFGFrameTimeGraph;
-	if (!hasGraphs) {
-		float fixedWidth = 325.0f * textScale;
+	perfOverlayState.hasGraphs = settings.PerfOverlay.ShowPreFGFrameTimeGraph || settings.PerfOverlay.ShowPostFGFrameTimeGraph;
+	if (!perfOverlayState.hasGraphs) {
+		float fixedWidth = 325.0f * perfOverlayState.textScale;
 		ImGui::SetNextWindowSize(ImVec2(fixedWidth, 0), ImGuiCond_Always);
 	}
 
@@ -1277,281 +1267,58 @@ void Menu::DrawPerfOverlay()
 	}
 
 	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4.0f, 1.0f));  // Tighter spacing
-	ImGui::SetWindowFontScale(textScale);
+	ImGui::SetWindowFontScale(perfOverlayState.textScale);
 
-	// Get frame timing data using QueryPerformanceCounter for precise measurements
-	static LARGE_INTEGER frequency;
-	static LARGE_INTEGER lastFrameCounter;
-	static LARGE_INTEGER currentFrameCounter;
-	static float frameTimeMs = 0.0f;
-	static float fps = 0.0f;
-	static float smoothFps = 0.0f;
-	static float smoothFrameTimeMs = 0.0f;
-	static float postFGSmoothFps = 0.0f;
-	static float postFGSmoothFrameTimeMs = 0.0f;
-	static float updateTimer = 0.0f;
-	static std::chrono::steady_clock::time_point lastUpdateTime = std::chrono::steady_clock::now();
-
-	if (frequency.QuadPart == 0) {
-		QueryPerformanceFrequency(&frequency);
-		QueryPerformanceCounter(&lastFrameCounter);
+	if (perfOverlayState.frequency.QuadPart == 0) {
+		QueryPerformanceFrequency(&perfOverlayState.frequency);
+		QueryPerformanceCounter(&perfOverlayState.lastFrameCounter);
 	}
 
-	QueryPerformanceCounter(&currentFrameCounter);
-	LONGLONG elapsedCounter = currentFrameCounter.QuadPart - lastFrameCounter.QuadPart;
-	lastFrameCounter = currentFrameCounter;
+	QueryPerformanceCounter(&perfOverlayState.currentFrameCounter);
+	LONGLONG elapsedCounter = perfOverlayState.currentFrameCounter.QuadPart - perfOverlayState.lastFrameCounter.QuadPart;
+	perfOverlayState.lastFrameCounter = perfOverlayState.currentFrameCounter;
 
-	// Calculate frametime in milliseconds
-	frameTimeMs = 1000.0f * (float)elapsedCounter / (float)frequency.QuadPart;
-
-	// Calculate FPS directly from frametime
-	fps = 1000.0f / frameTimeMs;
+	// Get frametime and fps
+	perfOverlayState.frameTimeMs = Util::performanceOverlay.CalcFrameTime(elapsedCounter, perfOverlayState.frequency);
+	perfOverlayState.fps = Util::performanceOverlay.CalcFPS(perfOverlayState.frameTimeMs);
 
 	// Calculate smooth values for display using the user-defined update interval
-	auto currentTime = std::chrono::steady_clock::now();
-	float deltaTime = std::chrono::duration<float>(currentTime - lastUpdateTime).count();
-	lastUpdateTime = currentTime;
+	auto now = std::chrono::steady_clock::now();
+	float deltaTime = std::chrono::duration<float>(now - perfOverlayState.lastUpdateTime).count();
+	perfOverlayState.lastUpdateTime = now;
 
-	// Frametime history graph data
-	const int FRAME_HISTORY_SIZE = 120;
-	static float frameTimeHistory[FRAME_HISTORY_SIZE] = {};
-	static int frameTimeHistoryIndex = 0;
-	static float postFGFrameTimeHistory[FRAME_HISTORY_SIZE] = {};
-	static int postFGFrameTimeHistoryIndex = 0;
-
-	// Update frametime history
-	frameTimeHistory[frameTimeHistoryIndex] = frameTimeMs;
-	frameTimeHistoryIndex = (frameTimeHistoryIndex + 1) % FRAME_HISTORY_SIZE;
+	// Update graph values
+	perfOverlayState.UpdateGraphValues(settings.PerfOverlay);
 
 	// Update smooth values with user-specified interval
-	updateTimer += deltaTime;
-	if (updateTimer >= settings.PerfOverlay.UpdateInterval) {
-		smoothFps = fps;
-		smoothFrameTimeMs = frameTimeMs;
-		updateTimer = 0.0f;
+	perfOverlayState.updateTimer += deltaTime;
+	if (perfOverlayState.updateTimer >= settings.PerfOverlay.UpdateInterval) {
+		perfOverlayState.smoothFps = perfOverlayState.fps;
+		perfOverlayState.smoothFrameTimeMs = perfOverlayState.frameTimeMs;
+		perfOverlayState.updateTimer = 0.0f;
 	}
 
 	// Check if Frame Generation is active
-	bool isFrameGenerationActive = globals::upscaling && globals::upscaling->IsFrameGenerationActive();
-	float postFGFrameTimeMs = 0.0f;
-	float postFGFps = 0.0f;
+	perfOverlayState.isFrameGenerationActive = globals::upscaling && globals::upscaling->IsFrameGenerationActive();
 
-	if (isFrameGenerationActive) {
-		// Get frametime directly from the Frame Generation system
-		float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
-		if (fgDeltaTime > 0.0f) {
-			postFGFrameTimeMs = fgDeltaTime * 1000.0f;
-			postFGFps = 1000.0f / postFGFrameTimeMs;
-
-			// Update post-FG smooth values when timer elapses
-			if (updateTimer == 0.0f) {
-				postFGSmoothFps = postFGFps;
-				postFGSmoothFrameTimeMs = postFGFrameTimeMs;
-			}
-
-			// Update post-FG frametime history
-			postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
-			postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % FRAME_HISTORY_SIZE;
-		} else {
-			// Fallback if FG time is not available
-			postFGFrameTimeMs = frameTimeMs / 2.0f;  // Approximate
-			postFGFps = fps * 2.0f;                  // Approximate
-
-			// Update smooth values when timer elapses
-			if (updateTimer == 0.0f) {
-				postFGSmoothFps = postFGFps;
-				postFGSmoothFrameTimeMs = postFGFrameTimeMs;
-			}
-
-			// Update post-FG frametime history with approximation
-			postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
-			postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % FRAME_HISTORY_SIZE;
-		}
+	if (perfOverlayState.isFrameGenerationActive) {
+		perfOverlayState.UpdateFGFrameTime(settings.PerfOverlay);
 	}
 
 	// Show FPS counter if enabled
 	if (settings.PerfOverlay.ShowFPS) {
-		if (isFrameGenerationActive) {
-			if (settings.PerfOverlay.ShowPostFGFPS) {
-				ImGui::Text("FPS: %.1f", postFGSmoothFps);
-			}
-
-			if (settings.PerfOverlay.ShowPreFGFPS) {
-				ImGui::Text("Pre-FG FPS: %.1f", smoothFps);
-			}
-		} else {
-			ImGui::Text("FPS: %.1f", smoothFps);
-		}
-
-		if (isFrameGenerationActive) {
-			if (settings.PerfOverlay.ShowPostFGFPS && settings.PerfOverlay.ShowPostFGFrameTime) {
-				ImGui::Text("Frametime: %.2f ms", postFGSmoothFrameTimeMs);
-			}
-			if (settings.PerfOverlay.ShowPreFGFPS && settings.PerfOverlay.ShowPreFGFrameTime) {
-				ImGui::Text("Pre-FG Frametime: %.2f ms", smoothFrameTimeMs);
-			}
-		} else {
-			if (settings.PerfOverlay.ShowPreFGFrameTime) {
-				ImGui::Text("Frametime: %.2f ms", smoothFrameTimeMs);
-			}
-		}
-
-		// Show Pre-FG frametime graph if enabled
-		if (settings.PerfOverlay.ShowPreFGFrameTimeGraph &&
-			((isFrameGenerationActive && settings.PerfOverlay.ShowPreFGFPS) || !isFrameGenerationActive)) {
-			// Find min and max values for better scaling
-			float minFrameTime = 1000.0f;
-			float maxFrameTime = 0.0f;
-
-			for (int i = 0; i < FRAME_HISTORY_SIZE; i++) {
-				if (frameTimeHistory[i] > 0.01f) {  // Ignore empty values
-					minFrameTime = std::min(minFrameTime, frameTimeHistory[i]);
-					maxFrameTime = std::max(maxFrameTime, frameTimeHistory[i]);
-				}
-			}
-
-			// Add some padding to min/max
-			minFrameTime = std::max(0.0f, minFrameTime - 1.0f);
-			maxFrameTime = maxFrameTime + 1.0f;
-
-			// Prepare overlay text
-			char overlay_text[128];
-			snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
-				"%s%.2f ms (%.1f FPS)",
-				isFrameGenerationActive ? "Pre-FG: " : "",
-				smoothFrameTimeMs, smoothFps);
-
-			// Set graph colors
-			ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));  // Green line
-
-			// Draw the graph
-			ImGui::PlotLines("##frametime",
-				frameTimeHistory,
-				FRAME_HISTORY_SIZE,
-				frameTimeHistoryIndex,
-				overlay_text,
-				minFrameTime, maxFrameTime,
-				ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
-
-			ImGui::PopStyleColor();
-
-			// Draw frametime target reference lines
-			if (ImGui::BeginTable("FrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
-				ImGui::TableNextColumn();
-				ImGui::Text("30 FPS: 33.3 ms");
-
-				ImGui::TableNextColumn();
-				ImGui::Text("60 FPS: 16.7 ms");
-
-				ImGui::TableNextColumn();
-				ImGui::Text("120 FPS: 8.3 ms");
-
-				ImGui::EndTable();
-			}
-		}
-
-		// Show Post-FG frametime graph if enabled
-		if (settings.PerfOverlay.ShowPostFGFrameTimeGraph && isFrameGenerationActive && settings.PerfOverlay.ShowPostFGFPS) {
-			// Find min and max values for better scaling
-			float minFrameTime = 1000.0f;
-			float maxFrameTime = 0.0f;
-
-			for (int i = 0; i < FRAME_HISTORY_SIZE; i++) {
-				if (postFGFrameTimeHistory[i] > 0.01f) {  // Ignore empty values
-					minFrameTime = std::min(minFrameTime, postFGFrameTimeHistory[i]);
-					maxFrameTime = std::max(maxFrameTime, postFGFrameTimeHistory[i]);
-				}
-			}
-
-			// Add some padding to min/max
-			minFrameTime = std::max(0.0f, minFrameTime - 1.0f);
-			maxFrameTime = maxFrameTime + 1.0f;
-
-			// Prepare overlay text
-			char overlay_text[128];
-			snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
-				"Post-FG: %.2f ms (%.1f FPS)",
-				postFGSmoothFrameTimeMs, postFGSmoothFps);
-
-			// Set graph colors - blue for post-FG
-			ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
-
-			// Draw the graph
-			ImGui::PlotLines("##postfgframetime",
-				postFGFrameTimeHistory,
-				FRAME_HISTORY_SIZE,
-				postFGFrameTimeHistoryIndex,
-				overlay_text,
-				minFrameTime, maxFrameTime,
-				ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
-
-			ImGui::PopStyleColor();
-
-			// Draw frametime target reference lines
-			if (ImGui::BeginTable("PostFGFrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
-				ImGui::TableNextColumn();
-				ImGui::Text("30 FPS: 33.3 ms");
-
-				ImGui::TableNextColumn();
-				ImGui::Text("60 FPS: 16.7 ms");
-
-				ImGui::TableNextColumn();
-				ImGui::Text("120 FPS: 8.3 ms");
-
-				ImGui::EndTable();
-			}
-		}
+		perfOverlayState.DrawFPS(settings.PerfOverlay);
 	}
 
 	// Show Draw Calls if enabled
 	if (settings.PerfOverlay.ShowDrawCalls) {
-		ImGui::Text("Draw Calls:");
-		ImGui::Indent();
-		ImGui::Text("Grass: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Grass]));
-		ImGui::Text("Sky: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Sky]));
-		ImGui::Text("Water: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Water]));
-		ImGui::Text("Lighting: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Lighting]));
-		ImGui::Text("Effect: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Effect]));
-		ImGui::Text("Utility: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Utility]));
-		ImGui::Text("Distant Tree: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::DistantTree]));
-		ImGui::Text("Particle: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Particle]));
-		ImGui::Text("Total: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Total]));
-		ImGui::Unindent();
+		perfOverlayState.DrawDrawCalls();
 	}
 
 	// VRAM & GPU Usage
-	if (settings.PerfOverlay.ShowVRAM && dxgiAdapter3) {
-		DXGI_QUERY_VIDEO_MEMORY_INFO videoMemoryInfo{};
-		HRESULT hr = dxgiAdapter3->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &videoMemoryInfo);
-
-		// Only proceed if the call succeeded and Budget is not zero
-		if (SUCCEEDED(hr) && videoMemoryInfo.Budget > 0) {
-			float currentGpuUsage = videoMemoryInfo.CurrentUsage / (1024.f * 1024.f * 1024.f);
-			float totalGpuMemory = videoMemoryInfo.Budget / (1024.f * 1024.f * 1024.f);
-			float percent = currentGpuUsage / totalGpuMemory;
-
-			// Center the VRAM text
-			ImGui::Text("VRAM Usage:");
-
-			// Use a centered text format for the numeric values
-			std::string vramText = std::format("{:.2f}GB/{:.2f}GB ({:.1f}%)", currentGpuUsage, totalGpuMemory, 100 * percent);
-			float textWidth = ImGui::CalcTextSize(vramText.c_str()).x;
-			float windowWidth = ImGui::GetWindowWidth();
-
-			// Center the text if it fits within the window
-			if (textWidth < windowWidth) {
-				ImGui::SetCursorPosX((windowWidth - textWidth) * 0.5f);
-				ImGui::Text("%s", vramText.c_str());
-			} else {
-				ImGui::Text("%s", vramText.c_str());
-			}
-
-			// Only move the progress bar, not the text
-			ImGui::ProgressBar(percent, ImVec2(ImGui::GetWindowWidth() * 0.9f, 0.0f), "");
-		} else {
-			// Display a fallback message if we couldn't get the VRAM info
-			ImGui::Text("VRAM Usage: Not available");
-		}
+	if (settings.PerfOverlay.ShowVRAM && dxgiAdapter3) 
+	{
+		perfOverlayState.DrawVRAM(dxgiAdapter3);
 	}
 
 	ImGui::PopStyleVar();             // ItemSpacing
@@ -1560,6 +1327,378 @@ void Menu::DrawPerfOverlay()
 	ImGui::End();
 	ImGui::PopStyleVar();    // WindowBorderSize
 	ImGui::PopStyleColor();  // WindowBg
+}
+
+float Menu::PerfOverlayState::SetTextScale(Settings::PerfOverlaySettings& settings)
+{
+	switch (settings.Size) {
+		case Settings::PerfOverlaySettings::TextSize::Small:
+			return 0.8f;
+		case Settings::PerfOverlaySettings::TextSize::Medium:
+			return 1.0f;
+		case Settings::PerfOverlaySettings::TextSize::Large:
+			return 1.2f;
+	}
+	return 1.0f;
+}
+
+/**
+ * @brief Updates all runtime state related to the performance overlay graph.
+ *
+ * This function synchronizes the frame time history buffer, tracks min/max frame times,
+ * and computes the normalized Y-axis range for the frame time graph using statistical analysis.
+ * 
+ * Steps performed:
+ *   1. Resizes the frame time history buffer if the user has changed the setting.
+ *   2. Inserts the latest frame time into the circular history buffer.
+ *   3. Updates instantaneous min/max frame time values, with full rescans if necessary.
+ *   4. Calculates the average (mean) and standard deviation of frame times in the buffer.
+ *   5. Sets the graph Y-axis range to be centered on the average, with a spread of ±2 standard deviations,
+ *      clamped to user-friendly minimum and maximum values.
+ *   6. Smooths the min/max Y-axis values for visual stability using exponential smoothing.
+ *
+ *
+ * @param settings Reference to the current performance overlay settings (controls buffer size, etc.).
+ */
+void Menu::PerfOverlayState::UpdateGraphValues(Settings::PerfOverlaySettings& settings)
+{
+    // Sync frame history buffer size with user settings
+    UpdateFrameTimeHistorySizes(settings);
+
+    // Insert latest frame time into circular buffer
+    float oldFrameTime = frameTimeHistory[frameTimeHistoryIndex];
+    frameTimeHistory[frameTimeHistoryIndex] = frameTimeMs;
+    frameTimeHistoryIndex = (frameTimeHistoryIndex + 1) % settings.FrameHistorySize;
+
+    // Maintain instantaneous min/max tracking
+    if (frameTimeMs > maxFrameTime) {
+        maxFrameTime = frameTimeMs;
+    } else if (frameTimeMs < minFrameTime) {
+        minFrameTime = frameTimeMs;
+    } else if (oldFrameTime == minFrameTime) {
+        UpdateMinFrameTime();
+    } else if (oldFrameTime == maxFrameTime) {
+        UpdateMaxFrameTime();
+    }
+
+	float avgFrameTime, stdDev, graphMin, graphMax; 
+    // Calculate mean and standard deviation for normalized graph range
+    if (frameTimeHistory.empty()) {
+        // Default to 60 FPS
+        avgFrameTime = 16.67f;
+        stdDev = 0.0f;
+        graphMin = 0.0f;
+        graphMax = 33.0f;
+    } else {
+        // Calculate average frame time
+        avgFrameTime = std::accumulate(frameTimeHistory.begin(), frameTimeHistory.end(), 0.0f) / frameTimeHistory.size();
+
+        // Calculate standard deviation
+        float variance = 0.0f;
+        for (float ft : frameTimeHistory) {
+            float diff = ft - avgFrameTime;
+            variance += diff * diff;
+        }
+        variance /= frameTimeHistory.size();
+        stdDev = std::sqrt(variance);
+
+        // Calculate graph range
+        float spread = std::clamp(stdDev * 2.0f, 2.0f, 20.0f);
+        graphMin = std::max(0.0f, avgFrameTime - spread);
+        graphMax = avgFrameTime + spread;
+    }
+
+    // Exponential smoothing for stable graph scaling
+    smoothedMinFrameTime += kSmoothingFactor * (graphMin - smoothedMinFrameTime);
+    smoothedMaxFrameTime += kSmoothingFactor * (graphMax - smoothedMaxFrameTime);
+}
+
+/**
+ * @brief Updates the minimum frame time value by scanning the frame time history buffer.
+ *
+ * Finds the smallest frame time currently in the frameTimeHistory buffer and updates minFrameTime accordingly.
+ * Assumes frameTimeHistory is non-empty.
+ */
+void Menu::PerfOverlayState::UpdateMinFrameTime()
+{
+    minFrameTime = *std::min_element(frameTimeHistory.begin(), frameTimeHistory.end());
+}
+
+/**
+ * @brief Updates the maximum frame time value by scanning the frame time history buffer.
+ *
+ * Finds the largest frame time currently in the frameTimeHistory buffer and updates maxFrameTime accordingly.
+ * Assumes frameTimeHistory is non-empty.
+ */
+void Menu::PerfOverlayState::UpdateMaxFrameTime()
+{
+    maxFrameTime = *std::max_element(frameTimeHistory.begin(), frameTimeHistory.end());
+}
+
+/**
+ * @brief Updates post-frame generation (FG) frame time and FPS history values.
+ *
+ * Retrieves the latest frame time from the Frame Generation system if available, updates smoothed values,
+ * and maintains a circular buffer of post-FG frame times. Falls back to an approximation if FG timing is unavailable.
+ *
+ * @param settings Reference to the current performance overlay settings (controls buffer size, etc.).
+ */
+void Menu::PerfOverlayState::UpdateFGFrameTime(Settings::PerfOverlaySettings& settings)
+{
+    float postFGFrameTimeMs = 0.0f;
+    float postFGFps = 0.0f;
+    // Get frametime directly from the Frame Generation system
+    float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
+    if (fgDeltaTime > 0.0f) {
+        postFGFrameTimeMs = fgDeltaTime * 1000.0f;
+        postFGFps = 1000.0f / postFGFrameTimeMs;
+
+        // Update post-FG smooth values when timer elapses
+        if (updateTimer == 0.0f) {
+            postFGSmoothFps = postFGFps;
+            postFGSmoothFrameTimeMs = postFGFrameTimeMs;
+        }
+
+        // Update post-FG frametime history
+        postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
+        postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % settings.FrameHistorySize;
+    } else {
+        // Fallback if FG time is not available
+        postFGFrameTimeMs = frameTimeMs / 2.0f;  // Approximate
+        postFGFps = fps * 2.0f;                  // Approximate
+
+        // Update smooth values when timer elapses
+        if (updateTimer == 0.0f) {
+            postFGSmoothFps = postFGFps;
+            postFGSmoothFrameTimeMs = postFGFrameTimeMs;
+        }
+
+        // Update post-FG frametime history with approximation
+        postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
+        postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % settings.FrameHistorySize;
+    }
+}
+
+/**
+ * @brief Renders the FPS and frametime statistics using ImGui, including graphs and reference lines.
+ *
+ * Displays pre- and post-frame generation FPS and frametime values, as well as line graphs if enabled in settings.
+ * Handles both standard and frame generation rendering modes, and draws reference lines for common FPS targets.
+ *
+ * @param settings Reference to the current performance overlay settings (controls what is displayed).
+ */
+void Menu::PerfOverlayState::DrawFPS(Settings::PerfOverlaySettings& settings)
+{
+    if (isFrameGenerationActive) {
+        if (settings.ShowPostFGFPS) {
+            ImGui::Text("FPS: %.1f", postFGSmoothFps);
+        }
+
+        if (settings.ShowPreFGFPS) {
+            ImGui::Text("Pre-FG FPS: %.1f", smoothFps);
+        }
+    } else {
+        ImGui::Text("FPS: %.1f", smoothFps);
+    }
+
+    if (isFrameGenerationActive) {
+        if (settings.ShowPostFGFPS && settings.ShowPostFGFrameTime) {
+            ImGui::Text("Frametime: %.2f ms", postFGSmoothFrameTimeMs);
+        }
+        if (settings.ShowPreFGFPS && settings.ShowPreFGFrameTime) {
+            ImGui::Text("Pre-FG Frametime: %.2f ms", smoothFrameTimeMs);
+        }
+    } else {
+        if (settings.ShowPreFGFrameTime) {
+            ImGui::Text("Frametime: %.2f ms", smoothFrameTimeMs);
+        }
+    }
+
+    // Show Pre-FG frametime graph if enabled
+    if (settings.ShowPreFGFrameTimeGraph &&
+        (!isFrameGenerationActive || (isFrameGenerationActive && settings.ShowPreFGFPS))) 
+    {
+        // Prepare overlay text
+        char overlay_text[128];
+        snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
+            "%s%.2f ms (%.1f FPS)",
+            isFrameGenerationActive ? "Pre-FG: " : "",
+            smoothFrameTimeMs, smoothFps);
+
+        // Set graph colors
+        ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));  // Green line
+
+        // Draw the graph
+        ImGui::PlotLines("##frametime",
+            frameTimeHistory.data(),
+            settings.FrameHistorySize,
+            frameTimeHistoryIndex,
+            overlay_text,
+            smoothedMinFrameTime, smoothedMaxFrameTime,
+            ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
+
+        ImGui::PopStyleColor();
+
+        // Draw frametime target reference lines
+        if (ImGui::BeginTable("FrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
+            ImGui::TableNextColumn();
+            ImGui::Text("30 FPS: 33.3 ms");
+
+            ImGui::TableNextColumn();
+            ImGui::Text("60 FPS: 16.7 ms");
+
+            ImGui::TableNextColumn();
+            ImGui::Text("120 FPS: 8.3 ms");
+
+            ImGui::EndTable();
+        }
+    }
+
+    // Show Post-FG frametime graph if enabled
+    if (settings.ShowPostFGFrameTimeGraph && isFrameGenerationActive && settings.ShowPostFGFPS) 
+    {
+        DrawPostFGFrameTimeGraph(settings);
+    }
+}
+
+/**
+ * @brief Renders the post-frame generation frametime graph using ImGui.
+ *
+ * Plots the post-FG frametime history and displays reference lines for common FPS targets.
+ * Only called if frame generation is active and the relevant settings are enabled.
+ *
+ * @param settings Reference to the current performance overlay settings (controls graph appearance and size).
+ */
+void Menu::PerfOverlayState::DrawPostFGFrameTimeGraph(Settings::PerfOverlaySettings& settings)
+{
+    // Prepare overlay text
+    char overlay_text[128];
+    snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
+        "Post-FG: %.2f ms (%.1f FPS)",
+        postFGSmoothFrameTimeMs, postFGSmoothFps);
+
+    // Set graph colors - blue for post-FG
+    ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
+
+    // Draw the graph
+    ImGui::PlotLines("##postfgframetime",
+        postFGFrameTimeHistory.data(),
+        settings.FrameHistorySize,
+        postFGFrameTimeHistoryIndex,
+        overlay_text,
+        smoothedMinFrameTime, smoothedMaxFrameTime,
+        ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
+
+    ImGui::PopStyleColor();
+
+    // Draw frametime target reference lines
+    if (ImGui::BeginTable("PostFGFrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
+        ImGui::TableNextColumn();
+        ImGui::Text("30 FPS: 33.3 ms");
+
+        ImGui::TableNextColumn();
+        ImGui::Text("60 FPS: 16.7 ms");
+
+        ImGui::TableNextColumn();
+        ImGui::Text("120 FPS: 8.3 ms");
+
+        ImGui::EndTable();
+    }
+}
+
+/**
+ * @brief Renders the current draw call counts for various shader types using ImGui.
+ *
+ * Displays a breakdown of draw calls by type (e.g., Grass, Sky, Water, etc.) and the total count.
+ * Values are sourced from the global state.
+ */
+void Menu::PerfOverlayState::DrawDrawCalls()
+{
+    ImGui::Text("Draw Calls:");
+    ImGui::Indent();
+    ImGui::Text("Grass: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Grass]));
+    ImGui::Text("Sky: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Sky]));
+    ImGui::Text("Water: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Water]));
+    ImGui::Text("Lighting: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Lighting]));
+    ImGui::Text("Effect: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Effect]));
+    ImGui::Text("Utility: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Utility]));
+    ImGui::Text("Distant Tree: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::DistantTree]));
+    ImGui::Text("Particle: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Particle]));
+    ImGui::Text("Total: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Total]));
+    ImGui::Unindent();
+}
+
+/**
+ * @brief Renders the current GPU VRAM usage using ImGui.
+ *
+ * Queries the DXGI adapter for video memory info and displays current usage, total budget, and a progress bar.
+ * Falls back to a message if VRAM info is unavailable.
+ *
+ * @param dxgiAdapter3 A COM pointer to the IDXGIAdapter3 interface for querying video memory info.
+ */
+void Menu::PerfOverlayState::DrawVRAM(winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3)
+{
+    DXGI_QUERY_VIDEO_MEMORY_INFO videoMemoryInfo{};
+    HRESULT hr = dxgiAdapter3->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &videoMemoryInfo);
+
+    // Only proceed if the call succeeded and Budget is not zero
+    if (SUCCEEDED(hr) && videoMemoryInfo.Budget > 0) {
+        float currentGpuUsage = videoMemoryInfo.CurrentUsage / (1024.f * 1024.f * 1024.f);
+        float totalGpuMemory = videoMemoryInfo.Budget / (1024.f * 1024.f * 1024.f);
+        float percent = currentGpuUsage / totalGpuMemory;
+
+        // Center the VRAM text
+        ImGui::Text("VRAM Usage:");
+
+        // Use a centered text format for the numeric values
+        std::string vramText = std::format("{:.2f}GB/{:.2f}GB ({:.1f}%)", currentGpuUsage, totalGpuMemory, 100 * percent);
+        float textWidth = ImGui::CalcTextSize(vramText.c_str()).x;
+        float windowWidth = ImGui::GetWindowWidth();
+
+        // Center the text if it fits within the window
+        if (textWidth < windowWidth) {
+            ImGui::SetCursorPosX((windowWidth - textWidth) * 0.5f);
+            ImGui::Text("%s", vramText.c_str());
+        } else {
+            ImGui::Text("%s", vramText.c_str());
+        }
+
+        // Only move the progress bar, not the text
+        ImGui::ProgressBar(percent, ImVec2(ImGui::GetWindowWidth() * 0.9f, 0.0f), "");
+    } else {
+        // Display a fallback message if we couldn't get the VRAM info
+        ImGui::Text("VRAM Usage: Not available");
+    }
+}
+
+/**
+ * @brief Ensures frame time history buffers are sized according to the current settings.
+ *
+ * Resizes the frameTimeHistory and postFGFrameTimeHistory buffers to match the user-configured history size,
+ * clamping the size within allowed bounds. Resets indices if they are out of bounds after resizing.
+ *
+ * @param settings Reference to the current performance overlay settings (controls buffer size and limits).
+ */
+void Menu::PerfOverlayState::UpdateFrameTimeHistorySizes(Settings::PerfOverlaySettings& settings)
+{
+    settings.FrameHistorySize = std::clamp(
+        settings.FrameHistorySize,
+        settings.kMinFrameHistorySize,
+        settings.kMaxFrameHistorySize
+    );
+	
+	if (frameTimeHistory.size() != static_cast<size_t>(settings.FrameHistorySize)) {
+		frameTimeHistory.resize(settings.FrameHistorySize, 0.0f);
+		if (frameTimeHistoryIndex >= settings.FrameHistorySize) { // Reset index if it's out of new bounds
+			frameTimeHistoryIndex = 0;
+		}
+	}
+	if (postFGFrameTimeHistory.size() != static_cast<size_t>(settings.FrameHistorySize)) {
+		postFGFrameTimeHistory.resize(settings.FrameHistorySize, 0.0f);
+		if (postFGFrameTimeHistoryIndex >= settings.FrameHistorySize) {
+			postFGFrameTimeHistoryIndex = 0;
+		}
+	}
 }
 
 void Menu::DrawPerformanceOverlaySettings()
@@ -1665,8 +1804,23 @@ void Menu::DrawPerformanceOverlaySettings()
 
 			// FPS update interval slider - Make this slider affect all FPS and frametime displays
 			ImGui::SliderFloat("Update Interval", &settings.PerfOverlay.UpdateInterval, 0.001f, 2.0f, "%.2f seconds");
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+			ImGui::Text("?");
+			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("How frequently all performance metrics should update (FPS and frametime)");
+			}
+
+			// Frame history size slider
+			ImGui::SliderInt("Frame History Size", &settings.PerfOverlay.FrameHistorySize, Settings::PerfOverlaySettings::kMinFrameHistorySize, Settings::PerfOverlaySettings::kMaxFrameHistorySize);
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+			ImGui::Text("?");
+			ImGui::PopStyleColor();
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text("Number of frames to keep in history for graphing.\n"
+							"E.g. 60 frames = 1 second @ 60fps.");
 			}
 
 			// Position options - moved inside appearance section
@@ -1677,6 +1831,10 @@ void Menu::DrawPerformanceOverlaySettings()
 			if (ImGui::Button("Reset Position")) {
 				settings.PerfOverlay.PositionSet = false;
 			}
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+			ImGui::Text("?");
+			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Reset the position of the performance overlay to default");
 			}

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -597,23 +597,40 @@ void Menu::DrawGeneralSettings()
 			if (ImGui::Checkbox("Enable Shaders", &useCustomShaders)) {
 				shaderCache->SetEnabled(useCustomShaders);
 			}
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+			ImGui::Text("(?)");
+			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Disabling this effectively disables all features.");
 			}
 
 			bool useDiskCache = shaderCache->IsDiskCache();
+			
 			ImGui::TableNextColumn();
+			
 			if (ImGui::Checkbox("Enable Disk Cache", &useDiskCache)) {
 				shaderCache->SetDiskCache(useDiskCache);
 			}
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+			ImGui::Text("(?)");
+			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Disabling this stops shaders from being loaded from disk, as well as stops shaders from being saved to it.");
 			}
+
 			bool useAsync = shaderCache->IsAsync();
+			
 			ImGui::TableNextColumn();
+
 			if (ImGui::Checkbox("Enable Async", &useAsync)) {
 				shaderCache->SetAsync(useAsync);
 			}
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+			ImGui::Text("(?)");
+			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Skips a shader being replaced if it hasn't been compiled yet. Also makes compilation blazingly fast!");
 			}
@@ -780,6 +797,10 @@ void Menu::DrawAdvancedSettings()
 		if (ImGui::Checkbox("Dump Shaders", &useDump)) {
 			shaderCache->SetDump(useDump);
 		}
+		ImGui::SameLine();
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+		ImGui::Text("(?)");
+		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Dump shaders at startup. This should be used only when reversing shaders. Normal users don't need this.");
 		}
@@ -798,6 +819,10 @@ void Menu::DrawAdvancedSettings()
 			ImGui::SameLine();
 			globals::state->SetLogLevel(static_cast<spdlog::level::level_enum>(item_current));
 		}
+		ImGui::SameLine();
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+		ImGui::Text("(?)");
+		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Log level. Trace is most verbose. Default is info.");
 		}
@@ -812,17 +837,29 @@ void Menu::DrawAdvancedSettings()
 			globals::state->SetDefines(shaderDefines);
 			shaderCache->Clear();
 		}
+		ImGui::SameLine();
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+		ImGui::Text("(?)");
+		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Defines for Shader Compiler. Semicolon \";\" separated. Clear with space. Rebuild shaders after making change. Compute Shaders require a restart to recompile.");
 		}
 		ImGui::Spacing();
 		ImGui::SliderInt("Compiler Threads", &shaderCache->compilationThreadCount, 1, static_cast<int32_t>(std::thread::hardware_concurrency()));
+		ImGui::SameLine();
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+		ImGui::Text("(?)");
+		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Number of threads to use to compile shaders. "
 				"The more threads the faster compilation will finish but may make the system unresponsive. ");
 		}
 		ImGui::SliderInt("Background Compiler Threads", &shaderCache->backgroundCompilationThreadCount, 1, static_cast<int32_t>(std::thread::hardware_concurrency()));
+		ImGui::SameLine();
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+		ImGui::Text("(?)");
+		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Number of threads to use to compile shaders while playing game. "
@@ -843,6 +880,10 @@ void Menu::DrawAdvancedSettings()
 				logger::info("Setting new interval {}.", testInterval);
 			}
 		}
+		ImGui::SameLine();
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+		ImGui::Text("(?)");
+		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Sets number of seconds before toggling between default USER and TEST config. "
@@ -855,6 +896,10 @@ void Menu::DrawAdvancedSettings()
 		if (ImGui::Checkbox("Enable File Watcher", &useFileWatcher)) {
 			shaderCache->SetFileWatcher(useFileWatcher);
 		}
+		ImGui::SameLine();
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+		ImGui::Text("(?)");
+		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Automatically recompile shaders on file change. "
@@ -869,6 +914,10 @@ void Menu::DrawAdvancedSettings()
 			if (ImGui::Button(blockingButtonString.c_str(), { -1, 0 })) {
 				shaderCache->DisableShaderBlocking();
 			}
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+			ImGui::Text("(?)");
+			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text(
 					"Stop blocking Community Shaders shader. "
@@ -909,20 +958,34 @@ void Menu::DrawAdvancedSettings()
 			}
 			if (state->IsDeveloperMode()) {
 				ImGui::Checkbox("Vertex", &state->enableVShaders);
+				ImGui::SameLine();
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+				ImGui::Text("(?)");
+				ImGui::PopStyleColor();
 				if (auto _tt = Util::HoverTooltipWrapper()) {
 					ImGui::Text(
 						"Replace Vertex Shaders. "
 						"When false, will disable the custom Vertex Shaders for the types above. "
 						"For developers to test whether CS shaders match vanilla behavior. ");
 				}
+
 				ImGui::Checkbox("Pixel", &state->enablePShaders);
+				ImGui::SameLine();
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+				ImGui::Text("(?)");
+				ImGui::PopStyleColor();
 				if (auto _tt = Util::HoverTooltipWrapper()) {
 					ImGui::Text(
 						"Replace Pixel Shaders. "
 						"When false, will disable the custom Pixel Shaders for the types above. "
 						"For developers to test whether CS shaders match vanilla behavior. ");
 				}
+
 				ImGui::Checkbox("Compute", &state->enableCShaders);
+				ImGui::SameLine();
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+				ImGui::Text("(?)");
+				ImGui::PopStyleColor();
 				if (auto _tt = Util::HoverTooltipWrapper()) {
 					ImGui::Text(
 						"Replace Compute Shaders. "

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -607,9 +607,9 @@ void Menu::DrawGeneralSettings()
 			}
 
 			bool useDiskCache = shaderCache->IsDiskCache();
-			
+
 			ImGui::TableNextColumn();
-			
+
 			if (ImGui::Checkbox("Enable Disk Cache", &useDiskCache)) {
 				shaderCache->SetDiskCache(useDiskCache);
 			}
@@ -622,7 +622,7 @@ void Menu::DrawGeneralSettings()
 			}
 
 			bool useAsync = shaderCache->IsAsync();
-			
+
 			ImGui::TableNextColumn();
 
 			if (ImGui::Checkbox("Enable Async", &useAsync)) {
@@ -1316,8 +1316,7 @@ void Menu::DrawPerfOverlay()
 	}
 
 	// VRAM & GPU Usage
-	if (settings.PerfOverlay.ShowVRAM && dxgiAdapter3) 
-	{
+	if (settings.PerfOverlay.ShowVRAM && dxgiAdapter3) {
 		perfOverlayState.DrawVRAM(dxgiAdapter3);
 	}
 
@@ -1332,12 +1331,12 @@ void Menu::DrawPerfOverlay()
 float Menu::PerfOverlayState::SetTextScale(Settings::PerfOverlaySettings& settings)
 {
 	switch (settings.Size) {
-		case Settings::PerfOverlaySettings::TextSize::Small:
-			return 0.8f;
-		case Settings::PerfOverlaySettings::TextSize::Medium:
-			return 1.0f;
-		case Settings::PerfOverlaySettings::TextSize::Large:
-			return 1.2f;
+	case Settings::PerfOverlaySettings::TextSize::Small:
+		return 0.8f;
+	case Settings::PerfOverlaySettings::TextSize::Medium:
+		return 1.0f;
+	case Settings::PerfOverlaySettings::TextSize::Large:
+		return 1.2f;
 	}
 	return 1.0f;
 }
@@ -1347,7 +1346,7 @@ float Menu::PerfOverlayState::SetTextScale(Settings::PerfOverlaySettings& settin
  *
  * This function synchronizes the frame time history buffer, tracks min/max frame times,
  * and computes the normalized Y-axis range for the frame time graph using statistical analysis.
- * 
+ *
  * Steps performed:
  *   1. Resizes the frame time history buffer if the user has changed the setting.
  *   2. Inserts the latest frame time into the circular history buffer.
@@ -1362,55 +1361,55 @@ float Menu::PerfOverlayState::SetTextScale(Settings::PerfOverlaySettings& settin
  */
 void Menu::PerfOverlayState::UpdateGraphValues(Settings::PerfOverlaySettings& settings)
 {
-    // Sync frame history buffer size with user settings
-    UpdateFrameTimeHistorySizes(settings);
+	// Sync frame history buffer size with user settings
+	UpdateFrameTimeHistorySizes(settings);
 
-    // Insert latest frame time into circular buffer
-    float oldFrameTime = frameTimeHistory[frameTimeHistoryIndex];
-    frameTimeHistory[frameTimeHistoryIndex] = frameTimeMs;
-    frameTimeHistoryIndex = (frameTimeHistoryIndex + 1) % settings.FrameHistorySize;
+	// Insert latest frame time into circular buffer
+	float oldFrameTime = frameTimeHistory[frameTimeHistoryIndex];
+	frameTimeHistory[frameTimeHistoryIndex] = frameTimeMs;
+	frameTimeHistoryIndex = (frameTimeHistoryIndex + 1) % settings.FrameHistorySize;
 
-    // Maintain instantaneous min/max tracking
-    if (frameTimeMs > maxFrameTime) {
-        maxFrameTime = frameTimeMs;
-    } else if (frameTimeMs < minFrameTime) {
-        minFrameTime = frameTimeMs;
-    } else if (oldFrameTime == minFrameTime) {
-        UpdateMinFrameTime();
-    } else if (oldFrameTime == maxFrameTime) {
-        UpdateMaxFrameTime();
-    }
+	// Maintain instantaneous min/max tracking
+	if (frameTimeMs > maxFrameTime) {
+		maxFrameTime = frameTimeMs;
+	} else if (frameTimeMs < minFrameTime) {
+		minFrameTime = frameTimeMs;
+	} else if (oldFrameTime == minFrameTime) {
+		UpdateMinFrameTime();
+	} else if (oldFrameTime == maxFrameTime) {
+		UpdateMaxFrameTime();
+	}
 
-	float avgFrameTime, stdDev, graphMin, graphMax; 
-    // Calculate mean and standard deviation for normalized graph range
-    if (frameTimeHistory.empty()) {
-        // Default to 60 FPS
-        avgFrameTime = 16.67f;
-        stdDev = 0.0f;
-        graphMin = 0.0f;
-        graphMax = 33.0f;
-    } else {
-        // Calculate average frame time
-        avgFrameTime = std::accumulate(frameTimeHistory.begin(), frameTimeHistory.end(), 0.0f) / frameTimeHistory.size();
+	float avgFrameTime, stdDev, graphMin, graphMax;
+	// Calculate mean and standard deviation for normalized graph range
+	if (frameTimeHistory.empty()) {
+		// Default to 60 FPS
+		avgFrameTime = 16.67f;
+		stdDev = 0.0f;
+		graphMin = 0.0f;
+		graphMax = 33.0f;
+	} else {
+		// Calculate average frame time
+		avgFrameTime = std::accumulate(frameTimeHistory.begin(), frameTimeHistory.end(), 0.0f) / frameTimeHistory.size();
 
-        // Calculate standard deviation
-        float variance = 0.0f;
-        for (float ft : frameTimeHistory) {
-            float diff = ft - avgFrameTime;
-            variance += diff * diff;
-        }
-        variance /= frameTimeHistory.size();
-        stdDev = std::sqrt(variance);
+		// Calculate standard deviation
+		float variance = 0.0f;
+		for (float ft : frameTimeHistory) {
+			float diff = ft - avgFrameTime;
+			variance += diff * diff;
+		}
+		variance /= frameTimeHistory.size();
+		stdDev = std::sqrt(variance);
 
-        // Calculate graph range
-        float spread = std::clamp(stdDev * 2.0f, 2.0f, 20.0f);
-        graphMin = std::max(0.0f, avgFrameTime - spread);
-        graphMax = avgFrameTime + spread;
-    }
+		// Calculate graph range
+		float spread = std::clamp(stdDev * 2.0f, 2.0f, 20.0f);
+		graphMin = std::max(0.0f, avgFrameTime - spread);
+		graphMax = avgFrameTime + spread;
+	}
 
-    // Exponential smoothing for stable graph scaling
-    smoothedMinFrameTime += kSmoothingFactor * (graphMin - smoothedMinFrameTime);
-    smoothedMaxFrameTime += kSmoothingFactor * (graphMax - smoothedMaxFrameTime);
+	// Exponential smoothing for stable graph scaling
+	smoothedMinFrameTime += kSmoothingFactor * (graphMin - smoothedMinFrameTime);
+	smoothedMaxFrameTime += kSmoothingFactor * (graphMax - smoothedMaxFrameTime);
 }
 
 /**
@@ -1421,7 +1420,7 @@ void Menu::PerfOverlayState::UpdateGraphValues(Settings::PerfOverlaySettings& se
  */
 void Menu::PerfOverlayState::UpdateMinFrameTime()
 {
-    minFrameTime = *std::min_element(frameTimeHistory.begin(), frameTimeHistory.end());
+	minFrameTime = *std::min_element(frameTimeHistory.begin(), frameTimeHistory.end());
 }
 
 /**
@@ -1432,7 +1431,7 @@ void Menu::PerfOverlayState::UpdateMinFrameTime()
  */
 void Menu::PerfOverlayState::UpdateMaxFrameTime()
 {
-    maxFrameTime = *std::max_element(frameTimeHistory.begin(), frameTimeHistory.end());
+	maxFrameTime = *std::max_element(frameTimeHistory.begin(), frameTimeHistory.end());
 }
 
 /**
@@ -1445,38 +1444,38 @@ void Menu::PerfOverlayState::UpdateMaxFrameTime()
  */
 void Menu::PerfOverlayState::UpdateFGFrameTime(Settings::PerfOverlaySettings& settings)
 {
-    float postFGFrameTimeMs = 0.0f;
-    float postFGFps = 0.0f;
-    // Get frametime directly from the Frame Generation system
-    float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
-    if (fgDeltaTime > 0.0f) {
-        postFGFrameTimeMs = fgDeltaTime * 1000.0f;
-        postFGFps = 1000.0f / postFGFrameTimeMs;
+	float postFGFrameTimeMs = 0.0f;
+	float postFGFps = 0.0f;
+	// Get frametime directly from the Frame Generation system
+	float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
+	if (fgDeltaTime > 0.0f) {
+		postFGFrameTimeMs = fgDeltaTime * 1000.0f;
+		postFGFps = 1000.0f / postFGFrameTimeMs;
 
-        // Update post-FG smooth values when timer elapses
-        if (updateTimer == 0.0f) {
-            postFGSmoothFps = postFGFps;
-            postFGSmoothFrameTimeMs = postFGFrameTimeMs;
-        }
+		// Update post-FG smooth values when timer elapses
+		if (updateTimer == 0.0f) {
+			postFGSmoothFps = postFGFps;
+			postFGSmoothFrameTimeMs = postFGFrameTimeMs;
+		}
 
-        // Update post-FG frametime history
-        postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
-        postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % settings.FrameHistorySize;
-    } else {
-        // Fallback if FG time is not available
-        postFGFrameTimeMs = frameTimeMs / 2.0f;  // Approximate
-        postFGFps = fps * 2.0f;                  // Approximate
+		// Update post-FG frametime history
+		postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
+		postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % settings.FrameHistorySize;
+	} else {
+		// Fallback if FG time is not available
+		postFGFrameTimeMs = frameTimeMs / 2.0f;  // Approximate
+		postFGFps = fps * 2.0f;                  // Approximate
 
-        // Update smooth values when timer elapses
-        if (updateTimer == 0.0f) {
-            postFGSmoothFps = postFGFps;
-            postFGSmoothFrameTimeMs = postFGFrameTimeMs;
-        }
+		// Update smooth values when timer elapses
+		if (updateTimer == 0.0f) {
+			postFGSmoothFps = postFGFps;
+			postFGSmoothFrameTimeMs = postFGFrameTimeMs;
+		}
 
-        // Update post-FG frametime history with approximation
-        postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
-        postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % settings.FrameHistorySize;
-    }
+		// Update post-FG frametime history with approximation
+		postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
+		postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % settings.FrameHistorySize;
+	}
 }
 
 /**
@@ -1489,76 +1488,74 @@ void Menu::PerfOverlayState::UpdateFGFrameTime(Settings::PerfOverlaySettings& se
  */
 void Menu::PerfOverlayState::DrawFPS(Settings::PerfOverlaySettings& settings)
 {
-    if (isFrameGenerationActive) {
-        if (settings.ShowPostFGFPS) {
-            ImGui::Text("FPS: %.1f", postFGSmoothFps);
-        }
+	if (isFrameGenerationActive) {
+		if (settings.ShowPostFGFPS) {
+			ImGui::Text("FPS: %.1f", postFGSmoothFps);
+		}
 
-        if (settings.ShowPreFGFPS) {
-            ImGui::Text("Pre-FG FPS: %.1f", smoothFps);
-        }
-    } else {
-        ImGui::Text("FPS: %.1f", smoothFps);
-    }
+		if (settings.ShowPreFGFPS) {
+			ImGui::Text("Pre-FG FPS: %.1f", smoothFps);
+		}
+	} else {
+		ImGui::Text("FPS: %.1f", smoothFps);
+	}
 
-    if (isFrameGenerationActive) {
-        if (settings.ShowPostFGFPS && settings.ShowPostFGFrameTime) {
-            ImGui::Text("Frametime: %.2f ms", postFGSmoothFrameTimeMs);
-        }
-        if (settings.ShowPreFGFPS && settings.ShowPreFGFrameTime) {
-            ImGui::Text("Pre-FG Frametime: %.2f ms", smoothFrameTimeMs);
-        }
-    } else {
-        if (settings.ShowPreFGFrameTime) {
-            ImGui::Text("Frametime: %.2f ms", smoothFrameTimeMs);
-        }
-    }
+	if (isFrameGenerationActive) {
+		if (settings.ShowPostFGFPS && settings.ShowPostFGFrameTime) {
+			ImGui::Text("Frametime: %.2f ms", postFGSmoothFrameTimeMs);
+		}
+		if (settings.ShowPreFGFPS && settings.ShowPreFGFrameTime) {
+			ImGui::Text("Pre-FG Frametime: %.2f ms", smoothFrameTimeMs);
+		}
+	} else {
+		if (settings.ShowPreFGFrameTime) {
+			ImGui::Text("Frametime: %.2f ms", smoothFrameTimeMs);
+		}
+	}
 
-    // Show Pre-FG frametime graph if enabled
-    if (settings.ShowPreFGFrameTimeGraph &&
-        (!isFrameGenerationActive || (isFrameGenerationActive && settings.ShowPreFGFPS))) 
-    {
-        // Prepare overlay text
-        char overlay_text[128];
-        snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
-            "%s%.2f ms (%.1f FPS)",
-            isFrameGenerationActive ? "Pre-FG: " : "",
-            smoothFrameTimeMs, smoothFps);
+	// Show Pre-FG frametime graph if enabled
+	if (settings.ShowPreFGFrameTimeGraph &&
+		(!isFrameGenerationActive || (isFrameGenerationActive && settings.ShowPreFGFPS))) {
+		// Prepare overlay text
+		char overlay_text[128];
+		snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
+			"%s%.2f ms (%.1f FPS)",
+			isFrameGenerationActive ? "Pre-FG: " : "",
+			smoothFrameTimeMs, smoothFps);
 
-        // Set graph colors
-        ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));  // Green line
+		// Set graph colors
+		ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));  // Green line
 
-        // Draw the graph
-        ImGui::PlotLines("##frametime",
-            frameTimeHistory.data(),
-            settings.FrameHistorySize,
-            frameTimeHistoryIndex,
-            overlay_text,
-            smoothedMinFrameTime, smoothedMaxFrameTime,
-            ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
+		// Draw the graph
+		ImGui::PlotLines("##frametime",
+			frameTimeHistory.data(),
+			settings.FrameHistorySize,
+			frameTimeHistoryIndex,
+			overlay_text,
+			smoothedMinFrameTime, smoothedMaxFrameTime,
+			ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
 
-        ImGui::PopStyleColor();
+		ImGui::PopStyleColor();
 
-        // Draw frametime target reference lines
-        if (ImGui::BeginTable("FrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
-            ImGui::TableNextColumn();
-            ImGui::Text("30 FPS: 33.3 ms");
+		// Draw frametime target reference lines
+		if (ImGui::BeginTable("FrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
+			ImGui::TableNextColumn();
+			ImGui::Text("30 FPS: 33.3 ms");
 
-            ImGui::TableNextColumn();
-            ImGui::Text("60 FPS: 16.7 ms");
+			ImGui::TableNextColumn();
+			ImGui::Text("60 FPS: 16.7 ms");
 
-            ImGui::TableNextColumn();
-            ImGui::Text("120 FPS: 8.3 ms");
+			ImGui::TableNextColumn();
+			ImGui::Text("120 FPS: 8.3 ms");
 
-            ImGui::EndTable();
-        }
-    }
+			ImGui::EndTable();
+		}
+	}
 
-    // Show Post-FG frametime graph if enabled
-    if (settings.ShowPostFGFrameTimeGraph && isFrameGenerationActive && settings.ShowPostFGFPS) 
-    {
-        DrawPostFGFrameTimeGraph(settings);
-    }
+	// Show Post-FG frametime graph if enabled
+	if (settings.ShowPostFGFrameTimeGraph && isFrameGenerationActive && settings.ShowPostFGFPS) {
+		DrawPostFGFrameTimeGraph(settings);
+	}
 }
 
 /**
@@ -1571,39 +1568,39 @@ void Menu::PerfOverlayState::DrawFPS(Settings::PerfOverlaySettings& settings)
  */
 void Menu::PerfOverlayState::DrawPostFGFrameTimeGraph(Settings::PerfOverlaySettings& settings)
 {
-    // Prepare overlay text
-    char overlay_text[128];
-    snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
-        "Post-FG: %.2f ms (%.1f FPS)",
-        postFGSmoothFrameTimeMs, postFGSmoothFps);
+	// Prepare overlay text
+	char overlay_text[128];
+	snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
+		"Post-FG: %.2f ms (%.1f FPS)",
+		postFGSmoothFrameTimeMs, postFGSmoothFps);
 
-    // Set graph colors - blue for post-FG
-    ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
+	// Set graph colors - blue for post-FG
+	ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
 
-    // Draw the graph
-    ImGui::PlotLines("##postfgframetime",
-        postFGFrameTimeHistory.data(),
-        settings.FrameHistorySize,
-        postFGFrameTimeHistoryIndex,
-        overlay_text,
-        smoothedMinFrameTime, smoothedMaxFrameTime,
-        ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
+	// Draw the graph
+	ImGui::PlotLines("##postfgframetime",
+		postFGFrameTimeHistory.data(),
+		settings.FrameHistorySize,
+		postFGFrameTimeHistoryIndex,
+		overlay_text,
+		smoothedMinFrameTime, smoothedMaxFrameTime,
+		ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
 
-    ImGui::PopStyleColor();
+	ImGui::PopStyleColor();
 
-    // Draw frametime target reference lines
-    if (ImGui::BeginTable("PostFGFrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
-        ImGui::TableNextColumn();
-        ImGui::Text("30 FPS: 33.3 ms");
+	// Draw frametime target reference lines
+	if (ImGui::BeginTable("PostFGFrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
+		ImGui::TableNextColumn();
+		ImGui::Text("30 FPS: 33.3 ms");
 
-        ImGui::TableNextColumn();
-        ImGui::Text("60 FPS: 16.7 ms");
+		ImGui::TableNextColumn();
+		ImGui::Text("60 FPS: 16.7 ms");
 
-        ImGui::TableNextColumn();
-        ImGui::Text("120 FPS: 8.3 ms");
+		ImGui::TableNextColumn();
+		ImGui::Text("120 FPS: 8.3 ms");
 
-        ImGui::EndTable();
-    }
+		ImGui::EndTable();
+	}
 }
 
 /**
@@ -1614,18 +1611,18 @@ void Menu::PerfOverlayState::DrawPostFGFrameTimeGraph(Settings::PerfOverlaySetti
  */
 void Menu::PerfOverlayState::DrawDrawCalls()
 {
-    ImGui::Text("Draw Calls:");
-    ImGui::Indent();
-    ImGui::Text("Grass: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Grass]));
-    ImGui::Text("Sky: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Sky]));
-    ImGui::Text("Water: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Water]));
-    ImGui::Text("Lighting: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Lighting]));
-    ImGui::Text("Effect: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Effect]));
-    ImGui::Text("Utility: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Utility]));
-    ImGui::Text("Distant Tree: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::DistantTree]));
-    ImGui::Text("Particle: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Particle]));
-    ImGui::Text("Total: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Total]));
-    ImGui::Unindent();
+	ImGui::Text("Draw Calls:");
+	ImGui::Indent();
+	ImGui::Text("Grass: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Grass]));
+	ImGui::Text("Sky: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Sky]));
+	ImGui::Text("Water: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Water]));
+	ImGui::Text("Lighting: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Lighting]));
+	ImGui::Text("Effect: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Effect]));
+	ImGui::Text("Utility: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Utility]));
+	ImGui::Text("Distant Tree: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::DistantTree]));
+	ImGui::Text("Particle: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Particle]));
+	ImGui::Text("Total: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Total]));
+	ImGui::Unindent();
 }
 
 /**
@@ -1638,37 +1635,37 @@ void Menu::PerfOverlayState::DrawDrawCalls()
  */
 void Menu::PerfOverlayState::DrawVRAM(winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3)
 {
-    DXGI_QUERY_VIDEO_MEMORY_INFO videoMemoryInfo{};
-    HRESULT hr = dxgiAdapter3->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &videoMemoryInfo);
+	DXGI_QUERY_VIDEO_MEMORY_INFO videoMemoryInfo{};
+	HRESULT hr = dxgiAdapter3->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &videoMemoryInfo);
 
-    // Only proceed if the call succeeded and Budget is not zero
-    if (SUCCEEDED(hr) && videoMemoryInfo.Budget > 0) {
-        float currentGpuUsage = videoMemoryInfo.CurrentUsage / (1024.f * 1024.f * 1024.f);
-        float totalGpuMemory = videoMemoryInfo.Budget / (1024.f * 1024.f * 1024.f);
-        float percent = currentGpuUsage / totalGpuMemory;
+	// Only proceed if the call succeeded and Budget is not zero
+	if (SUCCEEDED(hr) && videoMemoryInfo.Budget > 0) {
+		float currentGpuUsage = videoMemoryInfo.CurrentUsage / (1024.f * 1024.f * 1024.f);
+		float totalGpuMemory = videoMemoryInfo.Budget / (1024.f * 1024.f * 1024.f);
+		float percent = currentGpuUsage / totalGpuMemory;
 
-        // Center the VRAM text
-        ImGui::Text("VRAM Usage:");
+		// Center the VRAM text
+		ImGui::Text("VRAM Usage:");
 
-        // Use a centered text format for the numeric values
-        std::string vramText = std::format("{:.2f}GB/{:.2f}GB ({:.1f}%)", currentGpuUsage, totalGpuMemory, 100 * percent);
-        float textWidth = ImGui::CalcTextSize(vramText.c_str()).x;
-        float windowWidth = ImGui::GetWindowWidth();
+		// Use a centered text format for the numeric values
+		std::string vramText = std::format("{:.2f}GB/{:.2f}GB ({:.1f}%)", currentGpuUsage, totalGpuMemory, 100 * percent);
+		float textWidth = ImGui::CalcTextSize(vramText.c_str()).x;
+		float windowWidth = ImGui::GetWindowWidth();
 
-        // Center the text if it fits within the window
-        if (textWidth < windowWidth) {
-            ImGui::SetCursorPosX((windowWidth - textWidth) * 0.5f);
-            ImGui::Text("%s", vramText.c_str());
-        } else {
-            ImGui::Text("%s", vramText.c_str());
-        }
+		// Center the text if it fits within the window
+		if (textWidth < windowWidth) {
+			ImGui::SetCursorPosX((windowWidth - textWidth) * 0.5f);
+			ImGui::Text("%s", vramText.c_str());
+		} else {
+			ImGui::Text("%s", vramText.c_str());
+		}
 
-        // Only move the progress bar, not the text
-        ImGui::ProgressBar(percent, ImVec2(ImGui::GetWindowWidth() * 0.9f, 0.0f), "");
-    } else {
-        // Display a fallback message if we couldn't get the VRAM info
-        ImGui::Text("VRAM Usage: Not available");
-    }
+		// Only move the progress bar, not the text
+		ImGui::ProgressBar(percent, ImVec2(ImGui::GetWindowWidth() * 0.9f, 0.0f), "");
+	} else {
+		// Display a fallback message if we couldn't get the VRAM info
+		ImGui::Text("VRAM Usage: Not available");
+	}
 }
 
 /**
@@ -1681,15 +1678,14 @@ void Menu::PerfOverlayState::DrawVRAM(winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3
  */
 void Menu::PerfOverlayState::UpdateFrameTimeHistorySizes(Settings::PerfOverlaySettings& settings)
 {
-    settings.FrameHistorySize = std::clamp(
-        settings.FrameHistorySize,
-        settings.kMinFrameHistorySize,
-        settings.kMaxFrameHistorySize
-    );
-	
+	settings.FrameHistorySize = std::clamp(
+		settings.FrameHistorySize,
+		settings.kMinFrameHistorySize,
+		settings.kMaxFrameHistorySize);
+
 	if (frameTimeHistory.size() != static_cast<size_t>(settings.FrameHistorySize)) {
 		frameTimeHistory.resize(settings.FrameHistorySize, 0.0f);
-		if (frameTimeHistoryIndex >= settings.FrameHistorySize) { // Reset index if it's out of new bounds
+		if (frameTimeHistoryIndex >= settings.FrameHistorySize) {  // Reset index if it's out of new bounds
 			frameTimeHistoryIndex = 0;
 		}
 	}
@@ -1819,8 +1815,9 @@ void Menu::DrawPerformanceOverlaySettings()
 			ImGui::Text("?");
 			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text("Number of frames to keep in history for graphing.\n"
-							"E.g. 60 frames = 1 second @ 60fps.");
+				ImGui::Text(
+					"Number of frames to keep in history for graphing.\n"
+					"E.g. 60 frames = 1 second @ 60fps.");
 			}
 
 			// Position options - moved inside appearance section

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -159,6 +159,9 @@ public:
 			bool ShowPostFGFrameTime = true;
 			bool ShowPostFGFrameTimeGraph = true;
 			float UpdateInterval = 0.5f;
+			int FrameHistorySize = 120; // Default 120 frames = 2s @ 60fps. Clamped using static values to prevent config file values going outside of slider bounds.
+			static constexpr int kMinFrameHistorySize = 60;	// 60 frames = 1s @ 60fps. Reasonable minimum.
+			static constexpr int kMaxFrameHistorySize = 480; // 480 frames = 10s @ 60fps or 2s @ 240fps. Reasonable maximum.
 			enum class TextSize
 			{
 				Small,
@@ -188,6 +191,43 @@ private:
 	uint32_t testInterval = 0;     // Seconds to wait before toggling user/test settings
 	bool inTestMode = false;       // Whether we're in test mode
 	bool usingTestConfig = false;  // Whether we're using the test config
+
+	class PerfOverlayState {
+		public:
+			std::vector<float> frameTimeHistory;
+			std::vector<float> postFGFrameTimeHistory;
+			bool hasGraphs = false;
+			int frameTimeHistoryIndex = 0;
+			int postFGFrameTimeHistoryIndex = 0;
+			bool isFrameGenerationActive = false;
+			LARGE_INTEGER frequency;
+			LARGE_INTEGER lastFrameCounter;
+			LARGE_INTEGER currentFrameCounter;
+			float frameTimeMs = 0.0f;
+			float fps = 0.0f;
+			float smoothFps = 0.0f;
+			float smoothFrameTimeMs = 0.0f;
+			float postFGSmoothFps = 0.0f;
+			float postFGSmoothFrameTimeMs = 0.0f;
+			float updateTimer = 0.0f;
+			float minFrameTime = 1000.0f;
+			float maxFrameTime = 0.0f;
+			float smoothedMinFrameTime = 0.0f;
+			float smoothedMaxFrameTime = 50.0f;
+			float textScale = 1.0f;
+			float kSmoothingFactor = 0.15f; // Smoothing factor: 0.1f = slow, 0.3f = fast.
+			std::chrono::steady_clock::time_point lastUpdateTime;
+			void UpdateGraphValues(Settings::PerfOverlaySettings& settings);
+			void UpdateFrameTimeHistorySizes(Settings::PerfOverlaySettings& settings);
+			void UpdateMinFrameTime();
+			void UpdateMaxFrameTime();
+			void UpdateFGFrameTime(Settings::PerfOverlaySettings& settings);
+			void DrawPostFGFrameTimeGraph(Settings::PerfOverlaySettings& settings);
+			float SetTextScale(Settings::PerfOverlaySettings& settings);
+			void DrawDrawCalls();
+			void DrawFPS(Settings::PerfOverlaySettings& settings);
+			void DrawVRAM(winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3);
+	} perfOverlayState;
 
 	std::chrono::steady_clock::time_point lastTestSwitch = high_resolution_clock::now();  // Time of last test switch
 

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -159,9 +159,9 @@ public:
 			bool ShowPostFGFrameTime = true;
 			bool ShowPostFGFrameTimeGraph = true;
 			float UpdateInterval = 0.5f;
-			int FrameHistorySize = 120; // Default 120 frames = 2s @ 60fps. Clamped using static values to prevent config file values going outside of slider bounds.
-			static constexpr int kMinFrameHistorySize = 60;	// 60 frames = 1s @ 60fps. Reasonable minimum.
-			static constexpr int kMaxFrameHistorySize = 480; // 480 frames = 10s @ 60fps or 2s @ 240fps. Reasonable maximum.
+			int FrameHistorySize = 120;                       // Default 120 frames = 2s @ 60fps. Clamped using static values to prevent config file values going outside of slider bounds.
+			static constexpr int kMinFrameHistorySize = 60;   // 60 frames = 1s @ 60fps. Reasonable minimum.
+			static constexpr int kMaxFrameHistorySize = 480;  // 480 frames = 10s @ 60fps or 2s @ 240fps. Reasonable maximum.
 			enum class TextSize
 			{
 				Small,
@@ -192,41 +192,42 @@ private:
 	bool inTestMode = false;       // Whether we're in test mode
 	bool usingTestConfig = false;  // Whether we're using the test config
 
-	class PerfOverlayState {
-		public:
-			std::vector<float> frameTimeHistory;
-			std::vector<float> postFGFrameTimeHistory;
-			bool hasGraphs = false;
-			int frameTimeHistoryIndex = 0;
-			int postFGFrameTimeHistoryIndex = 0;
-			bool isFrameGenerationActive = false;
-			LARGE_INTEGER frequency;
-			LARGE_INTEGER lastFrameCounter;
-			LARGE_INTEGER currentFrameCounter;
-			float frameTimeMs = 0.0f;
-			float fps = 0.0f;
-			float smoothFps = 0.0f;
-			float smoothFrameTimeMs = 0.0f;
-			float postFGSmoothFps = 0.0f;
-			float postFGSmoothFrameTimeMs = 0.0f;
-			float updateTimer = 0.0f;
-			float minFrameTime = 1000.0f;
-			float maxFrameTime = 0.0f;
-			float smoothedMinFrameTime = 0.0f;
-			float smoothedMaxFrameTime = 50.0f;
-			float textScale = 1.0f;
-			float kSmoothingFactor = 0.15f; // Smoothing factor: 0.1f = slow, 0.3f = fast.
-			std::chrono::steady_clock::time_point lastUpdateTime;
-			void UpdateGraphValues(Settings::PerfOverlaySettings& settings);
-			void UpdateFrameTimeHistorySizes(Settings::PerfOverlaySettings& settings);
-			void UpdateMinFrameTime();
-			void UpdateMaxFrameTime();
-			void UpdateFGFrameTime(Settings::PerfOverlaySettings& settings);
-			void DrawPostFGFrameTimeGraph(Settings::PerfOverlaySettings& settings);
-			float SetTextScale(Settings::PerfOverlaySettings& settings);
-			void DrawDrawCalls();
-			void DrawFPS(Settings::PerfOverlaySettings& settings);
-			void DrawVRAM(winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3);
+	class PerfOverlayState
+	{
+	public:
+		std::vector<float> frameTimeHistory;
+		std::vector<float> postFGFrameTimeHistory;
+		bool hasGraphs = false;
+		int frameTimeHistoryIndex = 0;
+		int postFGFrameTimeHistoryIndex = 0;
+		bool isFrameGenerationActive = false;
+		LARGE_INTEGER frequency;
+		LARGE_INTEGER lastFrameCounter;
+		LARGE_INTEGER currentFrameCounter;
+		float frameTimeMs = 0.0f;
+		float fps = 0.0f;
+		float smoothFps = 0.0f;
+		float smoothFrameTimeMs = 0.0f;
+		float postFGSmoothFps = 0.0f;
+		float postFGSmoothFrameTimeMs = 0.0f;
+		float updateTimer = 0.0f;
+		float minFrameTime = 1000.0f;
+		float maxFrameTime = 0.0f;
+		float smoothedMinFrameTime = 0.0f;
+		float smoothedMaxFrameTime = 50.0f;
+		float textScale = 1.0f;
+		float kSmoothingFactor = 0.15f;  // Smoothing factor: 0.1f = slow, 0.3f = fast.
+		std::chrono::steady_clock::time_point lastUpdateTime;
+		void UpdateGraphValues(Settings::PerfOverlaySettings& settings);
+		void UpdateFrameTimeHistorySizes(Settings::PerfOverlaySettings& settings);
+		void UpdateMinFrameTime();
+		void UpdateMaxFrameTime();
+		void UpdateFGFrameTime(Settings::PerfOverlaySettings& settings);
+		void DrawPostFGFrameTimeGraph(Settings::PerfOverlaySettings& settings);
+		float SetTextScale(Settings::PerfOverlaySettings& settings);
+		void DrawDrawCalls();
+		void DrawFPS(Settings::PerfOverlaySettings& settings);
+		void DrawVRAM(winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3);
 	} perfOverlayState;
 
 	std::chrono::steady_clock::time_point lastTestSwitch = high_resolution_clock::now();  // Time of last test switch

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -2469,8 +2469,13 @@ namespace SIE
 
 	void ShaderCache::ProcessCompilationSet(std::stop_token stoken, SIE::ShaderCompilationTask task)
 	{
+		if (stoken.stop_requested()) { return; }
+		
 		SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_BELOW_NORMAL);
 		task.Perform();
+
+		if (stoken.stop_requested()) { return; }
+		
 		compilationSet.Complete(task);
 	}
 

--- a/src/ShaderTools/ShaderCompiler.h
+++ b/src/ShaderTools/ShaderCompiler.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "d3d11.h"
+
 namespace ShaderCompiler
 {
-	ID3D11PixelShader* RegisterPixelShader(const std::wstring& a_filePath);
-	ID3D11PixelShader* CompileAndRegisterPixelShader(const std::wstring& a_filePath);
+	ID3D11PixelShader* RegisterPixelShader(const std::wstring a_filePath);
+	ID3D11PixelShader* CompileAndRegisterPixelShader(const std::wstring a_filePath);
 }

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -14,6 +14,7 @@
 #include "Streamline.h"
 #include "TruePBR.h"
 #include "Upscaling.h"
+#include "Features/RayTracing/RayTracing.h"
 
 void State::Draw()
 {

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -7,6 +7,7 @@
 #include "DX12SwapChain.h"
 #include "Deferred.h"
 #include "Features/CloudShadows.h"
+#include "Features/RayTracing/RayTracing.h"
 #include "Features/TerrainBlending.h"
 #include "Features/TerrainHelper.h"
 #include "Menu.h"
@@ -14,7 +15,6 @@
 #include "Streamline.h"
 #include "TruePBR.h"
 #include "Upscaling.h"
-#include "Features/RayTracing/RayTracing.h"
 
 void State::Draw()
 {

--- a/src/Upscaling.cpp
+++ b/src/Upscaling.cpp
@@ -42,6 +42,10 @@ void Upscaling::DrawSettings()
 
 	// Slider for method selection
 	ImGui::SliderInt("Method", (int*)currentUpscaleMode, 0, availableModes, std::format("{}", upscaleModes[(uint)*currentUpscaleMode]).c_str());
+	ImGui::SameLine();
+	ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+	ImGui::Text("(?)");
+	ImGui::PopStyleColor();
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text(
 			"Disabled:\n"
@@ -82,6 +86,10 @@ void Upscaling::DrawSettings()
 		settings.dlssPreset = std::clamp(settings.dlssPreset, 0u, 1u);
 		ImGui::SliderInt("DLSS Super Resolution Preset", (int*)&settings.dlssPreset, 0, 1, std::format("{}", dlssPresets[settings.dlssPreset]).c_str());
 		settings.dlssPreset = std::clamp(settings.dlssPreset, 0u, 1u);
+		ImGui::SameLine();
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+		ImGui::Text("(?)");
+		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("The new DLSS Transformer model offers more image stability, less ghosting and improved anti-aliasing in comparison with the original DLSS Convolutional Neural Network model.");
 		}

--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -2,6 +2,8 @@
 
 namespace Util
 {
+	PerfomanceOverlay performanceOverlay;
+
 	HoverTooltipWrapper::HoverTooltipWrapper()
 	{
 		hovered = ImGui::IsItemHovered();

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -39,4 +39,18 @@ namespace Util
 
 	bool PercentageSlider(const char* label, float* data, float lb = 0.f, float ub = 100.f, const char* format = "%.1f %%");
 	ImVec2 GetNativeViewportSizeScaled(float scale);
+
+	class PerfomanceOverlay {
+		public:
+			float CalcFrameTime(LONGLONG timeElapsed, LARGE_INTEGER frequency)
+			{
+				return 1000.0f * (float)timeElapsed / (float)frequency.QuadPart;
+			}
+
+			float CalcFPS(float frameTimeMs)
+			{
+				return 1000.0f / frameTimeMs;
+			}
+	};
+	extern PerfomanceOverlay performanceOverlay;
 }  // namespace Util

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -40,17 +40,18 @@ namespace Util
 	bool PercentageSlider(const char* label, float* data, float lb = 0.f, float ub = 100.f, const char* format = "%.1f %%");
 	ImVec2 GetNativeViewportSizeScaled(float scale);
 
-	class PerfomanceOverlay {
-		public:
-			float CalcFrameTime(LONGLONG timeElapsed, LARGE_INTEGER frequency)
-			{
-				return 1000.0f * (float)timeElapsed / (float)frequency.QuadPart;
-			}
+	class PerfomanceOverlay
+	{
+	public:
+		float CalcFrameTime(LONGLONG timeElapsed, LARGE_INTEGER frequency)
+		{
+			return 1000.0f * (float)timeElapsed / (float)frequency.QuadPart;
+		}
 
-			float CalcFPS(float frameTimeMs)
-			{
-				return 1000.0f / frameTimeMs;
-			}
+		float CalcFPS(float frameTimeMs)
+		{
+			return 1000.0f / frameTimeMs;
+		}
 	};
 	extern PerfomanceOverlay performanceOverlay;
 }  // namespace Util


### PR DESCRIPTION
- Added class PerfOverlayState in Menu private to encapsulate many variables and functions related to the Overlay.
- Split DrawPerfOverlay function into many functions as members of the class.
- Moved a couple small functions to Utils/UI from DrawPerfOverlay.
- Some optimization done on tracking the min and max values of the graph.
- Redid the smoothing and calculation of the graph boundaries as well.
- Added user setting PerfOverlaySettings::FrameHistorySize to allow users to control how much history the graph shows.
- Added constants PerfOverlaySettings::kMinFrameHistorySize, kMaxFrameHistorySize to ensure the FrameHistorySize is kept within reasonable limits.
- Added documentation to the new functions.

Should now be able to create separate files for the performance overlay and move over the encapsulated things without too much trouble.