### PR TITLE
perf(VL): replace ping-pong dispatches with single pass

### DIFF
--- a/package/Shaders/ISVolumetricLightingBlurHCS.hlsl
+++ b/package/Shaders/ISVolumetricLightingBlurHCS.hlsl
@@ -1,0 +1,55 @@
+Texture2D<float> InVLTexture : register(t0);
+Texture2D<float> DepthTexture : register(t1);
+SamplerState LinearSampler : register(s0);
+SamplerState PointSampler : register(s1);
+RWTexture2D<float> OutVLTexture : register(u0);
+
+#ifndef TG_DIM
+#	define TG_DIM 256
+#endif
+
+#ifndef WINDOW
+#	define WINDOW 12
+#endif
+
+cbuffer CBSize : register(b0)
+{
+	float4 invSize;
+	float4 maxUV;
+}
+
+cbuffer VLData : register(b1)
+{
+	int2 screenSize;
+	int2 screenSizeMin1;
+}
+
+groupshared float vl[TG_DIM];
+groupshared float depth[TG_DIM];
+
+[numthreads(TG_DIM, 1, 1)] void main(uint3 groupThreadId : SV_GroupThreadID, uint3 groupId : SV_GroupID) {
+	int idx = groupThreadId.x;
+	int base = idx - WINDOW;
+	int x = groupId.x * (TG_DIM - WINDOW * 2) + base;
+	int y = groupId.y;
+
+	int2 pix = min(int2(x, y), screenSizeMin1.xy);
+	float vlValue = InVLTexture[pix];
+	vl[idx] = vlValue;
+	float depthValue = DepthTexture[pix];
+	depth[idx] = depthValue;
+
+	GroupMemoryBarrierWithGroupSync();
+
+	if (base >= 0 && base < TG_DIM - WINDOW * 2) {
+		int min12 = idx - 12;
+		int min6 = idx - 6;
+		int plus6 = idx + 6;
+		int plus12 = idx + 12;
+
+		float diff = depthValue * 4 - depth[min12] - depth[min6] - depth[plus6] - depth[plus12];
+		vlValue = abs(diff) <= 0.002f ? vl[min12] * 0.178400f + vl[min6] * 0.210431f + vlValue * 0.222338f + vl[plus6] * 0.210431f + vl[plus12] * 0.178400f : vlValue;
+
+		OutVLTexture[int2(x, y)] = vlValue;
+	}
+}

--- a/package/Shaders/ISVolumetricLightingBlurVCS.hlsl
+++ b/package/Shaders/ISVolumetricLightingBlurVCS.hlsl
@@ -1,0 +1,55 @@
+Texture2D<float> InVLTexture : register(t0);
+Texture2D<float> DepthTexture : register(t1);
+SamplerState LinearSampler : register(s0);
+SamplerState PointSampler : register(s1);
+RWTexture2D<float> OutVLTexture : register(u0);
+
+#ifndef TG_DIM
+#	define TG_DIM 256
+#endif
+
+#ifndef WINDOW
+#	define WINDOW 12
+#endif
+
+cbuffer CBSize : register(b0)
+{
+	float4 invSize;
+	float4 maxUV;
+}
+
+cbuffer VLData : register(b1)
+{
+	int2 screenSize;
+	int2 screenSizeMin1;
+}
+
+groupshared float vl[TG_DIM];
+groupshared float depth[TG_DIM];
+
+[numthreads(1, TG_DIM, 1)] void main(uint3 groupThreadId : SV_GroupThreadID, uint3 groupId : SV_GroupID) {
+	int idx = groupThreadId.y;
+	int base = idx - WINDOW;
+	int x = groupId.x;
+	int y = groupId.y * (TG_DIM - WINDOW * 2) + base;
+	
+	int2 pix = min(int2(x, y), screenSizeMin1.xy);
+	float vlValue = InVLTexture[pix];
+	vl[idx] = vlValue;
+	float depthValue = DepthTexture[pix];
+	depth[idx] = depthValue;
+
+	GroupMemoryBarrierWithGroupSync();
+
+	if (base >= 0 && base < TG_DIM - WINDOW * 2) {
+		int min12 = idx - 12;
+		int min6 = idx - 6;
+		int plus6 = idx + 6;
+		int plus12 = idx + 12;
+
+		float diff = depthValue * 4 - depth[min12] - depth[min6] - depth[plus6] - depth[plus12];
+		vlValue = abs(diff) <= 0.002f ? vl[min12] * 0.178400f + vl[min6] * 0.210431f + vlValue * 0.222338f + vl[plus6] * 0.210431f + vl[plus12] * 0.178400f : vlValue;
+
+		OutVLTexture[int2(x, y)] = vlValue;
+	}
+}

