### PR TITLE
Fix: Hooks - Updated memory address to fix CTD on AE

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -1116,10 +1116,9 @@ namespace Hooks
 				REL::Relocation<std::uintptr_t>(renderPassCacheCtor, 0x191 - 2).address(),
 				reinterpret_cast<const uint8_t*>(&passCountSE), 4);
 		}
-
 		if (!REL::Module::IsVR()) {
 			stl::write_thunk_call<Main_Update_Begin>(REL::RelocationID(35565, 36564).address() + REL::Relocate(0x53, 0x6E));
-			stl::write_thunk_call<Main_Update_Swap>(REL::RelocationID(35565, 36564).address() + REL::Relocate(0x5D2, 0xA92));
+			stl::write_thunk_call<Main_Update_Swap>(REL::RelocationID(35565, 36564).address() + REL::Relocate(0x5D2, 0xA97));
 		}
 	}
 


### PR DESCRIPTION
Flayan provided this updated address which seems to have resolved the CTD when arriving at main menu for AE version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted the location where a specific update hook is installed for improved accuracy.
- **Style**
	- Removed an unnecessary blank line for cleaner code formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->