### PR TITLE
ci: swap to windows-2022

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -107,7 +107,7 @@ jobs:
             (github.event_name == 'pull_request_target' &&
              !github.event.pull_request.draft))
         name: Build plugin and addons
-        runs-on: windows-latest
+        runs-on: windows-2022
         permissions:
             contents: read
         outputs:
@@ -175,7 +175,7 @@ jobs:
              (github.event_name == 'workflow_dispatch' &&
               github.event.inputs.validate-shaders == 'true'))
         name: Validate shader compilation
-        runs-on: windows-latest
+        runs-on: windows-2022
         permissions:
             contents: read
         strategy:
@@ -266,7 +266,7 @@ jobs:
         name: Post Prerelease from PR
         if: github.event_name == 'pull_request_target'
         needs: [cpp-build, shader-validation]
-        runs-on: windows-latest
+        runs-on: windows-2022
         permissions:
             contents: write
             pull-requests: write
@@ -358,7 +358,7 @@ jobs:
         if: >
             github.event_name == 'workflow_dispatch' ||
             startsWith(github.ref, 'refs/tags/v')
-        runs-on: windows-latest
+        runs-on: windows-2022
         permissions:
             contents: write
         steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the GitHub Actions workflow to use the latest Windows 2022 runner environment for all jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->