--- a/package/Shaders/ISVolumetricLightingBlurVCS.hlsl
+++ b/package/Shaders/ISVolumetricLightingBlurVCS.hlsl
@@ -32,7 +32,7 @@ groupshared float depth[TG_DIM];
 	int base = idx - WINDOW;
 	int x = groupId.x;
 	int y = groupId.y * (TG_DIM - WINDOW * 2) + base;
-	
+
 	int2 pix = min(int2(x, y), screenSizeMin1.xy);
 	float vlValue = InVLTexture[pix];
 	vl[idx] = vlValue;

--- a/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
+++ b/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
@@ -6,7 +6,7 @@
 SamplerState ShadowmapSampler : register(s0);
 SamplerState ShadowmapVLSampler : register(s1);
 SamplerState InverseRepartitionSampler : register(s2);
-SamplerState NoiseSampler : register(s3); 
+SamplerState NoiseSampler : register(s3);
 
 Texture2DArray<float> ShadowmapTex : register(t0);
 Texture2DArray<float> ShadowmapVLTex : register(t1);
@@ -99,11 +99,11 @@ cbuffer PerTechnique : register(b0)
 		uint cascadeIndex = ShadowMapCount >= 3.0f && shadowMapDepth > EndSplitDistances.y ? 2 : shadowMapDepth > EndSplitDistances.x ? 1 : 0;
 		float shadowMapThreshold = cascadeIndex == 0 ? 0.01f : 0.0f;
 		float4x3 lightProjectionMatrix = ShadowMapProj[eyeIndex][cascadeIndex];
-	
+
 		float3 positionLS = mul(transpose(lightProjectionMatrix), float4(positionWS.xyz, 1)).xyz;
 		float shadowMapValue = ShadowmapTex.SampleLevel(ShadowmapSampler, float3(positionLS.xy, cascadeIndex), 0);
 		noShadow = shadowMapValue >= positionLS.z - shadowMapThreshold;
