### PR TITLE
fix(input): resolve alt-tab and shift-tab bugs

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -614,11 +614,8 @@ namespace Hooks
 		static LRESULT thunk(HWND a_hwnd, UINT a_msg, WPARAM a_wParam, LPARAM a_lParam)
 		{
 			auto menu = globals::menu;
-			if (a_msg == WM_KILLFOCUS && menu->initialized) {
-				menu->OnFocusLost();
-				auto& io = ImGui::GetIO();
-				io.ClearInputKeys();
-				io.ClearEventsQueue();
+			if ((a_msg == WM_KILLFOCUS || a_msg == WM_SETFOCUS) && menu->initialized) {
+				menu->focusChanged = true;
 			}
 			return func(a_hwnd, a_msg, a_wParam, a_lParam);
 		}

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -8,6 +8,7 @@
 #include <imgui_impl_win32.h>
 #include <imgui_internal.h>
 #include <imgui_stdlib.h>
+#include <Windows.h>
 
 #include "DX12SwapChain.h"
 #include "Deferred.h"
@@ -2718,6 +2719,16 @@ void Menu::ProcessInputEventQueue()
 	}
 
 	_keyEventQueue.clear();
+
+	// Fallback: release stuck Shift and Tab if OS reports them not pressed
+	if ((io.KeysDown[ImGuiKey_LeftShift] && !(GetAsyncKeyState(VK_LSHIFT) & 0x8000)) ||
+		(io.KeysDown[ImGuiKey_RightShift] && !(GetAsyncKeyState(VK_RSHIFT) & 0x8000))) {
+		io.AddKeyEvent(ImGuiKey_LeftShift, false);
+		io.AddKeyEvent(ImGuiKey_RightShift, false);
+	}
+	if (io.KeysDown[ImGuiKey_Tab] && !(GetAsyncKeyState(VK_TAB) & 0x8000)) {
+		io.AddKeyEvent(ImGuiKey_Tab, false);
+	}
 }
 
 void Menu::addToEventQueue(KeyEvent e)

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -3,12 +3,12 @@
 #ifndef DIRECTINPUT_VERSION
 #	define DIRECTINPUT_VERSION 0x0800
 #endif
+#include <Windows.h>
 #include <dinput.h>
 #include <imgui_impl_dx11.h>
 #include <imgui_impl_win32.h>
 #include <imgui_internal.h>
 #include <imgui_stdlib.h>
-#include <Windows.h>
 
 #include "DX12SwapChain.h"
 #include "Deferred.h"

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -3,7 +3,6 @@
 #ifndef DIRECTINPUT_VERSION
 #	define DIRECTINPUT_VERSION 0x0800
 #endif
-#include <Windows.h>
 #include <dinput.h>
 #include <imgui_impl_dx11.h>
 #include <imgui_impl_win32.h>
@@ -130,6 +129,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	EffectToggleKey,
 	Theme,
 	PerfOverlay)
