### PR TITLE
feat(hair): hair self-shadow, finished marschner model and hair flow map support

### DIFF
--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -2,10 +2,10 @@
 #define __HAIR_DEPENDENCY_HLSL__
 
 #include "Common/BRDF.hlsli"
+#include "Common/Game.hlsli"
 #include "Common/Math.hlsli"
 
 #define HAIR_LIGHTING_MULTIPLIER Math::PI  // Compensating to adapt to vanilla lighting model
-#define GAME_UNIT_TO_CM 1.428f
 
 namespace Hair
 {

--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -4,11 +4,19 @@
 #include "Common/BRDF.hlsli"
 #include "Common/Math.hlsli"
 
-// #define MARSCHNER
+#define HAIR_LIGHTING_MULTIPLIER Math::PI  // Compensating to adapt to vanilla lighting model
+#define GAME_UNIT_TO_CM 1.428f
 
 namespace Hair
 {
 	Texture2D<float> TexTangentShift : register(t73);
+
+	float3 CalculateHairTangent(float3 T, float3 B, float3 N)
+	{
+		// TODO: Choose from T or B
+		B = normalize(B - N * dot(B, N));
+		return B;
+	}
 
 	// [Kajiya et al. 1989, "Rendering fur with three dimensional textures."]
 	// https://doi.org/10.1145/74334.74361
@@ -33,10 +41,26 @@ namespace Hair
 		return normalize(T + N * shift);
 	}
 
+	float3 ShiftNormal(float3 T, float3 N, float shift)
+	{
+		float3 T_shifted = ShiftTangent(T, N, shift);
+		float3 N_shifted = normalize(cross(T_shifted, cross(N, T_shifted)));
+		return N_shifted;
+	}
+
+	float3 ShiftWorldNormal(float3 T, float3 N, float n, float2 uv)
+	{
+		const float shift = TexTangentShift.SampleLevel(SampColorSampler, uv, 0).x - 0.5;
+		float3 T_shifted = ShiftTangent(T, N, shift + n);
+		float3 N_shifted = normalize(cross(T_shifted, cross(N, T_shifted)));
+		return N_shifted;
+	}
+
 	// [Scheuermann 2004, "Hair Rendering and Shading"]
 	// https://web.engr.oregonstate.edu/~mjb/cs557/Projects/Papers/HairRendering.pdf
-	void GetHairDirectLightScheuermann(out float3 dirDiffuse, out float3 dirSpecular, float3 T, float3 L, float3 V, float3 N, float3 VN, float3 lightColor, float shininess, float2 uv, float3 baseColor)
+	void GetHairDirectLightScheuermann(out float3 dirDiffuse, out float3 dirSpecular, float3 T, float3 L, float3 V, float3 N, float3 VN, float3 lightColor, float shininess, float selfShadow, float2 uv, float3 baseColor)
 	{
+		lightColor *= selfShadow;
 		const float3 H = normalize(L + V);
 		const float oNdotL = dot(N, L);
 		const float NdotL = saturate(oNdotL);
@@ -73,7 +97,6 @@ namespace Hair
 		float scatterFresnel2 = saturate(pow((1 - VNdotV), 20));
 		float3 specT = (scatterFresnel1 + scatterFresnel2 * scatterColor) * SharedData::hairSpecularSettings.Transmission;
 		float3 specTerm = specR + specT;
-		// specTerm = Color::LinearToGamma(specTerm);
 		dirSpecular = specTerm * lightColor;
 	}
 
@@ -84,6 +107,7 @@ namespace Hair
 
 	// [Marschner et al. 2003, "Light reflection from human hair fibers."]
 	// https://graphics.stanford.edu/papers/hair/hair-sg03final.pdf
+	// N is the vector parallel to hair pointing toward root
 	float3 D_Marschner(float3 L, float3 V, float3 N, float roughness, float3 baseColor, float area, float backlit)
 	{
 		const float NdotL = dot(N, L);
@@ -146,7 +170,7 @@ namespace Hair
 		Np = exp(17 * cosPhi - 16.78);
 		TRT = (Mp * Np) * (Fp * Tp);
 
-		return R + TT + TRT;
+		return max(R + TT + TRT, 0);
 	}
 
 	float3 GetHairDiffuseAttenuationKajiyaKay(float3 N, float3 V, float3 L, float shadow, float3 baseColor)
@@ -165,44 +189,37 @@ namespace Hair
 		float3 scatterTint = pow(abs(baseColor / luma), 1 - shadow);
 		S += sqrt(baseColor) * diffuseScatter * scatterTint;
 
-		return S;
+		return max(S, 0);
 	}
 
-	void GetHairDirectLightMarschner(out float3 dirDiffuse, out float3 dirSpecular, float3 T, float3 L, float3 V, float3 N, float3 lightColor, float shininess, float2 uv, float3 baseColor)
+	void GetHairDirectLightMarschner(out float3 dirDiffuse, out float3 dirSpecular, float3 T, float3 L, float3 V, float3 N, float3 VN, float3 lightColor, float shininess, float selfShadow, float2 uv, float3 baseColor)
 	{
-		lightColor *= Math::PI;
+		lightColor *= HAIR_LIGHTING_MULTIPLIER * selfShadow;
 		dirDiffuse = 0;
 		dirSpecular = 0;
-		const float roughness = pow(abs(2.0 / (shininess + 2.0)), 0.25);
+		// const float roughness = pow(abs(2.0 / (shininess + 2.0)), 0.25);
+		const float roughness = 1 - saturate(shininess * 0.01);
 
-		dirSpecular += D_Marschner(L, V, N, roughness, baseColor, 0, SharedData::hairSpecularSettings.Transmission) * lightColor;
-		dirDiffuse += GetHairDiffuseAttenuationKajiyaKay(N, V, L, 0, baseColor) * lightColor;
-		dirSpecular = max(dirSpecular, 0);
-		dirDiffuse = max(dirDiffuse, 0);
+		if (SharedData::hairSpecularSettings.EnableTangentShift) {
+			const float shift = TexTangentShift.SampleLevel(SampColorSampler, uv, 0).x - 0.5;
+			T = ShiftTangent(T, N, shift);
+		}
+
+		const float cosThetaV = dot(VN, V);
+
+		float backlit = SharedData::hairSpecularSettings.Transmission;
+
+		dirSpecular += D_Marschner(L, V, T, roughness, baseColor, 0, backlit) * lightColor;
+		dirDiffuse += GetHairDiffuseAttenuationKajiyaKay(T, V, L, 0, baseColor) * lightColor;
 	}
 