-		
+
 		if (EnableShadowCasting < 0.5) {
 			float shadowMapVLValue = ShadowmapVLTex.SampleLevel(ShadowmapVLSampler, float3(positionLS.xy, cascadeIndex), 0);
 			noShadow = noShadow & shadowMapVLValue >= positionLS.z - shadowMapThreshold;

--- a/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
+++ b/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
@@ -6,15 +6,14 @@
 SamplerState ShadowmapSampler : register(s0);
 SamplerState ShadowmapVLSampler : register(s1);
 SamplerState InverseRepartitionSampler : register(s2);
-SamplerState NoiseSampler : register(s3);
+SamplerState NoiseSampler : register(s3); 
 
-Texture2DArray<float4> ShadowmapTex : register(t0);
-Texture2DArray<float4> ShadowmapVLTex : register(t1);
-Texture1D<float4> InverseRepartitionTex : register(t2);
-Texture3D<float4> NoiseTex : register(t3);
+Texture2DArray<float> ShadowmapTex : register(t0);
+Texture2DArray<float> ShadowmapVLTex : register(t1);
+Texture1D<float> InverseRepartitionTex : register(t2);
+Texture3D<float> NoiseTex : register(t3);
 
-RWTexture3D<float4> DensityRW : register(u0);
-RWTexture3D<float4> DensityCopyRW : register(u1);
+RWTexture3D<float> DensityRW : register(u0);
 
 #	define LinearSampler ShadowmapSampler
 
@@ -34,8 +33,8 @@ RWTexture3D<float4> DensityCopyRW : register(u1);
 cbuffer PerTechnique : register(b0)
 {
 #	ifndef VR
-	float4x4 CameraViewProj[1] : packoffset(c0);
-	float4x4 CameraViewProjInverse[1] : packoffset(c4);
+	row_major float4x4 CameraViewProj[1] : packoffset(c0);
+	row_major float4x4 CameraViewProjInverse[1] : packoffset(c4);
 	float4x3 ShadowMapProj[1][3] : packoffset(c8);
 	float3 EndSplitDistances : packoffset(c17.x);
 	float ShadowMapCount : packoffset(c17.w);
@@ -50,8 +49,8 @@ cbuffer PerTechnique : register(b0)
 	float PhaseScattering : packoffset(c23.y);
 	float DensityContribution : packoffset(c23.z);
 #	else
-	float4x4 CameraViewProj[2] : packoffset(c0);
-	float4x4 CameraViewProjInverse[2] : packoffset(c8);
+	row_major float4x4 CameraViewProj[2] : packoffset(c0);
+	row_major float4x4 CameraViewProjInverse[2] : packoffset(c8);
 	float4x3 ShadowMapProj[2][3] : packoffset(c16);
 	float3 EndSplitDistances : packoffset(c34.x);
 	float ShadowMapCount : packoffset(c34.w);
@@ -69,84 +68,63 @@ cbuffer PerTechnique : register(b0)
 }
 
 [numthreads(32, 32, 1)] void main(uint3 dispatchID : SV_DispatchThreadID) {
-	const float3 StepCoefficients[] = { { 0, 0, 0 },
-		{ 0, 0, 1.000000 },
-		{ 0, 1.000000, 0 },
-		{ 0, 1.000000, 1.000000 },
-		{ 1.000000, 0, 0 },
-		{ 1.000000, 0, 1.000000 },
-		{ 1.000000, 1.000000, 0 },
-		{ 1.000000, 1.000000, 1.000000 } };
+	const float3 StepCoefficients[] = {
+		{ 0, 0, 0 },
+		{ 0, 0, 0.001 },
+		{ 0, 0.001, 0 },
+		{ 0, 0.001, 0.001 },
+		{ 0.001, 0, 0 },
+		{ 0.001, 0, 0.001 },
+		{ 0.001, 0.001, 0 },
+		{ 0.001, 0.001, 0.001 }
+	};
 
-	float3 normalizedCoordinates = dispatchID.xyz / TextureDimensions.xyz;
+	float3 normalizedCoordinates = dispatchID.xyz * rcp(TextureDimensions.xyz);
 	float2 uv = normalizedCoordinates.xy;
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
-	float3 depthUv = Stereo::ConvertFromStereoUV(normalizedCoordinates, eyeIndex) + 0.001 * StepCoefficients[IterationIndex].xyz;
-	float depth = InverseRepartitionTex.SampleLevel(InverseRepartitionSampler, depthUv.z, 0).x;
+	float3 depthUv = Stereo::ConvertFromStereoUV(normalizedCoordinates, eyeIndex) + StepCoefficients[IterationIndex];
+	float depth = InverseRepartitionTex.SampleLevel(InverseRepartitionSampler, depthUv.z, 0);
 	float4 positionCS = float4(2 * depthUv.x - 1, 1 - 2 * depthUv.y, depth, 1);
 
-	float4 positionWS = mul(transpose(CameraViewProjInverse[eyeIndex]), positionCS);
-	positionWS /= positionWS.w;
+	float4 positionWS = mul(CameraViewProjInverse[eyeIndex], positionCS);
+	positionWS *= rcp(positionWS.w);
 
-	float4 positionCSShifted = mul(transpose(CameraViewProj[eyeIndex]), positionWS);
-	positionCSShifted /= positionCSShifted.w;
+	float4 positionCSShifted = mul(CameraViewProj[eyeIndex], positionWS);
+	positionCSShifted *= rcp(positionCSShifted.w);
 
 	float shadowMapDepth = positionCSShifted.z;
 
-	float shadowContribution = 1;
+	bool noShadow = true;
 	if (EndSplitDistances.z >= shadowMapDepth) {
-		float4x3 lightProjectionMatrix = ShadowMapProj[eyeIndex][0];
-		float shadowMapThreshold = 0.01;
-		float cascadeIndex = 0;
-		if (2.5 < ShadowMapCount && EndSplitDistances.y < shadowMapDepth) {
-			lightProjectionMatrix = ShadowMapProj[eyeIndex][2];
-			shadowMapThreshold = 0;
-			cascadeIndex = 2;
-		} else if (EndSplitDistances.x < shadowMapDepth) {
-			lightProjectionMatrix = ShadowMapProj[eyeIndex][1];
-			shadowMapThreshold = 0;
-			cascadeIndex = 1;
-		}
-
+		uint cascadeIndex = ShadowMapCount >= 3.0f && shadowMapDepth > EndSplitDistances.y ? 2 : shadowMapDepth > EndSplitDistances.x ? 1 : 0;
+		float shadowMapThreshold = cascadeIndex == 0 ? 0.01f : 0.0f;
+		float4x3 lightProjectionMatrix = ShadowMapProj[eyeIndex][cascadeIndex];
+	
 		float3 positionLS = mul(transpose(lightProjectionMatrix), float4(positionWS.xyz, 1)).xyz;
-		float shadowMapValue = ShadowmapTex.SampleLevel(ShadowmapSampler, float3(positionLS.xy, cascadeIndex), 0).x;
-
+		float shadowMapValue = ShadowmapTex.SampleLevel(ShadowmapSampler, float3(positionLS.xy, cascadeIndex), 0);
+		noShadow = shadowMapValue >= positionLS.z - shadowMapThreshold;
+		
 		if (EnableShadowCasting < 0.5) {
-			float shadowMapVLValue = ShadowmapVLTex.SampleLevel(ShadowmapVLSampler, float3(positionLS.xy, cascadeIndex), 0).x;
-
-			float baseShadowVisibility = 0;
-			if (shadowMapValue >= positionLS.z - shadowMapThreshold) {
-				baseShadowVisibility = 1;
-			}
-
-			float vlShadowVisibility = 0;
-			if (shadowMapVLValue >= positionLS.z - shadowMapThreshold) {
-				vlShadowVisibility = 1;
-			}
-
-			shadowContribution = min(baseShadowVisibility, vlShadowVisibility);
-		} else if (shadowMapValue >= positionLS.z - shadowMapThreshold) {
-			shadowContribution = 1;
-		} else {
-			shadowContribution = 0;
+			float shadowMapVLValue = ShadowmapVLTex.SampleLevel(ShadowmapVLSampler, float3(positionLS.xy, cascadeIndex), 0);
+			noShadow = noShadow & shadowMapVLValue >= positionLS.z - shadowMapThreshold;
 		}
 	}
 
 	float3 noiseUv = 0.0125 * (InverseDensityScale * (positionWS.xyz + WindInput[eyeIndex]));
-	float noise = NoiseTex.SampleLevel(NoiseSampler, noiseUv, 0).x;
+	float noise = NoiseTex.SampleLevel(NoiseSampler, noiseUv, 0);
 	float densityFactor = noise * (1 - 0.75 * smoothstep(0, 1, saturate(2 * positionWS.z / 300)));
 	float densityContribution = lerp(1, densityFactor, DensityContribution);
 
-	float LdotN = dot(normalize(-positionWS.xyz), normalize(DirLightDirection));
-	float phaseFactor = (1 - PhaseScattering * PhaseScattering) / (4 * Math::PI * (1 - LdotN * PhaseScattering));
+	float LdotN = dot(normalize(-positionWS.xyz), DirLightDirection);
+	float phaseFactor = (1 - PhaseScattering * PhaseScattering) * rcp(4 * Math::PI * (1 - LdotN * PhaseScattering));
 	float phaseContribution = lerp(1, phaseFactor, PhaseContribution);
 
-	if (shadowContribution != 0.0 && !SharedData::InInterior && !SharedData::HideSky)
+	float shadowContribution = noShadow;
+	if (noShadow && !SharedData::InInterior && !SharedData::HideSky)
 		shadowContribution *= ShadowSampling::GetWorldShadow(positionWS.xyz, PosAdjust[eyeIndex].xyz, eyeIndex);
 
 	float vl = shadowContribution * densityContribution * phaseContribution;
 
 	DensityRW[dispatchID.xyz] = vl;
-	DensityCopyRW[dispatchID.xyz] = vl;
 }
 #endif

--- a/package/Shaders/ISVolumetricLightingRaymarchCS.hlsl
+++ b/package/Shaders/ISVolumetricLightingRaymarchCS.hlsl
@@ -1,6 +1,3 @@
-#define CSHADER
-
-#if defined(CSHADER)
 SamplerState DensitySampler : register(s0);
 RWTexture3D<float> DensityRW : register(u0);
 
@@ -19,4 +16,3 @@ cbuffer PerTechnique : register(b0)
 		DensityRW[currCoord] = acc;
 	}
 }
