### PR TITLE
fix(filesystem): improve file deletion error handling

### DIFF
--- a/src/FeatureIssues.cpp
+++ b/src/FeatureIssues.cpp
@@ -1358,17 +1358,15 @@ namespace FeatureIssues
 			for (const auto& testInfo : testInis) {
 				try {
 					if (testInfo.isNewFile) {
-						// Remove the test INI file we created
-						try {
-							bool removed = std::filesystem::remove(testInfo.testIniPath);
-							if (!removed) {
-								logger::warn("Failed to delete file {}", testInfo.testIniPath);
-							} else {
-								logger::debug("Deleted {}", testInfo.testIniPath);
-							}
-						} catch (const std::exception& e) {
-							logger::warn("Expected to delete {}, but ran into exception: {}", testInfo.testIniPath, e.what());
-						}					
+						// Remove the test INI file we created.
+						std::error_code ec; // Use the error_code overload to avoid exceptions for non-critical errors like the file not existing.
+						if (const bool removed = std::filesystem::remove(testInfo.testIniPath, ec); ec) {
+							logger::warn("Error while trying to delete {}: {}", testInfo.testIniPath, ec.message());
+							success = false;
+						} else if (removed) {
+							// Successfully deleted.
+							logger::debug("Deleted {}", testInfo.testIniPath);
+						} // If !removed and no error, the file didn't exist, which is fine.			
 					} else {
 						// Restore original version using INI functions
 						CSimpleIniA ini;

--- a/src/FeatureIssues.cpp
+++ b/src/FeatureIssues.cpp
@@ -1359,14 +1359,14 @@ namespace FeatureIssues
 				try {
 					if (testInfo.isNewFile) {
 						// Remove the test INI file we created.
-						std::error_code ec; // Use the error_code overload to avoid exceptions for non-critical errors like the file not existing.
+						std::error_code ec;  // Use the error_code overload to avoid exceptions for non-critical errors like the file not existing.
 						if (const bool removed = std::filesystem::remove(testInfo.testIniPath, ec); ec) {
 							logger::warn("Error while trying to delete {}: {}", testInfo.testIniPath, ec.message());
 							success = false;
 						} else if (removed) {
 							// Successfully deleted.
 							logger::debug("Deleted {}", testInfo.testIniPath);
-						} // If !removed and no error, the file didn't exist, which is fine.			
+						}  // If !removed and no error, the file didn't exist, which is fine.
 					} else {
 						// Restore original version using INI functions
 						CSimpleIniA ini;

--- a/src/FeatureIssues.cpp
+++ b/src/FeatureIssues.cpp
@@ -1359,10 +1359,16 @@ namespace FeatureIssues
 				try {
 					if (testInfo.isNewFile) {
 						// Remove the test INI file we created
-						if (std::filesystem::exists(testInfo.testIniPath)) {
-							std::filesystem::remove(testInfo.testIniPath);
-							logger::debug("Removed test INI: {}", testInfo.testIniPath);
-						}
+						try {
+							bool removed = std::filesystem::remove(testInfo.testIniPath);
+							if (!removed) {
+								logger::warn("Failed to delete file {}", testInfo.testIniPath);
+							} else {
+								logger::debug("Deleted {}", testInfo.testIniPath);
+							}
+						} catch (const std::exception& e) {
+							logger::warn("Expected to delete {}, but ran into exception: {}", testInfo.testIniPath, e.what());
+						}					
 					} else {
 						// Restore original version using INI functions
 						CSimpleIniA ini;
@@ -1395,13 +1401,17 @@ namespace FeatureIssues
 				}
 			}  // Clear the active test INIs tracking and remove persistent state
 			s_activeTestInis.clear();
+			const auto stateFilePath = GetTestStateFilePath();
+			const auto& stateFilePathString = Util::WStringToString(stateFilePath);
 			try {
-				const auto stateFilePath = GetTestStateFilePath();
-				if (std::filesystem::exists(stateFilePath)) {
-					std::filesystem::remove(stateFilePath);
+				bool removed = std::filesystem::remove(stateFilePath);
+				if (!removed) {
+					logger::warn("Failed to delete file {}", stateFilePathString);
+				} else {
+					logger::debug("Deleted {}", stateFilePathString);
 				}
 			} catch (const std::exception& e) {
-				logger::warn("Failed to remove persistent test state file: {}", e.what());
+				logger::warn("Expected to delete {}, but ran into exception: {}", stateFilePathString, e.what());
 			}
 			// Clear existing feature issues and rescan to update UI immediately
 			// This ensures the restored state is reflected without requiring a restart

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1923,16 +1923,12 @@ namespace SIE
 			const auto& filePathString = Util::WStringToString(filePath);
 			{
 				std::scoped_lock lockD{ compilationSet.compilationMutex };
-				try {
-					bool removed = std::filesystem::remove(filePath);
-					if (!removed) {
-						logger::warn("Failed to delete file {}", filePathString);
-					} else {
-						logger::debug("Deleted {}", filePathString);
-					}
-				} catch (const std::exception& e) {
-					logger::warn("Expected to delete {}, but ran into exception: {}", filePathString, e.what());
-				}
+				std::error_code ec; // Use the error_code overload to avoid exceptions for non-critical errors like the file not existing.
+				if (const bool removed = std::filesystem::remove(filePath, ec); ec) {
+					logger::warn("Error while trying to delete {}: {}", filePathString, ec.message());
+				} else if (removed) {
+					logger::debug("Deleted {}", filePathString);
+				} // If !removed and no error, the file didn't exist, which is fine.
 			}
 
 			logger::debug("Marking recompile for shader: {}", entry.key);

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1924,14 +1924,14 @@ namespace SIE
 			{
 				std::scoped_lock lockD{ compilationSet.compilationMutex };
 				try {
-					if (std::filesystem::exists(filePath)) {
-						std::filesystem::remove(filePath);
+					bool removed = std::filesystem::remove(filePath);
+					if (!removed) {
+						logger::warn("Failed to delete file {}", filePathString);
+					} else {
 						logger::debug("Deleted {}", filePathString);
 					}
 				} catch (const std::exception& e) {
-					logger::warn("Failed to delete file {}: {}", filePathString, e.what());
-				} catch (...) {
-					logger::warn("An unknown error occurred while trying to delete file '{}'", filePathString);
+					logger::warn("Expected to delete {}, but ran into exception: {}", filePathString, e.what());
 				}
 			}
 

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1923,12 +1923,12 @@ namespace SIE
 			const auto& filePathString = Util::WStringToString(filePath);
 			{
 				std::scoped_lock lockD{ compilationSet.compilationMutex };
-				std::error_code ec; // Use the error_code overload to avoid exceptions for non-critical errors like the file not existing.
+				std::error_code ec;  // Use the error_code overload to avoid exceptions for non-critical errors like the file not existing.
 				if (const bool removed = std::filesystem::remove(filePath, ec); ec) {
 					logger::warn("Error while trying to delete {}: {}", filePathString, ec.message());
 				} else if (removed) {
 					logger::debug("Deleted {}", filePathString);
-				} // If !removed and no error, the file didn't exist, which is fine.
+				}  // If !removed and no error, the file didn't exist, which is fine.
 			}
 
 			logger::debug("Marking recompile for shader: {}", entry.key);


### PR DESCRIPTION
Closes #1180 

Summary:
- Use `std::filesystem::remove`’s return value instead of a prior `exists()` check  
- Warn when `remove()` returns false (no file removed)  
- Debug-log on successful deletion  
- Catch exceptions and include the target path and error in the log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file deletion reliability and error handling during developer mode testing and shader cache clearing. Warnings are now logged if file removal fails, and unnecessary exceptions for missing files are avoided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->