### PR TITLE
fix(hair): remove marschner gamma conversion and clean unused code

### DIFF
--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -218,7 +218,6 @@ namespace Hair
 			GetHairDirectLightScheuermann(dirDiffuse, dirSpecular, T, L, V, N, VN, lightColor, shininess, selfShadow, uv, baseColor);
 		} else {
 			GetHairDirectLightMarschner(dirDiffuse, dirSpecular, T, L, V, N, VN, lightColor, shininess, selfShadow, uv, baseColor);
-			dirDiffuse = Color::LinearToGamma(dirDiffuse);
 			dirSpecular = Color::LinearToGamma(dirSpecular);
 		}
 	}
@@ -233,8 +232,6 @@ namespace Hair
 			specularLobeWeightPrimary = 0;
 			specularLobeWeightSecondary = 0;
 			float3 L = normalize(V - N * dot(V, N));
-			// float NdotL = dot(N, L);
-			// float VdotL = dot(V, L);
 
 			if (SharedData::hairSpecularSettings.EnableTangentShift) {
 				const float shift = TexTangentShift.SampleLevel(SampColorSampler, uv, 0).x - 0.5;


### PR DESCRIPTION
before, it would look too bright in interior by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified gamma correction handling for diffuse lighting in the Marschner hair model.
  * Removed unused commented-out code related to indirect specular lobe weight calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->