### PR TITLE
chore: add nexusmod links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/
 CMakeUserPresets.json
 shadertoolsconfig.json
 .vscode
+
+# Folder view configuration files
+.DS_Store

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -18,12 +18,12 @@ struct Feature
 
 protected:
 	// Helper method to construct Nexus Mods URL from mod ID
-	static std::string MakeNexusModURL(std::string_view modId) {
+	static std::string MakeNexusModURL(std::string_view modId)
+	{
 		return std::string(NEXUS_BASE_URL) + std::string(modId);
 	}
 
 public:
-
 	virtual bool HasShaderDefine(RE::BSShader::Type) { return false; }
 	/**
 	 * Whether the feature supports VR.

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -4,6 +4,8 @@
 
 struct Feature
 {
+	// Nexus Mods base URL for Skyrim Special Edition
+	static constexpr std::string_view NEXUS_BASE_URL = "https://www.nexusmods.com/skyrimspecialedition/mods/";
 	bool loaded = false;
 	std::string version;
 	std::string failedLoadedMessage;
@@ -13,6 +15,14 @@ struct Feature
 	virtual std::string GetFeatureModLink() { return ""; }
 	virtual std::string_view GetShaderDefineName() { return ""; }
 	virtual std::vector<std::pair<std::string_view, std::string_view>> GetShaderDefineOptions() { return {}; }
+
+protected:
+	// Helper method to construct Nexus Mods URL from mod ID
+	static std::string MakeNexusModURL(std::string_view modId) {
+		return std::string(NEXUS_BASE_URL) + std::string(modId);
+	}
+
+public:
 
 	virtual bool HasShaderDefine(RE::BSShader::Type) { return false; }
 	/**

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -18,9 +18,13 @@ struct Feature
 
 protected:
 	// Helper method to construct Nexus Mods URL from mod ID
-	static std::string MakeNexusModURL(std::string_view modId)
+	static std::string MakeNexusModURL(std::string_view modId) noexcept
 	{
-		return std::string(NEXUS_BASE_URL) + std::string(modId);
+		std::string url;
+		url.reserve(NEXUS_BASE_URL.size() + modId.size());
+		url.append(NEXUS_BASE_URL);
+		url.append(modId);
+		return url;
 	}
 
 public:

--- a/src/Features/CloudShadows.h
+++ b/src/Features/CloudShadows.h
@@ -2,6 +2,10 @@
 
 struct CloudShadows : Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "139185";
+
+public:
 	static CloudShadows* GetSingleton()
 	{
 		static CloudShadows singleton;
@@ -18,7 +22,7 @@ struct CloudShadows : Feature
 
 	virtual inline std::string GetName() override { return "Cloud Shadows"; }
 	virtual inline std::string GetShortName() override { return "CloudShadows"; }
-	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/139185"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "CLOUD_SHADOWS"; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/CloudShadows.h
+++ b/src/Features/CloudShadows.h
@@ -18,6 +18,7 @@ struct CloudShadows : Feature
 
 	virtual inline std::string GetName() override { return "Cloud Shadows"; }
 	virtual inline std::string GetShortName() override { return "CloudShadows"; }
+	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/139185"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "CLOUD_SHADOWS"; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/GrassCollision.h
+++ b/src/Features/GrassCollision.h
@@ -10,6 +10,7 @@ struct GrassCollision : Feature
 
 	virtual inline std::string GetName() override { return "Grass Collision"; }
 	virtual inline std::string GetShortName() override { return "GrassCollision"; }
+	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/87816"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "GRASS_COLLISION"; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/GrassCollision.h
+++ b/src/Features/GrassCollision.h
@@ -2,6 +2,10 @@
 
 struct GrassCollision : Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "87816";
+
+public:
 	static GrassCollision* GetSingleton()
 	{
 		static GrassCollision singleton;
@@ -10,7 +14,7 @@ struct GrassCollision : Feature
 
 	virtual inline std::string GetName() override { return "Grass Collision"; }
 	virtual inline std::string GetShortName() override { return "GrassCollision"; }
-	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/87816"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "GRASS_COLLISION"; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/GrassLighting.h
+++ b/src/Features/GrassLighting.h
@@ -10,6 +10,7 @@ struct GrassLighting : Feature
 
 	virtual inline std::string GetName() override { return "Grass Lighting"; }
 	virtual inline std::string GetShortName() override { return "GrassLighting"; }
+	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/86502"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "GRASS_LIGHTING"; }
 	virtual bool HasShaderDefine(RE::BSShader::Type shaderType) override { return shaderType == RE::BSShader::Type::Grass; };
 

--- a/src/Features/GrassLighting.h
+++ b/src/Features/GrassLighting.h
@@ -2,6 +2,10 @@
 
 struct GrassLighting : Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "86502";
+
+public:
 	static GrassLighting* GetSingleton()
 	{
 		static GrassLighting singleton;
@@ -10,7 +14,7 @@ struct GrassLighting : Feature
 
 	virtual inline std::string GetName() override { return "Grass Lighting"; }
 	virtual inline std::string GetShortName() override { return "GrassLighting"; }
-	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/86502"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "GRASS_LIGHTING"; }
 	virtual bool HasShaderDefine(RE::BSShader::Type shaderType) override { return shaderType == RE::BSShader::Type::Grass; };
 

--- a/src/Features/HairSpecular.h
+++ b/src/Features/HairSpecular.h
@@ -2,6 +2,10 @@
 
 struct HairSpecular : Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "149011";
+
+public:
 	static HairSpecular* GetSingleton()
 	{
 		static HairSpecular singleton;
@@ -24,7 +28,7 @@ struct HairSpecular : Feature
 	}
 	virtual bool HasShaderDefine(RE::BSShader::Type shaderType) override { return shaderType == RE::BSShader::Type::Lighting; };
 
-	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/149011"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 
 	virtual void Prepass() override;
 

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -13,6 +13,7 @@ public:
 
 	virtual inline std::string GetName() override { return "Light Limit Fix"; }
 	virtual inline std::string GetShortName() override { return "LightLimitFix"; }
+	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/99548"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "LIGHT_LIMIT_FIX"; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -4,6 +4,9 @@
 
 struct LightLimitFix : Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "99548";
+
 public:
 	static LightLimitFix* GetSingleton()
 	{
@@ -13,7 +16,7 @@ public:
 
 	virtual inline std::string GetName() override { return "Light Limit Fix"; }
 	virtual inline std::string GetShortName() override { return "LightLimitFix"; }
-	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/99548"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "LIGHT_LIMIT_FIX"; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/ScreenSpaceGI.h
+++ b/src/Features/ScreenSpaceGI.h
@@ -12,6 +12,7 @@ struct ScreenSpaceGI : Feature
 
 	virtual inline std::string GetName() override { return "Screen Space GI"; }
 	virtual inline std::string GetShortName() override { return "ScreenSpaceGI"; }
+	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/130375"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "SSGI"; }
 	virtual inline bool HasShaderDefine(RE::BSShader::Type t) override
 	{

--- a/src/Features/ScreenSpaceGI.h
+++ b/src/Features/ScreenSpaceGI.h
@@ -2,6 +2,10 @@
 
 struct ScreenSpaceGI : Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "130375";
+
+public:
 	static ScreenSpaceGI* GetSingleton()
 	{
 		static ScreenSpaceGI singleton;
@@ -12,7 +16,7 @@ struct ScreenSpaceGI : Feature
 
 	virtual inline std::string GetName() override { return "Screen Space GI"; }
 	virtual inline std::string GetShortName() override { return "ScreenSpaceGI"; }
-	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/130375"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "SSGI"; }
 	virtual inline bool HasShaderDefine(RE::BSShader::Type t) override
 	{

--- a/src/Features/ScreenSpaceShadows.h
+++ b/src/Features/ScreenSpaceShadows.h
@@ -10,6 +10,7 @@ struct ScreenSpaceShadows : Feature
 
 	virtual inline std::string GetName() override { return "Screen Space Shadows"; }
 	virtual inline std::string GetShortName() override { return "ScreenSpaceShadows"; }
+	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/93209"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "SCREEN_SPACE_SHADOWS"; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/ScreenSpaceShadows.h
+++ b/src/Features/ScreenSpaceShadows.h
@@ -2,6 +2,10 @@
 
 struct ScreenSpaceShadows : Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "93209";
+
+public:
 	static ScreenSpaceShadows* GetSingleton()
 	{
 		static ScreenSpaceShadows singleton;
@@ -10,7 +14,7 @@ struct ScreenSpaceShadows : Feature
 
 	virtual inline std::string GetName() override { return "Screen Space Shadows"; }
 	virtual inline std::string GetShortName() override { return "ScreenSpaceShadows"; }
-	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/93209"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "SCREEN_SPACE_SHADOWS"; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/Skylighting.h
+++ b/src/Features/Skylighting.h
@@ -2,6 +2,10 @@
 
 struct Skylighting : Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "139352";
+
+public:
 	static Skylighting* GetSingleton()
 	{
 		static Skylighting singleton;
@@ -12,7 +16,7 @@ struct Skylighting : Feature
 
 	virtual inline std::string GetName() override { return "Skylighting"; }
 	virtual inline std::string GetShortName() override { return "Skylighting"; }
-	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/139352"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "SKYLIGHTING"; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/Skylighting.h
+++ b/src/Features/Skylighting.h
@@ -12,6 +12,7 @@ struct Skylighting : Feature
 
 	virtual inline std::string GetName() override { return "Skylighting"; }
 	virtual inline std::string GetShortName() override { return "Skylighting"; }
+	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/139352"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "SKYLIGHTING"; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/SubsurfaceScattering.h
+++ b/src/Features/SubsurfaceScattering.h
@@ -4,6 +4,9 @@
 
 struct SubsurfaceScattering : Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "114114";
+
 public:
 	static SubsurfaceScattering* GetSingleton()
 	{
@@ -57,11 +60,11 @@ public:
 
 	ID3D11ComputeShader* horizontalSSBlur = nullptr;
 	ID3D11ComputeShader* verticalSSBlur = nullptr;
-	RE::BGSKeyword* isBeastRaceKeyword = nullptr;
+	RE::BGSKeyword* isBeastRaceKeyword = nullptr;	
 
 	virtual inline std::string GetName() override { return "Subsurface Scattering"; }
 	virtual inline std::string GetShortName() override { return "SubsurfaceScattering"; }
-	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/114114"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "SSS"; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/SubsurfaceScattering.h
+++ b/src/Features/SubsurfaceScattering.h
@@ -61,6 +61,7 @@ public:
 
 	virtual inline std::string GetName() override { return "Subsurface Scattering"; }
 	virtual inline std::string GetShortName() override { return "SubsurfaceScattering"; }
+	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/114114"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "SSS"; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/SubsurfaceScattering.h
+++ b/src/Features/SubsurfaceScattering.h
@@ -60,7 +60,7 @@ public:
 
 	ID3D11ComputeShader* horizontalSSBlur = nullptr;
 	ID3D11ComputeShader* verticalSSBlur = nullptr;
-	RE::BGSKeyword* isBeastRaceKeyword = nullptr;	
+	RE::BGSKeyword* isBeastRaceKeyword = nullptr;
 
 	virtual inline std::string GetName() override { return "Subsurface Scattering"; }
 	virtual inline std::string GetShortName() override { return "SubsurfaceScattering"; }

--- a/src/Features/TerrainHelper.h
+++ b/src/Features/TerrainHelper.h
@@ -43,7 +43,7 @@ public:
 
 	virtual void DataLoaded() override;
 	virtual bool SupportsVR() override { return true; };
-	virtual std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); };
+	virtual std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual void DrawUnloadedUI() override;
 	virtual bool DrawFailLoadMessage() const override { return false; };
 

--- a/src/Features/TerrainHelper.h
+++ b/src/Features/TerrainHelper.h
@@ -39,8 +39,8 @@ public:
 
 	std::shared_mutex extendedSlotsMutex;
 	std::unordered_map<uint32_t, ExtendedSlots> extendedSlots;
-	RE::BGSTextureSet* defaultLandTexture;	
-	
+	RE::BGSTextureSet* defaultLandTexture;
+
 	virtual void DataLoaded() override;
 	virtual bool SupportsVR() override { return true; };
 	virtual std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); };

--- a/src/Features/TerrainHelper.h
+++ b/src/Features/TerrainHelper.h
@@ -2,6 +2,10 @@
 
 struct TerrainHelper : Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "143149";
+
+public:
 	static TerrainHelper* GetSingleton()
 	{
 		static TerrainHelper singleton;
@@ -35,11 +39,11 @@ struct TerrainHelper : Feature
 
 	std::shared_mutex extendedSlotsMutex;
 	std::unordered_map<uint32_t, ExtendedSlots> extendedSlots;
-	RE::BGSTextureSet* defaultLandTexture;
-
+	RE::BGSTextureSet* defaultLandTexture;	
+	
 	virtual void DataLoaded() override;
 	virtual bool SupportsVR() override { return true; };
-	virtual std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/143149"; };
+	virtual std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); };
 	virtual void DrawUnloadedUI() override;
 	virtual bool DrawFailLoadMessage() const override { return false; };
 

--- a/src/Features/TerrainShadows.h
+++ b/src/Features/TerrainShadows.h
@@ -4,6 +4,10 @@
 
 struct TerrainShadows : public Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "135817";
+
+public:
 	static TerrainShadows* GetSingleton()
 	{
 		static TerrainShadows singleton;
@@ -12,7 +16,7 @@ struct TerrainShadows : public Feature
 
 	virtual inline std::string GetName() override { return "Terrain Shadows"; }
 	virtual inline std::string GetShortName() override { return "TerrainShadows"; }
-	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/135817"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "TERRAIN_SHADOWS"; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/TerrainShadows.h
+++ b/src/Features/TerrainShadows.h
@@ -12,6 +12,7 @@ struct TerrainShadows : public Feature
 
 	virtual inline std::string GetName() override { return "Terrain Shadows"; }
 	virtual inline std::string GetShortName() override { return "TerrainShadows"; }
+	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/135817"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "TERRAIN_SHADOWS"; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/TerrainVariation.h
+++ b/src/Features/TerrainVariation.h
@@ -2,6 +2,10 @@
 
 struct TerrainVariation : Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "148123";
+
+public:
 	static TerrainVariation* GetSingleton()
 	{
 		static TerrainVariation singleton;
@@ -10,7 +14,7 @@ struct TerrainVariation : Feature
 
 	virtual inline std::string GetName() override { return "Terrain Variation"; }
 	virtual inline std::string GetShortName() override { return "TerrainVariation"; }
-	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/148123"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "TERRAIN_VARIATION"; }
 	virtual inline bool HasShaderDefine(RE::BSShader::Type shaderType) override { return shaderType == RE::BSShader::Type::Lighting; }
 	virtual bool IsCore() const override { return false; };

--- a/src/Features/WaterEffects.h
+++ b/src/Features/WaterEffects.h
@@ -15,6 +15,7 @@ public:
 
 	virtual inline std::string GetName() override { return "Water Effects"; }
 	virtual inline std::string GetShortName() override { return "WaterEffects"; }
+	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/112762"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "WATER_EFFECTS"; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/WaterEffects.h
+++ b/src/Features/WaterEffects.h
@@ -4,6 +4,9 @@
 
 struct WaterEffects : Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "112762";
+
 public:
 	static WaterEffects* GetSingleton()
 	{
@@ -15,7 +18,7 @@ public:
 
 	virtual inline std::string GetName() override { return "Water Effects"; }
 	virtual inline std::string GetShortName() override { return "WaterEffects"; }
-	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/112762"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "WATER_EFFECTS"; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/WetnessEffects.h
+++ b/src/Features/WetnessEffects.h
@@ -2,6 +2,9 @@
 
 struct WetnessEffects : Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "112739";
+
 public:
 	static WetnessEffects* GetSingleton()
 	{
@@ -11,7 +14,7 @@ public:
 
 	virtual inline std::string GetName() override { return "Wetness Effects"; }
 	virtual inline std::string GetShortName() override { return "WetnessEffects"; }
-	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/112739"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "WETNESS_EFFECTS"; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/WetnessEffects.h
+++ b/src/Features/WetnessEffects.h
@@ -11,6 +11,7 @@ public:
 
 	virtual inline std::string GetName() override { return "Wetness Effects"; }
 	virtual inline std::string GetShortName() override { return "WetnessEffects"; }
+	virtual inline std::string GetFeatureModLink() override { return "https://www.nexusmods.com/skyrimspecialedition/mods/112739"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "WETNESS_EFFECTS"; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added direct links to each feature's Nexus Mods page, making it easier for users to access more information about individual features. These links are now available for Cloud Shadows, Grass Collision, Grass Lighting, Light Limit Fix, Screen Space GI, Screen Space Shadows, Skylighting, Subsurface Scattering, Terrain Shadows, Water Effects, Wetness Effects, Hair Specular, Terrain Helper, and Terrain Variation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->