### PR TITLE
fix: glint issues passing junk data & pbr brightness fixes

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1469,6 +1469,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		}
 		else
 		{
+			landRMAOS1 = float4(1 - glossiness.x, 0, 1, 0);
 		}
 		blendedRMAOS += landRMAOS1 * weight;
 #		endif
@@ -1549,7 +1550,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		}
 		else
 		{
-			landRMAOS2 = float4(1 - landNormal2.w, 0, 1, 0);
+			landRMAOS2 = input.LandBlendWeights1.y * float4(1 - glossiness.x, 0, 1, 0);
 		}
 		blendedRMAOS += landRMAOS2 * weight;
 #		endif
@@ -1629,7 +1630,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		}
 		else
 		{
-			landRMAOS3 = float4(1 - landNormal3.w, 0, 1, 0);
+			landRMAOS3 = input.LandBlendWeights1.z * float4(1 - glossiness.x, 0, 1, 0);
 		}
 		blendedRMAOS += landRMAOS3 * weight;
 #		endif
@@ -1709,7 +1710,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		}
 		else
 		{
-			landRMAOS4 = float4(1 - landNormal4.w, 0, 1, 0);
+			landRMAOS4 = input.LandBlendWeights1.w * float4(1 - glossiness.x, 0, 1, 0);
 		}
 		blendedRMAOS += landRMAOS4 * weight;
 #		endif
@@ -1790,7 +1791,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		}
 		else
 		{
-			landRMAOS5 = float4(1 - landNormal5.w, 0, 1, 0);
+			landRMAOS5 = input.LandBlendWeights2.x * float4(1 - glossiness.x, 0, 1, 0);
 		}
 		blendedRMAOS += landRMAOS5 * weight;
 #		endif
@@ -1870,7 +1871,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		}
 		else
 		{
-			landRMAOS6 = float4(1 - landNormal6.w, 0, 1, 0);
+			landRMAOS6 = input.LandBlendWeights2.y * float4(1 - glossiness.x, 0, 1, 0);
 		}
 		blendedRMAOS += landRMAOS6 * weight;
 #		endif

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1900,12 +1900,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		endif
 #	endif
 
-#	if defined(TRUE_PBR) && defined(LANDSCAPE)
-	[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile0PBR) == 0)
-	{
-		baseColor = float4(rawBaseColor.rgb / Color::PBRLightingScale, rawBaseColor.a);
-	}
-#	endif
 
 #	if defined(LOD_BLENDING)
 #		if defined(LODOBJECTS) || defined(LODOBJECTSHD)
@@ -1964,90 +1958,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		if defined(SNOW) && !defined(TRUE_PBR)
 	landSnowMask = LandscapeTexture1to4IsSnow.x * input.LandBlendWeights1.x;
 #		endif  // SNOW