-	void GetHairDirectLight(out float3 dirDiffuse, out float3 dirSpecular, float3 T, float3 L, float3 V, float3 N, float3 VN, float3 lightColor, float shininess, float2 uv, float3 baseColor)
+	void GetHairDirectLight(out float3 dirDiffuse, out float3 dirSpecular, float3 T, float3 L, float3 V, float3 N, float3 VN, float3 lightColor, float shininess, float selfShadow, float2 uv, float3 baseColor)
 	{
 #ifndef MARSCHNER
-		GetHairDirectLightScheuermann(dirDiffuse, dirSpecular, T, L, V, N, VN, lightColor, shininess, uv, baseColor);
+		GetHairDirectLightScheuermann(dirDiffuse, dirSpecular, T, L, V, N, VN, lightColor, shininess, selfShadow, uv, baseColor);
 #else
-		GetHairDirectLightMarschner(dirDiffuse, dirSpecular, T, L, V, N, lightColor, shininess, uv, baseColor);
+		GetHairDirectLightMarschner(dirDiffuse, dirSpecular, T, L, V, N, VN, lightColor, shininess, selfShadow, uv, baseColor);
 #endif
-	}
-
-	float3 ShiftNormal(float3 T, float3 N, float shift)
-	{
-		float3 T_shifted = ShiftTangent(T, N, shift);
-		float3 N_shifted = normalize(cross(T_shifted, cross(N, T_shifted)));
-		return N_shifted;
-	}
-
-	float3 ShiftWorldNormal(float3 T, float3 N, float n, float2 uv)
-	{
-		const float shift = TexTangentShift.SampleLevel(SampColorSampler, uv, 0).x - 0.5;
-		float3 T_shifted = ShiftTangent(T, N, shift + n);
-		float3 N_shifted = normalize(cross(T_shifted, cross(N, T_shifted)));
-		return N_shifted;
 	}
 
 	void GetHairIndirectSpecularLobeWeights(out float3 diffuseLobeWeight, out float3 specularLobeWeightPrimary, out float3 specularLobeWeightSecondary, float3 T, float3 N, float3 V, float3 VN, float shininess, float2 uv, float3 baseColor)
@@ -215,10 +232,16 @@ namespace Hair
 		specularLobeWeightPrimary = 0;
 		specularLobeWeightSecondary = 0;
 		float3 L = normalize(V - N * dot(V, N));
-		float NdotL = dot(N, L);
-		float VdotL = dot(V, L);
+		// float NdotL = dot(N, L);
+		// float VdotL = dot(V, L);
 
-		diffuseLobeWeight = D_Marschner(L, V, N, roughnessPrimary, baseColor * Math::PI, 0.2, 0);
+		if (SharedData::hairSpecularSettings.EnableTangentShift) {
+			const float shift = TexTangentShift.SampleLevel(SampColorSampler, uv, 0).x - 0.5;
+			T = ShiftTangent(T, N, shift);
+		}
+
+		diffuseLobeWeight = D_Marschner(L, V, T, roughnessPrimary, baseColor, 0.2, 0);
+		diffuseLobeWeight += GetHairDiffuseAttenuationKajiyaKay(T, V, L, 0, baseColor);
 		return;
 #else
 
@@ -260,6 +283,41 @@ namespace Hair
 	{
 		float luminance = Color::RGBToLuminance(color);
 		return saturate(lerp(float3(luminance, luminance, luminance), color, saturation));
+	}
+
+	float HairSelfShadow(float3 positionWS, float3 lightDirWS, float noise, uint eyeIndex)
+	{
+		if (!SharedData::hairSpecularSettings.EnableSelfShadow) {
+			return 1.0;
+		}
+
+		// Simple raymarch
+		const int stepCount = 4;
+
+		float3 positionVS = FrameBuffer::WorldToView(positionWS, true, eyeIndex);
+		float3 lightDirVS = FrameBuffer::WorldToView(lightDirWS, false, eyeIndex);
+		lightDirVS *= max(SharedData::hairSpecularSettings.SelfShadowScale * GAME_UNIT_TO_CM, 0.05);
+		float stepSize = 1.0 / stepCount;
+
+		float3 ray = positionVS + lightDirVS * (noise - 0.5) * 2 * stepSize;
+		float shadow = 1.0;
+		int hitCount = 0;
+
+		[unroll(stepCount)]
+		for(int i = 0; i < stepCount; ++i) {
+			ray += lightDirVS * stepSize;
+			float2 rayUV = FrameBuffer::ViewToUV(ray, true, eyeIndex);
+			float rayDepth = ray.z;
+			float sampleDepth = SharedData::GetScreenDepth(rayUV, eyeIndex);
+			if (sampleDepth < rayDepth) {
+				hitCount++;
+			}
+		}
+		
+		if (hitCount > 0) {
+			shadow -= pow(abs((float)hitCount / (float)stepCount), SharedData::hairSpecularSettings.SelfShadowExponent);
+		}
+		return lerp(1.0, shadow, SharedData::hairSpecularSettings.SelfShadowStrength);
 	}
 
 #if defined(DYNAMIC_CUBEMAPS)

--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -219,6 +219,7 @@ namespace Hair
 		GetHairDirectLightScheuermann(dirDiffuse, dirSpecular, T, L, V, N, VN, lightColor, shininess, selfShadow, uv, baseColor);
 #else
 		GetHairDirectLightMarschner(dirDiffuse, dirSpecular, T, L, V, N, VN, lightColor, shininess, selfShadow, uv, baseColor);
+		dirSpecular = Color::LinearToGamma(dirSpecular);
 #endif
 	}
 

