### PR TITLE
feat(ui): implement dynamic font scaling based on screen resolution

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -269,11 +269,18 @@ void Menu::Init()
 	font_config.RasterizerMultiply = 1.1f;   // Slightly darker font rendering
 	font_config.FontBuilderFlags = 0;        // No additional flags needed
 
-	// Add high-quality font with improved settings
-	imgui_io.Fonts->AddFontFromFileTTF("Data\\Interface\\CommunityShaders\\Fonts\\Jost-Regular.ttf", 36, &font_config);
-
+	// Load font
 	DXGI_SWAP_CHAIN_DESC desc;
 	globals::d3d::swapChain->GetDesc(&desc);
+	UINT height = desc.BufferDesc.Height; // Screen pixel height
+	// Calculate base font size based on screen height (e.g., 2% of screen height)
+	const float baseFontSize = height * 0.02f;
+	// Clamp between reasonable min/max values
+	const float fontSize = std::clamp(baseFontSize, 24.0f, 48.0f);
+
+	// Add font with dynamic size
+	imgui_io.Fonts->AddFontFromFileTTF("Data\\Interface\\CommunityShaders\\Fonts\\Jost-Regular.ttf", 
+											std::round(fontSize), &font_config);
 
 	// Setup Platform/Renderer backends
 	ImGui_ImplWin32_Init(desc.OutputWindow);

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -275,15 +275,15 @@ void Menu::Init()
 		logger::warn("Failed to get swap chain description. Using default 1080p font size.");
 		desc.BufferDesc.Height = 1080;
 	}
-	uint32_t height = desc.BufferDesc.Height; // Screen pixel height
+	uint32_t height = desc.BufferDesc.Height;  // Screen pixel height
 	// Calculate base font size based on screen height (e.g., 2% of screen height)
 	const float baseFontSize = height * 0.02f;
 	// Clamp between reasonable min/max values
 	const float fontSize = std::clamp(baseFontSize, 24.0f, 48.0f);
 
 	// Add font with dynamic size
-	if (!imgui_io.Fonts->AddFontFromFileTTF("Data\\Interface\\CommunityShaders\\Fonts\\Jost-Regular.ttf", 
-											std::round(fontSize), &font_config)) {
+	if (!imgui_io.Fonts->AddFontFromFileTTF("Data\\Interface\\CommunityShaders\\Fonts\\Jost-Regular.ttf",
+			std::round(fontSize), &font_config)) {
 		logger::warn("Failed to load custom font. Using default font.");
 		imgui_io.Fonts->AddFontDefault();
 	}

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -270,17 +270,23 @@ void Menu::Init()
 	font_config.FontBuilderFlags = 0;        // No additional flags needed
 
 	// Load font
-	DXGI_SWAP_CHAIN_DESC desc;
-	globals::d3d::swapChain->GetDesc(&desc);
-	UINT height = desc.BufferDesc.Height; // Screen pixel height
+	DXGI_SWAP_CHAIN_DESC desc{};
+	if (FAILED(globals::d3d::swapChain->GetDesc(&desc)) || desc.BufferDesc.Height == 0) {
+		logger::warn("Failed to get swap chain description. Using default 1080p font size.");
+		desc.BufferDesc.Height = 1080;
+	}
+	uint32_t height = desc.BufferDesc.Height; // Screen pixel height
 	// Calculate base font size based on screen height (e.g., 2% of screen height)
 	const float baseFontSize = height * 0.02f;
 	// Clamp between reasonable min/max values
 	const float fontSize = std::clamp(baseFontSize, 24.0f, 48.0f);
 
 	// Add font with dynamic size
-	imgui_io.Fonts->AddFontFromFileTTF("Data\\Interface\\CommunityShaders\\Fonts\\Jost-Regular.ttf", 
-											std::round(fontSize), &font_config);
+	if (!imgui_io.Fonts->AddFontFromFileTTF("Data\\Interface\\CommunityShaders\\Fonts\\Jost-Regular.ttf", 
+											std::round(fontSize), &font_config)) {
+		logger::warn("Failed to load custom font. Using default font.");
+		imgui_io.Fonts->AddFontDefault();
+	}
 
 	// Setup Platform/Renderer backends
 	ImGui_ImplWin32_Init(desc.OutputWindow);


### PR DESCRIPTION
Add dynamic font size calculation for the menu that scales with screen height. The font size is now calculated as 2% of the screen height, clamped between 24px and 48px for readability. This ensures consistent text appearance across different display resolutions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Font size in menu now automatically adjusts based on screen height for improved visual consistency across different display sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->