-
-	// Layer 1 (LandBlendWeights1.x)
-	if (input.LandBlendWeights1.x > 0.01) {
-#		if defined(SNOW) && !defined(TRUE_PBR)
-		float landSnowMask1 = GetLandSnowMaskValue(baseColor.w);
-		landSnowMask += LandscapeTexture1to4IsSnow.x * input.LandBlendWeights1.x * landSnowMask1;
-#		endif
-#		if defined(TRUE_PBR)
-		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile0HasGlint) != 0)
-		{
-			glintParameters += input.LandBlendWeights1.x * LandscapeTexture1GlintParameters;
-		}
-#		endif
-	}
-
-	// Layer 2 (LandBlendWeights1.y)
-	if (input.LandBlendWeights1.y > 0.01) {
-#		if defined(SNOW) && !defined(TRUE_PBR)
-		float landSnowMask2 = GetLandSnowMaskValue(baseColor.w);
-		landSnowMask += LandscapeTexture1to4IsSnow.y * input.LandBlendWeights1.y * landSnowMask2;
-#		endif
-#		if defined(TRUE_PBR)
-		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile1HasGlint) != 0)
-		{
-			glintParameters += input.LandBlendWeights1.y * LandscapeTexture2GlintParameters;
-		}
-#		endif
-	}
-
-	// Layer 3 (LandBlendWeights1.z)
-	if (input.LandBlendWeights1.z > 0.01) {
-#		if defined(SNOW) && !defined(TRUE_PBR)
-		float landSnowMask3 = GetLandSnowMaskValue(baseColor.w);
-		landSnowMask += LandscapeTexture1to4IsSnow.z * input.LandBlendWeights1.z * landSnowMask3;
-#		endif
-#		if defined(TRUE_PBR)
-		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile2HasGlint) != 0)
-		{
-			glintParameters += input.LandBlendWeights1.z * LandscapeTexture3GlintParameters;
-		}
-#		endif
-	}
-
-	// Layer 4 (LandBlendWeights1.w)
-	if (input.LandBlendWeights1.w > 0.01) {
-#		if defined(SNOW) && !defined(TRUE_PBR)
-		float landSnowMask4 = GetLandSnowMaskValue(baseColor.w);
-		landSnowMask += LandscapeTexture1to4IsSnow.w * input.LandBlendWeights1.w * landSnowMask4;
-#		endif
-#		if defined(TRUE_PBR)
-		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile3HasGlint) != 0)
-		{
-			glintParameters += input.LandBlendWeights1.w * LandscapeTexture4GlintParameters;
-		}
-#		endif
-	}
-
-	// Layer 5 (LandBlendWeights2.x)
-	if (input.LandBlendWeights2.x > 0.01) {
-#		if defined(SNOW) && !defined(TRUE_PBR)
-		float landSnowMask5 = GetLandSnowMaskValue(baseColor.w);
-		landSnowMask += LandscapeTexture5to6IsSnow.x * input.LandBlendWeights2.x * landSnowMask5;
-#		endif
-#		if defined(TRUE_PBR)
-		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile4HasGlint) != 0)
-		{
-			glintParameters += input.LandBlendWeights2.x * LandscapeTexture5GlintParameters;
-		}
-#		endif
-	}
-
-	// Layer 6 (LandBlendWeights2.y)
-	if (input.LandBlendWeights2.y > 0.01) {
-#		if defined(SNOW) && !defined(TRUE_PBR)
-		float landSnowMask6 = GetLandSnowMaskValue(baseColor.w);
-		landSnowMask += LandscapeTexture5to6IsSnow.y * input.LandBlendWeights2.y * landSnowMask6;
-#		endif
-#		if defined(TRUE_PBR)
-		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile5HasGlint) != 0)
-		{
-			glintParameters += input.LandBlendWeights2.y * LandscapeTexture6GlintParameters;
-		}
-#		endif
-	}
 #	endif  // LANDSCAPE
 
 #	if defined(EMAT_ENVMAP)

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1463,8 +1463,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS1 = TexRMAOSSampler.SampleBias(SampRMAOSSampler, uv, SharedData::MipBias) * float4(PBRParams1.x, 1, 1, PBRParams1.z);
 #			endif
-				glintParameters += weight * LandscapeTexture1GlintParameters;
 			if ((PBRFlags & PBR::TerrainFlags::LandTile0HasGlint) != 0) {
+				glintParameters += weight * LandscapeTexture1GlintParameters;
 			}
 		}
 		else
@@ -1544,8 +1544,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS2 = TexLandRMAOS2Sampler.SampleBias(SampLandRMAOS2Sampler, uv, SharedData::MipBias) * float4(LandscapeTexture2PBRParams.x, 1, 1, LandscapeTexture2PBRParams.z);
 #			endif
-				glintParameters += weight * LandscapeTexture2GlintParameters;
 			if ((PBRFlags & PBR::TerrainFlags::LandTile1HasGlint) != 0) {
+				glintParameters += weight * LandscapeTexture2GlintParameters;
 			}
 		}
 		else
@@ -1624,8 +1624,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS3 = TexLandRMAOS3Sampler.SampleBias(SampLandRMAOS3Sampler, uv, SharedData::MipBias) * float4(LandscapeTexture3PBRParams.x, 1, 1, LandscapeTexture3PBRParams.z);
 #			endif
-				glintParameters += weight * LandscapeTexture3GlintParameters;
 			if ((PBRFlags & PBR::TerrainFlags::LandTile2HasGlint) != 0) {
+				glintParameters += weight * LandscapeTexture3GlintParameters;
 			}
 		}
 		else
@@ -1704,8 +1704,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS4 = TexLandRMAOS4Sampler.SampleBias(SampLandRMAOS4Sampler, uv, SharedData::MipBias) * float4(LandscapeTexture4PBRParams.x, 1, 1, LandscapeTexture4PBRParams.z);
 #			endif
+			if ((PBRFlags & PBR::TerrainFlags::LandTile3HasGlint) != 0) {\
 				glintParameters += weight * LandscapeTexture4GlintParameters;
-			if ((PBRFlags & PBR::TerrainFlags::LandTile3HasGlint) != 0) {
 			}
 		}
 		else
@@ -1785,8 +1785,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS5 = TexLandRMAOS5Sampler.SampleBias(SampLandRMAOS5Sampler, uv, SharedData::MipBias) * float4(LandscapeTexture5PBRParams.x, 1, 1, LandscapeTexture5PBRParams.z);
 #			endif
-				glintParameters += weight * LandscapeTexture5GlintParameters;
 			if ((PBRFlags & PBR::TerrainFlags::LandTile4HasGlint) != 0) {
+				glintParameters += weight * LandscapeTexture5GlintParameters;
 			}
 		}
 		else