--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -215,12 +215,12 @@ namespace Hair
 
 	void GetHairDirectLight(out float3 dirDiffuse, out float3 dirSpecular, float3 T, float3 L, float3 V, float3 N, float3 VN, float3 lightColor, float shininess, float selfShadow, float2 uv, float3 baseColor)
 	{
-#ifndef MARSCHNER
-		GetHairDirectLightScheuermann(dirDiffuse, dirSpecular, T, L, V, N, VN, lightColor, shininess, selfShadow, uv, baseColor);
-#else
-		GetHairDirectLightMarschner(dirDiffuse, dirSpecular, T, L, V, N, VN, lightColor, shininess, selfShadow, uv, baseColor);
-		dirSpecular = Color::LinearToGamma(dirSpecular);
-#endif
+		if (SharedData::hairSpecularSettings.HairMode == 0) {
+			GetHairDirectLightScheuermann(dirDiffuse, dirSpecular, T, L, V, N, VN, lightColor, shininess, selfShadow, uv, baseColor);
+		} else {
+			GetHairDirectLightMarschner(dirDiffuse, dirSpecular, T, L, V, N, VN, lightColor, shininess, selfShadow, uv, baseColor);
+			dirSpecular = Color::LinearToGamma(dirSpecular);
+		}
 	}
 
 	void GetHairIndirectSpecularLobeWeights(out float3 diffuseLobeWeight, out float3 specularLobeWeightPrimary, out float3 specularLobeWeightSecondary, float3 T, float3 N, float3 V, float3 VN, float shininess, float2 uv, float3 baseColor)
@@ -229,55 +229,54 @@ namespace Hair
 		const float roughnessSecondary = pow(abs(2.0 / (shininess * 0.5 + 2.0)), 0.25);
 		const float NdotV = saturate(dot(N, V));
 
-#ifdef MARSCHNER
-		specularLobeWeightPrimary = 0;
-		specularLobeWeightSecondary = 0;
-		float3 L = normalize(V - N * dot(V, N));
-		// float NdotL = dot(N, L);
-		// float VdotL = dot(V, L);
+		if (SharedData::hairSpecularSettings.HairMode == 1) {
+			specularLobeWeightPrimary = 0;
+			specularLobeWeightSecondary = 0;
+			float3 L = normalize(V - N * dot(V, N));
+			// float NdotL = dot(N, L);
+			// float VdotL = dot(V, L);
 
-		if (SharedData::hairSpecularSettings.EnableTangentShift) {
-			const float shift = TexTangentShift.SampleLevel(SampColorSampler, uv, 0).x - 0.5;
-			T = ShiftTangent(T, N, shift);
+			if (SharedData::hairSpecularSettings.EnableTangentShift) {
+				const float shift = TexTangentShift.SampleLevel(SampColorSampler, uv, 0).x - 0.5;
+				T = ShiftTangent(T, N, shift);
+			}
+
+			diffuseLobeWeight = D_Marschner(L, V, T, roughnessPrimary, baseColor, 0.2, 0);
+			diffuseLobeWeight += GetHairDiffuseAttenuationKajiyaKay(T, V, L, 0, baseColor);
+			return;
+		} else {
+			float NdotVshifted = NdotV;
+			float NdotVshifted2 = NdotV;
+
+			if (SharedData::hairSpecularSettings.EnableTangentShift) {
+				const float shift = TexTangentShift.SampleLevel(SampColorSampler, uv, 0).x - 0.5;
+				NdotVshifted = saturate(dot(ShiftNormal(T, N, shift + SharedData::hairSpecularSettings.PrimaryTangentShift), V));
+				NdotVshifted2 = saturate(dot(ShiftNormal(T, N, shift + SharedData::hairSpecularSettings.SecondaryTangentShift), V));
+			}
+
+			diffuseLobeWeight = baseColor;
+			specularLobeWeightPrimary = 0;
+			specularLobeWeightSecondary = 0;
+
+			const float2 specularBRDFPrimary = BRDF::EnvBRDFApproxLazarov(roughnessPrimary, NdotVshifted);
+			const float2 specularBRDFSecondary = BRDF::EnvBRDFApproxLazarov(roughnessSecondary, NdotVshifted2);
+
+			const float3 F0 = HairF0();
+			specularLobeWeightPrimary = F0 * specularBRDFPrimary.x + specularBRDFPrimary.y;
+			diffuseLobeWeight *= (1 - specularLobeWeightPrimary);
+			diffuseLobeWeight = saturate(diffuseLobeWeight);
+			specularLobeWeightPrimary *= 1 + F0 * (1 / (specularBRDFPrimary.x + specularBRDFPrimary.y) - 1);
+
+			specularLobeWeightSecondary = F0 * specularBRDFSecondary.x + specularBRDFSecondary.y;
+			specularLobeWeightSecondary *= 1 + F0 * (1 / (specularBRDFSecondary.x + specularBRDFSecondary.y) - 1);
+			specularLobeWeightSecondary *= baseColor;
+
+			float3 R = reflect(-V, N);
+			float horizon = min(1.0 + dot(R, VN), 1.0);
+			horizon = horizon * horizon;
+			specularLobeWeightPrimary *= horizon;
+			specularLobeWeightSecondary *= horizon;
 		}
-
-		diffuseLobeWeight = D_Marschner(L, V, T, roughnessPrimary, baseColor, 0.2, 0);
-		diffuseLobeWeight += GetHairDiffuseAttenuationKajiyaKay(T, V, L, 0, baseColor);
-		return;
-#else
-
-		float NdotVshifted = NdotV;
-		float NdotVshifted2 = NdotV;
-
-		if (SharedData::hairSpecularSettings.EnableTangentShift) {
-			const float shift = TexTangentShift.SampleLevel(SampColorSampler, uv, 0).x - 0.5;
-			NdotVshifted = saturate(dot(ShiftNormal(T, N, shift + SharedData::hairSpecularSettings.PrimaryTangentShift), V));
-			NdotVshifted2 = saturate(dot(ShiftNormal(T, N, shift + SharedData::hairSpecularSettings.SecondaryTangentShift), V));
-		}
-
-		diffuseLobeWeight = baseColor;
-		specularLobeWeightPrimary = 0;
-		specularLobeWeightSecondary = 0;
-
-		const float2 specularBRDFPrimary = BRDF::EnvBRDFApproxLazarov(roughnessPrimary, NdotVshifted);
-		const float2 specularBRDFSecondary = BRDF::EnvBRDFApproxLazarov(roughnessSecondary, NdotVshifted2);
-
-		const float3 F0 = HairF0();
-		specularLobeWeightPrimary = F0 * specularBRDFPrimary.x + specularBRDFPrimary.y;
-		diffuseLobeWeight *= (1 - specularLobeWeightPrimary);
-		diffuseLobeWeight = saturate(diffuseLobeWeight);
-		specularLobeWeightPrimary *= 1 + F0 * (1 / (specularBRDFPrimary.x + specularBRDFPrimary.y) - 1);
-
-		specularLobeWeightSecondary = F0 * specularBRDFSecondary.x + specularBRDFSecondary.y;
-		specularLobeWeightSecondary *= 1 + F0 * (1 / (specularBRDFSecondary.x + specularBRDFSecondary.y) - 1);
-		specularLobeWeightSecondary *= baseColor;
-
-		float3 R = reflect(-V, N);
-		float horizon = min(1.0 + dot(R, VN), 1.0);
-		horizon = horizon * horizon;
-		specularLobeWeightPrimary *= horizon;
-		specularLobeWeightSecondary *= horizon;
-#endif
 	}
 
 	float3 Saturation(float3 color, float saturation)

