### PR TITLE
fix: terrain variation broken parallax shadows & incorrect mipmapping.

### DIFF
--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -67,7 +67,7 @@ inline float4 StochasticEffect(float rnd, float mipLevel, Texture2D tex, Sampler
 {
 	// If feature is disabled, return standard sample
 	if (!SharedData::terrainVariationSettings.enableTilingFix)
-		return tex.SampleLevel(samp, uv, mipLevel);
+		return tex.SampleGrad(samp, uv, dx, dy);
 
 	// Calculate distance factor (0 when close, 1 when far)
 	float distanceFactor = ComputeDistanceFactor(distance);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2523,6 +2523,35 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 		float parallaxShadow = 1;
 
+#			if defined(EMAT)
+		[branch] if (
+			SharedData::extendedMaterialSettings.EnableShadows &&
+			!(light.lightFlags & LightLimitFix::LightFlags::Simple) &&
+			lightAngle > 0.0 &&
+			shadowComponent != 0.0 &&
+			contactShadow != 0.0)
+		{
+			float3 lightDirectionTS = normalize(mul(refractedLightDirection, tbn).xyz);
+#				if defined(PARALLAX)
+			[branch] if (SharedData::extendedMaterialSettings.EnableParallax)
+				parallaxShadow = ExtendedMaterials::GetParallaxSoftShadowMultiplier(uv, mipLevel, lightDirectionTS, sh0, TexParallaxSampler, SampParallaxSampler, 0, parallaxShadowQuality, screenNoise, displacementParams);
+#				elif defined(LANDSCAPE)
+			[branch] if (SharedData::extendedMaterialSettings.EnableTerrainParallax)
+#					if defined(TERRAIN_VARIATION)
+				parallaxShadow = ExtendedMaterials::GetParallaxSoftShadowMultiplierTerrain(input, uv, mipLevels, lightDirectionTS, sh0, parallaxShadowQuality, screenNoise, displacementParams, sharedOffset, dx, dy, viewDistance);
+#					else
+				parallaxShadow = ExtendedMaterials::GetParallaxSoftShadowMultiplierTerrain(input, uv, mipLevels, lightDirectionTS, sh0, parallaxShadowQuality, screenNoise, displacementParams);
+#					endif
+#				elif defined(EMAT_ENVMAP)
+			[branch] if (complexMaterialParallax)
+				parallaxShadow = ExtendedMaterials::GetParallaxSoftShadowMultiplier(uv, mipLevel, lightDirectionTS, sh0, TexEnvMaskSampler, SampEnvMaskSampler, 3, parallaxShadowQuality, screenNoise, displacementParams);
+#				elif defined(TRUE_PBR) && !defined(LODLANDSCAPE)
+			[branch] if (PBRParallax)
+				parallaxShadow = ExtendedMaterials::GetParallaxSoftShadowMultiplier(uv, mipLevel, lightDirectionTS, sh0, TexParallaxSampler, SampParallaxSampler, 0, parallaxShadowQuality, screenNoise, displacementParams);
+#				endif
+		}
+#			endif
+
 #			if defined(TRUE_PBR)
 		{
 			PBR::LightProperties lightProperties = PBR::InitLightProperties(lightColor, lightShadow * contactShadow, parallaxShadow);


### PR DESCRIPTION
Hotfix for two issues introduced by original terrain variation merge.

These will carry through to the rewrite, but are important to get in so other dev builds don't have these issues.

No failed shaders, fixed shadow issues in interiors for parallax shadows. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved texture sampling for terrain variation when the tiling fix is disabled, resulting in more accurate rendering in certain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->