### PR TITLE
fix: move shadercache validation after feature PostPostLoad

### DIFF
--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -1,4 +1,3 @@
-
 #include "DX12SwapChain.h"
 #include "Deferred.h"
 #include "FrameAnnotations.h"
@@ -91,16 +90,18 @@ void MessageHandler(SKSE::MessagingInterface::Message* message)
 
 				auto shaderCache = globals::shaderCache;
 
-				shaderCache->ValidateDiskCache();
-
-				if (shaderCache->UseFileWatcher())
-					shaderCache->StartFileWatcher();
-
+				// Run feature PostPostLoad() first so features can disable themselves if needed
 				for (auto* feature : Feature::GetFeatureList()) {
 					if (feature->loaded) {
 						feature->PostPostLoad();
 					}
 				}
+
+				// Now validate disk cache after features have had a chance to modify their state
+				shaderCache->ValidateDiskCache();
+
+				if (shaderCache->UseFileWatcher())
+					shaderCache->StartFileWatcher();
 			}
 
 			break;


### PR DESCRIPTION
Fixes shadercache constantly rebuilding when features disable themselves on load.

- Move ValidateDiskCache() call after feature PostPostLoad() calls
- Ensures cache validation uses correct feature state
- Prevents unnecessary cache rebuilds due to timing issues

Closes #1164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted the sequence of operations during feature loading to ensure features can update their state before disk cache validation and file watcher activation. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->