### PR TITLE
refactor: performance overlay

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1458,11 +1458,11 @@ void Menu::PerfOverlayState::UpdateFGFrameTime(Settings::PerfOverlaySettings& se
         postFGFrameTimeMs = fgDeltaTime * 1000.0f;
         postFGFps = 1000.0f / postFGFrameTimeMs;
 
-        // Update post-FG smooth values when timer elapses
-        if (updateTimer <= 0.0f) {
-            postFGSmoothFps = postFGFps;
-            postFGSmoothFrameTimeMs = postFGFrameTimeMs;
-        }
+		// Update post-FG smooth values when timer elapses
+		if (updateTimer <= 0.0f) {
+			postFGSmoothFps = postFGFps;
+			postFGSmoothFrameTimeMs = postFGFrameTimeMs;
+		}
 
         // Update post-FG frametime history
         postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
@@ -1472,11 +1472,11 @@ void Menu::PerfOverlayState::UpdateFGFrameTime(Settings::PerfOverlaySettings& se
         postFGFrameTimeMs = frameTimeMs / 2.0f;  // Approximate
         postFGFps = fps * 2.0f;                  // Approximate
 
-        // Update smooth values when timer elapses
-        if (updateTimer <= 0.0f) {
-            postFGSmoothFps = postFGFps;
-            postFGSmoothFrameTimeMs = postFGFrameTimeMs;
-        }
+		// Update smooth values when timer elapses
+		if (updateTimer <= 0.0f) {
+			postFGSmoothFps = postFGFps;
+			postFGSmoothFrameTimeMs = postFGFrameTimeMs;
+		}
 
         // Update post-FG frametime history with approximation
         postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -45,6 +45,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ShowPostFGFrameTime,
 	ShowPostFGFrameTimeGraph,
 	UpdateInterval,
+	FrameHistorySize,
 	Size,
 	BackgroundOpacity,
 	ShowBorder,
@@ -597,23 +598,40 @@ void Menu::DrawGeneralSettings()
 			if (ImGui::Checkbox("Enable Shaders", &useCustomShaders)) {
 				shaderCache->SetEnabled(useCustomShaders);
 			}
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+			ImGui::Text("(?)");
+			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Disabling this effectively disables all features.");
 			}
 
 			bool useDiskCache = shaderCache->IsDiskCache();
+			
 			ImGui::TableNextColumn();
+			
 			if (ImGui::Checkbox("Enable Disk Cache", &useDiskCache)) {
 				shaderCache->SetDiskCache(useDiskCache);
 			}
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+			ImGui::Text("(?)");
+			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Disabling this stops shaders from being loaded from disk, as well as stops shaders from being saved to it.");
 			}
+
 			bool useAsync = shaderCache->IsAsync();
+			
 			ImGui::TableNextColumn();
+
 			if (ImGui::Checkbox("Enable Async", &useAsync)) {
 				shaderCache->SetAsync(useAsync);
 			}
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+			ImGui::Text("(?)");
+			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Skips a shader being replaced if it hasn't been compiled yet. Also makes compilation blazingly fast!");
 			}
@@ -780,6 +798,10 @@ void Menu::DrawAdvancedSettings()
 		if (ImGui::Checkbox("Dump Shaders", &useDump)) {
 			shaderCache->SetDump(useDump);
 		}
+		ImGui::SameLine();
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+		ImGui::Text("(?)");
+		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Dump shaders at startup. This should be used only when reversing shaders. Normal users don't need this.");
 		}
@@ -798,6 +820,10 @@ void Menu::DrawAdvancedSettings()
 			ImGui::SameLine();
 			globals::state->SetLogLevel(static_cast<spdlog::level::level_enum>(item_current));
 		}
+		ImGui::SameLine();
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+		ImGui::Text("(?)");
+		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Log level. Trace is most verbose. Default is info.");
 		}
@@ -812,17 +838,29 @@ void Menu::DrawAdvancedSettings()
 			globals::state->SetDefines(shaderDefines);
 			shaderCache->Clear();
 		}
+		ImGui::SameLine();
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+		ImGui::Text("(?)");
+		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Defines for Shader Compiler. Semicolon \";\" separated. Clear with space. Rebuild shaders after making change. Compute Shaders require a restart to recompile.");
 		}
 		ImGui::Spacing();
 		ImGui::SliderInt("Compiler Threads", &shaderCache->compilationThreadCount, 1, static_cast<int32_t>(std::thread::hardware_concurrency()));
+		ImGui::SameLine();
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+		ImGui::Text("(?)");
+		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Number of threads to use to compile shaders. "
 				"The more threads the faster compilation will finish but may make the system unresponsive. ");
 		}
 		ImGui::SliderInt("Background Compiler Threads", &shaderCache->backgroundCompilationThreadCount, 1, static_cast<int32_t>(std::thread::hardware_concurrency()));
+		ImGui::SameLine();
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+		ImGui::Text("(?)");
+		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Number of threads to use to compile shaders while playing game. "
@@ -843,6 +881,10 @@ void Menu::DrawAdvancedSettings()
 				logger::info("Setting new interval {}.", testInterval);
 			}
 		}
+		ImGui::SameLine();
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+		ImGui::Text("(?)");
+		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Sets number of seconds before toggling between default USER and TEST config. "
@@ -855,6 +897,10 @@ void Menu::DrawAdvancedSettings()
 		if (ImGui::Checkbox("Enable File Watcher", &useFileWatcher)) {
 			shaderCache->SetFileWatcher(useFileWatcher);
 		}
+		ImGui::SameLine();
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+		ImGui::Text("(?)");
+		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Automatically recompile shaders on file change. "
@@ -869,6 +915,10 @@ void Menu::DrawAdvancedSettings()
 			if (ImGui::Button(blockingButtonString.c_str(), { -1, 0 })) {
 				shaderCache->DisableShaderBlocking();
 			}
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+			ImGui::Text("(?)");
+			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text(
 					"Stop blocking Community Shaders shader. "
@@ -909,20 +959,34 @@ void Menu::DrawAdvancedSettings()
 			}
 			if (state->IsDeveloperMode()) {
 				ImGui::Checkbox("Vertex", &state->enableVShaders);
+				ImGui::SameLine();
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+				ImGui::Text("(?)");
+				ImGui::PopStyleColor();
 				if (auto _tt = Util::HoverTooltipWrapper()) {
 					ImGui::Text(
 						"Replace Vertex Shaders. "
 						"When false, will disable the custom Vertex Shaders for the types above. "
 						"For developers to test whether CS shaders match vanilla behavior. ");
 				}
+
 				ImGui::Checkbox("Pixel", &state->enablePShaders);
+				ImGui::SameLine();
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+				ImGui::Text("(?)");
+				ImGui::PopStyleColor();
 				if (auto _tt = Util::HoverTooltipWrapper()) {
 					ImGui::Text(
 						"Replace Pixel Shaders. "
 						"When false, will disable the custom Pixel Shaders for the types above. "
 						"For developers to test whether CS shaders match vanilla behavior. ");
 				}
+
 				ImGui::Checkbox("Compute", &state->enableCShaders);
+				ImGui::SameLine();
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+				ImGui::Text("(?)");
+				ImGui::PopStyleColor();
 				if (auto _tt = Util::HoverTooltipWrapper()) {
 					ImGui::Text(
 						"Replace Compute Shaders. "
@@ -1168,18 +1232,7 @@ void Menu::DrawPerfOverlay()
 			settings.PerfOverlay.BackgroundOpacity));
 
 	// Set text size based on user preference
-	float textScale = 1.0f;
-	switch (settings.PerfOverlay.Size) {
-	case Settings::PerfOverlaySettings::TextSize::Small:
-		textScale = 0.8f;
-		break;
-	case Settings::PerfOverlaySettings::TextSize::Medium:
-		textScale = 1.0f;
-		break;
-	case Settings::PerfOverlaySettings::TextSize::Large:
-		textScale = 1.2f;
-		break;
-	}
+	perfOverlayState.textScale = perfOverlayState.SetTextScale(settings.PerfOverlay);
 
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, settings.PerfOverlay.ShowBorder ? 1.0f : 0.0f);
 
@@ -1193,9 +1246,9 @@ void Menu::DrawPerfOverlay()
 	}
 
 	// Set window size based on whether graphs are shown, was rapidly changing size based on text
-	bool hasGraphs = settings.PerfOverlay.ShowPreFGFrameTimeGraph || settings.PerfOverlay.ShowPostFGFrameTimeGraph;
-	if (!hasGraphs) {
-		float fixedWidth = 325.0f * textScale;
+	perfOverlayState.hasGraphs = settings.PerfOverlay.ShowPreFGFrameTimeGraph || settings.PerfOverlay.ShowPostFGFrameTimeGraph;
+	if (!perfOverlayState.hasGraphs) {
+		float fixedWidth = 325.0f * perfOverlayState.textScale;
 		ImGui::SetNextWindowSize(ImVec2(fixedWidth, 0), ImGuiCond_Always);
 	}
 
@@ -1214,281 +1267,58 @@ void Menu::DrawPerfOverlay()
 	}
 
 	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4.0f, 1.0f));  // Tighter spacing
-	ImGui::SetWindowFontScale(textScale);
+	ImGui::SetWindowFontScale(perfOverlayState.textScale);
 
