### PR TITLE
fix(ui): show message when no settings available

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -835,7 +835,20 @@ void Menu::DrawSettings()
 									ImGui::Text("Enable the feature above to access its configuration options.");
 								} else {
 									if (isLoaded) {
+										// Check if the feature has any settings by monitoring cursor position (if the feature draws settings, the imgui cursor position will change)
+										ImVec2 cursorPosBefore = ImGui::GetCursorPos();
+										
 										feat->DrawSettings();
+										
+										ImVec2 cursorPosAfter = ImGui::GetCursorPos();
+										
+										// If cursor position hasn't changed significantly, no visible settings were drawn
+										const float epsilon = 0.1f; // Simple check to ensure we don't trigger on minor cursor movements / weird imgui math
+										bool cursorMoved = (std::abs(cursorPosAfter.x - cursorPosBefore.x) > epsilon || 
+										                   std::abs(cursorPosAfter.y - cursorPosBefore.y) > epsilon);
+										if (!cursorMoved) {
+											ImGui::TextColored(themeSettings.StatusPalette.Disable, "There are no settings available for this feature.");
+										}
 									} else {
 										// Check if INI file exists to avoid showing obsolete "missing file" messages
 										// when feature was re-enabled after being disabled at boot

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -837,15 +837,15 @@ void Menu::DrawSettings()
 									if (isLoaded) {
 										// Check if the feature has any settings by monitoring cursor position (if the feature draws settings, the imgui cursor position will change)
 										ImVec2 cursorPosBefore = ImGui::GetCursorPos();
-										
+
 										feat->DrawSettings();
-										
+
 										ImVec2 cursorPosAfter = ImGui::GetCursorPos();
-										
+
 										// If cursor position hasn't changed significantly, no visible settings were drawn
-										const float epsilon = 0.1f; // Simple check to ensure we don't trigger on minor cursor movements / weird imgui math
-										bool cursorMoved = (std::abs(cursorPosAfter.x - cursorPosBefore.x) > epsilon || 
-										                   std::abs(cursorPosAfter.y - cursorPosBefore.y) > epsilon);
+										const float epsilon = 0.1f;  // Simple check to ensure we don't trigger on minor cursor movements / weird imgui math
+										bool cursorMoved = (std::abs(cursorPosAfter.x - cursorPosBefore.x) > epsilon ||
+															std::abs(cursorPosAfter.y - cursorPosBefore.y) > epsilon);
 										if (!cursorMoved) {
 											ImGui::TextColored(themeSettings.StatusPalette.Disable, "There are no settings available for this feature.");
 										}


### PR DESCRIPTION
![202506~3](https://github.com/user-attachments/assets/6ff6e291-570d-41a2-babb-b34c44ca9428)


Simple message added when imgui cursor pos doesn't move (aka no settings were drawn). Simple & lightweight, automatic and doesn't need header modification. Works for Terrain Helper & Water Effects currently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Displays a message when a feature has no available settings, providing clearer feedback in the settings area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->