-#endif

--- a/package/Shaders/ISVolumetricLightingRaymarchCS.hlsl
+++ b/package/Shaders/ISVolumetricLightingRaymarchCS.hlsl
@@ -1,9 +1,8 @@
+#define CSHADER
+
 #if defined(CSHADER)
 SamplerState DensitySampler : register(s0);
-
-Texture3D<float4> DensityTex : register(t0);
-
-RWTexture3D<float4> DensityRW : register(u0);
+RWTexture3D<float> DensityRW : register(u0);
 
 cbuffer PerTechnique : register(b0)
 {
@@ -12,12 +11,12 @@ cbuffer PerTechnique : register(b0)
 }
 
 [numthreads(32, 32, 1)] void main(uint3 dispatchID : SV_DispatchThreadID) {
-	float3 previousPosition = (0.5 + float3(dispatchID.xy, StepIndex - 1)) / TextureDimensions.xyz;
-	float previousDensity = DensityTex.SampleLevel(DensitySampler, previousPosition, 0).x;
-	DensityRW[uint3(dispatchID.xy, StepIndex - 1)] = previousDensity;
-
-	float3 position = (0.5 + float3(dispatchID.xy, StepIndex)) / TextureDimensions.xyz;
-	float density = DensityTex.SampleLevel(DensitySampler, position, 0).x;
-	DensityRW[uint3(dispatchID.xy, StepIndex)] = previousDensity + density;
+	uint depth = (uint)TextureDimensions.z;
+	uint3 currCoord = uint3(dispatchID.xy, 0);
+	float acc = DensityRW[currCoord];
+	for (currCoord.z = 1; currCoord.z < depth; currCoord.z++) {
+		acc += DensityRW[currCoord];
+		DensityRW[currCoord] = acc;
+	}
 }
 #endif

