### PR TITLE
fix: nullptr check for land in PBR TESObjectLAND_SetupMaterial

### DIFF
--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -1093,6 +1093,10 @@ RE::TESLandTexture* GetDefaultLandTexture()
 
 bool TruePBR::TESObjectLAND_SetupMaterial(RE::TESObjectLAND* land)
 {
+	if (land == nullptr) {
+		return false;
+	}
+
 	auto singleton = globals::truePBR;
 
 	bool isPbr = false;


### PR DESCRIPTION
I don't think this was ever actually causing crashes, but I noticed it while debugging something else.

Just adds a nullptr check that returns false for the `TESObjectLAND` object

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by preventing potential crashes when invalid input is detected during material setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->