### PR TITLE
fix(terrain helper): Fix for nullptr lookup and running without plugin

### DIFF
--- a/src/Features/TerrainHelper.cpp
+++ b/src/Features/TerrainHelper.cpp
@@ -30,11 +30,18 @@ void TerrainHelper::DataLoaded()
 	if (defaultLandTextureSet != nullptr) {
 		logger::info("[Terrain Helper] LandscapeDefault EDID texture set found");
 		defaultLandTexture = defaultLandTextureSet;
+		// only enable if TerrainHelper.esp is loaded
+		enabled = true;
 	}
 }
 
 bool TerrainHelper::TESObjectLAND_SetupMaterial(RE::TESObjectLAND* land)
 {
+	if (!enabled) {
+		// terrain helper is not enabled
+		return false;
+	}
+
 	if (land == nullptr || land->loadedData == nullptr || land->loadedData->mesh[0] == nullptr) {
 		// this is not terrain or vanilla material failed
 		return false;
@@ -142,6 +149,11 @@ void TerrainHelper::SetShaderResouces(ID3D11DeviceContext* a_context)
 
 void TerrainHelper::BSLightingShader_SetupMaterial(RE::BSLightingShaderMaterialBase const* material)
 {
+	if (!enabled) {
+		// terrain helper is not enabled
+		return;
+	}
+
 	if (material == nullptr) {
 		return;
 	}

--- a/src/Features/TerrainHelper.cpp
+++ b/src/Features/TerrainHelper.cpp
@@ -32,6 +32,9 @@ void TerrainHelper::DataLoaded()
 		defaultLandTexture = defaultLandTextureSet;
 		// only enable if TerrainHelper.esp is loaded
 		enabled = true;
+	} else {
+		logger::warn("[Terrain Helper] LandscapeDefault EDID texture set from TerrainHelper.esp not found. Terrain helper is disabled.");
+		enabled = false;
 	}
 }
 

--- a/src/Features/TerrainHelper.cpp
+++ b/src/Features/TerrainHelper.cpp
@@ -30,10 +30,6 @@ void TerrainHelper::DataLoaded()
 	if (defaultLandTextureSet != nullptr) {
 		logger::info("[Terrain Helper] LandscapeDefault EDID texture set found");
 		defaultLandTexture = defaultLandTextureSet;
-	} else {
-		logger::info("[Terrain Helper] LandscapeDefault EDID texture set not found, using default");
-		const auto bgsDefaultLandTex = *REL::Relocation<RE::TESLandTexture**>(RELOCATION_ID(514783, 400936));
-		defaultLandTexture = bgsDefaultLandTex->textureSet;
 	}
 }
 

--- a/src/Features/TerrainHelper.h
+++ b/src/Features/TerrainHelper.h
@@ -41,6 +41,7 @@ public:
 	std::shared_mutex extendedSlotsMutex;
 	std::unordered_map<uint32_t, ExtendedSlots> extendedSlots;
 	RE::BGSTextureSet* defaultLandTexture;
+	bool enabled = false;
 
 	virtual void DataLoaded() override;
 	virtual bool SupportsVR() override { return true; };


### PR DESCRIPTION
This PR fixes 2 things:
* Sometimes the default skyrim terrain TXST does not exist at data loaded time (this is hooked continuously by PBR until it does exist but TH does not do this so it occasionally CTDs on the nullptr resolution). TH doesn't actually need this since it only replaces parallax texture in the shader, not diffuse/normal, so it is simply removed.
* As a default texture set is required for terrain helper, this also adds an enabled bool which only enables if the plugin's record was found on data loaded. Otherwise the hooks will do nothing and terrain helper will do nothing, which is intentional.

In the future I would like to unify the default texture set system with PBR but need to do this in a non-breaking way to existing PBR terrain mods so I will think about that some more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Terrain helper functionality is now automatically enabled only when the required texture set is detected, ensuring it runs only when compatible mods are loaded.

- **Bug Fixes**
  - Prevented terrain helper features from running if the necessary texture set is missing, improving stability and reducing unwanted warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->