### PR TITLE
style(ui): standardize feature version format from (1-0-0) to (1.0.0) in UI

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -770,7 +770,9 @@ void Menu::DrawSettings()
 					// Display version if loaded
 					if (isLoaded) {
 						ImGui::SameLine();
-						ImGui::TextDisabled(fmt::format("({})", feat->version).c_str());
+						std::string formattedVersion = feat->version;
+						std::replace(formattedVersion.begin(), formattedVersion.end(), '-', '.');
+						ImGui::TextDisabled(fmt::format("({})", formattedVersion).c_str());
 					}
 				}
 			};


### PR DESCRIPTION
Changes the version info printed next to features to use decimals instead of hyphens for style cohesiveness.
Every other version printed in the UI is now a decimal, so just a simple fix to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the display of feature version strings in the menu to replace hyphens with dots for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->