--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -219,6 +219,7 @@ namespace Hair
 			GetHairDirectLightScheuermann(dirDiffuse, dirSpecular, T, L, V, N, VN, lightColor, shininess, selfShadow, uv, baseColor);
 		} else {
 			GetHairDirectLightMarschner(dirDiffuse, dirSpecular, T, L, V, N, VN, lightColor, shininess, selfShadow, uv, baseColor);
+			dirDiffuse = Color::LinearToGamma(dirDiffuse);
 			dirSpecular = Color::LinearToGamma(dirSpecular);
 		}
 	}
@@ -243,6 +244,7 @@ namespace Hair
 
 			diffuseLobeWeight = D_Marschner(L, V, T, roughnessPrimary, baseColor, 0.2, 0);
 			diffuseLobeWeight += GetHairDiffuseAttenuationKajiyaKay(T, V, L, 0, baseColor);
+			diffuseLobeWeight = Color::LinearToGamma(diffuseLobeWeight);
 			return;
 		} else {
 			float NdotVshifted = NdotV;

--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -197,7 +197,6 @@ namespace Hair
 		lightColor *= HAIR_LIGHTING_MULTIPLIER * selfShadow;
 		dirDiffuse = 0;
 		dirSpecular = 0;
-		// const float roughness = pow(abs(2.0 / (shininess + 2.0)), 0.25);
 		const float roughness = 1 - saturate(shininess * 0.01);
 
 		if (SharedData::hairSpecularSettings.EnableTangentShift) {

--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -307,6 +307,8 @@ namespace Hair
 		for(int i = 0; i < stepCount; ++i) {
 			ray += lightDirVS * stepSize;
 			float2 rayUV = FrameBuffer::ViewToUV(ray, true, eyeIndex);
+			if (FrameBuffer::IsOutsideFrame(rayUV))
+				continue;
 			float rayDepth = ray.z;
 			float sampleDepth = SharedData::GetScreenDepth(rayUV, eyeIndex);
 			if (sampleDepth < rayDepth) {

--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -317,7 +317,7 @@ namespace Hair
 				hitCount++;
 			}
 		}
-		
+
 		if (hitCount > 0) {
 			shadow -= pow(abs((float)hitCount / (float)stepCount), SharedData::hairSpecularSettings.SelfShadowExponent);
 		}

--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -11,11 +11,11 @@ namespace Hair
 {
 	Texture2D<float> TexTangentShift : register(t73);
 
-	float3 CalculateHairTangent(float3 T, float3 B, float3 N)
+	float3 ReorientTangent(float3 T, float3 N)
 	{
-		// TODO: Choose from T or B
-		B = normalize(B - N * dot(B, N));
-		return B;
+		// Reorient tangent to be orthogonal to normal
+		float3 T_reoriented = normalize(T - N * dot(T, N));
+		return T_reoriented;
 	}
 
 	// [Kajiya et al. 1989, "Rendering fur with three dimensional textures."]

--- a/package/Shaders/Common/Game.hlsli
+++ b/package/Shaders/Common/Game.hlsli
@@ -11,7 +11,7 @@
 
 // Wind speed conversions
 #define WIND_RAW_TO_NORMALIZED 1.0f / 255.0f
-#define WIND_RAW_TO_PERCENT    100.0f / 255.0f 
+#define WIND_RAW_TO_PERCENT    100.0f / 255.0f
 
 // Direction conversions
 #define DIR_RAW_TO_DEGREES   360.0f / 256.0f

--- a/package/Shaders/Common/Game.hlsli
+++ b/package/Shaders/Common/Game.hlsli
@@ -1,0 +1,21 @@
+#ifndef __GAME_HLSLI__
+#define __GAME_HLSLI__
+
+#include "Common/Math.hlsli"
+
+// Conversion constants
+#define GAME_UNIT_TO_CM     1.428f
+#define GAME_UNIT_TO_M      GAME_UNIT_TO_CM / 100.0f
+#define GAME_UNIT_TO_FEET   GAME_UNIT_TO_CM / 30.48f
+#define GAME_UNIT_TO_INCHES GAME_UNIT_TO_CM / 2.54f
+
+// Wind speed conversions
+#define WIND_RAW_TO_NORMALIZED 1.0f / 255.0f
+#define WIND_RAW_TO_PERCENT    100.0f / 255.0f 
+
+// Direction conversions
+#define DIR_RAW_TO_DEGREES   360.0f / 256.0f
+#define DIR_RANGE_TO_DEGREES 180.0f / 256.0f
+#define RADIANS_TO_DEGREES   180.0f / Math::PI
+
+#endif // __GAME_HLSLI__

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -164,6 +164,8 @@ namespace SharedData
 		float SelfShadowStrength;
 		float SelfShadowExponent;
 		float SelfShadowScale;
+		uint HairMode;  // 0: Kajiya-Kay, 1: Marschner
+		uint3 pad;
 	};
 
 	struct TerrainVariationSettings

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -160,6 +160,10 @@ namespace SharedData
 		float DiffuseIndirectMult;
 		float BaseColorMult;
 		float Transmission;
+		uint EnableSelfShadow;
+		float SelfShadowStrength;
+		float SelfShadowExponent;
+		float SelfShadowScale;
 	};
 
 	struct TerrainVariationSettings

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1841,7 +1841,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 #	if defined(HAIR) && defined(CS_HAIR)
 	float3 hairTint = 0;
-	const float3 hairT = normalize(float3(input.TBN0.y, input.TBN1.y, input.TBN2.y));
 
 	if (SharedData::hairSpecularSettings.Enabled) {
 		hairTint = lerp(1, TintColor.xyz, input.Color.y);
@@ -2000,6 +1999,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float3 screenSpaceNormal = normalize(FrameBuffer::WorldToView(worldSpaceNormal, false, eyeIndex));
 
 #	if defined(HAIR) && defined(CS_HAIR)
+	float3 hairB = normalize(float3(input.TBN0.y, input.TBN1.y, input.TBN2.y));
+	float3 hairT = normalize(float3(input.TBN0.x, input.TBN1.x, input.TBN2.x));
+	hairT = Hair::CalculateHairTangent(hairT, hairB, worldSpaceNormal);
+
 	if (SharedData::hairSpecularSettings.Enabled && SharedData::hairSpecularSettings.EnableTangentShift) {
 		float3 shiftedNormal = Hair::ShiftWorldNormal(hairT, worldSpaceNormal, 0, uv);
 		screenSpaceNormal = normalize(FrameBuffer::WorldToView(shiftedNormal, false, eyeIndex));
@@ -2361,8 +2364,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		endif
 	} else {
 #		if defined(HAIR) && defined(CS_HAIR)
-		if (SharedData::hairSpecularSettings.Enabled)
-			Hair::GetHairDirectLight(dirDiffuseColor, lightsSpecularColor, hairT, DirLightDirection, viewDirection, modelNormal.xyz, worldSpaceVertexNormal.xyz, dirLightColor.xyz * dirDetailShadow, SharedData::hairSpecularSettings.HairGlossiness, uv, baseColor.xyz);
+		if (SharedData::hairSpecularSettings.Enabled) {
+			float hairShadow = Hair::HairSelfShadow(input.WorldPosition.xyz, DirLightDirection, screenNoise, eyeIndex);
+			Hair::GetHairDirectLight(dirDiffuseColor, lightsSpecularColor, hairT, DirLightDirection, viewDirection, modelNormal.xyz, worldSpaceVertexNormal.xyz, dirLightColor.xyz * dirDetailShadow, SharedData::hairSpecularSettings.HairGlossiness, hairShadow, uv, baseColor.xyz);
+		}
 		else {
 #			if defined(SPECULAR)
 			lightsSpecularColor = GetLightSpecularInput(input, DirLightDirection, viewDirection, modelNormal.xyz, dirLightColor.xyz * dirDetailShadow, shininess, uv);
@@ -2440,7 +2445,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #				if defined(HAIR) && defined(CS_HAIR)
 		if (SharedData::hairSpecularSettings.Enabled) {
 			float3 lightSpecularColor = 0;
-			Hair::GetHairDirectLight(lightDiffuseColor, lightSpecularColor, hairT, normalizedLightDirection, viewDirection, modelNormal.xyz, worldSpaceVertexNormal.xyz, lightColor, SharedData::hairSpecularSettings.HairGlossiness, uv, baseColor.xyz);
+			float hairShadow = Hair::HairSelfShadow(input.WorldPosition.xyz, normalizedLightDirection, screenNoise, eyeIndex);
+			Hair::GetHairDirectLight(lightDiffuseColor, lightSpecularColor, hairT, normalizedLightDirection, viewDirection, modelNormal.xyz, worldSpaceVertexNormal.xyz, lightColor, SharedData::hairSpecularSettings.HairGlossiness, hairShadow, uv, baseColor.xyz);
 			lightsSpecularColor += lightSpecularColor;
 		} else {
 #					if defined(SPECULAR)
@@ -2606,8 +2612,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 #				if defined(HAIR) && defined(CS_HAIR) && (defined(SKINNED) || !defined(MODELSPACENORMALS))
 		if (SharedData::hairSpecularSettings.Enabled) {
+			float hairShadow = Hair::HairSelfShadow(input.WorldPosition.xyz, normalizedLightDirection, screenNoise, eyeIndex);
 			float3 lightSpecularColor = 0;
-			Hair::GetHairDirectLight(lightDiffuseColor, lightSpecularColor, hairT, normalizedLightDirection, viewDirection, modelNormal.xyz, worldSpaceVertexNormal.xyz, lightColor * contactShadow, SharedData::hairSpecularSettings.HairGlossiness, uv, baseColor.xyz);
+			Hair::GetHairDirectLight(lightDiffuseColor, lightSpecularColor, hairT, normalizedLightDirection, viewDirection, modelNormal.xyz, worldSpaceVertexNormal.xyz, lightColor * contactShadow, SharedData::hairSpecularSettings.HairGlossiness, hairShadow, uv, baseColor.xyz);
 			lightsSpecularColor += lightSpecularColor;
 		} else {
 #					if defined(SPECULAR)

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2016,13 +2016,14 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float3 screenSpaceNormal = normalize(FrameBuffer::WorldToView(worldSpaceNormal, false, eyeIndex));
 
 #	if defined(HAIR) && defined(CS_HAIR)
-	float3 hairB = normalize(float3(input.TBN0.y, input.TBN1.y, input.TBN2.y));
-	float3 hairT = normalize(float3(input.TBN0.x, input.TBN1.x, input.TBN2.x));
+	float3 Bitangent = normalize(float3(input.TBN0.y, input.TBN1.y, input.TBN2.y));
+	float3 hairT = 0;
 #		if defined(BACK_LIGHTING)
-	hairT = useHairFlowMap ? normalize(mul(tbn, sampledHairFlow)) : Hair::CalculateHairTangent(hairT, hairB, worldSpaceNormal);
+	hairT = useHairFlowMap ? normalize(mul(tbn, sampledHairFlow)) : Bitangent;
 #		else
-	hairT = Hair::CalculateHairTangent(hairT, hairB, worldSpaceNormal);
+	hairT = Bitangent;
 #		endif
+	hairT = Hair::ReorientTangent(hairT, worldSpaceNormal);
 
 	if (SharedData::hairSpecularSettings.Enabled && SharedData::hairSpecularSettings.EnableTangentShift) {
 		float3 shiftedNormal = Hair::ShiftWorldNormal(hairT, worldSpaceNormal, 0, uv);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2527,12 +2527,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 			SharedData::lightLimitFixSettings.EnableContactShadows &&
 			!(light.lightFlags & LightLimitFix::LightFlags::Simple) &&
 			shadowComponent != 0.0 &&
-#				if defined(HAIR) && defined(CS_HAIR)
-			true
-#				else
-			lightAngle > 0.0
-#				endif
-		)
+			lightAngle > 0.0)
 		{
 			float3 normalizedLightDirectionVS = normalize(light.positionVS[eyeIndex].xyz - viewPosition.xyz);
 			contactShadow = LightLimitFix::ContactShadows(viewPosition, screenNoise, normalizedLightDirectionVS, contactShadowSteps, eyeIndex);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1848,6 +1848,18 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		baseColor.xyz = Hair::Saturation(baseColor.xyz, SharedData::hairSpecularSettings.HairSaturation);
 		baseColor.xyz *= SharedData::hairSpecularSettings.BaseColorMult;
 	}
+
+	float3 sampledHairFlow = 0;
+	bool useHairFlowMap = false;
+#		if defined(BACK_LIGHTING)
+	if (SharedData::hairSpecularSettings.Enabled) {
+		uint2 hairFlowDimensions = uint2(0, 0);
+		sampledHairFlow = float3(TexBackLightSampler.Sample(SampBackLightSampler, uv).xy, 0.5f);
+		TexBackLightSampler.GetDimensions(hairFlowDimensions.x, hairFlowDimensions.y);
+		useHairFlowMap = (sampledHairFlow.x > 0.0 || sampledHairFlow.y > 0.0) && hairFlowDimensions.x > 32 && hairFlowDimensions.y > 32;
+		sampledHairFlow = useHairFlowMap ? sampledHairFlow * 2.0f - 1.0f : float3(0.5f, 0.5f, 0.5f);
+	}
+#		endif
 #	endif
 
 #	if defined(LOD_LAND_BLEND)
@@ -2001,7 +2013,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #	if defined(HAIR) && defined(CS_HAIR)
 	float3 hairB = normalize(float3(input.TBN0.y, input.TBN1.y, input.TBN2.y));
 	float3 hairT = normalize(float3(input.TBN0.x, input.TBN1.x, input.TBN2.x));
+#		if defined(BACK_LIGHTING)
+	hairT = useHairFlowMap ? normalize(mul(tbn, sampledHairFlow)) : Hair::CalculateHairTangent(hairT, hairB, worldSpaceNormal);
+#		else
 	hairT = Hair::CalculateHairTangent(hairT, hairB, worldSpaceNormal);
+#		endif
 
 	if (SharedData::hairSpecularSettings.Enabled && SharedData::hairSpecularSettings.EnableTangentShift) {
 		float3 shiftedNormal = Hair::ShiftWorldNormal(hairT, worldSpaceNormal, 0, uv);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1886,6 +1886,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 #	if defined(BACK_LIGHTING)
 	float4 backLightColor = TexBackLightSampler.Sample(SampBackLightSampler, uv);
+#		if defined(HAIR) && defined(CS_HAIR)
+	if (useHairFlowMap) {
+		backLightColor = 0.0f;
+	}
+#		endif
 #	endif  // BACK_LIGHTING
 
 #	if defined(RIM_LIGHTING) || defined(SOFT_LIGHTING) || defined(LOAD_SOFT_LIGHTING)

--- a/src/Features/HairSpecular.cpp
+++ b/src/Features/HairSpecular.cpp
@@ -27,20 +27,20 @@ void HairSpecular::DrawSettings()
 	ImGui::Checkbox("Enabled", (bool*)&settings.Enabled);
 	ImGui::Combo("Hair Mode", (int*)&settings.HairMode, "Kajiya-Kay\0Marschner\0");
 	if (auto _tt = Util::HoverTooltipWrapper()) {
-		ImGui::Text("Select the hair shading model to use.\n"
+		ImGui::Text(
+			"Select the hair shading model to use.\n"
 			"Kajiya-Kay is an empirical model that simulates hair specular highlights.\n"
 			"Marschner is a more physically-based model that simulates hair light interaction.\n"
 			"Both models are anisotropic and support tangent-based shading.\n"
-			"Note that colors in Marschner mode may appear darker and more saturated.\n"
-		);
+			"Note that colors in Marschner mode may appear darker and more saturated.\n");
 	}
 	ImGui::Spacing();
 	ImGui::SliderFloat("Glossiness", &settings.HairGlossiness, 0.0f, settings.HairMode == 0 ? 256.0f : 100.0f, "%.0f");
 	if (auto _tt = Util::HoverTooltipWrapper()) {
-		ImGui::Text("Controls the glossiness of the hair.\n"
+		ImGui::Text(
+			"Controls the glossiness of the hair.\n"
 			"Glossiness in Kajiya-Kay mode maps to the specular exponent.\n"
-			"In Marschner mode, it controls the roughness of the hair surface.\n"
-		);
+			"In Marschner mode, it controls the roughness of the hair surface.\n");
 	}
 	ImGui::SliderFloat("Specular Multiplier", &settings.SpecularMult, 0.0f, 10.0f, "%.2f");
 	ImGui::SliderFloat("Diffuse Multiplier", &settings.DiffuseMult, 0.0f, 10.0f, "%.2f");
@@ -52,9 +52,9 @@ void HairSpecular::DrawSettings()
 	ImGui::Spacing();
 	ImGui::Checkbox("Enable Tangent Shift", (bool*)&settings.EnableTangentShift);
 	if (auto _tt = Util::HoverTooltipWrapper()) {
-		ImGui::Text("Enables the use of a tangent shift texture to vary specular highlights across hair strands.\n"
-			"Result may vary based on the hair model used.\n"
-		);
+		ImGui::Text(
+			"Enables the use of a tangent shift texture to vary specular highlights across hair strands.\n"
+			"Result may vary based on the hair model used.\n");
 	}
 	if (settings.HairMode == 0) {
 		ImGui::SliderFloat("Primary Specular Tangent Shift", &settings.PrimaryTangentShift, -1.0f, 1.0f, "%.2f");
@@ -63,9 +63,9 @@ void HairSpecular::DrawSettings()
 	ImGui::Spacing();
 	ImGui::Checkbox("Enable Screen-Space Self Shadow", (bool*)&settings.EnableSelfShadow);
 	if (auto _tt = Util::HoverTooltipWrapper()) {
-		ImGui::Text("Enables screen-space self-shadowing for hair.\n"
-			"Marschner hair model requires this to be enabled for proper self-shadowing.\n"
-		);
+		ImGui::Text(
+			"Enables screen-space self-shadowing for hair.\n"
+			"Marschner hair model requires this to be enabled for proper self-shadowing.\n");
 	}
 	ImGui::SliderFloat("Self Shadow Strength", &settings.SelfShadowStrength, 0.0f, 1.0f, "%.2f");
 	ImGui::SliderFloat("Self Shadow Exponent", &settings.SelfShadowExponent, 0.0f, 10.0f, "%.2f");

--- a/src/Features/HairSpecular.cpp
+++ b/src/Features/HairSpecular.cpp
@@ -15,7 +15,11 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	SpecularIndirectMult,
 	DiffuseIndirectMult,
 	BaseColorMult,
-	Transmission)
+	Transmission,
+	EnableSelfShadow,
+	SelfShadowStrength,
+	SelfShadowExponent,
+	SelfShadowScale);
 
 void HairSpecular::DrawSettings()
 {
@@ -32,6 +36,11 @@ void HairSpecular::DrawSettings()
 	ImGui::Checkbox("Enable Tangent Shift", (bool*)&settings.EnableTangentShift);
 	ImGui::SliderFloat("Primary Specular Tangent Shift", &settings.PrimaryTangentShift, -1.0f, 1.0f, "%.2f");
 	ImGui::SliderFloat("Secondary Specular Tangent Shift", &settings.SecondaryTangentShift, -1.0f, 1.0f, "%.2f");
+	ImGui::Spacing();
+	ImGui::Checkbox("Enable Screen-Space Self Shadow", (bool*)&settings.EnableSelfShadow);
+	ImGui::SliderFloat("Self Shadow Strength", &settings.SelfShadowStrength, 0.0f, 1.0f, "%.2f");
+	ImGui::SliderFloat("Self Shadow Exponent", &settings.SelfShadowExponent, 0.0f, 10.0f, "%.2f");
+	ImGui::SliderFloat("Self Shadow Scale", &settings.SelfShadowScale, 0.0f, 10.0f, "%.2f");
 }
 
 void HairSpecular::LoadSettings(json& o_json)

--- a/src/Features/HairSpecular.cpp
+++ b/src/Features/HairSpecular.cpp
@@ -19,12 +19,29 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	EnableSelfShadow,
 	SelfShadowStrength,
 	SelfShadowExponent,
-	SelfShadowScale);
+	SelfShadowScale,
+	HairMode)
 
 void HairSpecular::DrawSettings()
 {
 	ImGui::Checkbox("Enabled", (bool*)&settings.Enabled);
-	ImGui::SliderFloat("Glossiness", &settings.HairGlossiness, 0.0f, 256.0f, "%.0f");
+	ImGui::Combo("Hair Mode", (int*)&settings.HairMode, "Kajiya-Kay\0Marschner\0");
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text("Select the hair shading model to use.\n"
+			"Kajiya-Kay is an empirical model that simulates hair specular highlights.\n"
+			"Marschner is a more physically-based model that simulates hair light interaction.\n"
+			"Both models are anisotropic and support tangent-based shading.\n"
+			"Note that colors in Marschner mode may appear darker and more saturated.\n"
+		);
+	}
+	ImGui::Spacing();
+	ImGui::SliderFloat("Glossiness", &settings.HairGlossiness, 0.0f, settings.HairMode == 0 ? 256.0f : 100.0f, "%.0f");
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text("Controls the glossiness of the hair.\n"
+			"Glossiness in Kajiya-Kay mode maps to the specular exponent.\n"
+			"In Marschner mode, it controls the roughness of the hair surface.\n"
+		);
+	}
 	ImGui::SliderFloat("Specular Multiplier", &settings.SpecularMult, 0.0f, 10.0f, "%.2f");
 	ImGui::SliderFloat("Diffuse Multiplier", &settings.DiffuseMult, 0.0f, 10.0f, "%.2f");
 	ImGui::SliderFloat("Indirect Specular Multiplier", &settings.SpecularIndirectMult, 0.0f, 10.0f, "%.2f");
@@ -34,10 +51,17 @@ void HairSpecular::DrawSettings()
 	ImGui::SliderFloat("Transmission", &settings.Transmission, 0.0f, 1.0f, "%.2f");
 	ImGui::Spacing();
 	ImGui::Checkbox("Enable Tangent Shift", (bool*)&settings.EnableTangentShift);
-	ImGui::SliderFloat("Primary Specular Tangent Shift", &settings.PrimaryTangentShift, -1.0f, 1.0f, "%.2f");
-	ImGui::SliderFloat("Secondary Specular Tangent Shift", &settings.SecondaryTangentShift, -1.0f, 1.0f, "%.2f");
+	if (settings.HairMode == 0) {
+		ImGui::SliderFloat("Primary Specular Tangent Shift", &settings.PrimaryTangentShift, -1.0f, 1.0f, "%.2f");
+		ImGui::SliderFloat("Secondary Specular Tangent Shift", &settings.SecondaryTangentShift, -1.0f, 1.0f, "%.2f");
+	}
 	ImGui::Spacing();
 	ImGui::Checkbox("Enable Screen-Space Self Shadow", (bool*)&settings.EnableSelfShadow);
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text("Enables screen-space self-shadowing for hair.\n"
+			"Marschner hair model requires this to be enabled for proper self-shadowing.\n"
+		);
+	}
 	ImGui::SliderFloat("Self Shadow Strength", &settings.SelfShadowStrength, 0.0f, 1.0f, "%.2f");
 	ImGui::SliderFloat("Self Shadow Exponent", &settings.SelfShadowExponent, 0.0f, 10.0f, "%.2f");
 	ImGui::SliderFloat("Self Shadow Scale", &settings.SelfShadowScale, 0.0f, 10.0f, "%.2f");

--- a/src/Features/HairSpecular.cpp
+++ b/src/Features/HairSpecular.cpp
@@ -51,6 +51,11 @@ void HairSpecular::DrawSettings()
 	ImGui::SliderFloat("Transmission", &settings.Transmission, 0.0f, 1.0f, "%.2f");
 	ImGui::Spacing();
 	ImGui::Checkbox("Enable Tangent Shift", (bool*)&settings.EnableTangentShift);
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text("Enables the use of a tangent shift texture to vary specular highlights across hair strands.\n"
+			"Result may vary based on the hair model used.\n"
+		);
+	}
 	if (settings.HairMode == 0) {
 		ImGui::SliderFloat("Primary Specular Tangent Shift", &settings.PrimaryTangentShift, -1.0f, 1.0f, "%.2f");
 		ImGui::SliderFloat("Secondary Specular Tangent Shift", &settings.SecondaryTangentShift, -1.0f, 1.0f, "%.2f");

--- a/src/Features/HairSpecular.cpp
+++ b/src/Features/HairSpecular.cpp
@@ -32,7 +32,8 @@ void HairSpecular::DrawSettings()
 			"Kajiya-Kay is an empirical model that simulates hair specular highlights.\n"
 			"Marschner is a more physically-based model that simulates hair light interaction.\n"
 			"Both models are anisotropic and support tangent-based shading.\n"
-			"Note that colors in Marschner mode may appear darker and more saturated.\n");
+			"Note that colors in Marschner mode may appear darker and more saturated.\n"
+			"Also, without self-shadowing enabled, Marschner mode may look overly bright because of transmission.\n");
 	}
 	ImGui::Spacing();
 	ImGui::SliderFloat("Glossiness", &settings.HairGlossiness, 0.0f, settings.HairMode == 0 ? 256.0f : 100.0f, "%.0f");
