### PR TITLE
ci: streamline build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,10 @@ permissions:
     contents: read
     pull-requests: read
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
     build:
         if: >
@@ -166,6 +170,7 @@ jobs:
               uses: thollander/actions-comment-pull-request@v3
               with:
                   mode: upsert
+                  comment-tag: prerelease-build
                   message: |
                       ✅ A pre-release build is available for this PR:
                       [Download](https://github.com/${{ github.repository }}/releases/tag/v${{ needs.build.outputs.version }}-pr${{ github.event.pull_request.number }})


### PR DESCRIPTION
- Cancel the build with new commits
- Only comment once on a pr with prerelease

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved workflow efficiency by ensuring only one run per pull request or branch is active at a time, with automatic cancellation of previous runs.
  - Enhanced prerelease job comments with a unique tag for easier identification and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->