### PR TITLE
fix: non-emat case mip level initialisation overwrote previously computed miplevels

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1339,9 +1339,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			endif
 		}
 	}
-#		endif  // EMAT
+#		else
 	// Initialize mip levels for non-EMAT case
 	mipLevels[0] = mipLevels[1] = mipLevels[2] = mipLevels[3] = mipLevels[4] = mipLevels[5] = 0.0;
+#		endif  // EMAT
 #	endif      // LANDSCAPE
 
 #	if defined(SPARKLE)


### PR DESCRIPTION
Currently the Initialize mip levels for non-EMAT case just overwrites the previously calculated miplevels provided by GetMipLevel.

Addition of the #else check allows this to only be initialised when there is no previous data from EMAT.