@@ -65,7 +66,7 @@ void HairSpecular::DrawSettings()
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text(
 			"Enables screen-space self-shadowing for hair.\n"
-			"Marschner hair model requires this to be enabled for proper self-shadowing.\n");
+			"Marschner hair model might have overly bright transmission without self-shadowing.\n");
 	}
 	ImGui::SliderFloat("Self Shadow Strength", &settings.SelfShadowStrength, 0.0f, 1.0f, "%.2f");
 	ImGui::SliderFloat("Self Shadow Exponent", &settings.SelfShadowExponent, 0.0f, 10.0f, "%.2f");

--- a/src/Features/HairSpecular.h
+++ b/src/Features/HairSpecular.h
@@ -50,8 +50,8 @@ public:
 		float Transmission = 1.0f;
 		uint EnableSelfShadow = true;
 		float SelfShadowStrength = 1.0f;
-		float SelfShadowExponent = 1.0f;
-		float SelfShadowScale = 1.0f;
+		float SelfShadowExponent = 0.1f;
+		float SelfShadowScale = 5.0f;
 		uint HairMode = 0; // 0: Kajiya-Kay, 1: Marschner
 		uint pad[3];
 	} settings;

--- a/src/Features/HairSpecular.h
+++ b/src/Features/HairSpecular.h
@@ -37,7 +37,7 @@ public:
 	struct alignas(16) Settings
 	{
 		uint Enabled = true;
-		float HairGlossiness = 80.0f;
+		float HairGlossiness = 70.0f;
 		float SpecularMult = 1.0f;
 		float DiffuseMult = 1.0f;
 		uint EnableTangentShift = true;

--- a/src/Features/HairSpecular.h
+++ b/src/Features/HairSpecular.h
@@ -52,7 +52,7 @@ public:
 		float SelfShadowStrength = 1.0f;
 		float SelfShadowExponent = 0.1f;
 		float SelfShadowScale = 5.0f;
-		uint HairMode = 0; // 0: Kajiya-Kay, 1: Marschner
+		uint HairMode = 0;  // 0: Kajiya-Kay, 1: Marschner
 		uint pad[3];
 	} settings;
 