--- a/src/Features/VolumetricLighting.cpp
+++ b/src/Features/VolumetricLighting.cpp
@@ -178,10 +178,40 @@ void VolumetricLighting::PostPostLoad()
 	gVolumetricLightingSizeMedium = reinterpret_cast<TextureSize*>(REL::RelocationID(527973, 414919).address());
 	gVolumetricLightingSizeHigh = reinterpret_cast<TextureSize*>(REL::RelocationID(527976, 414922).address());
 	defaultSizeHigh = *gVolumetricLightingSizeHigh;
+
+	// Ensure the VL raymarch compute shader is only dispatched once, rather than once for every level of depth
+	// The updated raymarch shader iterates through the depth now instead
+	// Skip the first call, the second call has read/write texture setup in the correct order
+	REL::safe_fill(REL::RelocationID(100309, 107023).address() + REL::Relocate(0xA4, 0x406), REL::NOP, 3);
+	// Exit the loop after the first iteration
+	REL::safe_fill(REL::RelocationID(100309, 107023).address() + REL::Relocate(0x147, 0x4A9), REL::NOP, 6);
+}
+
+void VolumetricLighting::SetupResources()
+{
+	vlDataCB = new ConstantBuffer(ConstantBufferDesc<VLData>());
 }
 
 void VolumetricLighting::EarlyPrepass()
 {
+	const auto& mainDepth = globals::game::renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
+	D3D11_TEXTURE2D_DESC texDesc;
+	mainDepth.texture->GetDesc(&texDesc);
+
+	int32_t width = static_cast<int32_t>(texDesc.Width);
+	int32_t height = static_cast<int32_t>(texDesc.Height);
+
+	if (width != vlData.screenX || height != vlData.screenY) {
+		blurHCS = nullptr;
+		blurVCS = nullptr;
+	}
+
+	vlData.screenX = texDesc.Width;
+	vlData.screenY = texDesc.Height;
+	vlData.screenXMin1 = texDesc.Width - 1;
+	vlData.screenYMin1 = texDesc.Height - 1;
+	vlDataCB->Update(vlData);
+
 	const auto interiorCell = globals::game::tes->interiorCell;
 	const bool currentlyInInterior = interiorCell != nullptr;
 
@@ -239,4 +269,60 @@ void VolumetricLighting::RenderDepth::thunk()
 	func();
 	if (*GetSingleton()->bEnableVolumetricLighting)
 		RenderVolumetricLighting(&GetVLDescriptor(), RE::Main::WorldRootCamera(), false);
+}
+
+RE::BSImagespaceShader* VolumetricLighting::CreateShader(const std::string_view& name, const std::string_view& fileName, RE::BSComputeShader* computeShader)
+{
+	auto shader = RE::BSImagespaceShader::Create();
+	shader->shaderType = RE::BSShader::Type::ImageSpace;
+	shader->fxpFilename = fileName.data();
+	shader->name = name.data();
+	shader->originalShaderName = fileName.data();
+	shader->computeShader = computeShader;
+	shader->isComputeShader = true;
+	return shader;
+}
+
+RE::BSImagespaceShader* VolumetricLighting::GetOrCreateGenerateCS(RE::BSComputeShader* computeShader)
+{
+	if (generateCS == nullptr)
+		generateCS = CreateShader("BSImagespaceShaderVolumetricLightingGenerateCS", "ISVolumetricLightingGenerateCS", computeShader);
+	return generateCS;
+}
+
+RE::BSImagespaceShader* VolumetricLighting::GetOrCreateRaymarchCS(RE::BSComputeShader* computeShader)
+{
+	if (raymarchCS == nullptr)
+		raymarchCS = CreateShader("BSImagespaceShaderVolumetricLightingRaymarchCS", "ISVolumetricLightingRaymarchCS", computeShader);
+	return raymarchCS;
+}
+
+RE::BSImagespaceShader* VolumetricLighting::GetOrCreateBlurHCS(RE::BSComputeShader* computeShader)
+{
+	if (blurHCS == nullptr)
+		blurHCS = CreateShader("BSImagespaceShaderVolumetricLightingBlurHCS", "ISVolumetricLightingBlurHCS", computeShader);
+	return blurHCS;
+}
+
+RE::BSImagespaceShader* VolumetricLighting::GetOrCreateBlurVCS(RE::BSComputeShader* computeShader)
+{
+	if (blurVCS == nullptr)
+		blurVCS = CreateShader("BSImagespaceShaderVolumetricLightingBlurVCS", "ISVolumetricLightingBlurVCS", computeShader);
+	return blurVCS;
+}
+
+void VolumetricLighting::SetDimensionsCB() const
+{
+	auto cb = vlDataCB->CB();
+	globals::d3d::context->CSSetConstantBuffers(1, 1, &cb);
+}
+
+void VolumetricLighting::SetGroupCountsHCS(uint32_t& threadGroupCountX) const
+{
+	threadGroupCountX = (vlData.screenX + BlurThreadGroupSizeX - BlurWindow * 2u - 1u) / (BlurThreadGroupSizeX - BlurWindow * 2u);
+}
+
+void VolumetricLighting::SetGroupCountsVCS(uint32_t& threadGroupCountY) const
+{
+	threadGroupCountY = (vlData.screenY + BlurThreadGroupSizeY - BlurWindow * 2u - 1u) / (BlurThreadGroupSizeY - BlurWindow * 2u);
 }