@@ -1865,8 +1865,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS6 = TexLandRMAOS6Sampler.SampleBias(SampLandRMAOS6Sampler, uv, SharedData::MipBias) * float4(LandscapeTexture6PBRParams.x, 1, 1, LandscapeTexture6PBRParams.z);
 #			endif
-				glintParameters += weight * LandscapeTexture6GlintParameters;
 			if ((PBRFlags & PBR::TerrainFlags::LandTile5HasGlint) != 0) {
+				glintParameters += weight * LandscapeTexture6GlintParameters;
 			}
 		}
 		else

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1463,8 +1463,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS1 = TexRMAOSSampler.SampleBias(SampRMAOSSampler, uv, SharedData::MipBias) * float4(PBRParams1.x, 1, 1, PBRParams1.z);
 #			endif
-			if ((PBRFlags & PBR::TerrainFlags::LandTile0HasGlint) != 0) {
-				glintParameters += input.LandBlendWeights1.x * LandscapeTexture1GlintParameters;
+			if ((PBRFlags & PBR::TerrainFlags::LandTile0HasGlint) != 0 && weight > 1e-6) {
+				glintParameters += weight * LandscapeTexture1GlintParameters;
 			}
 		}
 		else
@@ -1544,8 +1544,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS2 = TexLandRMAOS2Sampler.SampleBias(SampLandRMAOS2Sampler, uv, SharedData::MipBias) * float4(LandscapeTexture2PBRParams.x, 1, 1, LandscapeTexture2PBRParams.z);
 #			endif
-			if ((PBRFlags & PBR::TerrainFlags::LandTile1HasGlint) != 0) {
-				glintParameters += input.LandBlendWeights1.y * LandscapeTexture2GlintParameters;
+			if ((PBRFlags & PBR::TerrainFlags::LandTile1HasGlint) != 0 && weight > 1e-6) {
+				glintParameters += weight * LandscapeTexture2GlintParameters;
 			}
 		}
 		else
@@ -1624,8 +1624,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS3 = TexLandRMAOS3Sampler.SampleBias(SampLandRMAOS3Sampler, uv, SharedData::MipBias) * float4(LandscapeTexture3PBRParams.x, 1, 1, LandscapeTexture3PBRParams.z);
 #			endif
-			if ((PBRFlags & PBR::TerrainFlags::LandTile2HasGlint) != 0) {
-				glintParameters += input.LandBlendWeights1.z * LandscapeTexture3GlintParameters;
+			if ((PBRFlags & PBR::TerrainFlags::LandTile2HasGlint) != 0 && weight > 1e-6) {
+				glintParameters += weight * LandscapeTexture3GlintParameters;
 			}
 		}
 		else
@@ -1704,8 +1704,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS4 = TexLandRMAOS4Sampler.SampleBias(SampLandRMAOS4Sampler, uv, SharedData::MipBias) * float4(LandscapeTexture4PBRParams.x, 1, 1, LandscapeTexture4PBRParams.z);
 #			endif
-			if ((PBRFlags & PBR::TerrainFlags::LandTile3HasGlint) != 0) {
-				glintParameters += input.LandBlendWeights1.w * LandscapeTexture4GlintParameters;
+			if ((PBRFlags & PBR::TerrainFlags::LandTile3HasGlint) != 0 && weight > 1e-6) {
+				glintParameters += weight * LandscapeTexture4GlintParameters;
 			}
 		}
 		else
@@ -1785,8 +1785,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS5 = TexLandRMAOS5Sampler.SampleBias(SampLandRMAOS5Sampler, uv, SharedData::MipBias) * float4(LandscapeTexture5PBRParams.x, 1, 1, LandscapeTexture5PBRParams.z);
 #			endif
-			if ((PBRFlags & PBR::TerrainFlags::LandTile4HasGlint) != 0) {
-				glintParameters += input.LandBlendWeights2.x * LandscapeTexture5GlintParameters;
+			if ((PBRFlags & PBR::TerrainFlags::LandTile4HasGlint) != 0 && weight > 1e-6) {
+				glintParameters += weight * LandscapeTexture5GlintParameters;
 			}
 		}
 		else
@@ -1865,8 +1865,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS6 = TexLandRMAOS6Sampler.SampleBias(SampLandRMAOS6Sampler, uv, SharedData::MipBias) * float4(LandscapeTexture6PBRParams.x, 1, 1, LandscapeTexture6PBRParams.z);
 #			endif
-			if ((PBRFlags & PBR::TerrainFlags::LandTile5HasGlint) != 0) {
-				glintParameters += input.LandBlendWeights2.y * LandscapeTexture6GlintParameters;
+			if ((PBRFlags & PBR::TerrainFlags::LandTile5HasGlint) != 0 && weight > 1e-6) {
+				glintParameters += weight * LandscapeTexture6GlintParameters;
 			}
 		}
 		else

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1463,13 +1463,12 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS1 = TexRMAOSSampler.SampleBias(SampRMAOSSampler, uv, SharedData::MipBias) * float4(PBRParams1.x, 1, 1, PBRParams1.z);
 #			endif
