### PR TITLE
fix: added missing includes and add helper method to enable build

### DIFF
--- a/src/Feature.h
+++ b/src/Feature.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "Globals.h"
+#include "Menu.h"
+
 struct Feature
 {
 	bool loaded = false;
@@ -54,7 +57,7 @@ struct Feature
 		auto [description, keyFeatures] = GetFeatureSummary();
 
 		if (!description.empty() || !keyFeatures.empty()) {
-			ImGui::TextColored(globals::menu->settings.Theme.StatusPalette.Error, "This feature is not installed!");
+			ImGui::TextColored(Menu::GetSingleton()->GetTheme().StatusPalette.Error, "This feature is not installed!");
 			ImGui::Spacing();
 
 			if (!description.empty()) {

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -2,6 +2,7 @@
 
 #include "Utils/Serialize.h"
 #include <dxgi1_4.h>
+#include <winrt/Base.h>
 
 using namespace std::chrono;
 #define BUFFER_VIEWER_NODE(a_value, a_scale)                                                                 \
@@ -177,6 +178,8 @@ public:
 			uint32_t OverlayToggleKey = VK_F10;
 		} PerfOverlay;
 	};
+
+	const ThemeSettings& GetTheme() const { return settings.Theme; } // Provide read-only access to the Theme.
 
 private:
 	Settings settings;

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -179,7 +179,7 @@ public:
 		} PerfOverlay;
 	};
 
-	const ThemeSettings& GetTheme() const { return settings.Theme; } // Provide read-only access to the Theme.
+	const ThemeSettings& GetTheme() const { return settings.Theme; }  // Provide read-only access to the Theme.
 
 private:
 	Settings settings;


### PR DESCRIPTION
Wasn't able to build without adjusting these few missing includes and also since settings is private, I added a helper method to get the ThemeSettings publicly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved access to theme settings, allowing UI elements to display error messages with consistent styling.
- **Refactor**
  - Updated how the error color is retrieved for displaying messages in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->