### PR TITLE
fix: multiply fade in SharedData::DirLightColor

### DIFF
--- a/src/State.cpp
+++ b/src/State.cpp
@@ -671,7 +671,9 @@ void State::UpdateSharedData(bool a_inWorld, bool a_prepass)
 		auto shadowSceneNode = shaderManager->shadowSceneNode[0];
 		auto dirLight = skyrim_cast<RE::NiDirectionalLight*>(shadowSceneNode->GetRuntimeData().sunLight->light.get());
 
-		data.DirLightColor = { dirLight->GetLightRuntimeData().diffuse.red, dirLight->GetLightRuntimeData().diffuse.green, dirLight->GetLightRuntimeData().diffuse.blue, 1.0f };
+		auto& lightRuntimeData = dirLight->GetLightRuntimeData();
+		data.DirLightColor = { lightRuntimeData.diffuse.red, lightRuntimeData.diffuse.green, lightRuntimeData.diffuse.blue, 1.0f };
+		data.DirLightColor *= lightRuntimeData.fade;
 
 		auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
 		data.DirLightColor *= !globals::game::isVR ? imageSpaceManager->GetRuntimeData().data.baseData.hdr.sunlightScale : imageSpaceManager->GetVRRuntimeData().data.baseData.hdr.sunlightScale;


### PR DESCRIPTION
The SharedDataCB DirLightColor was missing a multiplier by the light's fade value. This was causing a mismatch between the game calculated DirLightColor passed into PerX cbuffers and the SharedData calculated value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of directional light color rendering by correctly applying the fade factor. This results in more realistic lighting effects in scenes with changing light intensity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->