### PR TITLE
fix(menu): prioritize obsolete feature detection over restart

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -847,20 +847,20 @@ void Menu::DrawSettings()
 										} else {
 											// INI file missing - show detailed unloaded UI with installation info
 											feat->DrawUnloadedUI();
-										// Add download link if available
-										if (!feat->GetFeatureModLink().empty()) {
-											ImGui::Spacing();
-											const auto downloadText = fmt::format("Click here to download this feature ({})", feat->GetFeatureModLink());
-											if (ImGui::Selectable(downloadText.c_str())) {
-												ShellExecuteA(NULL, "open", feat->GetFeatureModLink().c_str(), NULL, NULL, SW_SHOWNORMAL);
-											}
-											if (auto _tt = Util::HoverTooltipWrapper()) {
-												ImGui::Text("Download the feature from the mod page.");
+											// Add download link if available
+											if (!feat->GetFeatureModLink().empty()) {
+												ImGui::Spacing();
+												const auto downloadText = fmt::format("Click here to download this feature ({})", feat->GetFeatureModLink());
+												if (ImGui::Selectable(downloadText.c_str())) {
+													ShellExecuteA(NULL, "open", feat->GetFeatureModLink().c_str(), NULL, NULL, SW_SHOWNORMAL);
+												}
+												if (auto _tt = Util::HoverTooltipWrapper()) {
+													ImGui::Text("Download the feature from the mod page.");
+												}
 											}
 										}
 									}
 								}
-							}
 
 								// Error Messages (Not for obsolete features as this is already covered by DrawUnloadedUI)
 								if (hasFailedMessage && feat->DrawFailLoadMessage() && !FeatureIssues::IsObsoleteFeature(feat->GetShortName())) {

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1067,7 +1067,7 @@ void Menu::DrawSettings()
 			}
 
 			auto unloadedFeatures = sortedFeatureList | std::ranges::views::filter([](Feature* feat) {
-				return !feat->loaded && feat->IsInMenu();
+				return !feat->loaded && feat->IsInMenu() && (!FeatureIssues::IsObsoleteFeature(feat->GetShortName()) || globals::state->IsDeveloperMode());
 			});
 			if (std::ranges::distance(unloadedFeatures) != 0) {
 				menuList.push_back("Unloaded Features"s);

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -837,15 +837,16 @@ void Menu::DrawSettings()
 									if (isLoaded) {
 										feat->DrawSettings();
 									} else {
-										// Check if INI file exists to avoid showing obsolete "missing file" messages
-										// when feature was re-enabled after being disabled at boot
-										if (std::filesystem::exists(Util::PathHelpers::GetFeatureIniPath(feat->GetShortName()))) {
+										// Check if feature is obsolete first - always show error for obsolete features
+										if (FeatureIssues::IsObsoleteFeature(feat->GetShortName())) {
+											// Obsolete feature - show detailed unloaded UI with error info
+											feat->DrawUnloadedUI();
+										} else if (std::filesystem::exists(Util::PathHelpers::GetFeatureIniPath(feat->GetShortName()))) {
 											// INI file exists - show simple pending restart message
 											ImGui::Text("This feature will be available after restart.");
 										} else {
 											// INI file missing - show detailed unloaded UI with installation info
 											feat->DrawUnloadedUI();
-										}
 										// Add download link if available
 										if (!feat->GetFeatureModLink().empty()) {
 											ImGui::Spacing();
@@ -859,9 +860,10 @@ void Menu::DrawSettings()
 										}
 									}
 								}
+							}
 
-								// Error Messages
-								if (hasFailedMessage && feat->DrawFailLoadMessage()) {
+								// Error Messages (Not for obsolete features as this is already covered by DrawUnloadedUI)
+								if (hasFailedMessage && feat->DrawFailLoadMessage() && !FeatureIssues::IsObsoleteFeature(feat->GetShortName())) {
 									ImGui::Spacing();
 									ImGui::SeparatorText("Error");
 									ImGui::TextColored(themeSettings.StatusPalette.Error, feat->failedLoadedMessage.c_str());


### PR DESCRIPTION
Fixed obsolete feature UI logic that incorrectly displayed "This feature will be available after restart" for removed features like TerrainBlending. Now prioritizes obsolete feature detection before checking INI file existence, ensuring proper error messages are shown. Also prevents duplicate error display by excluding obsolete features from the Error section since DrawUnloadedUI() already handles their messaging appropriately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved menu UI to clearly indicate when features are obsolete, including detailed error information for such features.
  
* **Bug Fixes**
  * Suppressed error messages for failed loads of obsolete features to reduce unnecessary alerts.
  
* **Refactor**
  * Updated the display logic so that obsolete features are hidden from the "Unloaded Features" menu section for regular users, but remain visible in developer mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->