### PR TITLE
build: remove pause from build script

### DIFF
--- a/BuildRelease.bat
+++ b/BuildRelease.bat
@@ -11,5 +11,3 @@ cmake -S . --preset=%preset% --check-stamp-file "build\%preset%\CMakeFiles\gener
 if %ERRORLEVEL% NEQ 0 exit 1
 cmake --build --preset=%preset%
 if %ERRORLEVEL% NEQ 0 exit 1
-
-pause


### PR DESCRIPTION
This allows using the build script for scripting and testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the pause at the end of the release build script, allowing it to close automatically after completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->