### PR TITLE
fix: clear room nodes on update

### DIFF
--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -752,7 +752,7 @@ void LightLimitFix::UpdateLights()
 
 	// Process point lights
 
-	roomNodes.empty();
+	roomNodes.clear();
 
 	auto addRoom = [&](RE::NiNode* node, LightData& light) {
 		uint8_t roomIndex = 0;


### PR DESCRIPTION
This should address https://github.com/doodlum/skyrim-community-shaders/issues/1039. I believe the intent was always to `clear` this before updating the lights. Tested locally, the lights were visible throughout 9 hours of playtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where outdated lighting data could persist between frames, ensuring more accurate and consistent lighting updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->