--- a/src/Features/VolumetricLighting.h
+++ b/src/Features/VolumetricLighting.h
@@ -53,6 +53,7 @@ public:
 	virtual void DrawSettings() override;
 	virtual void DataLoaded() override;
 	virtual void PostPostLoad() override;
+	virtual void SetupResources() override;
 	virtual void EarlyPrepass() override;
 
 	std::map<std::string, Util::GameSetting> hiddenVRSettings{
@@ -74,6 +75,15 @@ public:
 
 	virtual bool SupportsVR() override { return true; };
 	virtual bool IsCore() const override { return true; };
+
+	static RE::BSImagespaceShader* CreateShader(const std::string_view& name, const std::string_view& fileName, RE::BSComputeShader* computeShader);
+	RE::BSImagespaceShader* GetOrCreateGenerateCS(RE::BSComputeShader* computeShader);
+	RE::BSImagespaceShader* GetOrCreateRaymarchCS(RE::BSComputeShader* computeShader);
+	RE::BSImagespaceShader* GetOrCreateBlurHCS(RE::BSComputeShader* computeShader);
+	RE::BSImagespaceShader* GetOrCreateBlurVCS(RE::BSComputeShader* computeShader);
+	void SetDimensionsCB() const;
+	void SetGroupCountsHCS(uint32_t& threadGroupCountX) const;
+	void SetGroupCountsVCS(uint32_t& threadGroupCountY) const;
 
 	// hooks
 
@@ -140,4 +150,23 @@ private:
 	bool initialised = false;
 	bool inInterior = false;
 	bool inInteriorWithSunShadows = false;
+
+	struct VLData
+	{
+		int32_t screenX;
+		int32_t screenY;
+		int32_t screenXMin1;
+		int32_t screenYMin1;
+	};
+	VLData vlData = VLData();
+	ConstantBuffer* vlDataCB = nullptr;
+
+	static constexpr int32_t BlurThreadGroupSizeX = 256;
+	static constexpr int32_t BlurThreadGroupSizeY = 256;
+	static constexpr int32_t BlurWindow = 12;
+
+	RE::BSImagespaceShader* generateCS = nullptr;
+	RE::BSImagespaceShader* raymarchCS = nullptr;
+	RE::BSImagespaceShader* blurHCS = nullptr;
+	RE::BSImagespaceShader* blurVCS = nullptr;
 };

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -12,6 +12,7 @@
 #include "Features/InteriorSunShadows.h"
 #include "Features/LightLimitFix.h"
 #include "Features/TerrainHelper.h"