--- a/src/Features/HairSpecular.h
+++ b/src/Features/HairSpecular.h
@@ -52,6 +52,8 @@ public:
 		float SelfShadowStrength = 1.0f;
 		float SelfShadowExponent = 1.0f;
 		float SelfShadowScale = 1.0f;
+		uint HairMode = 0; // 0: Kajiya-Kay, 1: Marschner
+		uint pad[3];
 	} settings;
 
 	eastl::unique_ptr<Texture2D> texTangentShift = nullptr;

--- a/src/Features/HairSpecular.h
+++ b/src/Features/HairSpecular.h
@@ -47,7 +47,11 @@ public:
 		float SpecularIndirectMult = 1.0f;
 		float DiffuseIndirectMult = 1.0f;
 		float BaseColorMult = 1.0f;
-		float Transmission = 0.5f;
+		float Transmission = 1.0f;
+		uint EnableSelfShadow = true;
+		float SelfShadowStrength = 1.0f;
+		float SelfShadowExponent = 1.0f;
+		float SelfShadowScale = 1.0f;
 	} settings;
 
 	eastl::unique_ptr<Texture2D> texTangentShift = nullptr;


### PR DESCRIPTION
Basically three new things with no disadvantages compared to before.
- A simple hair self-shadow based on a 4-step screen space raymarch, so the hair won't overglow with transmission.
- Marschner model is a more physically based hair shading model compared to the default kajiya-kay model used in hair specular. User can now freely choose one of them. This model is dependent on self-shadow as it simulates both reflection and transmission.
- Added support for hair flow map (or directional map). The texture needs to be put in the slot 7 (starting from 0) in the texture set, and back lighting flag has to be enabled in hair nif. Hair flow map is important for both of the hair models as they are anisotropic. The texture uses the RG channels to record the direction of hair strands in UV space. The direction always points from the hair tip to the root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for two selectable hair shading models: Kajiya-Kay and Marschner, with a UI option to choose between them.
  * Introduced configurable screen-space self-shadowing for hair, including controls for strength, exponent, and scale.
  * Enhanced user interface with contextual tooltips and dynamic controls based on the selected hair shading model.

* **Improvements**
  * Adjusted default values for hair glossiness and transmission for improved visual results.
  * Conditional display of tangent shift controls and glossiness range based on the chosen hair shading model.
  * Improved hair lighting with tangent reorientation, shifted normals, gamma correction, and clamped color outputs to prevent artifacts.
  * Integrated self-shadowing into hair lighting for more realistic shading effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->