### PR TITLE
chore: rename unused shared variable

### DIFF
--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -69,7 +69,7 @@ namespace SharedData
 		uint EnableContactShadows;
 		uint EnableLightsVisualisation;
 		uint LightsVisualisationMode;
-		float LightsFar;
+		float pad0;
 		uint4 ClusterSize;
 	};
 


### PR DESCRIPTION
LLF doesn't use this and matches the cpp declaration with a pad.
See https://github.com/doodlum/skyrim-community-shaders/blob/76ee59b86081e67824be284f36c6dda7490c508b/src/Features/LightLimitFix.h#L95-L102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated internal structure alignment for improved consistency; no changes to visible features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->