+
+constexpr std::uint16_t KEY_PRESSED_MASK = 0x8000;
 
 void Menu::SetupImGuiStyle() const
 {
@@ -2721,12 +2722,12 @@ void Menu::ProcessInputEventQueue()
 	_keyEventQueue.clear();
 
 	// Fallback: release stuck Shift and Tab if OS reports them not pressed
-	if ((io.KeysDown[ImGuiKey_LeftShift] && !(GetAsyncKeyState(VK_LSHIFT) & 0x8000)) ||
-		(io.KeysDown[ImGuiKey_RightShift] && !(GetAsyncKeyState(VK_RSHIFT) & 0x8000))) {
+	if ((io.KeysDown[ImGuiKey_LeftShift] && !(GetAsyncKeyState(VK_LSHIFT) & KEY_PRESSED_MASK)) ||
+		(io.KeysDown[ImGuiKey_RightShift] && !(GetAsyncKeyState(VK_RSHIFT) & KEY_PRESSED_MASK))) {
 		io.AddKeyEvent(ImGuiKey_LeftShift, false);
 		io.AddKeyEvent(ImGuiKey_RightShift, false);
 	}
-	if (io.KeysDown[ImGuiKey_Tab] && !(GetAsyncKeyState(VK_TAB) & 0x8000)) {
+	if (io.KeysDown[ImGuiKey_Tab] && !(GetAsyncKeyState(VK_TAB) & KEY_PRESSED_MASK)) {
 		io.AddKeyEvent(ImGuiKey_Tab, false);
 	}
 }

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -305,6 +305,10 @@ void Menu::Init()
 
 void Menu::DrawSettings()
 {
+	if (focusChanged) {
+		OnFocusChanged();
+		focusChanged = false;
+	}
 	ImGui::DockSpaceOverViewport(NULL, ImGuiDockNodeFlags_PassthruCentralNode);
 
 	ImGui::SetNextWindowPos(Util::GetNativeViewportSizeScaled(0.5f), ImGuiCond_FirstUseEver, ImVec2(0.5f, 0.5f));
@@ -2722,10 +2726,16 @@ void Menu::addToEventQueue(KeyEvent e)
 	_keyEventQueue.emplace_back(e);
 }
 
-void Menu::OnFocusLost()
+void Menu::OnFocusChanged()
 {
-	std::unique_lock<std::shared_mutex> mutex(_inputEventMutex);
-	_keyEventQueue.clear();
+	// Solves the alt+tab stuck issue, but disables tab after tabbing back in.
+	if (const auto& inputMgr = RE::BSInputDeviceManager::GetSingleton()) {
+		if (const auto& device = inputMgr->GetKeyboard()) {
+			device->Reset();
+		}
+	}
+	// Allows tab to work again after alt+tabbing back in.
+	ImGui::GetIO().ClearInputKeys();
 }
 
 void Menu::ProcessInputEvents(RE::InputEvent* const* a_events)

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -49,7 +49,7 @@ public:
 	bool ShouldSwallowInput();
 
 	// Used for resetting input keys to solve alt-tab stuck issue
-	bool focusChanged = false;
+	std::atomic<bool> focusChanged = false;
 	void OnFocusChanged();
 
 	// UI icon textures

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -47,7 +47,11 @@ public:
 
 	void ProcessInputEvents(RE::InputEvent* const* a_events);
 	bool ShouldSwallowInput();
-	void OnFocusLost();
+
+	// Used for resetting input keys to solve alt-tab stuck issue
+	bool focusChanged = false;
+	void OnFocusChanged();
+
 	// UI icon textures
 	struct UIIcon
 	{


### PR DESCRIPTION
closes [902](https://github.com/doodlum/skyrim-community-shaders/issues/902) 
closes [862](https://github.com/doodlum/skyrim-community-shaders/issues/862)

Addresses an issue where input keys, particularly the tab key, would become
stuck or unresponsive after alt-tabbing out of and back into the application.

This is resolved by:
- Introducing a `focusChanged` flag and OnFocusChanged method.
- Triggering `focusChanged` on `WM_KILLFOCUS` and `WM_SETFOCUS` window messages via a `WndProcHandler_Hook`.
- In [OnFocusChanged], resetting the keyboard device state via `RE::BSInputDeviceManager::GetSingleton()->GetKeyboard()->Reset()`.
- Clearing ImGui's internal input key states using `ImGui::GetIO().ClearInputKeys()` to ensure proper tab key functionality within the UI.

Additionally:
- Add OS-level fallback polling via `GetAsyncKeyState` to force-release stuck Shift and Tab keys
- Position fallback release logic to after `_keyEventQueue.clear()` to prevent duplicate Tab events on single taps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where keyboard input could become stuck after using Alt+Tab by improving how input focus changes are handled.
	- Fixed stuck Shift and Tab keys by adding fallback detection and release based on OS key states.
- **New Features**
	- The application now more reliably detects and processes focus changes, ensuring smoother user experience when switching between windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->