-	// Get frame timing data using QueryPerformanceCounter for precise measurements
-	static LARGE_INTEGER frequency;
-	static LARGE_INTEGER lastFrameCounter;
-	static LARGE_INTEGER currentFrameCounter;
-	static float frameTimeMs = 0.0f;
-	static float fps = 0.0f;
-	static float smoothFps = 0.0f;
-	static float smoothFrameTimeMs = 0.0f;
-	static float postFGSmoothFps = 0.0f;
-	static float postFGSmoothFrameTimeMs = 0.0f;
-	static float updateTimer = 0.0f;
-	static std::chrono::steady_clock::time_point lastUpdateTime = std::chrono::steady_clock::now();
-
-	if (frequency.QuadPart == 0) {
-		QueryPerformanceFrequency(&frequency);
-		QueryPerformanceCounter(&lastFrameCounter);
+	if (perfOverlayState.frequency.QuadPart == 0) {
+		QueryPerformanceFrequency(&perfOverlayState.frequency);
+		QueryPerformanceCounter(&perfOverlayState.lastFrameCounter);
 	}
 
-	QueryPerformanceCounter(&currentFrameCounter);
-	LONGLONG elapsedCounter = currentFrameCounter.QuadPart - lastFrameCounter.QuadPart;
-	lastFrameCounter = currentFrameCounter;
+	QueryPerformanceCounter(&perfOverlayState.currentFrameCounter);
+	LONGLONG elapsedCounter = perfOverlayState.currentFrameCounter.QuadPart - perfOverlayState.lastFrameCounter.QuadPart;
+	perfOverlayState.lastFrameCounter = perfOverlayState.currentFrameCounter;
 
-	// Calculate frametime in milliseconds
-	frameTimeMs = 1000.0f * (float)elapsedCounter / (float)frequency.QuadPart;
-
-	// Calculate FPS directly from frametime
-	fps = 1000.0f / frameTimeMs;
+	// Get frametime and fps
+	perfOverlayState.frameTimeMs = Util::performanceOverlay.CalcFrameTime(elapsedCounter, perfOverlayState.frequency);
+	perfOverlayState.fps = Util::performanceOverlay.CalcFPS(perfOverlayState.frameTimeMs);
 
 	// Calculate smooth values for display using the user-defined update interval
-	auto currentTime = std::chrono::steady_clock::now();
-	float deltaTime = std::chrono::duration<float>(currentTime - lastUpdateTime).count();
-	lastUpdateTime = currentTime;
+	auto now = std::chrono::steady_clock::now();
+	float deltaTime = std::chrono::duration<float>(now - perfOverlayState.lastUpdateTime).count();
+	perfOverlayState.lastUpdateTime = now;
 
-	// Frametime history graph data
-	const int FRAME_HISTORY_SIZE = 120;
-	static float frameTimeHistory[FRAME_HISTORY_SIZE] = {};
-	static int frameTimeHistoryIndex = 0;
-	static float postFGFrameTimeHistory[FRAME_HISTORY_SIZE] = {};
-	static int postFGFrameTimeHistoryIndex = 0;
-
-	// Update frametime history
-	frameTimeHistory[frameTimeHistoryIndex] = frameTimeMs;
-	frameTimeHistoryIndex = (frameTimeHistoryIndex + 1) % FRAME_HISTORY_SIZE;
+	// Update graph values
+	perfOverlayState.UpdateGraphValues(settings.PerfOverlay);
 
 	// Update smooth values with user-specified interval
-	updateTimer += deltaTime;
-	if (updateTimer >= settings.PerfOverlay.UpdateInterval) {
-		smoothFps = fps;
-		smoothFrameTimeMs = frameTimeMs;
-		updateTimer = 0.0f;
+	perfOverlayState.updateTimer += deltaTime;
+	if (perfOverlayState.updateTimer >= settings.PerfOverlay.UpdateInterval) {
+		perfOverlayState.smoothFps = perfOverlayState.fps;
+		perfOverlayState.smoothFrameTimeMs = perfOverlayState.frameTimeMs;
+		perfOverlayState.updateTimer = 0.0f;
 	}
 
 	// Check if Frame Generation is active
-	bool isFrameGenerationActive = globals::upscaling && globals::upscaling->IsFrameGenerationActive();
-	float postFGFrameTimeMs = 0.0f;
-	float postFGFps = 0.0f;
+	perfOverlayState.isFrameGenerationActive = globals::upscaling && globals::upscaling->IsFrameGenerationActive();
 
-	if (isFrameGenerationActive) {
-		// Get frametime directly from the Frame Generation system
-		float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
-		if (fgDeltaTime > 0.0f) {
-			postFGFrameTimeMs = fgDeltaTime * 1000.0f;
-			postFGFps = 1000.0f / postFGFrameTimeMs;
-
-			// Update post-FG smooth values when timer elapses
-			if (updateTimer == 0.0f) {
-				postFGSmoothFps = postFGFps;
-				postFGSmoothFrameTimeMs = postFGFrameTimeMs;
-			}
-
-			// Update post-FG frametime history
-			postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
-			postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % FRAME_HISTORY_SIZE;
-		} else {
-			// Fallback if FG time is not available
-			postFGFrameTimeMs = frameTimeMs / 2.0f;  // Approximate
-			postFGFps = fps * 2.0f;                  // Approximate
-
-			// Update smooth values when timer elapses
-			if (updateTimer == 0.0f) {
-				postFGSmoothFps = postFGFps;
-				postFGSmoothFrameTimeMs = postFGFrameTimeMs;
-			}
-
-			// Update post-FG frametime history with approximation
-			postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
-			postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % FRAME_HISTORY_SIZE;
-		}
+	if (perfOverlayState.isFrameGenerationActive) {
+		perfOverlayState.UpdateFGFrameTime(settings.PerfOverlay);
 	}
 
 	// Show FPS counter if enabled
 	if (settings.PerfOverlay.ShowFPS) {
-		if (isFrameGenerationActive) {
-			if (settings.PerfOverlay.ShowPostFGFPS) {
-				ImGui::Text("FPS: %.1f", postFGSmoothFps);
-			}
-
-			if (settings.PerfOverlay.ShowPreFGFPS) {
-				ImGui::Text("Pre-FG FPS: %.1f", smoothFps);
-			}
-		} else {
-			ImGui::Text("FPS: %.1f", smoothFps);
-		}
-
-		if (isFrameGenerationActive) {
-			if (settings.PerfOverlay.ShowPostFGFPS && settings.PerfOverlay.ShowPostFGFrameTime) {
-				ImGui::Text("Frametime: %.2f ms", postFGSmoothFrameTimeMs);
-			}
-			if (settings.PerfOverlay.ShowPreFGFPS && settings.PerfOverlay.ShowPreFGFrameTime) {
-				ImGui::Text("Pre-FG Frametime: %.2f ms", smoothFrameTimeMs);
-			}
-		} else {
-			if (settings.PerfOverlay.ShowPreFGFrameTime) {
-				ImGui::Text("Frametime: %.2f ms", smoothFrameTimeMs);
-			}
-		}
-
-		// Show Pre-FG frametime graph if enabled
-		if (settings.PerfOverlay.ShowPreFGFrameTimeGraph &&
-			((isFrameGenerationActive && settings.PerfOverlay.ShowPreFGFPS) || !isFrameGenerationActive)) {
-			// Find min and max values for better scaling
-			float minFrameTime = 1000.0f;
-			float maxFrameTime = 0.0f;
-
-			for (int i = 0; i < FRAME_HISTORY_SIZE; i++) {
-				if (frameTimeHistory[i] > 0.01f) {  // Ignore empty values
-					minFrameTime = std::min(minFrameTime, frameTimeHistory[i]);
-					maxFrameTime = std::max(maxFrameTime, frameTimeHistory[i]);
-				}
-			}
-
-			// Add some padding to min/max
-			minFrameTime = std::max(0.0f, minFrameTime - 1.0f);
-			maxFrameTime = maxFrameTime + 1.0f;
-
-			// Prepare overlay text
-			char overlay_text[128];
-			snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
-				"%s%.2f ms (%.1f FPS)",
-				isFrameGenerationActive ? "Pre-FG: " : "",
-				smoothFrameTimeMs, smoothFps);
-
-			// Set graph colors
-			ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));  // Green line
-
-			// Draw the graph
-			ImGui::PlotLines("##frametime",
-				frameTimeHistory,
-				FRAME_HISTORY_SIZE,
-				frameTimeHistoryIndex,
-				overlay_text,
-				minFrameTime, maxFrameTime,
-				ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
-
-			ImGui::PopStyleColor();
-
-			// Draw frametime target reference lines
-			if (ImGui::BeginTable("FrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
-				ImGui::TableNextColumn();
-				ImGui::Text("30 FPS: 33.3 ms");
-
-				ImGui::TableNextColumn();
-				ImGui::Text("60 FPS: 16.7 ms");
-
-				ImGui::TableNextColumn();
-				ImGui::Text("120 FPS: 8.3 ms");
-
-				ImGui::EndTable();
-			}
-		}
-
-		// Show Post-FG frametime graph if enabled
-		if (settings.PerfOverlay.ShowPostFGFrameTimeGraph && isFrameGenerationActive && settings.PerfOverlay.ShowPostFGFPS) {
-			// Find min and max values for better scaling
-			float minFrameTime = 1000.0f;
-			float maxFrameTime = 0.0f;
-
-			for (int i = 0; i < FRAME_HISTORY_SIZE; i++) {
-				if (postFGFrameTimeHistory[i] > 0.01f) {  // Ignore empty values
-					minFrameTime = std::min(minFrameTime, postFGFrameTimeHistory[i]);
-					maxFrameTime = std::max(maxFrameTime, postFGFrameTimeHistory[i]);
-				}
-			}
-
-			// Add some padding to min/max
-			minFrameTime = std::max(0.0f, minFrameTime - 1.0f);
-			maxFrameTime = maxFrameTime + 1.0f;
-
-			// Prepare overlay text
-			char overlay_text[128];
-			snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
-				"Post-FG: %.2f ms (%.1f FPS)",
-				postFGSmoothFrameTimeMs, postFGSmoothFps);
-
-			// Set graph colors - blue for post-FG
-			ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
-
-			// Draw the graph
-			ImGui::PlotLines("##postfgframetime",
-				postFGFrameTimeHistory,
-				FRAME_HISTORY_SIZE,
-				postFGFrameTimeHistoryIndex,
-				overlay_text,
-				minFrameTime, maxFrameTime,
-				ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
-
-			ImGui::PopStyleColor();
-
-			// Draw frametime target reference lines
-			if (ImGui::BeginTable("PostFGFrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
-				ImGui::TableNextColumn();
-				ImGui::Text("30 FPS: 33.3 ms");
-
-				ImGui::TableNextColumn();
-				ImGui::Text("60 FPS: 16.7 ms");
-
-				ImGui::TableNextColumn();
-				ImGui::Text("120 FPS: 8.3 ms");
-
-				ImGui::EndTable();
-			}
-		}
+		perfOverlayState.DrawFPS(settings.PerfOverlay);
 	}
 
 	// Show Draw Calls if enabled
 	if (settings.PerfOverlay.ShowDrawCalls) {
-		ImGui::Text("Draw Calls:");
-		ImGui::Indent();
-		ImGui::Text("Grass: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Grass]));
-		ImGui::Text("Sky: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Sky]));
-		ImGui::Text("Water: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Water]));
-		ImGui::Text("Lighting: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Lighting]));
-		ImGui::Text("Effect: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Effect]));
-		ImGui::Text("Utility: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Utility]));
-		ImGui::Text("Distant Tree: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::DistantTree]));
-		ImGui::Text("Particle: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Particle]));
-		ImGui::Text("Total: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Total]));
-		ImGui::Unindent();
+		perfOverlayState.DrawDrawCalls();
 	}
 
 	// VRAM & GPU Usage
-	if (settings.PerfOverlay.ShowVRAM && dxgiAdapter3) {
-		DXGI_QUERY_VIDEO_MEMORY_INFO videoMemoryInfo{};
-		HRESULT hr = dxgiAdapter3->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &videoMemoryInfo);
-
-		// Only proceed if the call succeeded and Budget is not zero
-		if (SUCCEEDED(hr) && videoMemoryInfo.Budget > 0) {
-			float currentGpuUsage = videoMemoryInfo.CurrentUsage / (1024.f * 1024.f * 1024.f);
-			float totalGpuMemory = videoMemoryInfo.Budget / (1024.f * 1024.f * 1024.f);
-			float percent = currentGpuUsage / totalGpuMemory;
-
-			// Center the VRAM text
-			ImGui::Text("VRAM Usage:");
-
-			// Use a centered text format for the numeric values
-			std::string vramText = std::format("{:.2f}GB/{:.2f}GB ({:.1f}%)", currentGpuUsage, totalGpuMemory, 100 * percent);
-			float textWidth = ImGui::CalcTextSize(vramText.c_str()).x;
-			float windowWidth = ImGui::GetWindowWidth();
-
-			// Center the text if it fits within the window
-			if (textWidth < windowWidth) {
-				ImGui::SetCursorPosX((windowWidth - textWidth) * 0.5f);
-				ImGui::Text("%s", vramText.c_str());
-			} else {
-				ImGui::Text("%s", vramText.c_str());
-			}
-
-			// Only move the progress bar, not the text
-			ImGui::ProgressBar(percent, ImVec2(ImGui::GetWindowWidth() * 0.9f, 0.0f), "");
-		} else {
-			// Display a fallback message if we couldn't get the VRAM info
-			ImGui::Text("VRAM Usage: Not available");
-		}
+	if (settings.PerfOverlay.ShowVRAM && dxgiAdapter3) 
+	{
+		perfOverlayState.DrawVRAM(dxgiAdapter3);
 	}
 
 	ImGui::PopStyleVar();             // ItemSpacing
@@ -1497,6 +1327,378 @@ void Menu::DrawPerfOverlay()
 	ImGui::End();
 	ImGui::PopStyleVar();    // WindowBorderSize
 	ImGui::PopStyleColor();  // WindowBg
+}
+
+float Menu::PerfOverlayState::SetTextScale(Settings::PerfOverlaySettings& settings)
+{
+	switch (settings.Size) {
+		case Settings::PerfOverlaySettings::TextSize::Small:
+			return 0.8f;
+		case Settings::PerfOverlaySettings::TextSize::Medium:
+			return 1.0f;
+		case Settings::PerfOverlaySettings::TextSize::Large:
+			return 1.2f;
+	}
+	return 1.0f;
+}
+
+/**
+ * @brief Updates all runtime state related to the performance overlay graph.
+ *
+ * This function synchronizes the frame time history buffer, tracks min/max frame times,
+ * and computes the normalized Y-axis range for the frame time graph using statistical analysis.
+ * 
+ * Steps performed:
+ *   1. Resizes the frame time history buffer if the user has changed the setting.
+ *   2. Inserts the latest frame time into the circular history buffer.
+ *   3. Updates instantaneous min/max frame time values, with full rescans if necessary.
+ *   4. Calculates the average (mean) and standard deviation of frame times in the buffer.
+ *   5. Sets the graph Y-axis range to be centered on the average, with a spread of ±2 standard deviations,
+ *      clamped to user-friendly minimum and maximum values.
+ *   6. Smooths the min/max Y-axis values for visual stability using exponential smoothing.
+ *
+ *
+ * @param settings Reference to the current performance overlay settings (controls buffer size, etc.).
+ */
+void Menu::PerfOverlayState::UpdateGraphValues(Settings::PerfOverlaySettings& settings)
+{
+    // Sync frame history buffer size with user settings
+    UpdateFrameTimeHistorySizes(settings);
+
+    // Insert latest frame time into circular buffer
+    float oldFrameTime = frameTimeHistory[frameTimeHistoryIndex];
+    frameTimeHistory[frameTimeHistoryIndex] = frameTimeMs;
+    frameTimeHistoryIndex = (frameTimeHistoryIndex + 1) % settings.FrameHistorySize;
+
+    // Maintain instantaneous min/max tracking
+    if (frameTimeMs > maxFrameTime) {
+        maxFrameTime = frameTimeMs;
+    } else if (frameTimeMs < minFrameTime) {
+        minFrameTime = frameTimeMs;
+    } else if (oldFrameTime == minFrameTime) {
+        UpdateMinFrameTime();
+    } else if (oldFrameTime == maxFrameTime) {
+        UpdateMaxFrameTime();
+    }
+
+	float avgFrameTime, stdDev, graphMin, graphMax; 
+    // Calculate mean and standard deviation for normalized graph range
+    if (frameTimeHistory.empty()) {
+        // Default to 60 FPS
+        avgFrameTime = 16.67f;
+        stdDev = 0.0f;
+        graphMin = 0.0f;
+        graphMax = 33.0f;
+    } else {
+        // Calculate average frame time
+        avgFrameTime = std::accumulate(frameTimeHistory.begin(), frameTimeHistory.end(), 0.0f) / frameTimeHistory.size();
+
+        // Calculate standard deviation
+        float variance = 0.0f;
+        for (float ft : frameTimeHistory) {
+            float diff = ft - avgFrameTime;
+            variance += diff * diff;
+        }
+        variance /= frameTimeHistory.size();
+        stdDev = std::sqrt(variance);
+
+        // Calculate graph range
+        float spread = std::clamp(stdDev * 2.0f, 2.0f, 20.0f);
+        graphMin = std::max(0.0f, avgFrameTime - spread);
+        graphMax = avgFrameTime + spread;
+    }
+
+    // Exponential smoothing for stable graph scaling
+    smoothedMinFrameTime += kSmoothingFactor * (graphMin - smoothedMinFrameTime);
+    smoothedMaxFrameTime += kSmoothingFactor * (graphMax - smoothedMaxFrameTime);
+}
+
+/**
+ * @brief Updates the minimum frame time value by scanning the frame time history buffer.
+ *
+ * Finds the smallest frame time currently in the frameTimeHistory buffer and updates minFrameTime accordingly.
+ * Assumes frameTimeHistory is non-empty.
+ */
+void Menu::PerfOverlayState::UpdateMinFrameTime()
+{
+    minFrameTime = *std::min_element(frameTimeHistory.begin(), frameTimeHistory.end());
+}
+
+/**
+ * @brief Updates the maximum frame time value by scanning the frame time history buffer.
+ *
+ * Finds the largest frame time currently in the frameTimeHistory buffer and updates maxFrameTime accordingly.
+ * Assumes frameTimeHistory is non-empty.
+ */
+void Menu::PerfOverlayState::UpdateMaxFrameTime()
+{
+    maxFrameTime = *std::max_element(frameTimeHistory.begin(), frameTimeHistory.end());
+}
+
+/**
+ * @brief Updates post-frame generation (FG) frame time and FPS history values.
+ *
+ * Retrieves the latest frame time from the Frame Generation system if available, updates smoothed values,
+ * and maintains a circular buffer of post-FG frame times. Falls back to an approximation if FG timing is unavailable.
+ *
+ * @param settings Reference to the current performance overlay settings (controls buffer size, etc.).
+ */
+void Menu::PerfOverlayState::UpdateFGFrameTime(Settings::PerfOverlaySettings& settings)
+{
+    float postFGFrameTimeMs = 0.0f;
+    float postFGFps = 0.0f;
+    // Get frametime directly from the Frame Generation system
+    float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
+    if (fgDeltaTime > 0.0f) {
+        postFGFrameTimeMs = fgDeltaTime * 1000.0f;
+        postFGFps = 1000.0f / postFGFrameTimeMs;
+
+        // Update post-FG smooth values when timer elapses
+        if (updateTimer == 0.0f) {
+            postFGSmoothFps = postFGFps;
+            postFGSmoothFrameTimeMs = postFGFrameTimeMs;
+        }
+
+        // Update post-FG frametime history
+        postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
+        postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % settings.FrameHistorySize;
+    } else {
+        // Fallback if FG time is not available
+        postFGFrameTimeMs = frameTimeMs / 2.0f;  // Approximate
+        postFGFps = fps * 2.0f;                  // Approximate
+
+        // Update smooth values when timer elapses
+        if (updateTimer == 0.0f) {
+            postFGSmoothFps = postFGFps;
+            postFGSmoothFrameTimeMs = postFGFrameTimeMs;
+        }
+
+        // Update post-FG frametime history with approximation
+        postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
+        postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % settings.FrameHistorySize;
+    }
+}
+
+/**
+ * @brief Renders the FPS and frametime statistics using ImGui, including graphs and reference lines.
+ *
+ * Displays pre- and post-frame generation FPS and frametime values, as well as line graphs if enabled in settings.
+ * Handles both standard and frame generation rendering modes, and draws reference lines for common FPS targets.
+ *
+ * @param settings Reference to the current performance overlay settings (controls what is displayed).
+ */
+void Menu::PerfOverlayState::DrawFPS(Settings::PerfOverlaySettings& settings)
+{
+    if (isFrameGenerationActive) {
+        if (settings.ShowPostFGFPS) {
+            ImGui::Text("FPS: %.1f", postFGSmoothFps);
+        }
+
+        if (settings.ShowPreFGFPS) {
+            ImGui::Text("Pre-FG FPS: %.1f", smoothFps);
+        }
+    } else {
+        ImGui::Text("FPS: %.1f", smoothFps);
+    }
+
+    if (isFrameGenerationActive) {
+        if (settings.ShowPostFGFPS && settings.ShowPostFGFrameTime) {
+            ImGui::Text("Frametime: %.2f ms", postFGSmoothFrameTimeMs);
+        }
+        if (settings.ShowPreFGFPS && settings.ShowPreFGFrameTime) {
+            ImGui::Text("Pre-FG Frametime: %.2f ms", smoothFrameTimeMs);
+        }
+    } else {
+        if (settings.ShowPreFGFrameTime) {
+            ImGui::Text("Frametime: %.2f ms", smoothFrameTimeMs);
+        }
+    }
+
+    // Show Pre-FG frametime graph if enabled
+    if (settings.ShowPreFGFrameTimeGraph &&
+        (!isFrameGenerationActive || (isFrameGenerationActive && settings.ShowPreFGFPS))) 
+    {
+        // Prepare overlay text
+        char overlay_text[128];
+        snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
+            "%s%.2f ms (%.1f FPS)",
+            isFrameGenerationActive ? "Pre-FG: " : "",
+            smoothFrameTimeMs, smoothFps);
+
+        // Set graph colors
+        ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));  // Green line
+
+        // Draw the graph
+        ImGui::PlotLines("##frametime",
+            frameTimeHistory.data(),
+            settings.FrameHistorySize,
+            frameTimeHistoryIndex,
+            overlay_text,
+            smoothedMinFrameTime, smoothedMaxFrameTime,
+            ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
+
+        ImGui::PopStyleColor();
+
+        // Draw frametime target reference lines
+        if (ImGui::BeginTable("FrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
+            ImGui::TableNextColumn();
+            ImGui::Text("30 FPS: 33.3 ms");
+
+            ImGui::TableNextColumn();
+            ImGui::Text("60 FPS: 16.7 ms");
+
+            ImGui::TableNextColumn();
+            ImGui::Text("120 FPS: 8.3 ms");
+
+            ImGui::EndTable();
+        }
+    }
+
+    // Show Post-FG frametime graph if enabled
+    if (settings.ShowPostFGFrameTimeGraph && isFrameGenerationActive && settings.ShowPostFGFPS) 
+    {
+        DrawPostFGFrameTimeGraph(settings);
+    }
+}
+
+/**
+ * @brief Renders the post-frame generation frametime graph using ImGui.
+ *
+ * Plots the post-FG frametime history and displays reference lines for common FPS targets.
+ * Only called if frame generation is active and the relevant settings are enabled.
+ *
+ * @param settings Reference to the current performance overlay settings (controls graph appearance and size).
+ */
+void Menu::PerfOverlayState::DrawPostFGFrameTimeGraph(Settings::PerfOverlaySettings& settings)
+{
+    // Prepare overlay text
+    char overlay_text[128];
+    snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
+        "Post-FG: %.2f ms (%.1f FPS)",
+        postFGSmoothFrameTimeMs, postFGSmoothFps);
+
+    // Set graph colors - blue for post-FG
+    ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
+
+    // Draw the graph
+    ImGui::PlotLines("##postfgframetime",
+        postFGFrameTimeHistory.data(),
+        settings.FrameHistorySize,
+        postFGFrameTimeHistoryIndex,
+        overlay_text,
+        smoothedMinFrameTime, smoothedMaxFrameTime,
+        ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
+
+    ImGui::PopStyleColor();
+
+    // Draw frametime target reference lines
+    if (ImGui::BeginTable("PostFGFrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
+        ImGui::TableNextColumn();
+        ImGui::Text("30 FPS: 33.3 ms");
+
+        ImGui::TableNextColumn();
+        ImGui::Text("60 FPS: 16.7 ms");
+
+        ImGui::TableNextColumn();
+        ImGui::Text("120 FPS: 8.3 ms");
+
+        ImGui::EndTable();
+    }
+}
+
+/**
+ * @brief Renders the current draw call counts for various shader types using ImGui.
+ *
+ * Displays a breakdown of draw calls by type (e.g., Grass, Sky, Water, etc.) and the total count.
+ * Values are sourced from the global state.
+ */
+void Menu::PerfOverlayState::DrawDrawCalls()
+{
+    ImGui::Text("Draw Calls:");
+    ImGui::Indent();
+    ImGui::Text("Grass: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Grass]));
+    ImGui::Text("Sky: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Sky]));
+    ImGui::Text("Water: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Water]));
+    ImGui::Text("Lighting: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Lighting]));
+    ImGui::Text("Effect: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Effect]));
+    ImGui::Text("Utility: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Utility]));
+    ImGui::Text("Distant Tree: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::DistantTree]));
+    ImGui::Text("Particle: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Particle]));
+    ImGui::Text("Total: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Total]));
+    ImGui::Unindent();
+}
+
+/**
+ * @brief Renders the current GPU VRAM usage using ImGui.
+ *
+ * Queries the DXGI adapter for video memory info and displays current usage, total budget, and a progress bar.
+ * Falls back to a message if VRAM info is unavailable.
+ *
+ * @param dxgiAdapter3 A COM pointer to the IDXGIAdapter3 interface for querying video memory info.
+ */
+void Menu::PerfOverlayState::DrawVRAM(winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3)
+{
+    DXGI_QUERY_VIDEO_MEMORY_INFO videoMemoryInfo{};
+    HRESULT hr = dxgiAdapter3->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &videoMemoryInfo);
+
+    // Only proceed if the call succeeded and Budget is not zero
+    if (SUCCEEDED(hr) && videoMemoryInfo.Budget > 0) {
+        float currentGpuUsage = videoMemoryInfo.CurrentUsage / (1024.f * 1024.f * 1024.f);
+        float totalGpuMemory = videoMemoryInfo.Budget / (1024.f * 1024.f * 1024.f);
+        float percent = currentGpuUsage / totalGpuMemory;
+
+        // Center the VRAM text
+        ImGui::Text("VRAM Usage:");
+
+        // Use a centered text format for the numeric values
+        std::string vramText = std::format("{:.2f}GB/{:.2f}GB ({:.1f}%)", currentGpuUsage, totalGpuMemory, 100 * percent);
+        float textWidth = ImGui::CalcTextSize(vramText.c_str()).x;
+        float windowWidth = ImGui::GetWindowWidth();
+
+        // Center the text if it fits within the window
+        if (textWidth < windowWidth) {
+            ImGui::SetCursorPosX((windowWidth - textWidth) * 0.5f);
+            ImGui::Text("%s", vramText.c_str());
+        } else {
+            ImGui::Text("%s", vramText.c_str());
+        }
+
+        // Only move the progress bar, not the text
+        ImGui::ProgressBar(percent, ImVec2(ImGui::GetWindowWidth() * 0.9f, 0.0f), "");
+    } else {
+        // Display a fallback message if we couldn't get the VRAM info
+        ImGui::Text("VRAM Usage: Not available");
+    }
+}
+
+/**
+ * @brief Ensures frame time history buffers are sized according to the current settings.
+ *
+ * Resizes the frameTimeHistory and postFGFrameTimeHistory buffers to match the user-configured history size,
+ * clamping the size within allowed bounds. Resets indices if they are out of bounds after resizing.
+ *
+ * @param settings Reference to the current performance overlay settings (controls buffer size and limits).
+ */
+void Menu::PerfOverlayState::UpdateFrameTimeHistorySizes(Settings::PerfOverlaySettings& settings)
+{
+    settings.FrameHistorySize = std::clamp(
+        settings.FrameHistorySize,
+        settings.kMinFrameHistorySize,
+        settings.kMaxFrameHistorySize
+    );
+	
+	if (frameTimeHistory.size() != static_cast<size_t>(settings.FrameHistorySize)) {
+		frameTimeHistory.resize(settings.FrameHistorySize, 0.0f);
+		if (frameTimeHistoryIndex >= settings.FrameHistorySize) { // Reset index if it's out of new bounds
+			frameTimeHistoryIndex = 0;
+		}
+	}
+	if (postFGFrameTimeHistory.size() != static_cast<size_t>(settings.FrameHistorySize)) {
+		postFGFrameTimeHistory.resize(settings.FrameHistorySize, 0.0f);
+		if (postFGFrameTimeHistoryIndex >= settings.FrameHistorySize) {
+			postFGFrameTimeHistoryIndex = 0;
+		}
+	}
 }
 
 void Menu::DrawPerformanceOverlaySettings()
@@ -1602,8 +1804,23 @@ void Menu::DrawPerformanceOverlaySettings()
 
 			// FPS update interval slider - Make this slider affect all FPS and frametime displays
 			ImGui::SliderFloat("Update Interval", &settings.PerfOverlay.UpdateInterval, 0.001f, 2.0f, "%.2f seconds");
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+			ImGui::Text("?");
+			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("How frequently all performance metrics should update (FPS and frametime)");
+			}
+
+			// Frame history size slider
+			ImGui::SliderInt("Frame History Size", &settings.PerfOverlay.FrameHistorySize, Settings::PerfOverlaySettings::kMinFrameHistorySize, Settings::PerfOverlaySettings::kMaxFrameHistorySize);
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+			ImGui::Text("?");
+			ImGui::PopStyleColor();
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text("Number of frames to keep in history for graphing.\n"
+							"E.g. 60 frames = 1 second @ 60fps.");
 			}
 
 			// Position options - moved inside appearance section
@@ -1614,6 +1831,10 @@ void Menu::DrawPerformanceOverlaySettings()
 			if (ImGui::Button("Reset Position")) {
 				settings.PerfOverlay.PositionSet = false;
 			}
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+			ImGui::Text("?");
+			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Reset the position of the performance overlay to default");
 			}

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -786,10 +786,6 @@ void Menu::DrawAdvancedSettings()
 		if (ImGui::Checkbox("Dump Shaders", &useDump)) {
 			shaderCache->SetDump(useDump);
 		}
-		ImGui::SameLine();
-		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
-		ImGui::Text("(?)");
-		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Dump shaders at startup. This should be used only when reversing shaders. Normal users don't need this.");
 		}
@@ -808,10 +804,6 @@ void Menu::DrawAdvancedSettings()
 			ImGui::SameLine();
 			globals::state->SetLogLevel(static_cast<spdlog::level::level_enum>(item_current));
 		}
-		ImGui::SameLine();
-		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
-		ImGui::Text("(?)");
-		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Log level. Trace is most verbose. Default is info.");
 		}
@@ -826,29 +818,17 @@ void Menu::DrawAdvancedSettings()
 			globals::state->SetDefines(shaderDefines);
 			shaderCache->Clear();
 		}
-		ImGui::SameLine();
-		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
-		ImGui::Text("(?)");
-		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Defines for Shader Compiler. Semicolon \";\" separated. Clear with space. Rebuild shaders after making change. Compute Shaders require a restart to recompile.");
 		}
 		ImGui::Spacing();
 		ImGui::SliderInt("Compiler Threads", &shaderCache->compilationThreadCount, 1, static_cast<int32_t>(std::thread::hardware_concurrency()));
-		ImGui::SameLine();
-		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
-		ImGui::Text("(?)");
-		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Number of threads to use to compile shaders. "
 				"The more threads the faster compilation will finish but may make the system unresponsive. ");
 		}
 		ImGui::SliderInt("Background Compiler Threads", &shaderCache->backgroundCompilationThreadCount, 1, static_cast<int32_t>(std::thread::hardware_concurrency()));
-		ImGui::SameLine();
-		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
-		ImGui::Text("(?)");
-		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Number of threads to use to compile shaders while playing game. "
@@ -869,10 +849,6 @@ void Menu::DrawAdvancedSettings()
 				logger::info("Setting new interval {}.", testInterval);
 			}
 		}
-		ImGui::SameLine();
-		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
-		ImGui::Text("(?)");
-		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Sets number of seconds before toggling between default USER and TEST config. "
@@ -885,10 +861,6 @@ void Menu::DrawAdvancedSettings()
 		if (ImGui::Checkbox("Enable File Watcher", &useFileWatcher)) {
 			shaderCache->SetFileWatcher(useFileWatcher);
 		}
-		ImGui::SameLine();
-		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
-		ImGui::Text("(?)");
-		ImGui::PopStyleColor();
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Automatically recompile shaders on file change. "
@@ -903,10 +875,6 @@ void Menu::DrawAdvancedSettings()
 			if (ImGui::Button(blockingButtonString.c_str(), { -1, 0 })) {
 				shaderCache->DisableShaderBlocking();
 			}
-			ImGui::SameLine();
-			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
-			ImGui::Text("(?)");
-			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text(
 					"Stop blocking Community Shaders shader. "
@@ -947,10 +915,6 @@ void Menu::DrawAdvancedSettings()
 			}
 			if (state->IsDeveloperMode()) {
 				ImGui::Checkbox("Vertex", &state->enableVShaders);
-				ImGui::SameLine();
-				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
-				ImGui::Text("(?)");
-				ImGui::PopStyleColor();
 				if (auto _tt = Util::HoverTooltipWrapper()) {
 					ImGui::Text(
 						"Replace Vertex Shaders. "
@@ -959,10 +923,6 @@ void Menu::DrawAdvancedSettings()
 				}
 
 				ImGui::Checkbox("Pixel", &state->enablePShaders);
-				ImGui::SameLine();
-				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
-				ImGui::Text("(?)");
-				ImGui::PopStyleColor();
 				if (auto _tt = Util::HoverTooltipWrapper()) {
 					ImGui::Text(
 						"Replace Pixel Shaders. "
@@ -971,10 +931,6 @@ void Menu::DrawAdvancedSettings()
 				}
 
 				ImGui::Checkbox("Compute", &state->enableCShaders);
-				ImGui::SameLine();
-				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
-				ImGui::Text("(?)");
-				ImGui::PopStyleColor();
 				if (auto _tt = Util::HoverTooltipWrapper()) {
 					ImGui::Text(
 						"Replace Compute Shaders. "
@@ -1799,20 +1755,12 @@ void Menu::DrawPerformanceOverlaySettings()
 
 			// FPS update interval slider - Make this slider affect all FPS and frametime displays
 			ImGui::SliderFloat("Update Interval", &settings.PerfOverlay.UpdateInterval, 0.001f, 2.0f, "%.2f seconds");
-			ImGui::SameLine();
-			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-			ImGui::Text("?");
-			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("How frequently all performance metrics should update (FPS and frametime)");
 			}
 
 			// Frame history size slider
 			ImGui::SliderInt("Frame History Size", &settings.PerfOverlay.FrameHistorySize, Settings::PerfOverlaySettings::kMinFrameHistorySize, Settings::PerfOverlaySettings::kMaxFrameHistorySize);
-			ImGui::SameLine();
-			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-			ImGui::Text("?");
-			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Number of frames to keep in history for graphing.\n"
 							"E.g. 60 frames = 1 second @ 60fps.");
@@ -1826,10 +1774,6 @@ void Menu::DrawPerformanceOverlaySettings()
 			if (ImGui::Button("Reset Position")) {
 				settings.PerfOverlay.PositionSet = false;
 			}
-			ImGui::SameLine();
-			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-			ImGui::Text("?");
-			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Reset the position of the performance overlay to default");
 			}

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1257,8 +1257,9 @@ void Menu::DrawPerfOverlay()
 	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4.0f, 1.0f));  // Tighter spacing
 	ImGui::SetWindowFontScale(perfOverlayState.textScale);
 
+	// Initialize Performance Counter if necessary
 	if (perfOverlayState.frequency == 0) {
-		LARGE_INTEGER temp;
+		LARGE_INTEGER temp; // LARGE_INTEGER is required for called QueryPerformanceCounter
 		QueryPerformanceFrequency(&temp);
 		perfOverlayState.frequency = temp.QuadPart;
 		QueryPerformanceCounter(&temp);
@@ -1271,7 +1272,7 @@ void Menu::DrawPerfOverlay()
 	int64_t elapsedCounter = perfOverlayState.currentFrameCounter - perfOverlayState.lastFrameCounter;
 	perfOverlayState.lastFrameCounter = perfOverlayState.currentFrameCounter;
 
-	// Get frametime and fps
+	// Calculate frametime and fps
 	perfOverlayState.frameTimeMs = Util::performanceOverlay.CalcFrameTime(elapsedCounter, perfOverlayState.frequency);
 	perfOverlayState.fps = Util::performanceOverlay.CalcFPS(perfOverlayState.frameTimeMs);
 

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -598,10 +598,6 @@ void Menu::DrawGeneralSettings()
 			if (ImGui::Checkbox("Enable Shaders", &useCustomShaders)) {
 				shaderCache->SetEnabled(useCustomShaders);
 			}
-			ImGui::SameLine();
-			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
-			ImGui::Text("(?)");
-			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Disabling this effectively disables all features.");
 			}
@@ -613,10 +609,6 @@ void Menu::DrawGeneralSettings()
 			if (ImGui::Checkbox("Enable Disk Cache", &useDiskCache)) {
 				shaderCache->SetDiskCache(useDiskCache);
 			}
-			ImGui::SameLine();
-			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
-			ImGui::Text("(?)");
-			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Disabling this stops shaders from being loaded from disk, as well as stops shaders from being saved to it.");
 			}
@@ -628,10 +620,6 @@ void Menu::DrawGeneralSettings()
 			if (ImGui::Checkbox("Enable Async", &useAsync)) {
 				shaderCache->SetAsync(useAsync);
 			}
-			ImGui::SameLine();
-			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
-			ImGui::Text("(?)");
-			ImGui::PopStyleColor();
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Skips a shader being replaced if it hasn't been compiled yet. Also makes compilation blazingly fast!");
 			}

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1269,13 +1269,18 @@ void Menu::DrawPerfOverlay()
 	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4.0f, 1.0f));  // Tighter spacing
 	ImGui::SetWindowFontScale(perfOverlayState.textScale);
 
-	if (perfOverlayState.frequency.QuadPart == 0) {
-		QueryPerformanceFrequency(&perfOverlayState.frequency);
-		QueryPerformanceCounter(&perfOverlayState.lastFrameCounter);
+	if (perfOverlayState.frequency == 0) {
+		LARGE_INTEGER temp;
+		QueryPerformanceFrequency(&temp);
+		perfOverlayState.frequency = temp.QuadPart;
+		QueryPerformanceCounter(&temp);
+		perfOverlayState.lastFrameCounter = temp.QuadPart;
 	}
 
-	QueryPerformanceCounter(&perfOverlayState.currentFrameCounter);
-	LONGLONG elapsedCounter = perfOverlayState.currentFrameCounter.QuadPart - perfOverlayState.lastFrameCounter.QuadPart;
+	LARGE_INTEGER temp;
+	QueryPerformanceCounter(&temp);
+	perfOverlayState.currentFrameCounter = temp.QuadPart;
+	int64_t elapsedCounter = perfOverlayState.currentFrameCounter - perfOverlayState.lastFrameCounter;
 	perfOverlayState.lastFrameCounter = perfOverlayState.currentFrameCounter;
 
 	// Get frametime and fps
@@ -1454,7 +1459,7 @@ void Menu::PerfOverlayState::UpdateFGFrameTime(Settings::PerfOverlaySettings& se
         postFGFps = 1000.0f / postFGFrameTimeMs;
 
         // Update post-FG smooth values when timer elapses
-        if (updateTimer == 0.0f) {
+        if (updateTimer <= 0.0f) {
             postFGSmoothFps = postFGFps;
             postFGSmoothFrameTimeMs = postFGFrameTimeMs;
         }
@@ -1468,7 +1473,7 @@ void Menu::PerfOverlayState::UpdateFGFrameTime(Settings::PerfOverlaySettings& se
         postFGFps = fps * 2.0f;                  // Approximate
 
         // Update smooth values when timer elapses
-        if (updateTimer == 0.0f) {
+        if (updateTimer <= 0.0f) {
             postFGSmoothFps = postFGFps;
             postFGSmoothFrameTimeMs = postFGFrameTimeMs;
         }

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1234,7 +1234,13 @@ void Menu::DrawPerfOverlay()
 	}
 
 	// Set window size based on whether graphs are shown, was rapidly changing size based on text
-	perfOverlayState.hasGraphs = settings.PerfOverlay.ShowPreFGFrameTimeGraph || settings.PerfOverlay.ShowPostFGFrameTimeGraph;
+	perfOverlayState.hasGraphs = 
+		(settings.PerfOverlay.ShowPreFGFrameTimeGraph && 
+			(!perfOverlayState.isFrameGenerationActive || 
+			(perfOverlayState.isFrameGenerationActive && settings.PerfOverlay.ShowPreFGFPS))) || 
+		(settings.PerfOverlay.ShowPostFGFrameTimeGraph && 
+			perfOverlayState.isFrameGenerationActive && 
+			settings.PerfOverlay.ShowPostFGFPS);
 	if (!perfOverlayState.hasGraphs) {
 		float fixedWidth = 325.0f * perfOverlayState.textScale;
 		ImGui::SetNextWindowSize(ImVec2(fixedWidth, 0), ImGuiCond_Always);

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1264,50 +1264,47 @@ void Menu::DrawPerfOverlay()
 	ImGui::SetWindowFontScale(perfOverlayState.textScale);
 
 	// Initialize Performance Counter if necessary
-	if (perfOverlayState.frequency == 0) {
-		LARGE_INTEGER temp;  // LARGE_INTEGER is required for called QueryPerformanceCounter
-		QueryPerformanceFrequency(&temp);
-		perfOverlayState.frequency = temp.QuadPart;
-		QueryPerformanceCounter(&temp);
-		perfOverlayState.lastFrameCounter = temp.QuadPart;
+	if (!perfOverlayState.initialized) {
+		REX::W32::QueryPerformanceFrequency(&perfOverlayState.frequency);
+		REX::W32::QueryPerformanceCounter(&perfOverlayState.lastFrameCounter);
+		perfOverlayState.initialized = true;
 	}
+	else {
+		REX::W32::QueryPerformanceCounter(&perfOverlayState.currentFrameCounter);
+		int64_t elapsedCounter = perfOverlayState.currentFrameCounter - perfOverlayState.lastFrameCounter;
+		perfOverlayState.lastFrameCounter = perfOverlayState.currentFrameCounter;
 
-	LARGE_INTEGER temp;
-	QueryPerformanceCounter(&temp);
-	perfOverlayState.currentFrameCounter = temp.QuadPart;
-	int64_t elapsedCounter = perfOverlayState.currentFrameCounter - perfOverlayState.lastFrameCounter;
-	perfOverlayState.lastFrameCounter = perfOverlayState.currentFrameCounter;
+		// Calculate frametime and fps
+		perfOverlayState.frameTimeMs = Util::performanceOverlay.CalcFrameTime(elapsedCounter, perfOverlayState.frequency);
+		perfOverlayState.fps = Util::performanceOverlay.CalcFPS(perfOverlayState.frameTimeMs);
 
-	// Calculate frametime and fps
-	perfOverlayState.frameTimeMs = Util::performanceOverlay.CalcFrameTime(elapsedCounter, perfOverlayState.frequency);
-	perfOverlayState.fps = Util::performanceOverlay.CalcFPS(perfOverlayState.frameTimeMs);
+		// Calculate smooth values for display using the user-defined update interval
+		auto now = std::chrono::steady_clock::now();
+		float deltaTime = std::chrono::duration<float>(now - perfOverlayState.lastUpdateTime).count();
+		perfOverlayState.lastUpdateTime = now;
 
-	// Calculate smooth values for display using the user-defined update interval
-	auto now = std::chrono::steady_clock::now();
-	float deltaTime = std::chrono::duration<float>(now - perfOverlayState.lastUpdateTime).count();
-	perfOverlayState.lastUpdateTime = now;
+		// Update graph values
+		perfOverlayState.UpdateGraphValues(settings.PerfOverlay);
 
-	// Update graph values
-	perfOverlayState.UpdateGraphValues(settings.PerfOverlay);
+		// Update smooth values with user-specified interval
+		perfOverlayState.updateTimer += deltaTime;
+		if (perfOverlayState.updateTimer >= settings.PerfOverlay.UpdateInterval) {
+			perfOverlayState.smoothFps = perfOverlayState.fps;
+			perfOverlayState.smoothFrameTimeMs = perfOverlayState.frameTimeMs;
+			perfOverlayState.updateTimer = 0.0f;
+		}
 
-	// Update smooth values with user-specified interval
-	perfOverlayState.updateTimer += deltaTime;
-	if (perfOverlayState.updateTimer >= settings.PerfOverlay.UpdateInterval) {
-		perfOverlayState.smoothFps = perfOverlayState.fps;
-		perfOverlayState.smoothFrameTimeMs = perfOverlayState.frameTimeMs;
-		perfOverlayState.updateTimer = 0.0f;
-	}
+		// Check if Frame Generation is active
+		perfOverlayState.isFrameGenerationActive = globals::upscaling && globals::upscaling->IsFrameGenerationActive();
 
-	// Check if Frame Generation is active
-	perfOverlayState.isFrameGenerationActive = globals::upscaling && globals::upscaling->IsFrameGenerationActive();
+		if (perfOverlayState.isFrameGenerationActive) {
+			perfOverlayState.UpdateFGFrameTime(settings.PerfOverlay);
+		}
 
-	if (perfOverlayState.isFrameGenerationActive) {
-		perfOverlayState.UpdateFGFrameTime(settings.PerfOverlay);
-	}
-
-	// Show FPS counter if enabled
-	if (settings.PerfOverlay.ShowFPS) {
-		perfOverlayState.DrawFPS(settings.PerfOverlay);
+		// Show FPS counter if enabled
+		if (settings.PerfOverlay.ShowFPS) {
+			perfOverlayState.DrawFPS(settings.PerfOverlay);
+		}
 	}
 
 	// Show Draw Calls if enabled
@@ -1445,8 +1442,6 @@ void Menu::PerfOverlayState::UpdateMaxFrameTime()
  */
 void Menu::PerfOverlayState::UpdateFGFrameTime(Settings::PerfOverlaySettings& settings)
 {
-    float postFGFrameTimeMs = 0.0f;
-    float postFGFps = 0.0f;
     // Get frametime directly from the Frame Generation system
     float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
     if (fgDeltaTime > 0.0f) {

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1259,7 +1259,7 @@ void Menu::DrawPerfOverlay()
 
 	// Initialize Performance Counter if necessary
 	if (perfOverlayState.frequency == 0) {
-		LARGE_INTEGER temp; // LARGE_INTEGER is required for called QueryPerformanceCounter
+		LARGE_INTEGER temp;  // LARGE_INTEGER is required for called QueryPerformanceCounter
 		QueryPerformanceFrequency(&temp);
 		perfOverlayState.frequency = temp.QuadPart;
 		QueryPerformanceCounter(&temp);

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -603,9 +603,9 @@ void Menu::DrawGeneralSettings()
 			}
 
 			bool useDiskCache = shaderCache->IsDiskCache();
-			
+
 			ImGui::TableNextColumn();
-			
+
 			if (ImGui::Checkbox("Enable Disk Cache", &useDiskCache)) {
 				shaderCache->SetDiskCache(useDiskCache);
 			}
@@ -614,7 +614,7 @@ void Menu::DrawGeneralSettings()
 			}
 
 			bool useAsync = shaderCache->IsAsync();
-			
+
 			ImGui::TableNextColumn();
 
 			if (ImGui::Checkbox("Enable Async", &useAsync)) {
@@ -1190,12 +1190,12 @@ void Menu::DrawPerfOverlay()
 	}
 
 	// Set window size based on whether graphs are shown, was rapidly changing size based on text
-	perfOverlayState.hasGraphs = 
-		(settings.PerfOverlay.ShowPreFGFrameTimeGraph && 
-			(!perfOverlayState.isFrameGenerationActive || 
-			(perfOverlayState.isFrameGenerationActive && settings.PerfOverlay.ShowPreFGFPS))) || 
-		(settings.PerfOverlay.ShowPostFGFrameTimeGraph && 
-			perfOverlayState.isFrameGenerationActive && 
+	perfOverlayState.hasGraphs =
+		(settings.PerfOverlay.ShowPreFGFrameTimeGraph &&
+			(!perfOverlayState.isFrameGenerationActive ||
+				(perfOverlayState.isFrameGenerationActive && settings.PerfOverlay.ShowPreFGFPS))) ||
+		(settings.PerfOverlay.ShowPostFGFrameTimeGraph &&
+			perfOverlayState.isFrameGenerationActive &&
 			settings.PerfOverlay.ShowPostFGFPS);
 	if (!perfOverlayState.hasGraphs) {
 		float fixedWidth = 325.0f * perfOverlayState.textScale;
@@ -1224,8 +1224,7 @@ void Menu::DrawPerfOverlay()
 		REX::W32::QueryPerformanceFrequency(&perfOverlayState.frequency);
 		REX::W32::QueryPerformanceCounter(&perfOverlayState.lastFrameCounter);
 		perfOverlayState.initialized = true;
-	}
-	else {
+	} else {
 		REX::W32::QueryPerformanceCounter(&perfOverlayState.currentFrameCounter);
 		int64_t elapsedCounter = perfOverlayState.currentFrameCounter - perfOverlayState.lastFrameCounter;
 		perfOverlayState.lastFrameCounter = perfOverlayState.currentFrameCounter;
@@ -1269,8 +1268,7 @@ void Menu::DrawPerfOverlay()
 	}
 
 	// VRAM & GPU Usage
-	if (settings.PerfOverlay.ShowVRAM && dxgiAdapter3) 
-	{
+	if (settings.PerfOverlay.ShowVRAM && dxgiAdapter3) {
 		perfOverlayState.DrawVRAM(dxgiAdapter3);
 	}
 
@@ -1285,12 +1283,12 @@ void Menu::DrawPerfOverlay()
 float Menu::PerfOverlayState::SetTextScale(Settings::PerfOverlaySettings& settings)
 {
 	switch (settings.Size) {
-		case Settings::PerfOverlaySettings::TextSize::Small:
-			return 0.8f;
-		case Settings::PerfOverlaySettings::TextSize::Medium:
-			return 1.0f;
-		case Settings::PerfOverlaySettings::TextSize::Large:
-			return 1.2f;
+	case Settings::PerfOverlaySettings::TextSize::Small:
+		return 0.8f;
+	case Settings::PerfOverlaySettings::TextSize::Medium:
+		return 1.0f;
+	case Settings::PerfOverlaySettings::TextSize::Large:
+		return 1.2f;
 	}
 	return 1.0f;
 }
@@ -1300,7 +1298,7 @@ float Menu::PerfOverlayState::SetTextScale(Settings::PerfOverlaySettings& settin
  *
  * This function synchronizes the frame time history buffer, tracks min/max frame times,
  * and computes the normalized Y-axis range for the frame time graph using statistical analysis.
- * 
+ *
  * Steps performed:
  *   1. Resizes the frame time history buffer if the user has changed the setting.
  *   2. Inserts the latest frame time into the circular history buffer.
@@ -1315,55 +1313,55 @@ float Menu::PerfOverlayState::SetTextScale(Settings::PerfOverlaySettings& settin
  */
 void Menu::PerfOverlayState::UpdateGraphValues(Settings::PerfOverlaySettings& settings)
 {
-    // Sync frame history buffer size with user settings
-    UpdateFrameTimeHistorySizes(settings);
+	// Sync frame history buffer size with user settings
+	UpdateFrameTimeHistorySizes(settings);
 
-    // Insert latest frame time into circular buffer
-    float oldFrameTime = frameTimeHistory[frameTimeHistoryIndex];
-    frameTimeHistory[frameTimeHistoryIndex] = frameTimeMs;
-    frameTimeHistoryIndex = (frameTimeHistoryIndex + 1) % settings.FrameHistorySize;
+	// Insert latest frame time into circular buffer
+	float oldFrameTime = frameTimeHistory[frameTimeHistoryIndex];
+	frameTimeHistory[frameTimeHistoryIndex] = frameTimeMs;
+	frameTimeHistoryIndex = (frameTimeHistoryIndex + 1) % settings.FrameHistorySize;
 
-    // Maintain instantaneous min/max tracking
-    if (frameTimeMs > maxFrameTime) {
-        maxFrameTime = frameTimeMs;
-    } else if (frameTimeMs < minFrameTime) {
-        minFrameTime = frameTimeMs;
-    } else if (oldFrameTime == minFrameTime) {
-        UpdateMinFrameTime();
-    } else if (oldFrameTime == maxFrameTime) {
-        UpdateMaxFrameTime();
-    }
+	// Maintain instantaneous min/max tracking
+	if (frameTimeMs > maxFrameTime) {
+		maxFrameTime = frameTimeMs;
+	} else if (frameTimeMs < minFrameTime) {
+		minFrameTime = frameTimeMs;
+	} else if (oldFrameTime == minFrameTime) {
+		UpdateMinFrameTime();
+	} else if (oldFrameTime == maxFrameTime) {
+		UpdateMaxFrameTime();
+	}
 
-	float avgFrameTime, stdDev, graphMin, graphMax; 
-    // Calculate mean and standard deviation for normalized graph range
-    if (frameTimeHistory.empty()) {
-        // Default to 60 FPS
-        avgFrameTime = 16.67f;
-        stdDev = 0.0f;
-        graphMin = 0.0f;
-        graphMax = 33.0f;
-    } else {
-        // Calculate average frame time
-        avgFrameTime = std::accumulate(frameTimeHistory.begin(), frameTimeHistory.end(), 0.0f) / frameTimeHistory.size();
+	float avgFrameTime, stdDev, graphMin, graphMax;
+	// Calculate mean and standard deviation for normalized graph range
+	if (frameTimeHistory.empty()) {
+		// Default to 60 FPS
+		avgFrameTime = 16.67f;
+		stdDev = 0.0f;
+		graphMin = 0.0f;
+		graphMax = 33.0f;
+	} else {
+		// Calculate average frame time
+		avgFrameTime = std::accumulate(frameTimeHistory.begin(), frameTimeHistory.end(), 0.0f) / frameTimeHistory.size();
 
-        // Calculate standard deviation
-        float variance = 0.0f;
-        for (float ft : frameTimeHistory) {
-            float diff = ft - avgFrameTime;
-            variance += diff * diff;
-        }
-        variance /= frameTimeHistory.size();
-        stdDev = std::sqrt(variance);
+		// Calculate standard deviation
+		float variance = 0.0f;
+		for (float ft : frameTimeHistory) {
+			float diff = ft - avgFrameTime;
+			variance += diff * diff;
+		}
+		variance /= frameTimeHistory.size();
+		stdDev = std::sqrt(variance);
 
-        // Calculate graph range
-        float spread = std::clamp(stdDev * 2.0f, 2.0f, 20.0f);
-        graphMin = std::max(0.0f, avgFrameTime - spread);
-        graphMax = avgFrameTime + spread;
-    }
+		// Calculate graph range
+		float spread = std::clamp(stdDev * 2.0f, 2.0f, 20.0f);
+		graphMin = std::max(0.0f, avgFrameTime - spread);
+		graphMax = avgFrameTime + spread;
+	}
 
-    // Exponential smoothing for stable graph scaling
-    smoothedMinFrameTime += kSmoothingFactor * (graphMin - smoothedMinFrameTime);
-    smoothedMaxFrameTime += kSmoothingFactor * (graphMax - smoothedMaxFrameTime);
+	// Exponential smoothing for stable graph scaling
+	smoothedMinFrameTime += kSmoothingFactor * (graphMin - smoothedMinFrameTime);
+	smoothedMaxFrameTime += kSmoothingFactor * (graphMax - smoothedMaxFrameTime);
 }
 
 /**
@@ -1374,7 +1372,7 @@ void Menu::PerfOverlayState::UpdateGraphValues(Settings::PerfOverlaySettings& se
  */
 void Menu::PerfOverlayState::UpdateMinFrameTime()
 {
-    minFrameTime = *std::min_element(frameTimeHistory.begin(), frameTimeHistory.end());
+	minFrameTime = *std::min_element(frameTimeHistory.begin(), frameTimeHistory.end());
 }
 
 /**
@@ -1385,7 +1383,7 @@ void Menu::PerfOverlayState::UpdateMinFrameTime()
  */
 void Menu::PerfOverlayState::UpdateMaxFrameTime()
 {
-    maxFrameTime = *std::max_element(frameTimeHistory.begin(), frameTimeHistory.end());
+	maxFrameTime = *std::max_element(frameTimeHistory.begin(), frameTimeHistory.end());
 }
 
 /**
@@ -1398,11 +1396,11 @@ void Menu::PerfOverlayState::UpdateMaxFrameTime()
  */
 void Menu::PerfOverlayState::UpdateFGFrameTime(Settings::PerfOverlaySettings& settings)
 {
-    // Get frametime directly from the Frame Generation system
-    float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
-    if (fgDeltaTime > 0.0f) {
-        postFGFrameTimeMs = fgDeltaTime * 1000.0f;
-        postFGFps = 1000.0f / postFGFrameTimeMs;
+	// Get frametime directly from the Frame Generation system
+	float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
+	if (fgDeltaTime > 0.0f) {
+		postFGFrameTimeMs = fgDeltaTime * 1000.0f;
+		postFGFps = 1000.0f / postFGFrameTimeMs;
 
 		// Update post-FG smooth values when timer elapses
 		if (updateTimer <= 0.0f) {
@@ -1410,13 +1408,13 @@ void Menu::PerfOverlayState::UpdateFGFrameTime(Settings::PerfOverlaySettings& se
 			postFGSmoothFrameTimeMs = postFGFrameTimeMs;
 		}
 
-        // Update post-FG frametime history
-        postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
-        postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % settings.FrameHistorySize;
-    } else {
-        // Fallback if FG time is not available
-        postFGFrameTimeMs = frameTimeMs / 2.0f;  // Approximate
-        postFGFps = fps * 2.0f;                  // Approximate
+		// Update post-FG frametime history
+		postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
+		postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % settings.FrameHistorySize;
+	} else {
+		// Fallback if FG time is not available
+		postFGFrameTimeMs = frameTimeMs / 2.0f;  // Approximate
+		postFGFps = fps * 2.0f;                  // Approximate
 
 		// Update smooth values when timer elapses
 		if (updateTimer <= 0.0f) {
@@ -1424,10 +1422,10 @@ void Menu::PerfOverlayState::UpdateFGFrameTime(Settings::PerfOverlaySettings& se
 			postFGSmoothFrameTimeMs = postFGFrameTimeMs;
 		}
 
-        // Update post-FG frametime history with approximation
-        postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
-        postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % settings.FrameHistorySize;
-    }
+		// Update post-FG frametime history with approximation
+		postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
+		postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % settings.FrameHistorySize;
+	}
 }
 
 /**
@@ -1440,76 +1438,74 @@ void Menu::PerfOverlayState::UpdateFGFrameTime(Settings::PerfOverlaySettings& se
  */
 void Menu::PerfOverlayState::DrawFPS(Settings::PerfOverlaySettings& settings)
 {
-    if (isFrameGenerationActive) {
-        if (settings.ShowPostFGFPS) {
-            ImGui::Text("FPS: %.1f", postFGSmoothFps);
-        }
+	if (isFrameGenerationActive) {
+		if (settings.ShowPostFGFPS) {
+			ImGui::Text("FPS: %.1f", postFGSmoothFps);
+		}
 
-        if (settings.ShowPreFGFPS) {
-            ImGui::Text("Pre-FG FPS: %.1f", smoothFps);
-        }
-    } else {
-        ImGui::Text("FPS: %.1f", smoothFps);
-    }
+		if (settings.ShowPreFGFPS) {
+			ImGui::Text("Pre-FG FPS: %.1f", smoothFps);
+		}
+	} else {
+		ImGui::Text("FPS: %.1f", smoothFps);
+	}
 
-    if (isFrameGenerationActive) {
-        if (settings.ShowPostFGFPS && settings.ShowPostFGFrameTime) {
-            ImGui::Text("Frametime: %.2f ms", postFGSmoothFrameTimeMs);
-        }
-        if (settings.ShowPreFGFPS && settings.ShowPreFGFrameTime) {
-            ImGui::Text("Pre-FG Frametime: %.2f ms", smoothFrameTimeMs);
-        }
-    } else {
-        if (settings.ShowPreFGFrameTime) {
-            ImGui::Text("Frametime: %.2f ms", smoothFrameTimeMs);
-        }
-    }
+	if (isFrameGenerationActive) {
+		if (settings.ShowPostFGFPS && settings.ShowPostFGFrameTime) {
+			ImGui::Text("Frametime: %.2f ms", postFGSmoothFrameTimeMs);
+		}
+		if (settings.ShowPreFGFPS && settings.ShowPreFGFrameTime) {
+			ImGui::Text("Pre-FG Frametime: %.2f ms", smoothFrameTimeMs);
+		}
+	} else {
+		if (settings.ShowPreFGFrameTime) {
+			ImGui::Text("Frametime: %.2f ms", smoothFrameTimeMs);
+		}
+	}
 
-    // Show Pre-FG frametime graph if enabled
-    if (settings.ShowPreFGFrameTimeGraph &&
-        (!isFrameGenerationActive || (isFrameGenerationActive && settings.ShowPreFGFPS))) 
-    {
-        // Prepare overlay text
-        char overlay_text[128];
-        snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
-            "%s%.2f ms (%.1f FPS)",
-            isFrameGenerationActive ? "Pre-FG: " : "",
-            smoothFrameTimeMs, smoothFps);
+	// Show Pre-FG frametime graph if enabled
+	if (settings.ShowPreFGFrameTimeGraph &&
+		(!isFrameGenerationActive || (isFrameGenerationActive && settings.ShowPreFGFPS))) {
+		// Prepare overlay text
+		char overlay_text[128];
+		snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
+			"%s%.2f ms (%.1f FPS)",
+			isFrameGenerationActive ? "Pre-FG: " : "",
+			smoothFrameTimeMs, smoothFps);
 
-        // Set graph colors
-        ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));  // Green line
+		// Set graph colors
+		ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));  // Green line
 
-        // Draw the graph
-        ImGui::PlotLines("##frametime",
-            frameTimeHistory.data(),
-            settings.FrameHistorySize,
-            frameTimeHistoryIndex,
-            overlay_text,
-            smoothedMinFrameTime, smoothedMaxFrameTime,
-            ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
+		// Draw the graph
+		ImGui::PlotLines("##frametime",
+			frameTimeHistory.data(),
+			settings.FrameHistorySize,
+			frameTimeHistoryIndex,
+			overlay_text,
+			smoothedMinFrameTime, smoothedMaxFrameTime,
+			ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
 
-        ImGui::PopStyleColor();
+		ImGui::PopStyleColor();
 
-        // Draw frametime target reference lines
-        if (ImGui::BeginTable("FrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
-            ImGui::TableNextColumn();
-            ImGui::Text("30 FPS: 33.3 ms");
+		// Draw frametime target reference lines
+		if (ImGui::BeginTable("FrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
+			ImGui::TableNextColumn();
+			ImGui::Text("30 FPS: 33.3 ms");
 
-            ImGui::TableNextColumn();
-            ImGui::Text("60 FPS: 16.7 ms");
+			ImGui::TableNextColumn();
+			ImGui::Text("60 FPS: 16.7 ms");
 
-            ImGui::TableNextColumn();
-            ImGui::Text("120 FPS: 8.3 ms");
+			ImGui::TableNextColumn();
+			ImGui::Text("120 FPS: 8.3 ms");
 
-            ImGui::EndTable();
-        }
-    }
+			ImGui::EndTable();
+		}
+	}
 
-    // Show Post-FG frametime graph if enabled
-    if (settings.ShowPostFGFrameTimeGraph && isFrameGenerationActive && settings.ShowPostFGFPS) 
-    {
-        DrawPostFGFrameTimeGraph(settings);
-    }
+	// Show Post-FG frametime graph if enabled
+	if (settings.ShowPostFGFrameTimeGraph && isFrameGenerationActive && settings.ShowPostFGFPS) {
+		DrawPostFGFrameTimeGraph(settings);
+	}
 }
 
 /**
@@ -1522,39 +1518,39 @@ void Menu::PerfOverlayState::DrawFPS(Settings::PerfOverlaySettings& settings)
  */
 void Menu::PerfOverlayState::DrawPostFGFrameTimeGraph(Settings::PerfOverlaySettings& settings)
 {
-    // Prepare overlay text
-    char overlay_text[128];
-    snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
-        "Post-FG: %.2f ms (%.1f FPS)",
-        postFGSmoothFrameTimeMs, postFGSmoothFps);
+	// Prepare overlay text
+	char overlay_text[128];
+	snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
+		"Post-FG: %.2f ms (%.1f FPS)",
+		postFGSmoothFrameTimeMs, postFGSmoothFps);
 
-    // Set graph colors - blue for post-FG
-    ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
+	// Set graph colors - blue for post-FG
+	ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
 
-    // Draw the graph
-    ImGui::PlotLines("##postfgframetime",
-        postFGFrameTimeHistory.data(),
-        settings.FrameHistorySize,
-        postFGFrameTimeHistoryIndex,
-        overlay_text,
-        smoothedMinFrameTime, smoothedMaxFrameTime,
-        ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
+	// Draw the graph
+	ImGui::PlotLines("##postfgframetime",
+		postFGFrameTimeHistory.data(),
+		settings.FrameHistorySize,
+		postFGFrameTimeHistoryIndex,
+		overlay_text,
+		smoothedMinFrameTime, smoothedMaxFrameTime,
+		ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
 
-    ImGui::PopStyleColor();
+	ImGui::PopStyleColor();
 
-    // Draw frametime target reference lines
-    if (ImGui::BeginTable("PostFGFrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
-        ImGui::TableNextColumn();
-        ImGui::Text("30 FPS: 33.3 ms");
+	// Draw frametime target reference lines
+	if (ImGui::BeginTable("PostFGFrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
+		ImGui::TableNextColumn();
+		ImGui::Text("30 FPS: 33.3 ms");
 
-        ImGui::TableNextColumn();
-        ImGui::Text("60 FPS: 16.7 ms");
+		ImGui::TableNextColumn();
+		ImGui::Text("60 FPS: 16.7 ms");
 
-        ImGui::TableNextColumn();
-        ImGui::Text("120 FPS: 8.3 ms");
+		ImGui::TableNextColumn();
+		ImGui::Text("120 FPS: 8.3 ms");
 
-        ImGui::EndTable();
-    }
+		ImGui::EndTable();
+	}
 }
 
 /**
@@ -1565,18 +1561,18 @@ void Menu::PerfOverlayState::DrawPostFGFrameTimeGraph(Settings::PerfOverlaySetti
  */
 void Menu::PerfOverlayState::DrawDrawCalls()
 {
-    ImGui::Text("Draw Calls:");
-    ImGui::Indent();
-    ImGui::Text("Grass: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Grass]));
-    ImGui::Text("Sky: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Sky]));
-    ImGui::Text("Water: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Water]));
-    ImGui::Text("Lighting: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Lighting]));
-    ImGui::Text("Effect: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Effect]));
-    ImGui::Text("Utility: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Utility]));
-    ImGui::Text("Distant Tree: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::DistantTree]));
-    ImGui::Text("Particle: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Particle]));
-    ImGui::Text("Total: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Total]));
-    ImGui::Unindent();
+	ImGui::Text("Draw Calls:");
+	ImGui::Indent();
+	ImGui::Text("Grass: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Grass]));
+	ImGui::Text("Sky: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Sky]));
+	ImGui::Text("Water: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Water]));
+	ImGui::Text("Lighting: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Lighting]));
+	ImGui::Text("Effect: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Effect]));
+	ImGui::Text("Utility: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Utility]));
+	ImGui::Text("Distant Tree: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::DistantTree]));
+	ImGui::Text("Particle: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Particle]));
+	ImGui::Text("Total: %d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Total]));
+	ImGui::Unindent();
 }
 
 /**
@@ -1589,37 +1585,37 @@ void Menu::PerfOverlayState::DrawDrawCalls()
  */
 void Menu::PerfOverlayState::DrawVRAM(winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3)
 {
-    DXGI_QUERY_VIDEO_MEMORY_INFO videoMemoryInfo{};
-    HRESULT hr = dxgiAdapter3->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &videoMemoryInfo);
+	DXGI_QUERY_VIDEO_MEMORY_INFO videoMemoryInfo{};
+	HRESULT hr = dxgiAdapter3->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &videoMemoryInfo);
 
-    // Only proceed if the call succeeded and Budget is not zero
-    if (SUCCEEDED(hr) && videoMemoryInfo.Budget > 0) {
-        float currentGpuUsage = videoMemoryInfo.CurrentUsage / (1024.f * 1024.f * 1024.f);
-        float totalGpuMemory = videoMemoryInfo.Budget / (1024.f * 1024.f * 1024.f);
-        float percent = currentGpuUsage / totalGpuMemory;
+	// Only proceed if the call succeeded and Budget is not zero
+	if (SUCCEEDED(hr) && videoMemoryInfo.Budget > 0) {
+		float currentGpuUsage = videoMemoryInfo.CurrentUsage / (1024.f * 1024.f * 1024.f);
+		float totalGpuMemory = videoMemoryInfo.Budget / (1024.f * 1024.f * 1024.f);
+		float percent = currentGpuUsage / totalGpuMemory;
 
-        // Center the VRAM text
-        ImGui::Text("VRAM Usage:");
+		// Center the VRAM text
+		ImGui::Text("VRAM Usage:");
 
-        // Use a centered text format for the numeric values
-        std::string vramText = std::format("{:.2f}GB/{:.2f}GB ({:.1f}%)", currentGpuUsage, totalGpuMemory, 100 * percent);
-        float textWidth = ImGui::CalcTextSize(vramText.c_str()).x;
-        float windowWidth = ImGui::GetWindowWidth();
+		// Use a centered text format for the numeric values
+		std::string vramText = std::format("{:.2f}GB/{:.2f}GB ({:.1f}%)", currentGpuUsage, totalGpuMemory, 100 * percent);
+		float textWidth = ImGui::CalcTextSize(vramText.c_str()).x;
+		float windowWidth = ImGui::GetWindowWidth();
 
-        // Center the text if it fits within the window
-        if (textWidth < windowWidth) {
-            ImGui::SetCursorPosX((windowWidth - textWidth) * 0.5f);
-            ImGui::Text("%s", vramText.c_str());
-        } else {
-            ImGui::Text("%s", vramText.c_str());
-        }
+		// Center the text if it fits within the window
+		if (textWidth < windowWidth) {
+			ImGui::SetCursorPosX((windowWidth - textWidth) * 0.5f);
+			ImGui::Text("%s", vramText.c_str());
+		} else {
+			ImGui::Text("%s", vramText.c_str());
+		}
 
-        // Only move the progress bar, not the text
-        ImGui::ProgressBar(percent, ImVec2(ImGui::GetWindowWidth() * 0.9f, 0.0f), "");
-    } else {
-        // Display a fallback message if we couldn't get the VRAM info
-        ImGui::Text("VRAM Usage: Not available");
-    }
+		// Only move the progress bar, not the text
+		ImGui::ProgressBar(percent, ImVec2(ImGui::GetWindowWidth() * 0.9f, 0.0f), "");
+	} else {
+		// Display a fallback message if we couldn't get the VRAM info
+		ImGui::Text("VRAM Usage: Not available");
+	}
 }
 
 /**
@@ -1632,15 +1628,14 @@ void Menu::PerfOverlayState::DrawVRAM(winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3
  */
 void Menu::PerfOverlayState::UpdateFrameTimeHistorySizes(Settings::PerfOverlaySettings& settings)
 {
-    settings.FrameHistorySize = std::clamp(
-        settings.FrameHistorySize,
-        settings.kMinFrameHistorySize,
-        settings.kMaxFrameHistorySize
-    );
-	
+	settings.FrameHistorySize = std::clamp(
+		settings.FrameHistorySize,
+		settings.kMinFrameHistorySize,
+		settings.kMaxFrameHistorySize);
+
 	if (frameTimeHistory.size() != static_cast<size_t>(settings.FrameHistorySize)) {
 		frameTimeHistory.resize(settings.FrameHistorySize, 0.0f);
-		if (frameTimeHistoryIndex >= settings.FrameHistorySize) { // Reset index if it's out of new bounds
+		if (frameTimeHistoryIndex >= settings.FrameHistorySize) {  // Reset index if it's out of new bounds
 			frameTimeHistoryIndex = 0;
 		}
 	}
@@ -1762,8 +1757,9 @@ void Menu::DrawPerformanceOverlaySettings()
 			// Frame history size slider
 			ImGui::SliderInt("Frame History Size", &settings.PerfOverlay.FrameHistorySize, Settings::PerfOverlaySettings::kMinFrameHistorySize, Settings::PerfOverlaySettings::kMaxFrameHistorySize);
 			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text("Number of frames to keep in history for graphing.\n"
-							"E.g. 60 frames = 1 second @ 60fps.");
+				ImGui::Text(
+					"Number of frames to keep in history for graphing.\n"
+					"E.g. 60 frames = 1 second @ 60fps.");
 			}
 
 			// Position options - moved inside appearance section

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -159,6 +159,9 @@ public:
 			bool ShowPostFGFrameTime = true;
 			bool ShowPostFGFrameTimeGraph = true;
 			float UpdateInterval = 0.5f;
+			int FrameHistorySize = 120; // Default 120 frames = 2s @ 60fps. Clamped using static values to prevent config file values going outside of slider bounds.
+			static constexpr int kMinFrameHistorySize = 60;	// 60 frames = 1s @ 60fps. Reasonable minimum.
+			static constexpr int kMaxFrameHistorySize = 480; // 480 frames = 10s @ 60fps or 2s @ 240fps. Reasonable maximum.
 			enum class TextSize
 			{
 				Small,
@@ -188,6 +191,43 @@ private:
 	uint32_t testInterval = 0;     // Seconds to wait before toggling user/test settings
 	bool inTestMode = false;       // Whether we're in test mode
 	bool usingTestConfig = false;  // Whether we're using the test config
+
+	class PerfOverlayState {
+		public:
+			std::vector<float> frameTimeHistory;
+			std::vector<float> postFGFrameTimeHistory;
+			bool hasGraphs = false;
+			int frameTimeHistoryIndex = 0;
+			int postFGFrameTimeHistoryIndex = 0;
+			bool isFrameGenerationActive = false;
+			LARGE_INTEGER frequency;
+			LARGE_INTEGER lastFrameCounter;
+			LARGE_INTEGER currentFrameCounter;
+			float frameTimeMs = 0.0f;
+			float fps = 0.0f;
+			float smoothFps = 0.0f;
+			float smoothFrameTimeMs = 0.0f;
+			float postFGSmoothFps = 0.0f;
+			float postFGSmoothFrameTimeMs = 0.0f;
+			float updateTimer = 0.0f;
+			float minFrameTime = 1000.0f;
+			float maxFrameTime = 0.0f;
+			float smoothedMinFrameTime = 0.0f;
+			float smoothedMaxFrameTime = 50.0f;
+			float textScale = 1.0f;
+			float kSmoothingFactor = 0.15f; // Smoothing factor: 0.1f = slow, 0.3f = fast.
+			std::chrono::steady_clock::time_point lastUpdateTime;
+			void UpdateGraphValues(Settings::PerfOverlaySettings& settings);
+			void UpdateFrameTimeHistorySizes(Settings::PerfOverlaySettings& settings);
+			void UpdateMinFrameTime();
+			void UpdateMaxFrameTime();
+			void UpdateFGFrameTime(Settings::PerfOverlaySettings& settings);
+			void DrawPostFGFrameTimeGraph(Settings::PerfOverlaySettings& settings);
+			float SetTextScale(Settings::PerfOverlaySettings& settings);
+			void DrawDrawCalls();
+			void DrawFPS(Settings::PerfOverlaySettings& settings);
+			void DrawVRAM(winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3);
+	} perfOverlayState;
 
 	std::chrono::steady_clock::time_point lastTestSwitch = high_resolution_clock::now();  // Time of last test switch
 

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -200,9 +200,9 @@ private:
 			int frameTimeHistoryIndex = 0;
 			int postFGFrameTimeHistoryIndex = 0;
 			bool isFrameGenerationActive = false;
-			LARGE_INTEGER frequency;
-			LARGE_INTEGER lastFrameCounter;
-			LARGE_INTEGER currentFrameCounter;
+			uint64_t frequency;
+			uint64_t lastFrameCounter;
+			uint64_t currentFrameCounter;
 			float frameTimeMs = 0.0f;
 			float fps = 0.0f;
 			float smoothFps = 0.0f;
@@ -215,15 +215,15 @@ private:
 			float smoothedMinFrameTime = 0.0f;
 			float smoothedMaxFrameTime = 50.0f;
 			float textScale = 1.0f;
-			float kSmoothingFactor = 0.15f; // Smoothing factor: 0.1f = slow, 0.3f = fast.
+			static constexpr float kSmoothingFactor = 0.15f; // Smoothing factor: 0.1f = slow, 0.3f = fast.
 			std::chrono::steady_clock::time_point lastUpdateTime;
+			float SetTextScale(Settings::PerfOverlaySettings& settings);
 			void UpdateGraphValues(Settings::PerfOverlaySettings& settings);
 			void UpdateFrameTimeHistorySizes(Settings::PerfOverlaySettings& settings);
 			void UpdateMinFrameTime();
 			void UpdateMaxFrameTime();
 			void UpdateFGFrameTime(Settings::PerfOverlaySettings& settings);
 			void DrawPostFGFrameTimeGraph(Settings::PerfOverlaySettings& settings);
-			float SetTextScale(Settings::PerfOverlaySettings& settings);
 			void DrawDrawCalls();
 			void DrawFPS(Settings::PerfOverlaySettings& settings);
 			void DrawVRAM(winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3);

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -197,15 +197,18 @@ private:
 	public:
 		std::vector<float> frameTimeHistory;
 		std::vector<float> postFGFrameTimeHistory;
+		bool initialized = false;
 		bool hasGraphs = false;
 		int frameTimeHistoryIndex = 0;
 		int postFGFrameTimeHistoryIndex = 0;
 		bool isFrameGenerationActive = false;
-		uint64_t frequency;
-		uint64_t lastFrameCounter;
-		uint64_t currentFrameCounter;
+		int64_t frequency;
+		int64_t lastFrameCounter;
+		int64_t currentFrameCounter;
 		float frameTimeMs = 0.0f;
 		float fps = 0.0f;
+		float postFGFrameTimeMs = 0.0f;
+		float postFGFps = 0.0f;
 		float smoothFps = 0.0f;
 		float smoothFrameTimeMs = 0.0f;
 		float postFGSmoothFps = 0.0f;

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -192,41 +192,42 @@ private:
 	bool inTestMode = false;       // Whether we're in test mode
 	bool usingTestConfig = false;  // Whether we're using the test config
 
-	class PerfOverlayState {
-		public:
-			std::vector<float> frameTimeHistory;
-			std::vector<float> postFGFrameTimeHistory;
-			bool hasGraphs = false;
-			int frameTimeHistoryIndex = 0;
-			int postFGFrameTimeHistoryIndex = 0;
-			bool isFrameGenerationActive = false;
-			uint64_t frequency;
-			uint64_t lastFrameCounter;
-			uint64_t currentFrameCounter;
-			float frameTimeMs = 0.0f;
-			float fps = 0.0f;
-			float smoothFps = 0.0f;
-			float smoothFrameTimeMs = 0.0f;
-			float postFGSmoothFps = 0.0f;
-			float postFGSmoothFrameTimeMs = 0.0f;
-			float updateTimer = 0.0f;
-			float minFrameTime = 1000.0f;
-			float maxFrameTime = 0.0f;
-			float smoothedMinFrameTime = 0.0f;
-			float smoothedMaxFrameTime = 50.0f;
-			float textScale = 1.0f;
-			static constexpr float kSmoothingFactor = 0.15f; // Smoothing factor: 0.1f = slow, 0.3f = fast.
-			std::chrono::steady_clock::time_point lastUpdateTime;
-			float SetTextScale(Settings::PerfOverlaySettings& settings);
-			void UpdateGraphValues(Settings::PerfOverlaySettings& settings);
-			void UpdateFrameTimeHistorySizes(Settings::PerfOverlaySettings& settings);
-			void UpdateMinFrameTime();
-			void UpdateMaxFrameTime();
-			void UpdateFGFrameTime(Settings::PerfOverlaySettings& settings);
-			void DrawPostFGFrameTimeGraph(Settings::PerfOverlaySettings& settings);
-			void DrawDrawCalls();
-			void DrawFPS(Settings::PerfOverlaySettings& settings);
-			void DrawVRAM(winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3);
+	class PerfOverlayState
+	{
+	public:
+		std::vector<float> frameTimeHistory;
+		std::vector<float> postFGFrameTimeHistory;
+		bool hasGraphs = false;
+		int frameTimeHistoryIndex = 0;
+		int postFGFrameTimeHistoryIndex = 0;
+		bool isFrameGenerationActive = false;
+		uint64_t frequency;
+		uint64_t lastFrameCounter;
+		uint64_t currentFrameCounter;
+		float frameTimeMs = 0.0f;
+		float fps = 0.0f;
+		float smoothFps = 0.0f;
+		float smoothFrameTimeMs = 0.0f;
+		float postFGSmoothFps = 0.0f;
+		float postFGSmoothFrameTimeMs = 0.0f;
+		float updateTimer = 0.0f;
+		float minFrameTime = 1000.0f;
+		float maxFrameTime = 0.0f;
+		float smoothedMinFrameTime = 0.0f;
+		float smoothedMaxFrameTime = 50.0f;
+		float textScale = 1.0f;
+		static constexpr float kSmoothingFactor = 0.15f;  // Smoothing factor: 0.1f = slow, 0.3f = fast.
+		std::chrono::steady_clock::time_point lastUpdateTime;
+		float SetTextScale(Settings::PerfOverlaySettings& settings);
+		void UpdateGraphValues(Settings::PerfOverlaySettings& settings);
+		void UpdateFrameTimeHistorySizes(Settings::PerfOverlaySettings& settings);
+		void UpdateMinFrameTime();
+		void UpdateMaxFrameTime();
+		void UpdateFGFrameTime(Settings::PerfOverlaySettings& settings);
+		void DrawPostFGFrameTimeGraph(Settings::PerfOverlaySettings& settings);
+		void DrawDrawCalls();
+		void DrawFPS(Settings::PerfOverlaySettings& settings);
+		void DrawVRAM(winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3);
 	} perfOverlayState;
 
 	std::chrono::steady_clock::time_point lastTestSwitch = high_resolution_clock::now();  // Time of last test switch

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -159,9 +159,9 @@ public:
 			bool ShowPostFGFrameTime = true;
 			bool ShowPostFGFrameTimeGraph = true;
 			float UpdateInterval = 0.5f;
-			int FrameHistorySize = 120; // Default 120 frames = 2s @ 60fps. Clamped using static values to prevent config file values going outside of slider bounds.
-			static constexpr int kMinFrameHistorySize = 60;	// 60 frames = 1s @ 60fps. Reasonable minimum.
-			static constexpr int kMaxFrameHistorySize = 480; // 480 frames = 10s @ 60fps or 2s @ 240fps. Reasonable maximum.
+			int FrameHistorySize = 120;                       // Default 120 frames = 2s @ 60fps. Clamped using static values to prevent config file values going outside of slider bounds.
+			static constexpr int kMinFrameHistorySize = 60;   // 60 frames = 1s @ 60fps. Reasonable minimum.
+			static constexpr int kMaxFrameHistorySize = 480;  // 480 frames = 10s @ 60fps or 2s @ 240fps. Reasonable maximum.
 			enum class TextSize
 			{
 				Small,

--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -2,7 +2,7 @@
 
 namespace Util
 {
-	PerfomanceOverlay performanceOverlay;
+	PerformanceOverlay performanceOverlay;
 
 	HoverTooltipWrapper::HoverTooltipWrapper()
 	{

--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -2,6 +2,8 @@
 
 namespace Util
 {
+	PerfomanceOverlay performanceOverlay;
+
 	HoverTooltipWrapper::HoverTooltipWrapper()
 	{
 		hovered = ImGui::IsItemHovered();

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -39,4 +39,18 @@ namespace Util
 
 	bool PercentageSlider(const char* label, float* data, float lb = 0.f, float ub = 100.f, const char* format = "%.1f %%");
 	ImVec2 GetNativeViewportSizeScaled(float scale);
+
+	class PerfomanceOverlay {
+		public:
+			float CalcFrameTime(LONGLONG timeElapsed, LARGE_INTEGER frequency)
+			{
+				return 1000.0f * (float)timeElapsed / (float)frequency.QuadPart;
+			}
+
+			float CalcFPS(float frameTimeMs)
+			{
+				return 1000.0f / frameTimeMs;
+			}
+	};
+	extern PerfomanceOverlay performanceOverlay;
 }  // namespace Util

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -40,17 +40,17 @@ namespace Util
 	bool PercentageSlider(const char* label, float* data, float lb = 0.f, float ub = 100.f, const char* format = "%.1f %%");
 	ImVec2 GetNativeViewportSizeScaled(float scale);
 
-	class PerfomanceOverlay {
+	class PerformanceOverlay {
 		public:
-			float CalcFrameTime(LONGLONG timeElapsed, LARGE_INTEGER frequency)
+			static float CalcFrameTime(uint64_t timeElapsed, uint64_t frequency)
 			{
-				return 1000.0f * (float)timeElapsed / (float)frequency.QuadPart;
+				return 1000.0f * (float)timeElapsed / (float)frequency;
 			}
 
-			float CalcFPS(float frameTimeMs)
+			static float CalcFPS(float frameTimeMs)
 			{
 				return 1000.0f / frameTimeMs;
 			}
 	};
-	extern PerfomanceOverlay performanceOverlay;
+	extern PerformanceOverlay performanceOverlay;
 }  // namespace Util

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -40,17 +40,18 @@ namespace Util
 	bool PercentageSlider(const char* label, float* data, float lb = 0.f, float ub = 100.f, const char* format = "%.1f %%");
 	ImVec2 GetNativeViewportSizeScaled(float scale);
 
-	class PerformanceOverlay {
-		public:
-			static float CalcFrameTime(uint64_t timeElapsed, uint64_t frequency)
-			{
-				return 1000.0f * (float)timeElapsed / (float)frequency;
-			}
+	class PerformanceOverlay
+	{
+	public:
+		static float CalcFrameTime(uint64_t timeElapsed, uint64_t frequency)
+		{
+			return 1000.0f * (float)timeElapsed / (float)frequency;
+		}
 
-			static float CalcFPS(float frameTimeMs)
-			{
-				return 1000.0f / frameTimeMs;
-			}
+		static float CalcFPS(float frameTimeMs)
+		{
+			return 1000.0f / frameTimeMs;
+		}
 	};
 	extern PerformanceOverlay performanceOverlay;
 }  // namespace Util


### PR DESCRIPTION
closes #1110 

-     Added class PerfOverlayState in Menu private to encapsulate many variables and functions related to the Overlay.
-     Split DrawPerfOverlay function into many functions as members of the class.
-     Moved a couple small functions to Utils/UI from DrawPerfOverlay.
-     Some optimization done on tracking the min and max values of the graph.
-     Redid the smoothing and calculation of the graph boundaries as well.
-     Added user setting PerfOverlaySettings::FrameHistorySize to allow users to control how much history the graph shows.
-     Added constants PerfOverlaySettings::kMinFrameHistorySize, kMaxFrameHistorySize to ensure the FrameHistorySize is kept within reasonable limits.
-     Added documentation to the new functions.

Should now be able to create separate files for the performance overlay and move over the encapsulated things without too much trouble. 
Lord have mercy on my soul and doom this platform straight to hell


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a user-adjustable setting for frame history size in the performance overlay, allowing customization of the number of frames displayed in performance graphs.
  - Introduced help icons with tooltips next to various sliders and buttons in the settings UI for improved clarity and guidance.
- **Improvements**
  - Enhanced performance overlay graphs with smoother scaling and more stable min/max frame time calculations.
  - Improved input handling for hotkeys in the performance overlay.
  - Refined performance overlay rendering and data management with modular updates for FPS, frametime, and VRAM display.
- **Other**
  - No changes affecting existing user workflows; all additions are optional and enhance usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->