### PR TITLE
fix(vr): disable ssgi by default

### DIFF
--- a/package/Shaders/Common/VR.hlsli
+++ b/package/Shaders/Common/VR.hlsli
@@ -2,6 +2,13 @@
 #define __VR_DEPENDENCY_HLSL__
 #ifdef VR
 
+
+// First person model depth threshold for VR occlusion logic
+#ifndef VR_FP_Z
+#define VR_FP_Z 18.0
+#endif
+
+
 #	if defined(VSHADER)
 #		include "Common/Math.hlsli"
 #	endif  // VSHADER
@@ -308,10 +315,31 @@ namespace Stereo
 	}
 
 	/**
+	* @brief Returns a smooth fade factor for UVs near the edge of the frame.
+	*
+	* This helps avoid abrupt transitions when one eye's SSGI is out of frame or occluded.
+	* Fade width is tunable; 0.02 is 2% of the frame.
+	*/
+	float IsOutsideFrameFade(float2 uv, bool dynamicres = false)
+	{
+		float2 max = dynamicres ? FrameBuffer::DynamicResolutionParams1.xy : float2(1, 1);
+		float2 min = float2(0, 0);
+		float fadeWidth = 0.02;
+		float edgeFade = 1.0;
+		edgeFade *= smoothstep(min.x, min.x + fadeWidth, uv.x);
+		edgeFade *= smoothstep(max.x, max.x - fadeWidth, uv.x);
+		edgeFade *= smoothstep(min.y, min.y + fadeWidth, uv.y);
+		edgeFade *= smoothstep(max.y, max.y - fadeWidth, uv.y);
+		return edgeFade;
+	}
+
+	/**
 	* @brief Blends color data from two eyes based on their UV coordinates and validity.
 	*
 	* This function checks the validity of the colors based on their UV coordinates and
 	* alpha values. It blends the colors while ensuring proper handling of transparency.
+	* If one eye sees the first person model (depth < VR_FP_Z) and the other sees world geometry (depth > VR_FP_Z),
+	* the first person model's color is dropped from the blend to avoid outlines.
 	*
 	* @param uv1 UV coordinates for the first eye.
 	* @param color1 Color from the first eye.
@@ -327,25 +355,36 @@ namespace Stereo
 		float4 color2,
 		bool dynamicres = false)
 	{
-		// Check validity for color1
-		bool validColor1 = IsNonZeroColor(color1) && !FrameBuffer::IsOutsideFrame(uv1.xy, dynamicres);
-		// Check validity for color2
-		bool validColor2 = IsNonZeroColor(color2) && !FrameBuffer::IsOutsideFrame(uv2.xy, dynamicres);
+		// Use smooth fade at edge for each eye
+		float fade1 = IsOutsideFrameFade(uv1.xy, dynamicres);
+		float fade2 = IsOutsideFrameFade(uv2.xy, dynamicres);
 
-		// Calculate alpha values
-		float alpha1 = validColor1 ? color1.a : 0.0f;
-		float alpha2 = validColor2 ? color2.a : 0.0f;
+		// Stereo-consistent edge fade: use maximum fade so either eye can keep color if in bounds
+		float edgeFade = max(fade1, fade2);
 
-		// Total alpha
-		float totalAlpha = alpha1 + alpha2;
+		// Occlusion-aware confidence based on depth difference
+		float depthDiff = abs(uv1.z - uv2.z);
+		float confidence = 1.0 - smoothstep(0.01, 0.05, depthDiff);
 
-		// Blend based on higher alpha
-		float4 blendedColor = (validColor1 ? color1 * (alpha1 / max(totalAlpha, 1e-5)) : float4(0, 0, 0, 0)) +
-		                      (validColor2 ? color2 * (alpha2 / max(totalAlpha, 1e-5)) : float4(0, 0, 0, 0));
+		// Soft first person model mask: fade out FP model near threshold
+		float fp_fade1 = 1.0 - smoothstep(VR_FP_Z - 1.0, VR_FP_Z + 1.0, uv1.z); // fades from 1 to 0 as depth crosses VR_FP_Z
+		float fp_fade2 = 1.0 - smoothstep(VR_FP_Z - 1.0, VR_FP_Z + 1.0, uv2.z);
 
-		// Final alpha determination
-		blendedColor.a = max(color1.a, color2.a);
+		// If one eye is world and the other is FP, fade out FP smoothly
+		bool eye1_is_fp = uv1.z < VR_FP_Z;
+		bool eye2_is_fp = uv2.z < VR_FP_Z;
+		bool eyes_disagree = eye1_is_fp != eye2_is_fp;
+		if (eyes_disagree) {
+			if (eye1_is_fp) fade1 *= fp_fade1;
+			if (eye2_is_fp) fade2 *= fp_fade2;
+		}
 
+		fade1 *= confidence * edgeFade;
+		fade2 *= confidence * edgeFade;
+
+		float totalFade = fade1 + fade2 + 1e-5;
+		float4 blendedColor = (color1 * fade1 + color2 * fade2) / totalFade;
+		blendedColor.a = max(color1.a * fade1, color2.a * fade2);
 		return blendedColor;
 	}
 

--- a/src/Features/ScreenSpaceGI.h
+++ b/src/Features/ScreenSpaceGI.h
@@ -70,13 +70,13 @@ public:
 
 	struct Settings
 	{
-		bool Enabled = true;
-		bool EnableGI = true;
+		bool Enabled = REL::Module::IsVR() ? false : true;   // disabled in VR by default
+		bool EnableGI = REL::Module::IsVR() ? false : true;  // AO only for VR by default
 		bool EnableExperimentalSpecularGI = false;
 		// performance/quality
-		uint NumSlices = 4;
-		uint NumSteps = 8;
-		int ResolutionMode = 1;  // 0-full, 1-half, 2-quarter
+		uint NumSlices = REL::Module::IsVR() ? 1u : 4u;  // AO preset for VR
+		uint NumSteps = REL::Module::IsVR() ? 6u : 8u;   // AO preset for VR
+		int ResolutionMode = 1;                          // 0-full, 1-half, 2-quarter
 		// visual
 		float MinScreenRadius = 0.01f;
 		float AORadius = 256.f;

--- a/src/Features/ScreenSpaceGI.h
+++ b/src/Features/ScreenSpaceGI.h
@@ -28,15 +28,24 @@ public:
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{
-		return {
-			"Screen Space Global Illumination adds realistic indirect lighting and ambient occlusion to the game.\n"
-			"This technique simulates how light bounces off surfaces to illuminate other objects naturally.",
-			{ "Realistic indirect lighting",
+		std::string desc =
+			"Screen Space Global Illumination adds realistic indirect lighting and "
+			"ambient occlusion to the game. This technique simulates how light "
+			"bounces off surfaces to illuminate other objects naturally.";
+		if (REL::Module::IsVR()) {
+			desc +=
+				"\n\nWarning: In VR, this feature may have visual artifacts and "
+				"can have a significant performance impact due to the nature of "
+				"screen space effects.";
+		}
+		return std::make_pair(
+			desc,
+			std::vector<std::string>{
+				"Realistic indirect lighting",
 				"Enhanced ambient occlusion",
 				"Improved visual depth and atmosphere",
 				"Temporal denoising for smooth results",
-				"Configurable quality and performance settings" }
-		};
+				"Configurable quality and performance settings" });
 	}
 
 	virtual void RestoreDefaultSettings() override;


### PR DESCRIPTION
Refine BlendEyeColors to use stereo-consistent edge fade (max of both eyes), add occlusion-aware confidence blending based on depth difference, and implement soft first person model mask using VR_FP_Z. This reduces artifacts at occlusion boundaries and improves visual consistency in VR.

VR screen space effects will always have some artifacts given the different eyes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved blending of eye colors in VR, resulting in smoother transitions at frame edges and better handling of occlusion between first person models and world geometry.
  * Added smooth fading near the edges of the frame to prevent abrupt visual transitions.
  * Enhanced masking for first person models to reduce unwanted outlines and visual artifacts.
  * Introduced VR-aware adjustments to Screen Space Global Illumination, including conditional disabling and reduced quality settings to optimize VR performance and reduce visual artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->