-			if ((PBRFlags & PBR::TerrainFlags::LandTile0HasGlint) != 0 && weight > 1e-6) {
 				glintParameters += weight * LandscapeTexture1GlintParameters;
+			if ((PBRFlags & PBR::TerrainFlags::LandTile0HasGlint) != 0) {
 			}
 		}
 		else
 		{
-			landRMAOS1 = float4(1 - glossiness.x, 0, 1, 0);
 		}
 		blendedRMAOS += landRMAOS1 * weight;
 #		endif
@@ -1544,8 +1543,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS2 = TexLandRMAOS2Sampler.SampleBias(SampLandRMAOS2Sampler, uv, SharedData::MipBias) * float4(LandscapeTexture2PBRParams.x, 1, 1, LandscapeTexture2PBRParams.z);
 #			endif
-			if ((PBRFlags & PBR::TerrainFlags::LandTile1HasGlint) != 0 && weight > 1e-6) {
 				glintParameters += weight * LandscapeTexture2GlintParameters;
+			if ((PBRFlags & PBR::TerrainFlags::LandTile1HasGlint) != 0) {
 			}
 		}
 		else
@@ -1624,8 +1623,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS3 = TexLandRMAOS3Sampler.SampleBias(SampLandRMAOS3Sampler, uv, SharedData::MipBias) * float4(LandscapeTexture3PBRParams.x, 1, 1, LandscapeTexture3PBRParams.z);
 #			endif
-			if ((PBRFlags & PBR::TerrainFlags::LandTile2HasGlint) != 0 && weight > 1e-6) {
 				glintParameters += weight * LandscapeTexture3GlintParameters;
+			if ((PBRFlags & PBR::TerrainFlags::LandTile2HasGlint) != 0) {
 			}
 		}
 		else
@@ -1704,8 +1703,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS4 = TexLandRMAOS4Sampler.SampleBias(SampLandRMAOS4Sampler, uv, SharedData::MipBias) * float4(LandscapeTexture4PBRParams.x, 1, 1, LandscapeTexture4PBRParams.z);
 #			endif
-			if ((PBRFlags & PBR::TerrainFlags::LandTile3HasGlint) != 0 && weight > 1e-6) {
 				glintParameters += weight * LandscapeTexture4GlintParameters;
+			if ((PBRFlags & PBR::TerrainFlags::LandTile3HasGlint) != 0) {
 			}
 		}
 		else
@@ -1785,8 +1784,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS5 = TexLandRMAOS5Sampler.SampleBias(SampLandRMAOS5Sampler, uv, SharedData::MipBias) * float4(LandscapeTexture5PBRParams.x, 1, 1, LandscapeTexture5PBRParams.z);
 #			endif
-			if ((PBRFlags & PBR::TerrainFlags::LandTile4HasGlint) != 0 && weight > 1e-6) {
 				glintParameters += weight * LandscapeTexture5GlintParameters;
+			if ((PBRFlags & PBR::TerrainFlags::LandTile4HasGlint) != 0) {
 			}
 		}
 		else
@@ -1865,8 +1864,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			else
 			landRMAOS6 = TexLandRMAOS6Sampler.SampleBias(SampLandRMAOS6Sampler, uv, SharedData::MipBias) * float4(LandscapeTexture6PBRParams.x, 1, 1, LandscapeTexture6PBRParams.z);
 #			endif
-			if ((PBRFlags & PBR::TerrainFlags::LandTile5HasGlint) != 0 && weight > 1e-6) {
 				glintParameters += weight * LandscapeTexture6GlintParameters;
+			if ((PBRFlags & PBR::TerrainFlags::LandTile5HasGlint) != 0) {
 			}
 		}
 		else

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1469,7 +1469,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		}
 		else
 		{
-			landRMAOS1 = float4(1 - glossiness.x, 0, 1, 0);
+			landRMAOS1 = input.LandBlendWeights1.x * float4(1 - glossiness.x, 0, 1, 0);
 		}
 		blendedRMAOS += landRMAOS1 * weight;
 #		endif

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1469,7 +1469,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		}
 		else
 		{
-			landRMAOS1 = float4(1 - landNormal1.w, 0, 1, 0);
+			landRMAOS1 = float4(1 - glossiness.x, 0, 1, 0);
 		}
 		blendedRMAOS += landRMAOS1 * weight;
 #		endif


### PR DESCRIPTION
removed duplicate code leftover by mistake from tv v1-2. fixed pbr brightness issues for some landblendweights.

Fixes completely black landblendweights where glint normal data was wrong. updated all to use glossiness.x value and now working as intended.