### PR TITLE
fix: reduce Terrain Variation mip penalty from +2 to +1 for clarity

### DIFF
--- a/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
+++ b/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
@@ -78,7 +78,7 @@ namespace ExtendedMaterials
 
 		#if defined(TERRAIN_VARIATION) && defined(LANDSCAPE)
 			#if !defined(VR)
-				mipLevel += 2.0; // Increase mip level to match vanilla appearance since terrain variation tends to be sharper than vanilla.
+				mipLevel++; // Increase mip level to match vanilla appearance since terrain variation tends to be sharper than vanilla.
 			#else
 				// When VR + terrain variation are both active, no additional mip penalty - VR gets only TV features without mip changes
 			#endif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted mip level calculation for terrain variation to provide a visual appearance closer to the original (vanilla) style when certain settings are enabled. This may result in slightly sharper terrain textures under specific conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->