### PR TITLE
refactor: move BUFFER_VIEW_NODE from Menu.h to Util

### DIFF
--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -3,8 +3,8 @@
 #include <DirectXTex.h>
 
 #include "Deferred.h"
-#include "Menu.h"
 #include "State.h"
+#include "Util.h"
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ScreenSpaceGI::Settings,

--- a/src/Features/TerrainShadows.cpp
+++ b/src/Features/TerrainShadows.cpp
@@ -3,8 +3,8 @@
 #include <DirectXTex.h>
 #include <pystring/pystring.h>
 
-#include "Menu.h"
 #include "State.h"
+#include "Util.h"
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	TerrainShadows::Settings,

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -6,15 +6,6 @@
 #include <winrt/base.h>
 
 using namespace std::chrono;
-#define BUFFER_VIEWER_NODE(a_value, a_scale)                                                                 \
-	if (ImGui::TreeNode(#a_value)) {                                                                         \
-		ImGui::Image(a_value->srv.get(), { a_value->desc.Width * a_scale, a_value->desc.Height * a_scale }); \
-		ImGui::TreePop();                                                                                    \
-	}
-
-#define BUFFER_VIEWER_NODE_BULLET(a_value, a_scale) \
-	ImGui::BulletText(#a_value);                    \
-	ImGui::Image(a_value->srv.get(), { a_value->desc.Width * a_scale, a_value->desc.Height * a_scale });
 
 #define ADDRESS_NODE(a_value)                                                                        \
 	if (ImGui::Button(#a_value)) {                                                                   \

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -7,13 +7,6 @@
 
 using namespace std::chrono;
 
-#define ADDRESS_NODE(a_value)                                                                        \
-	if (ImGui::Button(#a_value)) {                                                                   \
-		ImGui::SetClipboardText(std::format("{0:x}", reinterpret_cast<uintptr_t>(a_value)).c_str()); \
-	}                                                                                                \
-	if (ImGui::IsItemHovered())                                                                      \
-		ImGui::SetTooltip(std::format("Copy {} Address to Clipboard", #a_value).c_str());
-
 class Menu
 {
 public:

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -11,6 +11,16 @@ struct ID3D11ShaderResourceView;
 struct ImVec2;
 class Menu;
 
+#define BUFFER_VIEWER_NODE(a_value, a_scale)                                                                 \
+	if (ImGui::TreeNode(#a_value)) {                                                                         \
+		ImGui::Image(a_value->srv.get(), { a_value->desc.Width * a_scale, a_value->desc.Height * a_scale }); \
+		ImGui::TreePop();                                                                                    \
+	}
+
+#define BUFFER_VIEWER_NODE_BULLET(a_value, a_scale) \
+	ImGui::BulletText(#a_value);                    \
+	ImGui::Image(a_value->srv.get(), { a_value->desc.Width * a_scale, a_value->desc.Height * a_scale });
+
 namespace Util
 {
 	// Text rendering constants

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -21,6 +21,13 @@ class Menu;
 	ImGui::BulletText(#a_value);                    \
 	ImGui::Image(a_value->srv.get(), { a_value->desc.Width * a_scale, a_value->desc.Height * a_scale });
 
+#define ADDRESS_NODE(a_value)                                                                        \
+	if (ImGui::Button(#a_value)) {                                                                   \
+		ImGui::SetClipboardText(std::format("{0:x}", reinterpret_cast<uintptr_t>(a_value)).c_str()); \
+	}                                                                                                \
+	if (ImGui::IsItemHovered())                                                                      \
+		ImGui::SetTooltip(std::format("Copy {} Address to Clipboard", #a_value).c_str());
+
 namespace Util
 {
 	// Text rendering constants


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved organization of buffer viewer UI macros for image rendering by relocating them to a more appropriate location.
* **Style**
  * Updated internal file dependencies for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->