### PR TITLE
ci: fix cache restore

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -199,7 +199,6 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-cmake-msvc-${{ steps.msvc_version.outputs.version }}-${{ github.event.inputs.cache-key-suffix || 'default' }}-
                       ${{ runner.os }}-cmake-msvc-${{ steps.msvc_version.outputs.version }}-
-                      ${{ runner.os }}-cmake-
 
             - name: Remove stale CMake cache if drive letter changed
               shell: pwsh
@@ -370,8 +369,6 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-cmake-msvc-${{ steps.msvc_version.outputs.version }}-${{ matrix.config.name }}-${{ github.event.inputs.cache-key-suffix || 'default' }}-
                       ${{ runner.os }}-cmake-msvc-${{ steps.msvc_version.outputs.version }}-${{ matrix.config.name }}-
-                      ${{ runner.os }}-cmake-msvc-${{ steps.msvc_version.outputs.version }}-
-                      ${{ runner.os }}-cmake-
 
             - name: Remove stale CMake cache if drive letter changed
               if: steps.check-hlsl.outputs.skip != 'true'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified cache restore keys in the build workflow for Windows runners, reducing the number of fallback cache keys used during cache restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->