+#include "Features/VolumetricLighting.h"
 
 #include "ShaderTools/BSShaderHooks.h"
 
@@ -906,37 +907,6 @@ namespace Hooks
 		RE::BSComputeShader* CurrentlyDispatchedComputeShader = nullptr;
 		uint32_t CurrentComputeShaderTechniqueId = 0;
 
-		RE::BSImagespaceShader* vlGenerateShader = nullptr;
-		RE::BSImagespaceShader* vlRaymarchShader = nullptr;
-
-		RE::BSImagespaceShader* CreateVLShader(const std::string_view& name, const std::string_view& fileName, RE::BSComputeShader* computeShader)
-		{
-			auto shader = RE::BSImagespaceShader::Create();
-			shader->shaderType = RE::BSShader::Type::ImageSpace;
-			shader->fxpFilename = fileName.data();
-			shader->name = name.data();
-			shader->originalShaderName = fileName.data();
-			shader->computeShader = computeShader;
-			shader->isComputeShader = true;
-			return shader;
-		}
-
-		RE::BSImagespaceShader* GetOrCreateVLGenerateShader(RE::BSComputeShader* computeShader)
-		{
-			if (vlGenerateShader == nullptr) {
-				vlGenerateShader = CreateVLShader("BSImagespaceShaderVolumetricLightingGenerateCS", "ISVolumetricLightingGenerateCS", computeShader);
-			}
-			return vlGenerateShader;
-		}
-
-		RE::BSImagespaceShader* GetOrCreateVLRaymarchShader(RE::BSComputeShader* computeShader)
-		{
-			if (vlRaymarchShader == nullptr) {
-				vlRaymarchShader = CreateVLShader("BSImagespaceShaderVolumetricLightingRaymarchCS", "ISVolumetricLightingRaymarchCS", computeShader);
-			}
-			return vlRaymarchShader;
-		}
-
 		struct BSImagespaceShader_DispatchComputeShader
 		{
 			static void thunk(RE::BSImagespaceShader* shader, uint32_t threadGroupCountX, uint32_t threadGroupCountY, uint32_t threadGroupCountZ)
@@ -967,16 +937,28 @@ namespace Hooks
 			{
 				auto state = globals::state;
 				auto shaderCache = globals::shaderCache;
+				auto vl = globals::features::volumetricLighting;
+				
 				if (state->enabledClasses[RE::BSShader::Type::ImageSpace]) {
 					RE::BSImagespaceShader* isShader = CurrentlyDispatchedShader;
 					uint32_t techniqueId = CurrentComputeShaderTechniqueId;
 					if (CurrentlyDispatchedShader == nullptr) {
 						techniqueId = 0;
 						if (CurrentlyDispatchedComputeShader->name == std::string_view("ISVolumetricLightingGenerateCS")) {
-							isShader = GetOrCreateVLGenerateShader(CurrentlyDispatchedComputeShader);
+							isShader = globals::features::volumetricLighting->GetOrCreateGenerateCS(CurrentlyDispatchedComputeShader);
 						} else if (CurrentlyDispatchedComputeShader->name == std::string_view("ISVolumetricLightingRaymarchCS")) {
-							isShader = GetOrCreateVLRaymarchShader(CurrentlyDispatchedComputeShader);
-						}
+							isShader = globals::features::volumetricLighting->GetOrCreateRaymarchCS(CurrentlyDispatchedComputeShader);
+						} 
+					} else if (CurrentlyDispatchedComputeShader->name == std::string_view("ISVolumetricLightingBlurHCS")) {
+						techniqueId = 0;
+						isShader = vl->GetOrCreateBlurHCS(CurrentlyDispatchedComputeShader);
+						vl->SetDimensionsCB();
+						vl->SetGroupCountsHCS(threadGroupCountX);
+					} else if (CurrentlyDispatchedComputeShader->name == std::string_view("ISVolumetricLightingBlurVCS")) {
+						techniqueId = 0;
+						isShader = vl->GetOrCreateBlurVCS(CurrentlyDispatchedComputeShader);
+						vl->SetDimensionsCB();
+						vl->SetGroupCountsVCS(threadGroupCountY);
 					}
 					if (isShader != nullptr) {
 						if (auto* computeShader = shaderCache->GetComputeShader(*isShader, techniqueId)) {

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -938,7 +938,7 @@ namespace Hooks
 				auto state = globals::state;
 				auto shaderCache = globals::shaderCache;
 				auto vl = globals::features::volumetricLighting;
-				
+
 				if (state->enabledClasses[RE::BSShader::Type::ImageSpace]) {
 					RE::BSImagespaceShader* isShader = CurrentlyDispatchedShader;
 					uint32_t techniqueId = CurrentComputeShaderTechniqueId;
@@ -948,7 +948,7 @@ namespace Hooks
 							isShader = globals::features::volumetricLighting->GetOrCreateGenerateCS(CurrentlyDispatchedComputeShader);
 						} else if (CurrentlyDispatchedComputeShader->name == std::string_view("ISVolumetricLightingRaymarchCS")) {
 							isShader = globals::features::volumetricLighting->GetOrCreateRaymarchCS(CurrentlyDispatchedComputeShader);
-						} 
+						}
 					} else if (CurrentlyDispatchedComputeShader->name == std::string_view("ISVolumetricLightingBlurHCS")) {
 						techniqueId = 0;
 						isShader = vl->GetOrCreateBlurHCS(CurrentlyDispatchedComputeShader);

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1643,6 +1643,8 @@ namespace SIE
 
 				{ "BSImagespaceShaderVolumetricLightingRaymarchCS", 256 },
 				{ "BSImagespaceShaderVolumetricLightingGenerateCS", 257 },
+				{ "BSImagespaceShaderVolumetricLightingBlurHCS", static_cast<uint32_t>(ISVolumetricLightingBlurHCS) },
+				{ "BSImagespaceShaderVolumetricLightingBlurVCS", static_cast<uint32_t>(ISVolumetricLightingBlurVCS) },
 				{ "BSImagespaceShaderCopyDepthBuffer", 98 },
 				{ "BSImagespaceShaderCopyDepthBuffer", 99 },
 				{ "BSImagespaceShaderCopyDepthBuffer", 100 },

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -154,7 +154,7 @@ bool Load()
 	}
 
 	if (REL::Module::IsVR()) {
-		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.178.0", true);
+		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.179.0", true);
 	}
 
 	auto privateProfileRedirectorVersion = Util::GetDllVersion(L"Data/SKSE/Plugins/PrivateProfileRedirector.dll");


### PR DESCRIPTION
* Vanilla VL raymarch shader used a double buffer ping-pong strategy to walk the depth dimension of the volumetric texture and accumulate density towards the camera, this resulted in `n=depth` compute shader dispatches for a simple sum, now uses a single dispatch with an internal loop, this was the biggest performance gain
* Optimisation of ISVolumetricLightingGenerateCS
* RE and optimisations of the ISVolumetricLightingBlurHCS and ISVolumetricLightingBlurVCS compute shaders
* Tested total VL performance cost on my machine on high settings decreased from 1.11ms to 0.27ms, a ~75% reduction


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved volumetric lighting performance through optimized shader dispatch and resource management.
  * Dynamic handling of screen size changes for more robust lighting effects.
  * Added support for horizontal and vertical blur passes in volumetric lighting.

* **Bug Fixes**
  * Centralized shader management to ensure consistent behavior across lighting effects.

* **Chores**
  * Updated minimum required VR address library version to 0.179.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->