### PR TITLE
feat(ui): cleaned uninstalled feature missing ini message, added "required-version" based on cs version

### DIFF
--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -110,7 +110,7 @@ void Feature::Load(json& o_json)
 		hasError = true;
 		errorVersion = "unknown";
 		errorType = FeatureIssues::FeatureIssueInfo::IssueType::VERSION_MISMATCH;
-		failedLoadedMessage = std::format("{} missing version info; not successfully loaded", ini_filename);
+		failedLoadedMessage = std::format("The {} file is missing. This feature is not installed! Version required: {}", ini_filename, GetRequiredVersion());
 	}
 
 	if (hasError) {
@@ -228,4 +228,24 @@ bool Feature::ToggleAtBootSetting()
 	state->SetFeatureDisabled(featureName, !disabled);
 
 	return state->IsFeatureDisabled(featureName);  // Return the new state
+}
+
+std::string Feature::GetRequiredVersion() const
+{
+	try {
+		std::string shortName = const_cast<Feature*>(this)->GetShortName();
+
+		if (FeatureVersions::FEATURE_MINIMAL_VERSIONS.contains(shortName)) {
+			const auto& minimalFeatureVersion = FeatureVersions::FEATURE_MINIMAL_VERSIONS.at(shortName);
+			std::string minimalVersionString = minimalFeatureVersion.string();
+			// Remove trailing .0 if present
+			if (minimalVersionString.size() >= 2 && minimalVersionString.substr(minimalVersionString.size() - 2) == "-0") {
+				minimalVersionString = minimalVersionString.substr(0, minimalVersionString.size() - 2);
+			}
+			return minimalVersionString;
+		}
+		return "Unknown";
+	} catch (const std::exception&) {
+		return "Unknown";
+	}
 }

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -29,9 +29,11 @@
 
 #include "State.h"
 
