### PR TITLE
perf: set anisotropic filtering from 16 to 8

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -617,7 +617,7 @@ namespace Hooks
 				stl::detour_vfunc<12, ID3D11Device_CreateVertexShader>(globals::d3d::device);
 				stl::detour_vfunc<15, ID3D11Device_CreatePixelShader>(globals::d3d::device);
 			}
-			
+
 			stl::detour_vfunc<23, ID3D11Device_CreateSamplerState>(globals::d3d::device);
 
 			globals::menu->Init();

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -297,8 +297,7 @@ struct ID3D11Device_CreateSamplerState
 	static HRESULT STDMETHODCALLTYPE thunk(ID3D11Device* This, D3D11_SAMPLER_DESC* pSamplerDesc, ID3D11SamplerState** ppSamplerState)
 	{
 		// Limit Anisotropy to 8x for performance
-		if (pSamplerDesc->MaxAnisotropy == 16)
-			pSamplerDesc->MaxAnisotropy = 8;
+		pSamplerDesc->MaxAnisotropy = std::min(pSamplerDesc->MaxAnisotropy, 8u);
 		return func(This, pSamplerDesc, ppSamplerState);
 	}
 	static inline REL::Relocation<decltype(thunk)> func;

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -292,6 +292,18 @@ struct ID3D11Device_CreatePixelShader
 	static inline REL::Relocation<decltype(thunk)> func;
 };
 
+struct ID3D11Device_CreateSamplerState
+{
+	static HRESULT STDMETHODCALLTYPE thunk(ID3D11Device* This, D3D11_SAMPLER_DESC* pSamplerDesc, ID3D11SamplerState** ppSamplerState)
+	{
+		// Limit Anisotropy to 8x for performance
+		if (pSamplerDesc->MaxAnisotropy == 16)
+			pSamplerDesc->MaxAnisotropy = 8;
+		return func(This, pSamplerDesc, ppSamplerState);
+	}
+	static inline REL::Relocation<decltype(thunk)> func;
+};
+
 decltype(&CreateDXGIFactory) ptrCreateDXGIFactory;
 
 HRESULT WINAPI hk_CreateDXGIFactory(REFIID, void** ppFactory)
@@ -605,6 +617,9 @@ namespace Hooks
 				stl::detour_vfunc<12, ID3D11Device_CreateVertexShader>(globals::d3d::device);
 				stl::detour_vfunc<15, ID3D11Device_CreatePixelShader>(globals::d3d::device);
 			}
+			
+			stl::detour_vfunc<23, ID3D11Device_CreateSamplerState>(globals::d3d::device);
+
 			globals::menu->Init();
 		}
 		static inline REL::Relocation<decltype(thunk)> func;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anisotropic filtering is now capped at 8x for improved performance.

* **Chores**
  * Internal updates to enhance graphics settings management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->