-namespace {
+namespace
+{
 	// Utility function to clean up version strings by removing trailing "-0"
-	std::string CleanVersionString(const std::string& versionString) {
+	std::string CleanVersionString(const std::string& versionString)
+	{
 		if (versionString.size() >= 2 && versionString.substr(versionString.size() - 2) == "-0") {
 			return versionString.substr(0, versionString.size() - 2);
 		}

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -30,7 +30,6 @@
 
 #include "State.h"
 
-
 void Feature::Load(json& o_json)
 {
 	if (o_json[GetName()].is_structured()) {

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -55,16 +55,16 @@ void Feature::Load(json& o_json)
 	SI_Error rc = ini.LoadFile(ini_path.c_str());
 
 	if (rc < 0) {
-	if (FeatureIssues::IsObsoleteFeature(GetShortName())) {
+		if (FeatureIssues::IsObsoleteFeature(GetShortName())) {
 			// Handle obsolete features
 			version = "obsolete";  // Set version so it shows error color in UI
 			failedLoadedMessage = std::format("{} is an obsolete feature that has been removed.", GetShortName());
 			FeatureIssues::FeatureFileInfo fileInfo = FeatureIssues::GetFeatureFileInfo(GetShortName());
-			FeatureIssues::AddFeatureIssue(GetShortName(), "N/A", failedLoadedMessage, 
+			FeatureIssues::AddFeatureIssue(GetShortName(), "N/A", failedLoadedMessage,
 				FeatureIssues::FeatureIssueInfo::IssueType::OBSOLETE, fileInfo, "");
 		} else {
 			logger::info("{} failed to load, feature disabled", ini_filename);
-			
+
 			// Set error message for missing file
 			std::string requiredVersion = "Unknown";
 			auto iter = FeatureVersions::FEATURE_MINIMAL_VERSIONS.find(GetShortName());
@@ -72,10 +72,10 @@ void Feature::Load(json& o_json)
 				requiredVersion = Util::CleanVersionString(iter->second.string());
 			}
 			failedLoadedMessage = std::format("The {} file is missing. This feature is not installed! Version required: {}", ini_filename, requiredVersion);
-			
+
 			// Add to feature issues
 			FeatureIssues::FeatureFileInfo fileInfo = FeatureIssues::GetFeatureFileInfo(GetShortName());
-			FeatureIssues::AddFeatureIssue(GetShortName(), "unknown", failedLoadedMessage, 
+			FeatureIssues::AddFeatureIssue(GetShortName(), "unknown", failedLoadedMessage,
 				FeatureIssues::FeatureIssueInfo::IssueType::VERSION_MISMATCH, fileInfo, requiredVersion);
 		}
 		loaded = false;

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -2,7 +2,6 @@
 
 #include "FeatureIssues.h"
 #include "FeatureVersions.h"
-#include "Utils/Format.h"
 #include "Features/CloudShadows.h"
 #include "Features/DynamicCubemaps.h"
 #include "Features/ExtendedMaterials.h"
@@ -27,6 +26,7 @@
 #include "Features/VolumetricLighting.h"
 #include "Features/WaterEffects.h"
 #include "Features/WetnessEffects.h"
+#include "Utils/Format.h"
 
 #include "State.h"
 

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -56,8 +56,29 @@ void Feature::Load(json& o_json)
 	SI_Error rc = ini.LoadFile(ini_path.c_str());
 
 	if (rc < 0) {
-		if (!FeatureIssues::IsObsoleteFeature(GetShortName()))
+	if (FeatureIssues::IsObsoleteFeature(GetShortName())) {
+			// Handle obsolete features
+			version = "obsolete";  // Set version so it shows error color in UI
+			failedLoadedMessage = std::format("{} is an obsolete feature that has been removed.", GetShortName());
+			FeatureIssues::FeatureFileInfo fileInfo = FeatureIssues::GetFeatureFileInfo(GetShortName());
+			FeatureIssues::AddFeatureIssue(GetShortName(), "N/A", failedLoadedMessage, 
+				FeatureIssues::FeatureIssueInfo::IssueType::OBSOLETE, fileInfo, "");
+		} else {
 			logger::info("{} failed to load, feature disabled", ini_filename);
+			
+			// Set error message for missing file
+			std::string requiredVersion = "Unknown";
+			auto iter = FeatureVersions::FEATURE_MINIMAL_VERSIONS.find(GetShortName());
+			if (iter != FeatureVersions::FEATURE_MINIMAL_VERSIONS.end()) {
+				requiredVersion = Util::CleanVersionString(iter->second.string());
+			}
+			failedLoadedMessage = std::format("The {} file is missing. This feature is not installed! Version required: {}", ini_filename, requiredVersion);
+			
+			// Add to feature issues
+			FeatureIssues::FeatureFileInfo fileInfo = FeatureIssues::GetFeatureFileInfo(GetShortName());
+			FeatureIssues::AddFeatureIssue(GetShortName(), "unknown", failedLoadedMessage, 
+				FeatureIssues::FeatureIssueInfo::IssueType::VERSION_MISMATCH, fileInfo, requiredVersion);
+		}
 		loaded = false;
 		return;
 	}
@@ -66,9 +87,9 @@ void Feature::Load(json& o_json)
 	std::string errorVersion;
 	std::string requiredVersion = "Unknown";  // Store required version for later use
 	FeatureIssues::FeatureIssueInfo::IssueType errorType = FeatureIssues::FeatureIssueInfo::IssueType::UNKNOWN;
-
 	if (FeatureIssues::IsObsoleteFeature(GetShortName())) {
 		hasError = true;
+		version = "obsolete";  // Set version so it shows error color in UI
 		errorVersion = "N/A";
 		errorType = FeatureIssues::FeatureIssueInfo::IssueType::OBSOLETE;
 		failedLoadedMessage = std::format("{} is an obsolete feature that has been removed.", GetShortName());
@@ -116,18 +137,6 @@ void Feature::Load(json& o_json)
 			errorType = FeatureIssues::FeatureIssueInfo::IssueType::VERSION_MISMATCH;
 			failedLoadedMessage = std::format("{} {} has invalid version format: {}", GetShortName(), value, e.what());
 		}
-	} else {
-		hasError = true;
-		errorVersion = "unknown";
-		errorType = FeatureIssues::FeatureIssueInfo::IssueType::VERSION_MISMATCH;
-
-		// Look up the required version for the missing file error message
-		auto iter = FeatureVersions::FEATURE_MINIMAL_VERSIONS.find(GetShortName());
-		if (iter != FeatureVersions::FEATURE_MINIMAL_VERSIONS.end()) {
-			requiredVersion = Util::CleanVersionString(iter->second.string());
-		}
-
-		failedLoadedMessage = std::format("The {} file is missing. This feature is not installed! Version required: {}", ini_filename, requiredVersion);
 	}
 
 	if (hasError) {

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -2,6 +2,7 @@
 
 #include "FeatureIssues.h"
 #include "FeatureVersions.h"
+#include "Utils/Format.h"
 #include "Features/CloudShadows.h"
 #include "Features/DynamicCubemaps.h"
 #include "Features/ExtendedMaterials.h"
@@ -28,16 +29,6 @@
 #include "Features/WetnessEffects.h"
 
 #include "State.h"
-
-namespace {
-	// Utility function to clean up version strings by removing trailing "-0"
-	std::string CleanVersionString(const std::string& versionString) {
-		if (versionString.size() >= 2 && versionString.substr(versionString.size() - 2) == "-0") {
-			return versionString.substr(0, versionString.size() - 2);
-		}
-		return versionString;
-	}
-}
 
 void Feature::Load(json& o_json)
 {
@@ -89,7 +80,7 @@ void Feature::Load(json& o_json)
 				// Version compatibility check
 				auto& minimalFeatureVersion = iter->second;
 				std::string rawVersion = minimalFeatureVersion.string();
-				requiredVersion = CleanVersionString(rawVersion);
+				requiredVersion = Util::CleanVersionString(rawVersion);
 				bool oldFeature = featureVersion.compare(minimalFeatureVersion) == std::strong_ordering::less;
 				bool majorVersionMismatch = featureVersion.major() < minimalFeatureVersion.major();
 
@@ -101,7 +92,7 @@ void Feature::Load(json& o_json)
 					errorVersion = value;
 					errorType = FeatureIssues::FeatureIssueInfo::IssueType::VERSION_MISMATCH;
 
-					std::string minimalVersionString = CleanVersionString(minimalFeatureVersion.string());
+					std::string minimalVersionString = Util::CleanVersionString(minimalFeatureVersion.string());
 
 					if (majorVersionMismatch) {
 						failedLoadedMessage = std::format("{} {} is too old, major version incompatibility detected. Required: {}", GetShortName(), value, minimalVersionString);
@@ -126,7 +117,7 @@ void Feature::Load(json& o_json)
 		// Look up the required version for the missing file error message
 		auto iter = FeatureVersions::FEATURE_MINIMAL_VERSIONS.find(GetShortName());
 		if (iter != FeatureVersions::FEATURE_MINIMAL_VERSIONS.end()) {
-			requiredVersion = CleanVersionString(iter->second.string());
+			requiredVersion = Util::CleanVersionString(iter->second.string());
 		}
 
 		failedLoadedMessage = std::format("The {} file is missing. This feature is not installed! Version required: {}", ini_filename, requiredVersion);

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -32,7 +32,7 @@
 void Feature::Load(json& o_json)
 {
 	if (o_json[GetName()].is_structured()) {
-		logger::info("Loading {} settings", GetName());
+		logger::info("Loading {} settings.", GetName());
 		try {
 			LoadSettings(o_json[GetName()]);
 		} catch (...) {
@@ -40,7 +40,7 @@ void Feature::Load(json& o_json)
 			RestoreDefaultSettings();
 		}
 	} else {
-		logger::info("Loading default settings for {}", GetName());
+		logger::info("Loading default settings for {}.", GetName());
 		RestoreDefaultSettings();
 	}
 
@@ -63,7 +63,7 @@ void Feature::Load(json& o_json)
 		hasError = true;
 		errorVersion = "N/A";
 		errorType = FeatureIssues::FeatureIssueInfo::IssueType::OBSOLETE;
-		failedLoadedMessage = std::format("{} is an obsolete feature that has been removed", GetShortName());
+		failedLoadedMessage = std::format("{} is an obsolete feature that has been removed.", GetShortName());
 	} else if (auto value = ini.GetValue("Info", "Version")) {
 		try {
 			REL::Version featureVersion(std::regex_replace(value, std::regex("-"), "."));
@@ -158,7 +158,7 @@ void Feature::Load(json& o_json)
 
 			FeatureIssues::AddFeatureIssue(shortName, errorVersion, failedLoadedMessage, errorType, fileInfo, minimumVersion);
 		} else {
-			logger::error("Feature has empty short name, cannot add to feature issues list");
+			logger::error("Feature has empty short name, cannot add to feature issues list.");
 		}
 	}
 }
@@ -188,14 +188,14 @@ bool Feature::ValidateCache(CSimpleIniA& a_ini)
 	if (loaded) {
 		auto versionInCache = a_ini.GetValue(ini_name.c_str(), "Version");
 		if (strcmp(versionInCache, version.c_str()) != 0) {
-			logger::info("Change in version detected. Installed {} but {} in Disk Cache", version, versionInCache);
+			logger::info("Change in version detected. Installed {} but {} in Disk Cache.", version, versionInCache);
 			return false;
 		} else {
 			logger::info("Installed version and cached version match.");
 		}
 	}
 
-	logger::info("Cached feature is valid");
+	logger::info("Cached feature is valid.");
 	return true;
 }
 

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -32,18 +32,6 @@
 
 void Feature::Load(json& o_json)
 {
-	if (o_json[GetName()].is_structured()) {
-		logger::info("Loading {} settings", GetName());
-		try {
-			LoadSettings(o_json[GetName()]);
-		} catch (...) {
-			logger::warn("Invalid settings for {}, using default", GetName());
-			RestoreDefaultSettings();
-		}
-	} else {
-		logger::info("Loading default settings for {}", GetName());
-		RestoreDefaultSettings();
-	}
 	// Convert string to wstring
 	auto ini_filename = std::format("{}.ini", GetShortName());
 	std::wstring ini_filename_w;

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -56,6 +56,7 @@ void Feature::Load(json& o_json)
 
 	bool hasError = false;
 	std::string errorVersion;
+	std::string requiredVersion = "Unknown"; // Store required version for later use
 	FeatureIssues::FeatureIssueInfo::IssueType errorType = FeatureIssues::FeatureIssueInfo::IssueType::UNKNOWN;
 
 	if (FeatureIssues::IsObsoleteFeature(GetShortName())) {
@@ -77,6 +78,13 @@ void Feature::Load(json& o_json)
 			} else {
 				// Version compatibility check
 				auto& minimalFeatureVersion = iter->second;
+				std::string rawVersion = minimalFeatureVersion.string();
+				// Remove trailing "-0" if present
+				if (rawVersion.size() >= 2 && rawVersion.substr(rawVersion.size() - 2) == "-0") {
+					requiredVersion = rawVersion.substr(0, rawVersion.size() - 2);
+				} else {
+					requiredVersion = rawVersion;
+				}
 				bool oldFeature = featureVersion.compare(minimalFeatureVersion) == std::strong_ordering::less;
 				bool majorVersionMismatch = featureVersion.major() < minimalFeatureVersion.major();
 
@@ -89,7 +97,10 @@ void Feature::Load(json& o_json)
 					errorType = FeatureIssues::FeatureIssueInfo::IssueType::VERSION_MISMATCH;
 
 					std::string minimalVersionString = minimalFeatureVersion.string();
+				// Remove trailing "-0" if present for error messages
+				if (minimalVersionString.size() >= 2 && minimalVersionString.substr(minimalVersionString.size() - 2) == "-0") {
 					minimalVersionString = minimalVersionString.substr(0, minimalVersionString.size() - 2);
+				}
 
 					if (majorVersionMismatch) {
 						failedLoadedMessage = std::format("{} {} is too old, major version incompatibility detected. Required: {}", GetShortName(), value, minimalVersionString);
@@ -110,7 +121,20 @@ void Feature::Load(json& o_json)
 		hasError = true;
 		errorVersion = "unknown";
 		errorType = FeatureIssues::FeatureIssueInfo::IssueType::VERSION_MISMATCH;
-		failedLoadedMessage = std::format("The {} file is missing. This feature is not installed! Version required: {}", ini_filename, GetRequiredVersion());
+		
+		// Look up the required version for the missing file error message
+		auto iter = FeatureVersions::FEATURE_MINIMAL_VERSIONS.find(GetShortName());
+		if (iter != FeatureVersions::FEATURE_MINIMAL_VERSIONS.end()) {
+			std::string rawVersion = iter->second.string();
+			// Remove trailing "-0" if present
+			if (rawVersion.size() >= 2 && rawVersion.substr(rawVersion.size() - 2) == "-0") {
+				requiredVersion = rawVersion.substr(0, rawVersion.size() - 2);
+			} else {
+				requiredVersion = rawVersion;
+			}
+		}
+		
+		failedLoadedMessage = std::format("The {} file is missing. This feature is not installed! Version required: {}", ini_filename, requiredVersion);
 	}
 
 	if (hasError) {
@@ -228,24 +252,4 @@ bool Feature::ToggleAtBootSetting()
 	state->SetFeatureDisabled(featureName, !disabled);
 
 	return state->IsFeatureDisabled(featureName);  // Return the new state
-}
-
-std::string Feature::GetRequiredVersion() const
-{
-	try {
-		std::string shortName = const_cast<Feature*>(this)->GetShortName();
-
-		if (FeatureVersions::FEATURE_MINIMAL_VERSIONS.contains(shortName)) {
-			const auto& minimalFeatureVersion = FeatureVersions::FEATURE_MINIMAL_VERSIONS.at(shortName);
-			std::string minimalVersionString = minimalFeatureVersion.string();
-			// Remove trailing .0 if present
-			if (minimalVersionString.size() >= 2 && minimalVersionString.substr(minimalVersionString.size() - 2) == "-0") {
-				minimalVersionString = minimalVersionString.substr(0, minimalVersionString.size() - 2);
-			}
-			return minimalVersionString;
-		}
-		return "Unknown";
-	} catch (const std::exception&) {
-		return "Unknown";
-	}
 }

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -29,6 +29,16 @@
 
 #include "State.h"
 
+namespace {
+	// Utility function to clean up version strings by removing trailing "-0"
+	std::string CleanVersionString(const std::string& versionString) {
+		if (versionString.size() >= 2 && versionString.substr(versionString.size() - 2) == "-0") {
+			return versionString.substr(0, versionString.size() - 2);
+		}
+		return versionString;
+	}
+}
+
 void Feature::Load(json& o_json)
 {
 	if (o_json[GetName()].is_structured()) {
@@ -79,12 +89,7 @@ void Feature::Load(json& o_json)
 				// Version compatibility check
 				auto& minimalFeatureVersion = iter->second;
 				std::string rawVersion = minimalFeatureVersion.string();
-				// Remove trailing "-0" if present
-				if (rawVersion.size() >= 2 && rawVersion.substr(rawVersion.size() - 2) == "-0") {
-					requiredVersion = rawVersion.substr(0, rawVersion.size() - 2);
-				} else {
-					requiredVersion = rawVersion;
-				}
+				requiredVersion = CleanVersionString(rawVersion);
 				bool oldFeature = featureVersion.compare(minimalFeatureVersion) == std::strong_ordering::less;
 				bool majorVersionMismatch = featureVersion.major() < minimalFeatureVersion.major();
 
@@ -96,11 +101,7 @@ void Feature::Load(json& o_json)
 					errorVersion = value;
 					errorType = FeatureIssues::FeatureIssueInfo::IssueType::VERSION_MISMATCH;
 
-					std::string minimalVersionString = minimalFeatureVersion.string();
-					// Remove trailing "-0" if present for error messages
-					if (minimalVersionString.size() >= 2 && minimalVersionString.substr(minimalVersionString.size() - 2) == "-0") {
-						minimalVersionString = minimalVersionString.substr(0, minimalVersionString.size() - 2);
-					}
+					std::string minimalVersionString = CleanVersionString(minimalFeatureVersion.string());
 
 					if (majorVersionMismatch) {
 						failedLoadedMessage = std::format("{} {} is too old, major version incompatibility detected. Required: {}", GetShortName(), value, minimalVersionString);
@@ -125,13 +126,7 @@ void Feature::Load(json& o_json)
 		// Look up the required version for the missing file error message
 		auto iter = FeatureVersions::FEATURE_MINIMAL_VERSIONS.find(GetShortName());
 		if (iter != FeatureVersions::FEATURE_MINIMAL_VERSIONS.end()) {
-			std::string rawVersion = iter->second.string();
-			// Remove trailing "-0" if present
-			if (rawVersion.size() >= 2 && rawVersion.substr(rawVersion.size() - 2) == "-0") {
-				requiredVersion = rawVersion.substr(0, rawVersion.size() - 2);
-			} else {
-				requiredVersion = rawVersion;
-			}
+			requiredVersion = CleanVersionString(iter->second.string());
 		}
 
 		failedLoadedMessage = std::format("The {} file is missing. This feature is not installed! Version required: {}", ini_filename, requiredVersion);

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -30,17 +30,6 @@
 
 #include "State.h"
 
-namespace
-{
-	// Utility function to clean up version strings by removing trailing "-0"
-	std::string CleanVersionString(const std::string& versionString)
-	{
-		if (versionString.size() >= 2 && versionString.substr(versionString.size() - 2) == "-0") {
-			return versionString.substr(0, versionString.size() - 2);
-		}
-		return versionString;
-	}
-}
 
 void Feature::Load(json& o_json)
 {

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -32,15 +32,15 @@
 void Feature::Load(json& o_json)
 {
 	if (o_json[GetName()].is_structured()) {
-		logger::info("Loading {} settings.", GetName());
+		logger::info("Loading {} settings", GetName());
 		try {
 			LoadSettings(o_json[GetName()]);
 		} catch (...) {
-			logger::warn("Invalid settings for {}, using default.", GetName());
+			logger::warn("Invalid settings for {}, using default", GetName());
 			RestoreDefaultSettings();
 		}
 	} else {
-		logger::info("Loading default settings for {}.", GetName());
+		logger::info("Loading default settings for {}", GetName());
 		RestoreDefaultSettings();
 	}
 
@@ -158,7 +158,7 @@ void Feature::Load(json& o_json)
 
 			FeatureIssues::AddFeatureIssue(shortName, errorVersion, failedLoadedMessage, errorType, fileInfo, minimumVersion);
 		} else {
-			logger::error("Feature has empty short name, cannot add to feature issues list.");
+			logger::error("Feature has empty short name, cannot add to feature issues list");
 		}
 	}
 }
@@ -188,14 +188,14 @@ bool Feature::ValidateCache(CSimpleIniA& a_ini)
 	if (loaded) {
 		auto versionInCache = a_ini.GetValue(ini_name.c_str(), "Version");
 		if (strcmp(versionInCache, version.c_str()) != 0) {
-			logger::info("Change in version detected. Installed {} but {} in Disk Cache.", version, versionInCache);
+			logger::info("Change in version detected. Installed {} but {} in Disk Cache", version, versionInCache);
 			return false;
 		} else {
-			logger::info("Installed version and cached version match.");
+			logger::info("Installed version and cached version match");
 		}
 	}
 
-	logger::info("Cached feature is valid.");
+	logger::info("Cached feature is valid");
 	return true;
 }
 

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -56,7 +56,7 @@ void Feature::Load(json& o_json)
 
 	bool hasError = false;
 	std::string errorVersion;
-	std::string requiredVersion = "Unknown"; // Store required version for later use
+	std::string requiredVersion = "Unknown";  // Store required version for later use
 	FeatureIssues::FeatureIssueInfo::IssueType errorType = FeatureIssues::FeatureIssueInfo::IssueType::UNKNOWN;
 
 	if (FeatureIssues::IsObsoleteFeature(GetShortName())) {
@@ -97,10 +97,10 @@ void Feature::Load(json& o_json)
 					errorType = FeatureIssues::FeatureIssueInfo::IssueType::VERSION_MISMATCH;
 
 					std::string minimalVersionString = minimalFeatureVersion.string();
-				// Remove trailing "-0" if present for error messages
-				if (minimalVersionString.size() >= 2 && minimalVersionString.substr(minimalVersionString.size() - 2) == "-0") {
-					minimalVersionString = minimalVersionString.substr(0, minimalVersionString.size() - 2);
-				}
+					// Remove trailing "-0" if present for error messages
+					if (minimalVersionString.size() >= 2 && minimalVersionString.substr(minimalVersionString.size() - 2) == "-0") {
+						minimalVersionString = minimalVersionString.substr(0, minimalVersionString.size() - 2);
+					}
 
 					if (majorVersionMismatch) {
 						failedLoadedMessage = std::format("{} {} is too old, major version incompatibility detected. Required: {}", GetShortName(), value, minimalVersionString);
@@ -121,7 +121,7 @@ void Feature::Load(json& o_json)
 		hasError = true;
 		errorVersion = "unknown";
 		errorType = FeatureIssues::FeatureIssueInfo::IssueType::VERSION_MISMATCH;
-		
+
 		// Look up the required version for the missing file error message
 		auto iter = FeatureVersions::FEATURE_MINIMAL_VERSIONS.find(GetShortName());
 		if (iter != FeatureVersions::FEATURE_MINIMAL_VERSIONS.end()) {
@@ -133,7 +133,7 @@ void Feature::Load(json& o_json)
 				requiredVersion = rawVersion;
 			}
 		}
-		
+
 		failedLoadedMessage = std::format("The {} file is missing. This feature is not installed! Version required: {}", ini_filename, requiredVersion);
 	}
 

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -57,6 +57,7 @@ public:
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() { return {}; }
 
 	/**
+	 * Gets the minimum required version string for this feature
 	 * @return The minimum version string required by the Community Shaders
 	 */
 	std::string GetRequiredVersion() const;

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Menu.h"
+#include "Utils/Format.h"
 
 struct Feature
 {

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -50,6 +50,13 @@ public:
 	virtual bool IsInMenu() const { return true; }
 
 	/**
+	 * Whether to print the INI version missing message when this feature is unloaded
+	 * Default false to prevent duplicate error messages. Retains functionality for author to include custom error message.
+	 * Set to "true" in header file of individual feature.
+	 */
+	virtual bool DrawFailLoadMessage() const { return false; }
+
+	/**
 	 * Get feature summary and key features for hover tooltip and unloaded UI
 	 *
 	 * \return Pair containing feature summary description and vector of key feature bullet points

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -74,17 +74,17 @@ public:
 			ImGui::Spacing();
 		}
 
-			if (!description.empty()) {
-				ImGui::TextWrapped("%s", description.c_str());
-				ImGui::Spacing();
-			}
+		if (!description.empty()) {
+			ImGui::TextWrapped("%s", description.c_str());
+			ImGui::Spacing();
+		}
 
-			if (!keyFeatures.empty()) {
-				ImGui::TextWrapped("Key features:");
-				for (const auto& feature : keyFeatures) {
-					ImGui::BulletText("%s", feature.c_str());
-				}
-				ImGui::Spacing();
+		if (!keyFeatures.empty()) {
+			ImGui::TextWrapped("Key features:");
+			for (const auto& feature : keyFeatures) {
+				ImGui::BulletText("%s", feature.c_str());
+			}
+			ImGui::Spacing();
 		}
 	}
 

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -50,28 +50,28 @@ public:
 	virtual bool IsInMenu() const { return true; }
 
 	/**
-	 * Whether to print the INI version missing message when this feature is unloaded
-	 */
-	virtual bool DrawFailLoadMessage() const { return true; }
-
-	/**
 	 * Get feature summary and key features for hover tooltip and unloaded UI
 	 *
 	 * \return Pair containing feature summary description and vector of key feature bullet points
 	 */
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() { return {}; }
 
+	/**
+	 * @return The minimum version string required by the Community Shaders
+	 */
+	std::string GetRequiredVersion() const;
+
 	virtual void SetupResources() {}
 	virtual void Reset() {}
-
 	virtual void DrawSettings() {}
 	virtual void DrawUnloadedUI()
 	{
 		auto [description, keyFeatures] = GetFeatureSummary();
 
-		if (!description.empty() || !keyFeatures.empty()) {
-			ImGui::TextColored(Menu::GetSingleton()->GetTheme().StatusPalette.Error, "This feature is not installed!");
+		if (!failedLoadedMessage.empty()) {
+			ImGui::TextColored(Menu::GetSingleton()->GetTheme().StatusPalette.Error, "%s", failedLoadedMessage.c_str());
 			ImGui::Spacing();
+		}
 
 			if (!description.empty()) {
 				ImGui::TextWrapped("%s", description.c_str());
@@ -84,7 +84,6 @@ public:
 					ImGui::BulletText("%s", feature.c_str());
 				}
 				ImGui::Spacing();
-			}
 		}
 	}
 

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -51,7 +51,8 @@ public:
 
 	/**
 	 * Whether to print the INI version missing message when this feature is unloaded
-	 * Default false to prevent duplicate error messages. Retains functionality for author to include custom error message.
+	 * Default false to prevent duplicate error messages. This is handled by failedLoadedMessage in Feature.cpp.
+	 * Retains functionality for author to include custom error message.
 	 * Set to "true" in header file of individual feature.
 	 */
 	virtual bool DrawFailLoadMessage() const { return false; }

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -64,12 +64,6 @@ public:
 	 */
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() { return {}; }
 
-	/**
-	 * Gets the minimum required version string for this feature
-	 * @return The minimum version string required by the Community Shaders
-	 */
-	std::string GetRequiredVersion() const;
-
 	virtual void SetupResources() {}
 	virtual void Reset() {}
 	virtual void DrawSettings() {}

--- a/src/FeatureIssues.cpp
+++ b/src/FeatureIssues.cpp
@@ -4,6 +4,7 @@
 #include "Menu.h"
 #include "State.h"
 #include "Util.h"
+#include "Utils/Format.h"
 
 namespace FeatureIssues
 {
@@ -483,12 +484,12 @@ namespace FeatureIssues
 				ImGui::TextWrapped("INI Path: %s", issue.iniPath.c_str());
 				ImGui::Spacing();
 			}
-			if (!issue.version.empty()) {
-				ImGui::TextWrapped("Current Version: %s", issue.version.c_str());
+	if (!issue.version.empty()) {
+				ImGui::TextWrapped("Current Version: %s", Util::CleanVersionString(issue.version).c_str());
 				ImGui::Spacing();
 			}
 			if (issue.IsVersionMismatch() && !issue.minimumVersionRequired.empty()) {
-				ImGui::TextWrapped("Minimum Required: %s", issue.minimumVersionRequired.c_str());
+				ImGui::TextWrapped("Minimum Required: %s", Util::CleanVersionString(issue.minimumVersionRequired).c_str());
 				ImGui::Spacing();
 			}
 			ImGui::TextWrapped("Issue: %s", issue.rejectionReason.c_str());
@@ -577,15 +578,14 @@ namespace FeatureIssues
 			if (!issue.replacementFeatureModLink.empty()) {
 				std::string buttonText = issue.minimumVersionRequired.empty() ?
 				                             ("Download Latest " + issue.replacementFeatureDisplayName) :
-				                             ("Download " + issue.replacementFeatureDisplayName + " " + issue.minimumVersionRequired + "+");
+				                             ("Download " + issue.replacementFeatureDisplayName + " " + Util::CleanVersionString(issue.minimumVersionRequired) + "+");
 
 				if (ImGui::SmallButton(buttonText.c_str())) {
 					ShellExecuteA(0, 0, issue.replacementFeatureModLink.c_str(), 0, 0, SW_SHOW);
 				}
 
-				if (auto _tt = Util::HoverTooltipWrapper()) {
-					if (!issue.minimumVersionRequired.empty()) {
-						ImGui::Text("Download %s version %s or later", issue.replacementFeatureDisplayName.c_str(), issue.minimumVersionRequired.c_str());
+				if (auto _tt = Util::HoverTooltipWrapper()) {					if (!issue.minimumVersionRequired.empty()) {
+						ImGui::Text("Download %s version %s or later", issue.replacementFeatureDisplayName.c_str(), Util::CleanVersionString(issue.minimumVersionRequired).c_str());
 					} else {
 						ImGui::Text("Download the latest version of %s", issue.replacementFeatureDisplayName.c_str());
 					}
@@ -594,12 +594,12 @@ namespace FeatureIssues
 				// Show message when no download link is available
 				std::string updateText = issue.minimumVersionRequired.empty() ?
 				                             "Update Required" :
-				                             ("Update to " + issue.minimumVersionRequired + "+ Required");
+				                             ("Update to " + Util::CleanVersionString(issue.minimumVersionRequired) + "+ Required");
 
 				ImGui::TextWrapped("%s", updateText.c_str());
 				if (auto _tt = Util::HoverTooltipWrapper()) {
-					if (!issue.minimumVersionRequired.empty()) {
-						ImGui::Text("This feature needs to be updated to version %s or later. Check the mod page manually.", issue.minimumVersionRequired.c_str());
+	if (!issue.minimumVersionRequired.empty()) {
+						ImGui::Text("This feature needs to be updated to version %s or later. Check the mod page manually.", Util::CleanVersionString(issue.minimumVersionRequired).c_str());
 					} else {
 						ImGui::Text("This feature needs to be updated but no download link is available. Check the mod page manually.");
 					}

--- a/src/FeatureIssues.cpp
+++ b/src/FeatureIssues.cpp
@@ -484,7 +484,7 @@ namespace FeatureIssues
 				ImGui::TextWrapped("INI Path: %s", issue.iniPath.c_str());
 				ImGui::Spacing();
 			}
-	if (!issue.version.empty()) {
+			if (!issue.version.empty()) {
 				ImGui::TextWrapped("Current Version: %s", Util::CleanVersionString(issue.version).c_str());
 				ImGui::Spacing();
 			}
@@ -584,7 +584,8 @@ namespace FeatureIssues
 					ShellExecuteA(0, 0, issue.replacementFeatureModLink.c_str(), 0, 0, SW_SHOW);
 				}
 
-				if (auto _tt = Util::HoverTooltipWrapper()) {					if (!issue.minimumVersionRequired.empty()) {
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					if (!issue.minimumVersionRequired.empty()) {
 						ImGui::Text("Download %s version %s or later", issue.replacementFeatureDisplayName.c_str(), Util::CleanVersionString(issue.minimumVersionRequired).c_str());
 					} else {
 						ImGui::Text("Download the latest version of %s", issue.replacementFeatureDisplayName.c_str());
@@ -598,7 +599,7 @@ namespace FeatureIssues
 
 				ImGui::TextWrapped("%s", updateText.c_str());
 				if (auto _tt = Util::HoverTooltipWrapper()) {
-	if (!issue.minimumVersionRequired.empty()) {
+					if (!issue.minimumVersionRequired.empty()) {
 						ImGui::Text("This feature needs to be updated to version %s or later. Check the mod page manually.", Util::CleanVersionString(issue.minimumVersionRequired).c_str());
 					} else {
 						ImGui::Text("This feature needs to be updated but no download link is available. Check the mod page manually.");

--- a/src/Features/TerrainHelper.cpp
+++ b/src/Features/TerrainHelper.cpp
@@ -3,26 +3,6 @@
 #include "ShaderCache.h"
 #include "State.h"
 
-void TerrainHelper::DrawUnloadedUI()
-{
-	auto [description, keyFeatures] = GetFeatureSummary();
-
-	ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-	ImGui::Text("%s", description.c_str());
-
-	if (!keyFeatures.empty()) {
-		ImGui::Spacing();
-		ImGui::Text("Key Features:");
-		for (const auto& feature : keyFeatures) {
-			ImGui::BulletText("%s", feature.c_str());
-		}
-	}
-
-	ImGui::Spacing();
-	ImGui::TextWrapped("Note: This feature is only required if a terrain mod you are using specifically requires it, otherwise it does nothing.");
-	ImGui::PopTextWrapPos();
-}
-
 void TerrainHelper::DataLoaded()
 {
 	// Get the default landscape texture set for terrain helper

--- a/src/Features/TerrainHelper.h
+++ b/src/Features/TerrainHelper.h
@@ -44,8 +44,6 @@ public:
 	virtual void DataLoaded() override;
 	virtual bool SupportsVR() override { return true; };
 	virtual std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
-	virtual void DrawUnloadedUI() override;
-	virtual bool DrawFailLoadMessage() const override { return false; };
 
 	void SetShaderResouces(ID3D11DeviceContext* a_context);
 	bool TESObjectLAND_SetupMaterial(RE::TESObjectLAND* land);

--- a/src/Features/TerrainHelper.h
+++ b/src/Features/TerrainHelper.h
@@ -19,8 +19,7 @@ public:
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{
 		return {
-			"Provides enhanced terrain material support for terrain mods that require additional texture slots and parallax mapping capabilities.",
-			"\n Note: This feature is only required if a terrain mod you are using specifically requires it, otherwise it does nothing.",
+			"Provides enhanced terrain material support for terrain mods that require additional texture slots and parallax mapping capabilities.\nNote: This feature is only required if a terrain mod you are using specifically requires it, otherwise it does nothing.",
 			{ "Extended texture slot support for terrain materials",
 				"Parallax mapping integration for terrain textures",
 				"Automatic terrain material detection and setup",

--- a/src/Features/TerrainHelper.h
+++ b/src/Features/TerrainHelper.h
@@ -20,6 +20,7 @@ public:
 	{
 		return {
 			"Provides enhanced terrain material support for terrain mods that require additional texture slots and parallax mapping capabilities.",
+			"\n Note: This feature is only required if a terrain mod you are using specifically requires it, otherwise it does nothing.",
 			{ "Extended texture slot support for terrain materials",
 				"Parallax mapping integration for terrain textures",
 				"Automatic terrain material detection and setup",

--- a/src/Features/TerrainVariation.cpp
+++ b/src/Features/TerrainVariation.cpp
@@ -136,8 +136,3 @@ void TerrainVariation::SaveSettings(json& o_json)
 {
 	o_json = settings;
 }
-
-bool TerrainVariation::DrawFailLoadMessage() const
-{
-	return false;
-}

--- a/src/Features/TerrainVariation.h
+++ b/src/Features/TerrainVariation.h
@@ -25,7 +25,7 @@ public:
 		return {
 			"Terrain Variation reduces the repeating pattern effect on terrain textures.\n"
 			"This technique creates more natural-looking terrain by adding variation to texture sampling.",
-			{ "Reduces terrain texture tiling",
+			{ "Removes terrain texture tiling",
 				"Adjustable distance-based blending",
 				"Improved terrain visual quality",
 				"Compatible with Extended Materials parallax" }
@@ -56,9 +56,7 @@ public:
 		1.0f,      // shadowRayDirFactor
 		1          // hashQuality - default to high quality
 	};
-
 	virtual void DrawSettings() override;
-	virtual bool DrawFailLoadMessage() const override;
 	virtual void LoadSettings(json& o_json) override;
 	virtual void SaveSettings(json& o_json) override;
 	virtual void RestoreDefaultSettings() override

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -519,10 +519,10 @@ void Menu::DrawSettings()
 							}
 						}
 
-					ImGui::EndTable();
-				}
+						ImGui::EndTable();
+					}
 
-				if (!isDisabled) {
+					if (!isDisabled) {
 						if (ImGui::BeginChild("##FeatureConfigFrame", { 0, 0 }, true)) {
 							if (isLoaded) {
 								// draw settings for loaded feature

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -519,14 +519,10 @@ void Menu::DrawSettings()
 							}
 						}
 
-						ImGui::EndTable();
-					}
+					ImGui::EndTable();
+				}
 
-					if (hasFailedMessage && feat->DrawFailLoadMessage()) {
-						ImGui::TextColored(themeSettings.StatusPalette.Error, feat->failedLoadedMessage.c_str());
-					}
-
-					if (!isDisabled) {
+				if (!isDisabled) {
 						if (ImGui::BeginChild("##FeatureConfigFrame", { 0, 0 }, true)) {
 							if (isLoaded) {
 								// draw settings for loaded feature

--- a/src/Utils/Format.cpp
+++ b/src/Utils/Format.cpp
@@ -8,6 +8,14 @@ namespace Util
 		return v.substr(0, v.find_last_of("."));
 	}
 
+	std::string CleanVersionString(const std::string& versionString)
+	{
+		if (versionString.size() >= 2 && versionString.substr(versionString.size() - 2) == "-0") {
+			return versionString.substr(0, versionString.size() - 2);
+		}
+		return versionString;
+	}
+
 	std::string DefinesToString(const std::vector<std::pair<const char*, const char*>>& defines)
 	{
 		std::string result;

--- a/src/Utils/Format.h
+++ b/src/Utils/Format.h
@@ -6,6 +6,8 @@ namespace Util
 {
 	std::string GetFormattedVersion(const REL::Version& version);
 
+	std::string CleanVersionString(const std::string& versionString);
+
 	std::string DefinesToString(const std::vector<std::pair<const char*, const char*>>& defines);
 	std::string DefinesToString(const std::vector<D3D_SHADER_MACRO>& defines);
 


### PR DESCRIPTION
Cleans up the duplicate error messages when features are uninstalled or not loaded.

Adds a statement "Version required 1-0-0" (or whatever version). 
This indicates to users who might not have the latest base cs the specific version they should download to avoid conflicts.

![20A5EA~1](https://github.com/user-attachments/assets/8ced32fc-1499-41f2-a4fe-32fb92cc9221)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Error messages for missing feature files now clearly indicate when a feature is obsolete or not installed, including cleaned and consistent version information.

- **Bug Fixes**
  - Improved accuracy and clarity of error messages related to missing feature files.
  - Version strings in error and UI messages are now consistently formatted for better readability.

- **Refactor**
  - Simplified and streamlined failure message handling and display in the user interface.
  - Removed outdated or redundant UI elements and methods related to failure message display.

- **Style**
  - Updated feature summary wording for improved clarity, including stronger claims and additional notes.
  - Standardized messaging by adjusting punctuation in log and warning texts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->