### PR TITLE
perf(terrain variation): custom mip levels & parallax function

### DIFF
--- a/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
+++ b/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
@@ -63,7 +63,7 @@ namespace ExtendedMaterials
 			// Compute the current mip level  (* 0.5 is effectively computing a square root before )
 			float mipLevel = max(0.5 * log2(minTexCoordDelta), 0);
 
-		#if !defined(PARALLAX) && !defined(TRUE_PBR)
+		#if !defined(PARALLAX) && !defined(TRUE_PBR) && !defined(TERRAIN_VARIATION)
 				mipLevel++;
 		#endif
 

--- a/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
+++ b/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
@@ -68,16 +68,9 @@ namespace ExtendedMaterials
 		#endif
 
 		// VR: Apply more conservative mipmap level adjustments to reduce over-blurring and shimmering
-		#if defined(VR) && !defined(TERRAIN_VARIATION)
+		#if defined(VR)
 				mipLevel++;
 		#endif
-
-	#if defined(TERRAIN_VARIATION) && defined(LANDSCAPE) && !defined(VR)
-			// Only increase mip level when TAA is enabled (MipBias > 0 indicates TAA is active)
-			if (SharedData::MipBias > 0.0) {
-				mipLevel++; // Increase mip level to match vanilla appearance since terrain variation tends to be sharper than vanilla.
-			}
-	#endif
 
 		return mipLevel;
 	}
@@ -133,7 +126,7 @@ namespace ExtendedMaterials
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile0HasDisplacement) != 0 && w1.x > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[0] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[0], TexLandDisplacement0Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[0]);
+			heights[0] = ScaleDisplacement(StochasticEffectNoHeight(TexLandDisplacement0Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[0]);
 #		else
 			heights[0] = ScaleDisplacement(TexLandDisplacement0Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[0]).x, params[0]);
 #		endif
@@ -141,7 +134,7 @@ namespace ExtendedMaterials
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile1HasDisplacement) != 0 && w1.y > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[1] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[1], TexLandDisplacement1Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[1]);
+			heights[1] = ScaleDisplacement(StochasticEffectNoHeight(TexLandDisplacement1Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[1]);
 #		else
 			heights[1] = ScaleDisplacement(TexLandDisplacement1Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[1]).x, params[1]);
 #		endif
@@ -149,7 +142,7 @@ namespace ExtendedMaterials
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile2HasDisplacement) != 0 && w1.z > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[2] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[2], TexLandDisplacement2Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[2]);
+			heights[2] = ScaleDisplacement(StochasticEffectNoHeight(TexLandDisplacement2Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[2]);
 #		else
 			heights[2] = ScaleDisplacement(TexLandDisplacement2Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[2]).x, params[2]);
 #		endif
@@ -157,7 +150,7 @@ namespace ExtendedMaterials
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile3HasDisplacement) != 0 && w1.w > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[3] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[3], TexLandDisplacement3Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[3]);
+			heights[3] = ScaleDisplacement(StochasticEffectNoHeight(TexLandDisplacement3Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[3]);
 #		else
 			heights[3] = ScaleDisplacement(TexLandDisplacement3Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[3]).x, params[3]);
 #		endif
@@ -165,7 +158,7 @@ namespace ExtendedMaterials
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile4HasDisplacement) != 0 && w2.x > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[4] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[4], TexLandDisplacement4Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[4]);
+			heights[4] = ScaleDisplacement(StochasticEffectNoHeight(TexLandDisplacement4Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[4]);
 #		else
 			heights[4] = ScaleDisplacement(TexLandDisplacement4Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[4]).x, params[4]);
 #		endif
@@ -173,7 +166,7 @@ namespace ExtendedMaterials
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile5HasDisplacement) != 0 && w2.y > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[5] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[5], TexLandDisplacement5Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[5]);
+			heights[5] = ScaleDisplacement(StochasticEffectNoHeight(TexLandDisplacement5Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[5]);
 #		else
 			heights[5] = ScaleDisplacement(TexLandDisplacement5Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[5]).x, params[5]);
 #		endif
@@ -202,7 +195,7 @@ namespace ExtendedMaterials
 			[branch] if ((Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLand0HasDisplacement) != 0)
 			{
 #		if defined(TERRAIN_VARIATION)
-				heights[0] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[0], TexLandTHDisp0Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[0]);
+				heights[0] = ScaleDisplacement(StochasticEffectNoHeight(TexLandTHDisp0Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[0]);
 #		else
 				heights[0] = ScaleDisplacement(TexLandTHDisp0Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[0]).x, params[0]);
 #		endif
@@ -210,7 +203,7 @@ namespace ExtendedMaterials
 			else
 			{
 #		if defined(TERRAIN_VARIATION)
-				heights[0] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[0], TexColorSampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[0]);
+				heights[0] = ScaleDisplacement(StochasticEffectNoHeight(TexColorSampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[0]);
 #		else
 				heights[0] = ScaleDisplacement(TexColorSampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[0]).w, params[0]);
 #		endif
@@ -220,7 +213,7 @@ namespace ExtendedMaterials
 			[branch] if ((Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLand1HasDisplacement) != 0)
 			{
 #		if defined(TERRAIN_VARIATION)
-				heights[1] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[1], TexLandTHDisp1Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[1]);
+				heights[1] = ScaleDisplacement(StochasticEffectNoHeight(TexLandTHDisp1Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[1]);
 #		else
 				heights[1] = ScaleDisplacement(TexLandTHDisp1Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[1]).x, params[1]);
 #		endif
@@ -228,7 +221,7 @@ namespace ExtendedMaterials
 			else
 			{
 #		if defined(TERRAIN_VARIATION)
-				heights[1] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[1], TexLandColor2Sampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[1]);
+				heights[1] = ScaleDisplacement(StochasticEffectNoHeight(TexLandColor2Sampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[1]);
 #		else
 				heights[1] = ScaleDisplacement(TexLandColor2Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[1]).w, params[1]);
 #		endif
@@ -238,7 +231,7 @@ namespace ExtendedMaterials
 			[branch] if ((Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLand2HasDisplacement) != 0)
 			{
 #		if defined(TERRAIN_VARIATION)
-				heights[2] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[2], TexLandTHDisp2Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[2]);
+				heights[2] = ScaleDisplacement(StochasticEffectNoHeight(TexLandTHDisp2Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[2]);
 #		else
 				heights[2] = ScaleDisplacement(TexLandTHDisp2Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[2]).x, params[2]);
 #		endif
@@ -246,7 +239,7 @@ namespace ExtendedMaterials
 			else
 			{
 #		if defined(TERRAIN_VARIATION)
-				heights[2] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[2], TexLandColor3Sampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[2]);
+				heights[2] = ScaleDisplacement(StochasticEffectNoHeight(TexLandColor3Sampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[2]);
 #		else
 				heights[2] = ScaleDisplacement(TexLandColor3Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[2]).w, params[2]);
 #		endif
@@ -255,7 +248,7 @@ namespace ExtendedMaterials
 		[branch] if ((Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLand3HasDisplacement) != 0 && w1.w > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[3] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[3], TexLandTHDisp3Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[3]);
+			heights[3] = ScaleDisplacement(StochasticEffectNoHeight(TexLandTHDisp3Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[3]);
 #		else
 			heights[3] = ScaleDisplacement(TexLandTHDisp3Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[3]).x, params[3]);
 #		endif
@@ -263,7 +256,7 @@ namespace ExtendedMaterials
 		else if (w1.w > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[3] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[3], TexLandColor4Sampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[3]);
+			heights[3] = ScaleDisplacement(StochasticEffectNoHeight(TexLandColor4Sampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[3]);
 #		else
 			heights[3] = ScaleDisplacement(TexLandColor4Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[3]).w, params[3]);
 #		endif
@@ -271,7 +264,7 @@ namespace ExtendedMaterials
 		[branch] if ((Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLand4HasDisplacement) != 0 && w2.x > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[4] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[4], TexLandTHDisp4Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[4]);
+			heights[4] = ScaleDisplacement(StochasticEffectNoHeight(TexLandTHDisp4Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[4]);
 #		else
 			heights[4] = ScaleDisplacement(TexLandTHDisp4Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[4]).x, params[4]);
 #		endif
@@ -279,7 +272,7 @@ namespace ExtendedMaterials
 		else if (w2.x > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[4] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[4], TexLandColor5Sampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[4]);
+			heights[4] = ScaleDisplacement(StochasticEffectNoHeight(TexLandColor5Sampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[4]);
 #		else
 			heights[4] = ScaleDisplacement(TexLandColor5Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[4]).w, params[4]);
 #		endif
@@ -287,7 +280,7 @@ namespace ExtendedMaterials
 		[branch] if ((Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLand5HasDisplacement) != 0 && w2.y > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[5] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[5], TexLandTHDisp5Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[5]);
+			heights[5] = ScaleDisplacement(StochasticEffectNoHeight(TexLandTHDisp5Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[5]);
 #		else
 			heights[5] = ScaleDisplacement(TexLandTHDisp5Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[5]).x, params[5]);
 #		endif
@@ -295,7 +288,7 @@ namespace ExtendedMaterials
 		else if (w2.y > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[5] = ScaleDisplacement(StochasticEffectNoHeight(mipLevels[5], TexLandColor6Sampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[5]);
+			heights[5] = ScaleDisplacement(StochasticEffectNoHeight(TexLandColor6Sampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[5]);
 #		else
 			heights[5] = ScaleDisplacement(TexLandColor6Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[5]).w, params[5]);
 #		endif

--- a/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
+++ b/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
@@ -126,7 +126,7 @@ namespace ExtendedMaterials
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile0HasDisplacement) != 0 && w1.x > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[0] = ScaleDisplacement(StochasticEffectNoHeight(TexLandDisplacement0Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[0]);
+			heights[0] = ScaleDisplacement(StochasticEffectParallax(TexLandDisplacement0Sampler, SampTerrainParallaxSampler, coords, mipLevels[0], sharedOffset, dx, dy).x, params[0]);
 #		else
 			heights[0] = ScaleDisplacement(TexLandDisplacement0Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[0]).x, params[0]);
 #		endif
@@ -134,7 +134,7 @@ namespace ExtendedMaterials
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile1HasDisplacement) != 0 && w1.y > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[1] = ScaleDisplacement(StochasticEffectNoHeight(TexLandDisplacement1Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[1]);
+			heights[1] = ScaleDisplacement(StochasticEffectParallax(TexLandDisplacement1Sampler, SampTerrainParallaxSampler, coords, mipLevels[1], sharedOffset, dx, dy).x, params[1]);
 #		else
 			heights[1] = ScaleDisplacement(TexLandDisplacement1Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[1]).x, params[1]);
 #		endif
@@ -142,7 +142,7 @@ namespace ExtendedMaterials
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile2HasDisplacement) != 0 && w1.z > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[2] = ScaleDisplacement(StochasticEffectNoHeight(TexLandDisplacement2Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[2]);
+			heights[2] = ScaleDisplacement(StochasticEffectParallax(TexLandDisplacement2Sampler, SampTerrainParallaxSampler, coords, mipLevels[2], sharedOffset, dx, dy).x, params[2]);
 #		else
 			heights[2] = ScaleDisplacement(TexLandDisplacement2Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[2]).x, params[2]);
 #		endif
@@ -150,7 +150,7 @@ namespace ExtendedMaterials
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile3HasDisplacement) != 0 && w1.w > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[3] = ScaleDisplacement(StochasticEffectNoHeight(TexLandDisplacement3Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[3]);
+			heights[3] = ScaleDisplacement(StochasticEffectParallax(TexLandDisplacement3Sampler, SampTerrainParallaxSampler, coords, mipLevels[3], sharedOffset, dx, dy).x, params[3]);
 #		else
 			heights[3] = ScaleDisplacement(TexLandDisplacement3Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[3]).x, params[3]);
 #		endif
@@ -158,7 +158,7 @@ namespace ExtendedMaterials
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile4HasDisplacement) != 0 && w2.x > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[4] = ScaleDisplacement(StochasticEffectNoHeight(TexLandDisplacement4Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[4]);
+			heights[4] = ScaleDisplacement(StochasticEffectParallax(TexLandDisplacement4Sampler, SampTerrainParallaxSampler, coords, mipLevels[4], sharedOffset, dx, dy).x, params[4]);
 #		else
 			heights[4] = ScaleDisplacement(TexLandDisplacement4Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[4]).x, params[4]);
 #		endif
@@ -166,7 +166,7 @@ namespace ExtendedMaterials
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile5HasDisplacement) != 0 && w2.y > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[5] = ScaleDisplacement(StochasticEffectNoHeight(TexLandDisplacement5Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[5]);
+			heights[5] = ScaleDisplacement(StochasticEffectParallax(TexLandDisplacement5Sampler, SampTerrainParallaxSampler, coords, mipLevels[5], sharedOffset, dx, dy).x, params[5]);
 #		else
 			heights[5] = ScaleDisplacement(TexLandDisplacement5Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[5]).x, params[5]);
 #		endif
@@ -195,7 +195,7 @@ namespace ExtendedMaterials
 			[branch] if ((Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLand0HasDisplacement) != 0)
 			{
 #		if defined(TERRAIN_VARIATION)
-				heights[0] = ScaleDisplacement(StochasticEffectNoHeight(TexLandTHDisp0Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[0]);
+				heights[0] = ScaleDisplacement(StochasticEffectParallax(TexLandTHDisp0Sampler, SampTerrainParallaxSampler, coords, mipLevels[0], sharedOffset, dx, dy).x, params[0]);
 #		else
 				heights[0] = ScaleDisplacement(TexLandTHDisp0Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[0]).x, params[0]);
 #		endif
@@ -203,7 +203,7 @@ namespace ExtendedMaterials
 			else
 			{
 #		if defined(TERRAIN_VARIATION)
-				heights[0] = ScaleDisplacement(StochasticEffectNoHeight(TexColorSampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[0]);
+				heights[0] = ScaleDisplacement(StochasticEffectParallax(TexColorSampler, SampTerrainParallaxSampler, coords, mipLevels[0], sharedOffset, dx, dy).w, params[0]);
 #		else
 				heights[0] = ScaleDisplacement(TexColorSampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[0]).w, params[0]);
 #		endif
@@ -213,7 +213,7 @@ namespace ExtendedMaterials
 			[branch] if ((Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLand1HasDisplacement) != 0)
 			{
 #		if defined(TERRAIN_VARIATION)
-				heights[1] = ScaleDisplacement(StochasticEffectNoHeight(TexLandTHDisp1Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[1]);
+				heights[1] = ScaleDisplacement(StochasticEffectParallax(TexLandTHDisp1Sampler, SampTerrainParallaxSampler, coords, mipLevels[1], sharedOffset, dx, dy).x, params[1]);
 #		else
 				heights[1] = ScaleDisplacement(TexLandTHDisp1Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[1]).x, params[1]);
 #		endif
@@ -221,7 +221,7 @@ namespace ExtendedMaterials
 			else
 			{
 #		if defined(TERRAIN_VARIATION)
-				heights[1] = ScaleDisplacement(StochasticEffectNoHeight(TexLandColor2Sampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[1]);
+				heights[1] = ScaleDisplacement(StochasticEffectParallax(TexLandColor2Sampler, SampTerrainParallaxSampler, coords, mipLevels[1], sharedOffset, dx, dy).w, params[1]);
 #		else
 				heights[1] = ScaleDisplacement(TexLandColor2Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[1]).w, params[1]);
 #		endif
@@ -231,7 +231,7 @@ namespace ExtendedMaterials
 			[branch] if ((Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLand2HasDisplacement) != 0)
 			{
 #		if defined(TERRAIN_VARIATION)
-				heights[2] = ScaleDisplacement(StochasticEffectNoHeight(TexLandTHDisp2Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[2]);
+				heights[2] = ScaleDisplacement(StochasticEffectParallax(TexLandTHDisp2Sampler, SampTerrainParallaxSampler, coords, mipLevels[2], sharedOffset, dx, dy).x, params[2]);
 #		else
 				heights[2] = ScaleDisplacement(TexLandTHDisp2Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[2]).x, params[2]);
 #		endif
@@ -239,7 +239,7 @@ namespace ExtendedMaterials
 			else
 			{
 #		if defined(TERRAIN_VARIATION)
-				heights[2] = ScaleDisplacement(StochasticEffectNoHeight(TexLandColor3Sampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[2]);
+				heights[2] = ScaleDisplacement(StochasticEffectParallax(TexLandColor3Sampler, SampTerrainParallaxSampler, coords, mipLevels[2], sharedOffset, dx, dy).w, params[2]);
 #		else
 				heights[2] = ScaleDisplacement(TexLandColor3Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[2]).w, params[2]);
 #		endif
@@ -248,7 +248,7 @@ namespace ExtendedMaterials
 		[branch] if ((Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLand3HasDisplacement) != 0 && w1.w > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[3] = ScaleDisplacement(StochasticEffectNoHeight(TexLandTHDisp3Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[3]);
+			heights[3] = ScaleDisplacement(StochasticEffectParallax(TexLandTHDisp3Sampler, SampTerrainParallaxSampler, coords, mipLevels[3], sharedOffset, dx, dy).x, params[3]);
 #		else
 			heights[3] = ScaleDisplacement(TexLandTHDisp3Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[3]).x, params[3]);
 #		endif
@@ -256,7 +256,7 @@ namespace ExtendedMaterials
 		else if (w1.w > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[3] = ScaleDisplacement(StochasticEffectNoHeight(TexLandColor4Sampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[3]);
+			heights[3] = ScaleDisplacement(StochasticEffectParallax(TexLandColor4Sampler, SampTerrainParallaxSampler, coords, mipLevels[3], sharedOffset, dx, dy).w, params[3]);
 #		else
 			heights[3] = ScaleDisplacement(TexLandColor4Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[3]).w, params[3]);
 #		endif
@@ -264,7 +264,7 @@ namespace ExtendedMaterials
 		[branch] if ((Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLand4HasDisplacement) != 0 && w2.x > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[4] = ScaleDisplacement(StochasticEffectNoHeight(TexLandTHDisp4Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[4]);
+			heights[4] = ScaleDisplacement(StochasticEffectParallax(TexLandTHDisp4Sampler, SampTerrainParallaxSampler, coords, mipLevels[4], sharedOffset, dx, dy).x, params[4]);
 #		else
 			heights[4] = ScaleDisplacement(TexLandTHDisp4Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[4]).x, params[4]);
 #		endif
@@ -272,7 +272,7 @@ namespace ExtendedMaterials
 		else if (w2.x > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[4] = ScaleDisplacement(StochasticEffectNoHeight(TexLandColor5Sampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[4]);
+			heights[4] = ScaleDisplacement(StochasticEffectParallax(TexLandColor5Sampler, SampTerrainParallaxSampler, coords, mipLevels[4], sharedOffset, dx, dy).w, params[4]);
 #		else
 			heights[4] = ScaleDisplacement(TexLandColor5Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[4]).w, params[4]);
 #		endif
@@ -280,7 +280,7 @@ namespace ExtendedMaterials
 		[branch] if ((Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLand5HasDisplacement) != 0 && w2.y > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[5] = ScaleDisplacement(StochasticEffectNoHeight(TexLandTHDisp5Sampler, SampTerrainParallaxSampler, coords, sharedOffset).x, params[5]);
+			heights[5] = ScaleDisplacement(StochasticEffectParallax(TexLandTHDisp5Sampler, SampTerrainParallaxSampler, coords, mipLevels[5], sharedOffset, dx, dy).x, params[5]);
 #		else
 			heights[5] = ScaleDisplacement(TexLandTHDisp5Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[5]).x, params[5]);
 #		endif
@@ -288,7 +288,7 @@ namespace ExtendedMaterials
 		else if (w2.y > 0.01)
 		{
 #		if defined(TERRAIN_VARIATION)
-			heights[5] = ScaleDisplacement(StochasticEffectNoHeight(TexLandColor6Sampler, SampTerrainParallaxSampler, coords, sharedOffset).w, params[5]);
+			heights[5] = ScaleDisplacement(StochasticEffectParallax(TexLandColor6Sampler, SampTerrainParallaxSampler, coords, mipLevels[5], sharedOffset, dx, dy).w, params[5]);
 #		else
 			heights[5] = ScaleDisplacement(TexLandColor6Sampler.SampleLevel(SampTerrainParallaxSampler, coords, mipLevels[5]).w, params[5]);
 #		endif

--- a/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
+++ b/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
@@ -63,26 +63,21 @@ namespace ExtendedMaterials
 			// Compute the current mip level  (* 0.5 is effectively computing a square root before )
 			float mipLevel = max(0.5 * log2(minTexCoordDelta), 0);
 
-		#if !defined(PARALLAX) && !defined(TRUE_PBR) && !defined(TERRAIN_VARIATION)
+		#if !defined(PARALLAX) && !defined(TRUE_PBR)
 				mipLevel++;
 		#endif
 
 		// VR: Apply more conservative mipmap level adjustments to reduce over-blurring and shimmering
-		#if defined(VR)
-			#if defined(TERRAIN_VARIATION) && defined(LANDSCAPE)
-				// No additional VR mip penalty when terrain variation is active - let TV handle mip adjustments
-			#else
+		#if defined(VR) && !defined(TERRAIN_VARIATION)
 				mipLevel++;
-			#endif
 		#endif
 
-		#if defined(TERRAIN_VARIATION) && defined(LANDSCAPE)
-			#if !defined(VR)
+	#if defined(TERRAIN_VARIATION) && defined(LANDSCAPE) && !defined(VR)
+			// Only increase mip level when TAA is enabled (MipBias > 0 indicates TAA is active)
+			if (SharedData::MipBias > 0.0) {
 				mipLevel++; // Increase mip level to match vanilla appearance since terrain variation tends to be sharper than vanilla.
-			#else
-				// When VR + terrain variation are both active, no additional mip penalty - VR gets only TV features without mip changes
-			#endif
-		#endif
+			}
+	#endif
 
 		return mipLevel;
 	}

--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -20,11 +20,10 @@ static const float3 DEFAULT_WEIGHTS = float3(0.33, 0.33, 0.34);
 static const float3 LUMINANCE_WEIGHTS = float3(0.2126, 0.7152, 0.0722);
 // Hash constants
 static const float2 HASH_MULTIPLIER = float2(1271.5151, 3337.8237);
-static const float2 HASH_SINE_MULTIPLIER = float2(43758.5453, 28637.1369);
-// Mip level transition thresholds - DO NOT CHANGE THESE VALUES.
-static const float MIP_BLEND_START = 5.0;         // Mip level where blending starts transitioning to single sample
-static const float MIP_BLEND_RANGE = 1.5;         // Range over which blending transitions to single sample (5.0 to 6.5)
-static const float MIP_EARLY_EXIT_THRESHOLD = 1.0; // Threshold for early exit to single sample optimization
+// Performance optimization constants
+static const float MIP_LEVEL_INCREASE = 0.5;      // Additional mip level increase for distance optimization
+static const float DISTANCE_SAMPLE_REDUCTION = 2.0; // Mip level where we reduce to 2 samples
+static const float FAR_DISTANCE_THRESHOLD = 4.0;  // Mip level where we use single sample with higher mip level
 
 // Structure to hold stochastic sampling offsets and weights
 struct StochasticOffsets
@@ -45,8 +44,10 @@ float4 StochasticEffectParallax(Texture2D tex, SamplerState samp, float2 uv, flo
 // Hash function for stochastic sampling
 inline float2 hash2D2D(float2 s)
 {
-	s = s * HASH_MULTIPLIER;
-	return frac(sin(s.x + s.y) * HASH_SINE_MULTIPLIER);
+	// More efficient hash using frac and multiply operations
+	s = frac(s * HASH_MULTIPLIER);
+	s += dot(s, s.yx + 19.19);
+	return frac((s.xx + s.yy) * s.yx);
 }
 
 inline float2 hashLOD(float2 p)
@@ -58,6 +59,8 @@ inline float2 hashLOD(float2 p)
 inline float3 NormalizeWeights(float3 weights)
 {
 	float weightSum = weights.x + weights.y + weights.z;
+	// Skip expensive division if already normalized
+	if (abs(weightSum - 1.0) < 0.01) return weights;
 	float rcpWeightSum = rcp(max(weightSum, 1e-6));
 	return weights * rcpWeightSum;
 }
@@ -140,44 +143,40 @@ inline float4 StochasticEffect(Texture2D tex, SamplerState samp, float2 uv, Stoc
 	// Calculate custom mip level from original UVs.
 	float mipLevel = tex.CalculateLevelOfDetail(samp, uv);
 
+	// 3 Sample Blend
 	float4 sample1 = tex.SampleLevel(samp, uv + offsets.offset1, mipLevel);
-
-	// Early exit for very high mip levels - single sample is sufficient. Miplevels hide the artifacts.
-	float mipFactor = saturate((mipLevel - MIP_BLEND_START) / MIP_BLEND_RANGE);
-	if (mipFactor >= MIP_EARLY_EXIT_THRESHOLD)
-	{
-		return sample1;
-		// Wasted ALU since there are still 3 hash calls computed for the pixel, but doesn't really hurt performance and also avoids recalculating when moving closer/further away.
-	}
-
-	// Take three samples for blending at the same adjusted mip level
 	float4 sample2 = tex.SampleLevel(samp, uv + offsets.offset2, mipLevel);
 	float4 sample3 = tex.SampleLevel(samp, uv + offsets.offset3, mipLevel);
 
-	// Full height-based blending for low mip levels (close terrain) with improved contrast scaling
-	float contrastFactor = HEIGHT_BLEND_CONTRAST * (1.0 - HEIGHT_INFLUENCE) * (1.0 - 0.5 * mipFactor);
-	float3 blendWeights = pow(saturate(offsets.weights), max(1.0, min(100.0, contrastFactor)));
+	// Simplified blending for better performance - reduce contrast calculation overhead
+	float3 blendWeights = saturate(offsets.weights);
+	
+	// Gradual fade-out of height blending based on distance (mip level)
+	float heightBlendFactor = saturate(1.0 - (mipLevel - 1.0) / 2.0); // Fade from mip 1.0 to 3.0
+	
+	if (heightBlendFactor > 0.0)
+	{
+		// Use Extended Materials style height blending for better quality
+		float3 heights = float3(sample1.a, sample2.a, sample3.a);
+		
+		// Apply distance-based fade to height influence
+		float heightBlend = 1.0 + (HEIGHT_INFLUENCE * heightBlendFactor * 2.0); // Scale similar to ExtendedMaterials HEIGHT_POWER
+		
+		// Apply height-based weighting (simplified version of ExtendedMaterials ProcessTerrainHeightWeights)
+		float3 heightWeights = blendWeights * pow(heightBlend, 8.0 * heights); // HEIGHT_MULT = 8
+		heightWeights = min(100.0, pow(heightWeights, heightBlend));
+		
+		// Normalize weights
+		blendWeights = NormalizeWeights(heightWeights);
+	}
+	else
+	{
+		// Skip expensive height calculations for distant terrain
+		blendWeights = NormalizeWeights(blendWeights);
+	}
 
-	// Height calculation
-	float3 luminanceHeights = float3(
-		dot(sample1.rgb, LUMINANCE_WEIGHTS),
-		dot(sample2.rgb, LUMINANCE_WEIGHTS),
-		dot(sample3.rgb, LUMINANCE_WEIGHTS)
-	);
-
-	float3 alphaValues = float3(sample1.a, sample2.a, sample3.a);
-	float3 alphaMask = step(0.001, alphaValues);
-	float3 heights = lerp(luminanceHeights, alphaValues, alphaMask);
-
-	// Combined weight calculation and normalization
-	float3 weights = NormalizeWeights(blendWeights * (1.0 + HEIGHT_INFLUENCE * heights));
-
-	// Direct blend without intermediate variable
-	float4 highQualitySample = sample1 * weights.x + sample2 * weights.y + sample3 * weights.z;
-
-	// Smooth transition between high quality and single sample based on mip level
-	float smoothFactor = smoothstep(0.0, 1.0, mipFactor);
-	return lerp(highQualitySample, sample1, smoothFactor);
+	// Final blend
+	return sample1 * blendWeights.x + sample2 * blendWeights.y + sample3 * blendWeights.z;
 }
 
 // Stochastic sampling function without height blending for better performance
@@ -192,10 +191,17 @@ inline float4 StochasticEffectParallax(Texture2D tex, SamplerState samp, float2 
 		return tex.SampleLevel(samp, uv, mipLevel);
 	}
 
-	// Take three samples for blending
-	float4 sample1 = tex.SampleLevel(samp, uv + offsets.offset1, mipLevel); // Uses miplevels from EMAT.hlsl.
-	float4 sample2 = tex.SampleLevel(samp, uv + offsets.offset2, mipLevel);
-	float4 sample3 = tex.SampleLevel(samp, uv + offsets.offset3, mipLevel);
+	// Use progressive mip level increase for better performance in parallax
+	float adjustedMipLevel = mipLevel;
+	if (mipLevel > 1.0)
+	{
+		adjustedMipLevel = mipLevel + (MIP_LEVEL_INCREASE * 0.5);
+	}
+
+	// Take three samples for blending at the adjusted mip level
+	float4 sample1 = tex.SampleLevel(samp, uv + offsets.offset1, adjustedMipLevel);
+	float4 sample2 = tex.SampleLevel(samp, uv + offsets.offset2, adjustedMipLevel);
+	float4 sample3 = tex.SampleLevel(samp, uv + offsets.offset3, adjustedMipLevel);
 
 	// Simple barycentric blend without height influence
 	float3 weights = NormalizeWeights(saturate(offsets.weights));

--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -69,7 +69,7 @@ inline float4x3 ComputeBarycentricVerts(float2 landscapeUV)
     float2 skewUV = mul(SKEW_MATRIX, scaledUV);
     float2 vxID = floor(skewUV);
     float2 frac_uv = frac(skewUV);
-    
+
     float barry_z = 1.0 - frac_uv.x - frac_uv.y;
     float3 barry = float3(frac_uv, barry_z);
 

--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -37,8 +37,8 @@ struct StochasticOffsets
 
 // --------------------- FUNCTION DECLARATIONS --------------------- //
 float4 StochasticSampleLOD(float rnd, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsetsLOD, float2 dx, float2 dy);
-float4 StochasticEffect(float rnd, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy);
-float4 StochasticEffectParallax(Texture2D tex, SamplerState samp, float2 uv, float mipLevel, StochasticOffsets offsets);
+float4 StochasticEffect(Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy);
+float4 StochasticEffectParallax(Texture2D tex, SamplerState samp, float2 uv, float mipLevel, StochasticOffsets offsets, float2 dx, float2 dy)
 
 // --------------------- COMPUTE FUNCTIONS --------------------- //
 
@@ -182,7 +182,7 @@ inline float4 StochasticEffect(Texture2D tex, SamplerState samp, float2 uv, Stoc
 }
 
 // Stochastic sampling function without height blending for better performance
-// Disable X4000 warning: FXC incorrectly reports potentially uninitialized variables sdue to complex control flow with early returns and conditional sampling
+// Disable X4000 warning: FXC incorrectly reports potentially uninitialized variables due to complex control flow with early returns and conditional sampling
 #pragma warning(push)
 #pragma warning(disable : 4000)
 inline float4 StochasticEffectParallax(Texture2D tex, SamplerState samp, float2 uv, float mipLevel, StochasticOffsets offsets, float2 dx, float2 dy)

--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -150,22 +150,22 @@ inline float4 StochasticEffect(Texture2D tex, SamplerState samp, float2 uv, Stoc
 
 	// Simplified blending for better performance - reduce contrast calculation overhead
 	float3 blendWeights = saturate(offsets.weights);
-	
+
 	// Gradual fade-out of height blending based on distance (mip level)
 	float heightBlendFactor = saturate(1.0 - (mipLevel - 1.0) / 2.0); // Fade from mip 1.0 to 3.0
-	
+
 	if (heightBlendFactor > 0.0)
 	{
 		// Use Extended Materials style height blending for better quality
 		float3 heights = float3(sample1.a, sample2.a, sample3.a);
-		
+
 		// Apply distance-based fade to height influence
 		float heightBlend = 1.0 + (HEIGHT_INFLUENCE * heightBlendFactor * 2.0); // Scale similar to ExtendedMaterials HEIGHT_POWER
-		
+
 		// Apply height-based weighting (simplified version of ExtendedMaterials ProcessTerrainHeightWeights)
 		float3 heightWeights = blendWeights * pow(heightBlend, 8.0 * heights); // HEIGHT_MULT = 8
 		heightWeights = min(100.0, pow(heightWeights, heightBlend));
-		
+
 		// Normalize weights
 		blendWeights = NormalizeWeights(heightWeights);
 	}

--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -38,7 +38,7 @@ struct StochasticOffsets
 // --------------------- FUNCTION DECLARATIONS --------------------- //
 float4 StochasticSampleLOD(float rnd, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsetsLOD, float2 dx, float2 dy);
 float4 StochasticEffect(float rnd, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy);
-float4 StochasticEffectNoHeight(Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets);
+float4 StochasticEffectParallax(Texture2D tex, SamplerState samp, float2 uv, float mipLevel, StochasticOffsets offsets);
 
 // --------------------- COMPUTE FUNCTIONS --------------------- //
 
@@ -69,6 +69,7 @@ inline float4x3 ComputeBarycentricVerts(float2 landscapeUV)
     float2 skewUV = mul(SKEW_MATRIX, scaledUV);
     float2 vxID = floor(skewUV);
     float2 frac_uv = frac(skewUV);
+    
     float barry_z = 1.0 - frac_uv.x - frac_uv.y;
     float3 barry = float3(frac_uv, barry_z);
 
@@ -126,8 +127,6 @@ inline float4 StochasticSampleLOD(float rnd, Texture2D tex, SamplerState samp, f
 	// Apply simple scaled offsets
 	float2 microOffset1 = (offsetsLOD.offset1 + dir1) * offsetScale;
 	float2 microOffset2 = (offsetsLOD.offset2 + dir2) * offsetScale;
-
-	// Sample only two offsets using SampleBias like vanilla
 	float4 sample1 = tex.SampleBias(samp, uv + microOffset1, SharedData::MipBias);
 	float4 sample2 = tex.SampleBias(samp, uv + microOffset2, SharedData::MipBias);
 
@@ -136,7 +135,7 @@ inline float4 StochasticSampleLOD(float rnd, Texture2D tex, SamplerState samp, f
 }
 
 // Main stochastic sampling function
-inline float4 StochasticEffect(float rnd, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy)
+inline float4 StochasticEffect(Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy)
 {
 	// Take first sample (always needed)
 	float4 sample1 = tex.SampleBias(samp, uv + offsets.offset1, SharedData::MipBias);
@@ -157,9 +156,9 @@ inline float4 StochasticEffect(float rnd, Texture2D tex, SamplerState samp, floa
 	float4 sample2 = tex.SampleBias(samp, uv + offsets.offset2, SharedData::MipBias);
 	float4 sample3 = tex.SampleBias(samp, uv + offsets.offset3, SharedData::MipBias);
 
-	// Full height-based blending for low mip levels (close terrain)
-	float contrastFactor = HEIGHT_BLEND_CONTRAST * (1.0 - HEIGHT_INFLUENCE);
-	float3 blendWeights = pow(saturate(offsets.weights), contrastFactor);
+	// Full height-based blending for low mip levels (close terrain) with improved contrast scaling
+	float contrastFactor = HEIGHT_BLEND_CONTRAST * (1.0 - HEIGHT_INFLUENCE) * (1.0 - 0.5 * mipFactor); // Scale contrast with mip level
+	float3 blendWeights = pow(saturate(offsets.weights), max(1.0, min(100.0, contrastFactor))); // Clamp contrast factor to prevent extreme values
 
 	// Height calculation
 	float3 luminanceHeights = float3(
@@ -188,38 +187,22 @@ inline float4 StochasticEffect(float rnd, Texture2D tex, SamplerState samp, floa
 // due to complex control flow with early returns and conditional sampling
 #pragma warning(push)
 #pragma warning(disable : 4000)
-inline float4 StochasticEffectNoHeight(Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets)
+inline float4 StochasticEffectParallax(Texture2D tex, SamplerState samp, float2 uv, float mipLevel, StochasticOffsets offsets, float2 dx, float2 dy)
 {
 	// Early exit for disabled terrain variation - avoid all other computations
 	if (!SharedData::terrainVariationSettings.enableTilingFix)
 	{
-		return tex.SampleBias(samp, uv, SharedData::MipBias);
+		return tex.SampleLevel(samp, uv, mipLevel);
 	}
 
-	// Take first sample (always needed)
-	float4 sample1 = tex.SampleBias(samp, uv + offsets.offset1, SharedData::MipBias);
-
-	// Calculate smooth transition factor using automatic mip level detection
-	float autoMipLevel = tex.CalculateLevelOfDetail(samp, uv);
-	float mipFactor = saturate((autoMipLevel - MIP_BLEND_START) / MIP_BLEND_RANGE);
-
-	// Early exit for very high mip levels - single sample is sufficient. Miplevels hide the artifacts.
-	[branch] if (mipFactor >= MIP_EARLY_EXIT_THRESHOLD)
-	{
-		return sample1;
-	}
-
-	// Take remaining samples for blending
-	float4 sample2 = tex.SampleBias(samp, uv + offsets.offset2, SharedData::MipBias);
-	float4 sample3 = tex.SampleBias(samp, uv + offsets.offset3, SharedData::MipBias);
+	// Take three samples for blending
+	float4 sample1 = tex.SampleLevel(samp, uv + offsets.offset1, mipLevel);
+	float4 sample2 = tex.SampleLevel(samp, uv + offsets.offset2, mipLevel);
+	float4 sample3 = tex.SampleLevel(samp, uv + offsets.offset3, mipLevel);
 
 	// Simple barycentric blend without height influence
 	float3 weights = NormalizeWeights(saturate(offsets.weights));
-	float4 blendedSample = sample1 * weights.x + sample2 * weights.y + sample3 * weights.z;
-
-	// Smooth transition between blended and single sample based on mip level
-	float smoothFactor = smoothstep(0.0, 1.0, mipFactor);
-	return lerp(blendedSample, sample1, smoothFactor);
+	return sample1 * weights.x + sample2 * weights.y + sample3 * weights.z;
 }
 #pragma warning(pop)
 

--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -38,24 +38,24 @@ struct StochasticOffsets
 // --------------------- FUNCTION DECLARATIONS --------------------- //
 float4 StochasticSampleLOD(float rnd, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsetsLOD, float2 dx, float2 dy);
 float4 StochasticEffect(Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy);
-float4 StochasticEffectParallax(Texture2D tex, SamplerState samp, float2 uv, float mipLevel, StochasticOffsets offsets, float2 dx, float2 dy)
+float4 StochasticEffectParallax(Texture2D tex, SamplerState samp, float2 uv, float mipLevel, StochasticOffsets offsets, float2 dx, float2 dy);
 
 // --------------------- COMPUTE FUNCTIONS --------------------- //
 
 // Hash function for stochastic sampling
-float2 hash2D2D(float2 s)
+inline float2 hash2D2D(float2 s)
 {
 	s = s * HASH_MULTIPLIER;
 	return frac(sin(s.x + s.y) * HASH_SINE_MULTIPLIER);
 }
 
-float2 hashLOD(float2 p)
+inline float2 hashLOD(float2 p)
 {
 	p = frac(p * 0.318);
 	return frac(p.x + p.y * float2(17.0, 23.0));
 }
 
-float3 NormalizeWeights(float3 weights)
+inline float3 NormalizeWeights(float3 weights)
 {
 	float weightSum = weights.x + weights.y + weights.z;
 	float rcpWeightSum = rcp(max(weightSum, 1e-6));
@@ -63,7 +63,7 @@ float3 NormalizeWeights(float3 weights)
 }
 
 // Common barycentric coordinate calculation for stochastic sampling
-float4x3 ComputeBarycentricVerts(float2 landscapeUV)
+inline float4x3 ComputeBarycentricVerts(float2 landscapeUV)
 {
     float2 scaledUV = landscapeUV * (WORLD_SCALE);
     float2 skewUV = mul(SKEW_MATRIX, scaledUV);
@@ -78,7 +78,7 @@ float4x3 ComputeBarycentricVerts(float2 landscapeUV)
         float4x3(float3(vxID + float2(1, 1), 0), float3(vxID + float2(1, 0), 0), float3(vxID + float2(0, 1), 0), float3(-barry.z, 1.0 - barry.y, 1.0 - barry.x));
 }
 
-StochasticOffsets ComputeStochasticOffsets(float2 landscapeUV)
+inline StochasticOffsets ComputeStochasticOffsets(float2 landscapeUV)
 {
     float4x3 BW_vx = ComputeBarycentricVerts(landscapeUV);
 
@@ -91,7 +91,7 @@ StochasticOffsets ComputeStochasticOffsets(float2 landscapeUV)
     return offsets;
 }
 
-StochasticOffsets ComputeStochasticOffsetsLOD(float2 landscapeUV)
+inline StochasticOffsets ComputeStochasticOffsetsLOD(float2 landscapeUV)
 {
 	// Precomputed scaling: (WORLD_SCALE / 0.010416667) * 8.0 = ~255437
 	static const float LOD_SCALE = 255437.0;
@@ -116,7 +116,7 @@ StochasticOffsets ComputeStochasticOffsetsLOD(float2 landscapeUV)
 // --------------------- STOCHASTIC SAMPLING FUNCTIONS --------------------- //
 
 // Stochastic sampling function for Terrain LOD & LOD Mask.
-float4 StochasticSampleLOD(float rnd, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsetsLOD, float2 dx, float2 dy)
+inline float4 StochasticSampleLOD(float rnd, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsetsLOD, float2 dx, float2 dy)
 {
 	float offsetScale = 0.01;
 
@@ -135,7 +135,7 @@ float4 StochasticSampleLOD(float rnd, Texture2D tex, SamplerState samp, float2 u
 }
 
 // Main stochastic sampling function
-float4 StochasticEffect(Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy)
+inline float4 StochasticEffect(Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy)
 {
 	// Calculate custom mip level from original UVs.
 	float mipLevel = tex.CalculateLevelOfDetail(samp, uv);
@@ -185,7 +185,7 @@ float4 StochasticEffect(Texture2D tex, SamplerState samp, float2 uv, StochasticO
 // Disable X4000 warning: FXC incorrectly reports potentially uninitialized variables due to complex control flow with early returns and conditional sampling
 #pragma warning(push)
 #pragma warning(disable : 4000)
-float4 StochasticEffectParallax(Texture2D tex, SamplerState samp, float2 uv, float mipLevel, StochasticOffsets offsets, float2 dx, float2 dy)
+inline float4 StochasticEffectParallax(Texture2D tex, SamplerState samp, float2 uv, float mipLevel, StochasticOffsets offsets, float2 dx, float2 dy)
 {
 	// Early exit for disabled terrain variation - avoid all other computations
 	if (!SharedData::terrainVariationSettings.enableTilingFix)

--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -139,9 +139,8 @@ inline float4 StochasticEffect(Texture2D tex, SamplerState samp, float2 uv, Stoc
 {
 	// Calculate custom mip level from original UVs.
 	float mipLevel = tex.CalculateLevelOfDetail(samp, uv);
-	float adjustedMipLevel = mipLevel + SharedData::MipBias;
 
-	float4 sample1 = tex.SampleLevel(samp, uv + offsets.offset1, adjustedMipLevel);
+	float4 sample1 = tex.SampleLevel(samp, uv + offsets.offset1, mipLevel);
 
 	// Early exit for very high mip levels - single sample is sufficient. Miplevels hide the artifacts.
 	float mipFactor = saturate((mipLevel - MIP_BLEND_START) / MIP_BLEND_RANGE);
@@ -152,8 +151,8 @@ inline float4 StochasticEffect(Texture2D tex, SamplerState samp, float2 uv, Stoc
 	}
 
 	// Take three samples for blending at the same adjusted mip level
-	float4 sample2 = tex.SampleLevel(samp, uv + offsets.offset2, adjustedMipLevel);
-	float4 sample3 = tex.SampleLevel(samp, uv + offsets.offset3, adjustedMipLevel);
+	float4 sample2 = tex.SampleLevel(samp, uv + offsets.offset2, mipLevel);
+	float4 sample3 = tex.SampleLevel(samp, uv + offsets.offset3, mipLevel);
 
 	// Full height-based blending for low mip levels (close terrain) with improved contrast scaling
 	float contrastFactor = HEIGHT_BLEND_CONTRAST * (1.0 - HEIGHT_INFLUENCE) * (1.0 - 0.5 * mipFactor);

--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -36,9 +36,9 @@ struct StochasticOffsets
 };
 
 // --------------------- FUNCTION DECLARATIONS --------------------- //
-float4 StochasticSampleLOD(float rnd, float mipLevel, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsetsLOD, float2 dx, float2 dy);
-float4 StochasticEffect(float rnd, float mipLevel, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy);
-float4 StochasticEffectNoHeight(float mipLevel, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets);
+float4 StochasticSampleLOD(float rnd, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsetsLOD, float2 dx, float2 dy);
+float4 StochasticEffect(float rnd, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy);
+float4 StochasticEffectNoHeight(Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets);
 
 // --------------------- COMPUTE FUNCTIONS --------------------- //
 
@@ -115,7 +115,7 @@ inline StochasticOffsets ComputeStochasticOffsetsLOD(float2 landscapeUV)
 // --------------------- STOCHASTIC SAMPLING FUNCTIONS --------------------- //
 
 // Stochastic sampling function for Terrain LOD & LOD Mask.
-inline float4 StochasticSampleLOD(float rnd, float mipLevel, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsetsLOD, float2 dx, float2 dy)
+inline float4 StochasticSampleLOD(float rnd, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsetsLOD, float2 dx, float2 dy)
 {
 	float offsetScale = 0.01;
 
@@ -127,25 +127,24 @@ inline float4 StochasticSampleLOD(float rnd, float mipLevel, Texture2D tex, Samp
 	float2 microOffset1 = (offsetsLOD.offset1 + dir1) * offsetScale;
 	float2 microOffset2 = (offsetsLOD.offset2 + dir2) * offsetScale;
 
-	// Sample only two offsets
-	float4 sample1 = tex.SampleLevel(samp, uv + microOffset1, mipLevel);
-	float4 sample2 = tex.SampleLevel(samp, uv + microOffset2, mipLevel);
+	// Sample only two offsets using SampleBias like vanilla
+	float4 sample1 = tex.SampleBias(samp, uv + microOffset1, SharedData::MipBias);
+	float4 sample2 = tex.SampleBias(samp, uv + microOffset2, SharedData::MipBias);
 
 	// Simple 2-sample blend weighted toward first sample
 	return lerp(sample2, sample1, 0.65);
 }
 
 // Main stochastic sampling function
-inline float4 StochasticEffect(float rnd, float mipLevel, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy)
+inline float4 StochasticEffect(float rnd, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy)
 {
-	// Use standard mip bias - terrain variation disables MipBias at source when enabled
-	float adjustedMipLevel = mipLevel + SharedData::MipBias;
-
 	// Take first sample (always needed)
-	float4 sample1 = tex.SampleLevel(samp, uv + offsets.offset1, adjustedMipLevel);
+	float4 sample1 = tex.SampleBias(samp, uv + offsets.offset1, SharedData::MipBias);
 
-	// Calculate smooth transition factor - starts at mip 5.0, early exit at mip 6.5
-	float mipFactor = saturate((mipLevel - MIP_BLEND_START) / MIP_BLEND_RANGE);
+	// For terrain variation, we can use distance-based early exit but use SharedData::MipBias
+	// to automatically handle mip selection like vanilla textures
+	float autoMipLevel = tex.CalculateLevelOfDetail(samp, uv);
+	float mipFactor = saturate((autoMipLevel - MIP_BLEND_START) / MIP_BLEND_RANGE);
 
 	// Early exit for very high mip levels - single sample is sufficient. Miplevels hide the artifacts.
 	if (mipFactor >= MIP_EARLY_EXIT_THRESHOLD)
@@ -155,8 +154,8 @@ inline float4 StochasticEffect(float rnd, float mipLevel, Texture2D tex, Sampler
 	}
 
 	// Take remaining samples for blending
-	float4 sample2 = tex.SampleLevel(samp, uv + offsets.offset2, adjustedMipLevel);
-	float4 sample3 = tex.SampleLevel(samp, uv + offsets.offset3, adjustedMipLevel);
+	float4 sample2 = tex.SampleBias(samp, uv + offsets.offset2, SharedData::MipBias);
+	float4 sample3 = tex.SampleBias(samp, uv + offsets.offset3, SharedData::MipBias);
 
 	// Full height-based blending for low mip levels (close terrain)
 	float contrastFactor = HEIGHT_BLEND_CONTRAST * (1.0 - HEIGHT_INFLUENCE);
@@ -189,22 +188,20 @@ inline float4 StochasticEffect(float rnd, float mipLevel, Texture2D tex, Sampler
 // due to complex control flow with early returns and conditional sampling
 #pragma warning(push)
 #pragma warning(disable : 4000)
-inline float4 StochasticEffectNoHeight(float mipLevel, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets)
+inline float4 StochasticEffectNoHeight(Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets)
 {
-	// Use standard mip bias - terrain variation disables MipBias at source when enabled
-	float adjustedMipLevel = mipLevel + SharedData::MipBias;
-
 	// Early exit for disabled terrain variation - avoid all other computations
 	if (!SharedData::terrainVariationSettings.enableTilingFix)
 	{
-		return tex.SampleLevel(samp, uv, adjustedMipLevel);
+		return tex.SampleBias(samp, uv, SharedData::MipBias);
 	}
 
 	// Take first sample (always needed)
-	float4 sample1 = tex.SampleLevel(samp, uv + offsets.offset1, adjustedMipLevel);
+	float4 sample1 = tex.SampleBias(samp, uv + offsets.offset1, SharedData::MipBias);
 
-	// Calculate smooth transition factor - starts at mip 5.0, early exit at mip 6.5
-	float mipFactor = saturate((mipLevel - MIP_BLEND_START) / MIP_BLEND_RANGE);
+	// Calculate smooth transition factor using automatic mip level detection
+	float autoMipLevel = tex.CalculateLevelOfDetail(samp, uv);
+	float mipFactor = saturate((autoMipLevel - MIP_BLEND_START) / MIP_BLEND_RANGE);
 
 	// Early exit for very high mip levels - single sample is sufficient. Miplevels hide the artifacts.
 	[branch] if (mipFactor >= MIP_EARLY_EXIT_THRESHOLD)
@@ -213,8 +210,8 @@ inline float4 StochasticEffectNoHeight(float mipLevel, Texture2D tex, SamplerSta
 	}
 
 	// Take remaining samples for blending
-	float4 sample2 = tex.SampleLevel(samp, uv + offsets.offset2, adjustedMipLevel);
-	float4 sample3 = tex.SampleLevel(samp, uv + offsets.offset3, adjustedMipLevel);
+	float4 sample2 = tex.SampleBias(samp, uv + offsets.offset2, SharedData::MipBias);
+	float4 sample3 = tex.SampleBias(samp, uv + offsets.offset3, SharedData::MipBias);
 
 	// Simple barycentric blend without height influence
 	float3 weights = NormalizeWeights(saturate(offsets.weights));

--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -117,8 +117,6 @@ inline StochasticOffsets ComputeStochasticOffsetsLOD(float2 landscapeUV)
 // Stochastic sampling function for Terrain LOD & LOD Mask.
 inline float4 StochasticSampleLOD(float rnd, float mipLevel, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsetsLOD, float2 dx, float2 dy)
 {
-	// Apply mip bias to match normal sampling behavior
-	float adjustedMipLevel = mipLevel + SharedData::MipBias;
 	float offsetScale = 0.01;
 
 	// Cheap pseudo-rotation using simple transforms
@@ -130,8 +128,8 @@ inline float4 StochasticSampleLOD(float rnd, float mipLevel, Texture2D tex, Samp
 	float2 microOffset2 = (offsetsLOD.offset2 + dir2) * offsetScale;
 
 	// Sample only two offsets
-	float4 sample1 = tex.SampleLevel(samp, uv + microOffset1, adjustedMipLevel);
-	float4 sample2 = tex.SampleLevel(samp, uv + microOffset2, adjustedMipLevel);
+	float4 sample1 = tex.SampleLevel(samp, uv + microOffset1, mipLevel);
+	float4 sample2 = tex.SampleLevel(samp, uv + microOffset2, mipLevel);
 
 	// Simple 2-sample blend weighted toward first sample
 	return lerp(sample2, sample1, 0.65);
@@ -141,8 +139,8 @@ inline float4 StochasticSampleLOD(float rnd, float mipLevel, Texture2D tex, Samp
 inline float4 StochasticEffect(float rnd, float mipLevel, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy)
 {
 	// Apply mip bias to match normal sampling behavior
-	float adjustedMipLevel = mipLevel + SharedData::MipBias;
 
+	float adjustedMipLevel = mipLevel + (SharedData::MipBias == 0 ? -1.8 : SharedData::MipBias);
 	// Take first sample (always needed)
 	float4 sample1 = tex.SampleLevel(samp, uv + offsets.offset1, adjustedMipLevel);
 
@@ -194,7 +192,8 @@ inline float4 StochasticEffect(float rnd, float mipLevel, Texture2D tex, Sampler
 inline float4 StochasticEffectNoHeight(float mipLevel, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets)
 {
 	// Apply mip bias to match normal sampling behavior
-	float adjustedMipLevel = mipLevel + SharedData::MipBias;
+	// When TAA is disabled (MipBias = 0), apply negative bias to maintain sharpness
+	float adjustedMipLevel = mipLevel + (SharedData::MipBias == 0 ? -1.8 : SharedData::MipBias);
 
 	// Early exit for disabled terrain variation - avoid all other computations
 	if (!SharedData::terrainVariationSettings.enableTilingFix)

--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -140,7 +140,7 @@ inline float4 StochasticEffect(float rnd, float mipLevel, Texture2D tex, Sampler
 {
 	// Use standard mip bias - terrain variation disables MipBias at source when enabled
 	float adjustedMipLevel = mipLevel + SharedData::MipBias;
-	
+
 	// Take first sample (always needed)
 	float4 sample1 = tex.SampleLevel(samp, uv + offsets.offset1, adjustedMipLevel);
 

--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -137,28 +137,27 @@ inline float4 StochasticSampleLOD(float rnd, Texture2D tex, SamplerState samp, f
 // Main stochastic sampling function
 inline float4 StochasticEffect(Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy)
 {
-	// Take first sample (always needed)
-	float4 sample1 = tex.SampleBias(samp, uv + offsets.offset1, SharedData::MipBias);
+	// Calculate custom mip level from original UVs.
+	float mipLevel = tex.CalculateLevelOfDetail(samp, uv);
+	float adjustedMipLevel = mipLevel + SharedData::MipBias;
 
-	// For terrain variation, we can use distance-based early exit but use SharedData::MipBias
-	// to automatically handle mip selection like vanilla textures
-	float autoMipLevel = tex.CalculateLevelOfDetail(samp, uv);
-	float mipFactor = saturate((autoMipLevel - MIP_BLEND_START) / MIP_BLEND_RANGE);
+	float4 sample1 = tex.SampleLevel(samp, uv + offsets.offset1, adjustedMipLevel);
 
 	// Early exit for very high mip levels - single sample is sufficient. Miplevels hide the artifacts.
+	float mipFactor = saturate((mipLevel - MIP_BLEND_START) / MIP_BLEND_RANGE);
 	if (mipFactor >= MIP_EARLY_EXIT_THRESHOLD)
 	{
 		return sample1;
 		// Wasted ALU since there are still 3 hash calls computed for the pixel, but doesn't really hurt performance and also avoids recalculating when moving closer/further away.
 	}
 
-	// Take remaining samples for blending
-	float4 sample2 = tex.SampleBias(samp, uv + offsets.offset2, SharedData::MipBias);
-	float4 sample3 = tex.SampleBias(samp, uv + offsets.offset3, SharedData::MipBias);
+	// Take three samples for blending at the same adjusted mip level
+	float4 sample2 = tex.SampleLevel(samp, uv + offsets.offset2, adjustedMipLevel);
+	float4 sample3 = tex.SampleLevel(samp, uv + offsets.offset3, adjustedMipLevel);
 
 	// Full height-based blending for low mip levels (close terrain) with improved contrast scaling
-	float contrastFactor = HEIGHT_BLEND_CONTRAST * (1.0 - HEIGHT_INFLUENCE) * (1.0 - 0.5 * mipFactor); // Scale contrast with mip level
-	float3 blendWeights = pow(saturate(offsets.weights), max(1.0, min(100.0, contrastFactor))); // Clamp contrast factor to prevent extreme values
+	float contrastFactor = HEIGHT_BLEND_CONTRAST * (1.0 - HEIGHT_INFLUENCE) * (1.0 - 0.5 * mipFactor);
+	float3 blendWeights = pow(saturate(offsets.weights), max(1.0, min(100.0, contrastFactor)));
 
 	// Height calculation
 	float3 luminanceHeights = float3(
@@ -183,8 +182,7 @@ inline float4 StochasticEffect(Texture2D tex, SamplerState samp, float2 uv, Stoc
 }
 
 // Stochastic sampling function without height blending for better performance
-// Disable X4000 warning: FXC incorrectly reports potentially uninitialized variables
-// due to complex control flow with early returns and conditional sampling
+// Disable X4000 warning: FXC incorrectly reports potentially uninitialized variables sdue to complex control flow with early returns and conditional sampling
 #pragma warning(push)
 #pragma warning(disable : 4000)
 inline float4 StochasticEffectParallax(Texture2D tex, SamplerState samp, float2 uv, float mipLevel, StochasticOffsets offsets, float2 dx, float2 dy)
@@ -196,7 +194,7 @@ inline float4 StochasticEffectParallax(Texture2D tex, SamplerState samp, float2 
 	}
 
 	// Take three samples for blending
-	float4 sample1 = tex.SampleLevel(samp, uv + offsets.offset1, mipLevel);
+	float4 sample1 = tex.SampleLevel(samp, uv + offsets.offset1, mipLevel); // Uses miplevels from EMAT.hlsl.
 	float4 sample2 = tex.SampleLevel(samp, uv + offsets.offset2, mipLevel);
 	float4 sample3 = tex.SampleLevel(samp, uv + offsets.offset3, mipLevel);
 

--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -43,19 +43,19 @@ float4 StochasticEffectParallax(Texture2D tex, SamplerState samp, float2 uv, flo
 // --------------------- COMPUTE FUNCTIONS --------------------- //
 
 // Hash function for stochastic sampling
-inline float2 hash2D2D(float2 s)
+float2 hash2D2D(float2 s)
 {
 	s = s * HASH_MULTIPLIER;
 	return frac(sin(s.x + s.y) * HASH_SINE_MULTIPLIER);
 }
 
-inline float2 hashLOD(float2 p)
+float2 hashLOD(float2 p)
 {
 	p = frac(p * 0.318);
 	return frac(p.x + p.y * float2(17.0, 23.0));
 }
 
-inline float3 NormalizeWeights(float3 weights)
+float3 NormalizeWeights(float3 weights)
 {
 	float weightSum = weights.x + weights.y + weights.z;
 	float rcpWeightSum = rcp(max(weightSum, 1e-6));
@@ -63,7 +63,7 @@ inline float3 NormalizeWeights(float3 weights)
 }
 
 // Common barycentric coordinate calculation for stochastic sampling
-inline float4x3 ComputeBarycentricVerts(float2 landscapeUV)
+float4x3 ComputeBarycentricVerts(float2 landscapeUV)
 {
     float2 scaledUV = landscapeUV * (WORLD_SCALE);
     float2 skewUV = mul(SKEW_MATRIX, scaledUV);
@@ -78,7 +78,7 @@ inline float4x3 ComputeBarycentricVerts(float2 landscapeUV)
         float4x3(float3(vxID + float2(1, 1), 0), float3(vxID + float2(1, 0), 0), float3(vxID + float2(0, 1), 0), float3(-barry.z, 1.0 - barry.y, 1.0 - barry.x));
 }
 
-inline StochasticOffsets ComputeStochasticOffsets(float2 landscapeUV)
+StochasticOffsets ComputeStochasticOffsets(float2 landscapeUV)
 {
     float4x3 BW_vx = ComputeBarycentricVerts(landscapeUV);
 
@@ -91,7 +91,7 @@ inline StochasticOffsets ComputeStochasticOffsets(float2 landscapeUV)
     return offsets;
 }
 
-inline StochasticOffsets ComputeStochasticOffsetsLOD(float2 landscapeUV)
+StochasticOffsets ComputeStochasticOffsetsLOD(float2 landscapeUV)
 {
 	// Precomputed scaling: (WORLD_SCALE / 0.010416667) * 8.0 = ~255437
 	static const float LOD_SCALE = 255437.0;
@@ -116,7 +116,7 @@ inline StochasticOffsets ComputeStochasticOffsetsLOD(float2 landscapeUV)
 // --------------------- STOCHASTIC SAMPLING FUNCTIONS --------------------- //
 
 // Stochastic sampling function for Terrain LOD & LOD Mask.
-inline float4 StochasticSampleLOD(float rnd, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsetsLOD, float2 dx, float2 dy)
+float4 StochasticSampleLOD(float rnd, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsetsLOD, float2 dx, float2 dy)
 {
 	float offsetScale = 0.01;
 
@@ -135,7 +135,7 @@ inline float4 StochasticSampleLOD(float rnd, Texture2D tex, SamplerState samp, f
 }
 
 // Main stochastic sampling function
-inline float4 StochasticEffect(Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy)
+float4 StochasticEffect(Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy)
 {
 	// Calculate custom mip level from original UVs.
 	float mipLevel = tex.CalculateLevelOfDetail(samp, uv);
@@ -185,7 +185,7 @@ inline float4 StochasticEffect(Texture2D tex, SamplerState samp, float2 uv, Stoc
 // Disable X4000 warning: FXC incorrectly reports potentially uninitialized variables due to complex control flow with early returns and conditional sampling
 #pragma warning(push)
 #pragma warning(disable : 4000)
-inline float4 StochasticEffectParallax(Texture2D tex, SamplerState samp, float2 uv, float mipLevel, StochasticOffsets offsets, float2 dx, float2 dy)
+float4 StochasticEffectParallax(Texture2D tex, SamplerState samp, float2 uv, float mipLevel, StochasticOffsets offsets, float2 dx, float2 dy)
 {
 	// Early exit for disabled terrain variation - avoid all other computations
 	if (!SharedData::terrainVariationSettings.enableTilingFix)

--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -138,9 +138,9 @@ inline float4 StochasticSampleLOD(float rnd, float mipLevel, Texture2D tex, Samp
 // Main stochastic sampling function
 inline float4 StochasticEffect(float rnd, float mipLevel, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets, float2 dx, float2 dy)
 {
-	// Apply mip bias to match normal sampling behavior
-
-	float adjustedMipLevel = mipLevel + (SharedData::MipBias == 0 ? -1.8 : SharedData::MipBias);
+	// Use standard mip bias - terrain variation disables MipBias at source when enabled
+	float adjustedMipLevel = mipLevel + SharedData::MipBias;
+	
 	// Take first sample (always needed)
 	float4 sample1 = tex.SampleLevel(samp, uv + offsets.offset1, adjustedMipLevel);
 
@@ -191,9 +191,8 @@ inline float4 StochasticEffect(float rnd, float mipLevel, Texture2D tex, Sampler
 #pragma warning(disable : 4000)
 inline float4 StochasticEffectNoHeight(float mipLevel, Texture2D tex, SamplerState samp, float2 uv, StochasticOffsets offsets)
 {
-	// Apply mip bias to match normal sampling behavior
-	// When TAA is disabled (MipBias = 0), apply negative bias to maintain sharpness
-	float adjustedMipLevel = mipLevel + (SharedData::MipBias == 0 ? -1.8 : SharedData::MipBias);
+	// Use standard mip bias - terrain variation disables MipBias at source when enabled
+	float adjustedMipLevel = mipLevel + SharedData::MipBias;
 
 	// Early exit for disabled terrain variation - avoid all other computations
 	if (!SharedData::terrainVariationSettings.enableTilingFix)

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1299,13 +1299,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 #		if defined(EMAT)
 	if (SharedData::extendedMaterialSettings.EnableTerrainParallax) {
-		mipLevels[0] = ExtendedMaterials::GetMipLevel(uv, TexColorSampler);
-		mipLevels[1] = ExtendedMaterials::GetMipLevel(uv, TexLandColor2Sampler);
-		mipLevels[2] = ExtendedMaterials::GetMipLevel(uv, TexLandColor3Sampler);
-		mipLevels[3] = ExtendedMaterials::GetMipLevel(uv, TexLandColor4Sampler);
-		mipLevels[4] = ExtendedMaterials::GetMipLevel(uv, TexLandColor5Sampler);
-		mipLevels[5] = ExtendedMaterials::GetMipLevel(uv, TexLandColor6Sampler);
-
 		displacementParams[1] = displacementParams[0];
 		displacementParams[2] = displacementParams[0];
 		displacementParams[3] = displacementParams[0];
@@ -1324,8 +1317,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		// Initialize weights array
 		weights[0] = weights[1] = weights[2] = weights[3] = weights[4] = weights[5] = 0.0;
 #			if defined(TERRAIN_VARIATION)
+		float mipLevels[6] = { 0, 0, 0, 0, 0, 0 }; // Dummy array for parallax compatibility
 		uv = ExtendedMaterials::GetParallaxCoords(input, viewPosition.z, uv, mipLevels, viewDirection, tbnTr, screenNoise, displacementParams, sharedOffset, dx, dy, pixelOffset, weights);
 #			else
+		float mipLevels[6] = { 0, 0, 0, 0, 0, 0 }; // Dummy array for parallax compatibility
 		uv = ExtendedMaterials::GetParallaxCoords(input, viewPosition.z, uv, mipLevels, viewDirection, tbnTr, screenNoise, displacementParams, pixelOffset, weights);
 #			endif
 		if (SharedData::extendedMaterialSettings.EnableHeightBlending) {
@@ -1345,33 +1340,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			endif
 		}
 	}
-
-#		if defined(TERRAIN_VARIATION)
-	else if (useTerrainVariation) {
-		// Calculate proper mip levels for terrain variation when parallax is disabled but EMAT is available
-		mipLevels[0] = ExtendedMaterials::GetMipLevel(uv, TexColorSampler);
-		mipLevels[1] = ExtendedMaterials::GetMipLevel(uv, TexLandColor2Sampler);
-		mipLevels[2] = ExtendedMaterials::GetMipLevel(uv, TexLandColor3Sampler);
-		mipLevels[3] = ExtendedMaterials::GetMipLevel(uv, TexLandColor4Sampler);
-		mipLevels[4] = ExtendedMaterials::GetMipLevel(uv, TexLandColor5Sampler);
-		mipLevels[5] = ExtendedMaterials::GetMipLevel(uv, TexLandColor6Sampler);
-	}
-#		endif
 #		else
-	// Initialize mip levels for non-EMAT case
+	// Initialize mip levels for non-EMAT case (no longer needed)
 	mipLevels[0] = mipLevels[1] = mipLevels[2] = mipLevels[3] = mipLevels[4] = mipLevels[5] = 0.0;
 #		endif  // EMAT
-	// When terrain variation is enabled but parallax is disabled, calculate proper mip levels for stochastic sampling
-#		if defined(TERRAIN_VARIATION)
-	[branch] if (useTerrainVariation && !SharedData::extendedMaterialSettings.EnableTerrainParallax) {
-		mipLevels[0] = ExtendedMaterials::GetMipLevel(uv, TexColorSampler);
-		mipLevels[1] = ExtendedMaterials::GetMipLevel(uv, TexLandColor2Sampler);
-		mipLevels[2] = ExtendedMaterials::GetMipLevel(uv, TexLandColor3Sampler);
-		mipLevels[3] = ExtendedMaterials::GetMipLevel(uv, TexLandColor4Sampler);
-		mipLevels[4] = ExtendedMaterials::GetMipLevel(uv, TexLandColor5Sampler);
-		mipLevels[5] = ExtendedMaterials::GetMipLevel(uv, TexLandColor6Sampler);
-	}
-#		endif
 #	endif      // LANDSCAPE
 
 #	if defined(SPARKLE)
@@ -1407,7 +1379,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landColor1;
 		[branch] if (useTerrainVariation)
 		{
-			landColor1 = StochasticEffect(screenNoise, mipLevels[0], TexColorSampler, SampColorSampler, uv, sharedOffset, dx, dy);
+			landColor1 = StochasticEffect(screenNoise, TexColorSampler, SampColorSampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1431,7 +1403,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landNormal1;
 		[branch] if (useTerrainVariation)
 		{
-			landNormal1 = StochasticEffect(screenNoise, mipLevels[0], TexNormalSampler, SampNormalSampler, uv, sharedOffset, dx, dy);
+			landNormal1 = StochasticEffect(screenNoise, TexNormalSampler, SampNormalSampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1454,7 +1426,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TERRAIN_VARIATION)
 			[branch] if (useTerrainVariation)
 			{
-				landRMAOS1 = StochasticEffectNoHeight(mipLevels[0], TexRMAOSSampler, SampRMAOSSampler, uv, sharedOffset) * float4(PBRParams1.x, 1, 1, PBRParams1.z);
+				landRMAOS1 = StochasticEffectNoHeight(TexRMAOSSampler, SampRMAOSSampler, uv, sharedOffset) * float4(PBRParams1.x, 1, 1, PBRParams1.z);
 			}
 			else
 			{
@@ -1488,7 +1460,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landColor2;
 		[branch] if (useTerrainVariation)
 		{
-			landColor2 = StochasticEffect(screenNoise, mipLevels[1], TexLandColor2Sampler, SampLandColor2Sampler, uv, sharedOffset, dx, dy);
+			landColor2 = StochasticEffect(screenNoise, TexLandColor2Sampler, SampLandColor2Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1512,7 +1484,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landNormal2;
 		[branch] if (useTerrainVariation)
 		{
-			landNormal2 = StochasticEffect(screenNoise, mipLevels[1], TexLandNormal2Sampler, SampLandNormal2Sampler, uv, sharedOffset, dx, dy);
+			landNormal2 = StochasticEffect(screenNoise, TexLandNormal2Sampler, SampLandNormal2Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1535,7 +1507,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TERRAIN_VARIATION)
 			[branch] if (useTerrainVariation)
 			{
-				landRMAOS2 = StochasticEffectNoHeight(mipLevels[1], TexLandRMAOS2Sampler, SampLandRMAOS2Sampler, uv, sharedOffset) * float4(LandscapeTexture2PBRParams.x, 1, 1, LandscapeTexture2PBRParams.z);
+				landRMAOS2 = StochasticEffectNoHeight(TexLandRMAOS2Sampler, SampLandRMAOS2Sampler, uv, sharedOffset) * float4(LandscapeTexture2PBRParams.x, 1, 1, LandscapeTexture2PBRParams.z);
 			}
 			else
 			{
@@ -1568,7 +1540,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landColor3;
 		[branch] if (useTerrainVariation)
 		{
-			landColor3 = StochasticEffect(screenNoise, mipLevels[2], TexLandColor3Sampler, SampLandColor3Sampler, uv, sharedOffset, dx, dy);
+			landColor3 = StochasticEffect(screenNoise, TexLandColor3Sampler, SampLandColor3Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1592,7 +1564,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landNormal3;
 		[branch] if (useTerrainVariation)
 		{
-			landNormal3 = StochasticEffect(screenNoise, mipLevels[2], TexLandNormal3Sampler, SampLandNormal3Sampler, uv, sharedOffset, dx, dy);
+			landNormal3 = StochasticEffect(screenNoise, TexLandNormal3Sampler, SampLandNormal3Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1615,7 +1587,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TERRAIN_VARIATION)
 			[branch] if (useTerrainVariation)
 			{
-				landRMAOS3 = StochasticEffectNoHeight(mipLevels[2], TexLandRMAOS3Sampler, SampLandRMAOS3Sampler, uv, sharedOffset) * float4(LandscapeTexture3PBRParams.x, 1, 1, LandscapeTexture3PBRParams.z);
+				landRMAOS3 = StochasticEffectNoHeight(TexLandRMAOS3Sampler, SampLandRMAOS3Sampler, uv, sharedOffset) * float4(LandscapeTexture3PBRParams.x, 1, 1, LandscapeTexture3PBRParams.z);
 			}
 			else
 			{
@@ -1648,7 +1620,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landColor4;
 		[branch] if (useTerrainVariation)
 		{
-			landColor4 = StochasticEffect(screenNoise, mipLevels[3], TexLandColor4Sampler, SampLandColor4Sampler, uv, sharedOffset, dx, dy);
+			landColor4 = StochasticEffect(screenNoise, TexLandColor4Sampler, SampLandColor4Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1672,7 +1644,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landNormal4;
 		[branch] if (useTerrainVariation)
 		{
-			landNormal4 = StochasticEffect(screenNoise, mipLevels[3], TexLandNormal4Sampler, SampLandNormal4Sampler, uv, sharedOffset, dx, dy);
+			landNormal4 = StochasticEffect(screenNoise, TexLandNormal4Sampler, SampLandNormal4Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1695,7 +1667,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TERRAIN_VARIATION)
 			[branch] if (useTerrainVariation)
 			{
-				landRMAOS4 = StochasticEffectNoHeight(mipLevels[3], TexLandRMAOS4Sampler, SampLandRMAOS4Sampler, uv, sharedOffset) * float4(LandscapeTexture4PBRParams.x, 1, 1, LandscapeTexture4PBRParams.z);
+				landRMAOS4 = StochasticEffectNoHeight(TexLandRMAOS4Sampler, SampLandRMAOS4Sampler, uv, sharedOffset) * float4(LandscapeTexture4PBRParams.x, 1, 1, LandscapeTexture4PBRParams.z);
 			}
 			else
 			{
@@ -1728,7 +1700,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landColor5;
 		[branch] if (useTerrainVariation)
 		{
-			landColor5 = StochasticEffect(screenNoise, mipLevels[4], TexLandColor5Sampler, SampLandColor5Sampler, uv, sharedOffset, dx, dy);
+			landColor5 = StochasticEffect(screenNoise, TexLandColor5Sampler, SampLandColor5Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1752,7 +1724,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landNormal5;
 		[branch] if (useTerrainVariation)
 		{
-			landNormal5 = StochasticEffect(screenNoise, mipLevels[4], TexLandNormal5Sampler, SampLandNormal5Sampler, uv, sharedOffset, dx, dy);
+			landNormal5 = StochasticEffect(screenNoise, TexLandNormal5Sampler, SampLandNormal5Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1776,7 +1748,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TERRAIN_VARIATION)
 			[branch] if (useTerrainVariation)
 			{
-				landRMAOS5 = StochasticEffectNoHeight(mipLevels[4], TexLandRMAOS5Sampler, SampLandRMAOS5Sampler, uv, sharedOffset) * float4(LandscapeTexture5PBRParams.x, 1, 1, LandscapeTexture5PBRParams.z);
+				landRMAOS5 = StochasticEffectNoHeight(TexLandRMAOS5Sampler, SampLandRMAOS5Sampler, uv, sharedOffset) * float4(LandscapeTexture5PBRParams.x, 1, 1, LandscapeTexture5PBRParams.z);
 			}
 			else
 			{
@@ -1809,7 +1781,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landColor6;
 		[branch] if (useTerrainVariation)
 		{
-			landColor6 = StochasticEffect(screenNoise, mipLevels[5], TexLandColor6Sampler, SampLandColor6Sampler, uv, sharedOffset, dx, dy);
+			landColor6 = StochasticEffect(screenNoise, TexLandColor6Sampler, SampLandColor6Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1833,7 +1805,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landNormal6;
 		[branch] if (useTerrainVariation)
 		{
-			landNormal6 = StochasticEffect(screenNoise, mipLevels[5], TexLandNormal6Sampler, SampLandNormal6Sampler, uv, sharedOffset, dx, dy);
+			landNormal6 = StochasticEffect(screenNoise, TexLandNormal6Sampler, SampLandNormal6Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1856,7 +1828,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TERRAIN_VARIATION)
 			[branch] if (useTerrainVariation)
 			{
-				landRMAOS6 = StochasticEffectNoHeight(mipLevels[5], TexLandRMAOS6Sampler, SampLandRMAOS6Sampler, uv, sharedOffset) * float4(LandscapeTexture6PBRParams.x, 1, 1, LandscapeTexture6PBRParams.z);
+				landRMAOS6 = StochasticEffectNoHeight(TexLandRMAOS6Sampler, SampLandRMAOS6Sampler, uv, sharedOffset) * float4(LandscapeTexture6PBRParams.x, 1, 1, LandscapeTexture6PBRParams.z);
 			}
 			else
 			{
@@ -1917,7 +1889,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 			float2 dx = ddx(uv);
 			float2 dy = ddy(uv);
 			StochasticOffsets lodOffset = ComputeStochasticOffsetsLOD(uv);
-			float4 lodStochasticColor = StochasticSampleLOD(screenNoise, 0, TexColorSampler, SampColorSampler, uv, lodOffset, dx, dy);
+			float4 lodStochasticColor = StochasticSampleLOD(screenNoise, TexColorSampler, SampColorSampler, uv, lodOffset, dx, dy);
 
 			// Apply the stochastic result directly
 			baseColor.xyz = Color::Diffuse(lodStochasticColor.rgb);
@@ -2102,7 +2074,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float2 dx = ddx(blendColorUV);
 		float2 dy = ddy(blendColorUV);
 		StochasticOffsets lodBlendColorOffset = ComputeStochasticOffsetsLOD(blendColorUV);
-		lodLandColor = StochasticSampleLOD(screenNoise, 0, TexLandLodBlend1Sampler, SampLandLodBlend1Sampler, blendColorUV, lodBlendColorOffset, dx, dy);
+		lodLandColor = StochasticSampleLOD(screenNoise, TexLandLodBlend1Sampler, SampLandLodBlend1Sampler, blendColorUV, lodBlendColorOffset, dx, dy);
 	} else {
 		lodLandColor = TexLandLodBlend1Sampler.Sample(SampLandLodBlend1Sampler, input.TexCoord0.zw);
 	}

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1324,10 +1324,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		// Initialize weights array
 		weights[0] = weights[1] = weights[2] = weights[3] = weights[4] = weights[5] = 0.0;
 #			if defined(TERRAIN_VARIATION)
-		float mipLevels[6] = { 0, 0, 0, 0, 0, 0 }; // Dummy array for parallax compatibility
 		uv = ExtendedMaterials::GetParallaxCoords(input, viewPosition.z, uv, mipLevels, viewDirection, tbnTr, screenNoise, displacementParams, sharedOffset, dx, dy, pixelOffset, weights);
 #			else
-		float mipLevels[6] = { 0, 0, 0, 0, 0, 0 }; // Dummy array for parallax compatibility
 		uv = ExtendedMaterials::GetParallaxCoords(input, viewPosition.z, uv, mipLevels, viewDirection, tbnTr, screenNoise, displacementParams, pixelOffset, weights);
 #			endif
 		if (SharedData::extendedMaterialSettings.EnableHeightBlending) {
@@ -1348,7 +1346,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		}
 	}
 
-	#		if defined(TERRAIN_VARIATION)
+#		if defined(TERRAIN_VARIATION)
 	else if (useTerrainVariation) {
 		// Calculate proper mip levels for terrain variation when parallax is disabled but EMAT is available
 		mipLevels[0] = ExtendedMaterials::GetMipLevel(uv, TexColorSampler);
@@ -1360,7 +1358,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	}
 #		endif
 #		else
-	// Initialize mip levels for non-EMAT case (no longer needed)
+	// Initialize mip levels for non-EMAT case
 	mipLevels[0] = mipLevels[1] = mipLevels[2] = mipLevels[3] = mipLevels[4] = mipLevels[5] = 0.0;
 #		endif  // EMAT
 #	endif      // LANDSCAPE

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1299,6 +1299,13 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 #		if defined(EMAT)
 	if (SharedData::extendedMaterialSettings.EnableTerrainParallax) {
+		mipLevels[0] = ExtendedMaterials::GetMipLevel(uv, TexColorSampler);
+		mipLevels[1] = ExtendedMaterials::GetMipLevel(uv, TexLandColor2Sampler);
+		mipLevels[2] = ExtendedMaterials::GetMipLevel(uv, TexLandColor3Sampler);
+		mipLevels[3] = ExtendedMaterials::GetMipLevel(uv, TexLandColor4Sampler);
+		mipLevels[4] = ExtendedMaterials::GetMipLevel(uv, TexLandColor5Sampler);
+		mipLevels[5] = ExtendedMaterials::GetMipLevel(uv, TexLandColor6Sampler);
+
 		displacementParams[1] = displacementParams[0];
 		displacementParams[2] = displacementParams[0];
 		displacementParams[3] = displacementParams[0];
@@ -1340,6 +1347,18 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			endif
 		}
 	}
+
+	#		if defined(TERRAIN_VARIATION)
+	else if (useTerrainVariation) {
+		// Calculate proper mip levels for terrain variation when parallax is disabled but EMAT is available
+		mipLevels[0] = ExtendedMaterials::GetMipLevel(uv, TexColorSampler);
+		mipLevels[1] = ExtendedMaterials::GetMipLevel(uv, TexLandColor2Sampler);
+		mipLevels[2] = ExtendedMaterials::GetMipLevel(uv, TexLandColor3Sampler);
+		mipLevels[3] = ExtendedMaterials::GetMipLevel(uv, TexLandColor4Sampler);
+		mipLevels[4] = ExtendedMaterials::GetMipLevel(uv, TexLandColor5Sampler);
+		mipLevels[5] = ExtendedMaterials::GetMipLevel(uv, TexLandColor6Sampler);
+	}
+#		endif
 #		else
 	// Initialize mip levels for non-EMAT case (no longer needed)
 	mipLevels[0] = mipLevels[1] = mipLevels[2] = mipLevels[3] = mipLevels[4] = mipLevels[5] = 0.0;
@@ -1379,7 +1398,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landColor1;
 		[branch] if (useTerrainVariation)
 		{
-			landColor1 = StochasticEffect(screenNoise, TexColorSampler, SampColorSampler, uv, sharedOffset, dx, dy);
+			landColor1 = StochasticEffect(TexColorSampler, SampColorSampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1403,7 +1422,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landNormal1;
 		[branch] if (useTerrainVariation)
 		{
-			landNormal1 = StochasticEffect(screenNoise, TexNormalSampler, SampNormalSampler, uv, sharedOffset, dx, dy);
+			landNormal1 = StochasticEffect(TexNormalSampler, SampNormalSampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1426,7 +1445,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TERRAIN_VARIATION)
 			[branch] if (useTerrainVariation)
 			{
-				landRMAOS1 = StochasticEffectNoHeight(TexRMAOSSampler, SampRMAOSSampler, uv, sharedOffset) * float4(PBRParams1.x, 1, 1, PBRParams1.z);
+				landRMAOS1 = StochasticEffect(TexRMAOSSampler, SampRMAOSSampler, uv, sharedOffset, dx, dy) * float4(PBRParams1.x, 1, 1, PBRParams1.z);
 			}
 			else
 			{
@@ -1460,7 +1479,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landColor2;
 		[branch] if (useTerrainVariation)
 		{
-			landColor2 = StochasticEffect(screenNoise, TexLandColor2Sampler, SampLandColor2Sampler, uv, sharedOffset, dx, dy);
+			landColor2 = StochasticEffect(TexLandColor2Sampler, SampLandColor2Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1484,7 +1503,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landNormal2;
 		[branch] if (useTerrainVariation)
 		{
-			landNormal2 = StochasticEffect(screenNoise, TexLandNormal2Sampler, SampLandNormal2Sampler, uv, sharedOffset, dx, dy);
+			landNormal2 = StochasticEffect(TexLandNormal2Sampler, SampLandNormal2Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1507,7 +1526,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TERRAIN_VARIATION)
 			[branch] if (useTerrainVariation)
 			{
-				landRMAOS2 = StochasticEffectNoHeight(TexLandRMAOS2Sampler, SampLandRMAOS2Sampler, uv, sharedOffset) * float4(LandscapeTexture2PBRParams.x, 1, 1, LandscapeTexture2PBRParams.z);
+				landRMAOS2 = StochasticEffect(TexLandRMAOS2Sampler, SampLandRMAOS2Sampler, uv, sharedOffset, dx, dy) * float4(LandscapeTexture2PBRParams.x, 1, 1, LandscapeTexture2PBRParams.z);
 			}
 			else
 			{
@@ -1540,7 +1559,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landColor3;
 		[branch] if (useTerrainVariation)
 		{
-			landColor3 = StochasticEffect(screenNoise, TexLandColor3Sampler, SampLandColor3Sampler, uv, sharedOffset, dx, dy);
+			landColor3 = StochasticEffect(TexLandColor3Sampler, SampLandColor3Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1564,7 +1583,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landNormal3;
 		[branch] if (useTerrainVariation)
 		{
-			landNormal3 = StochasticEffect(screenNoise, TexLandNormal3Sampler, SampLandNormal3Sampler, uv, sharedOffset, dx, dy);
+			landNormal3 = StochasticEffect(TexLandNormal3Sampler, SampLandNormal3Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1587,7 +1606,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TERRAIN_VARIATION)
 			[branch] if (useTerrainVariation)
 			{
-				landRMAOS3 = StochasticEffectNoHeight(TexLandRMAOS3Sampler, SampLandRMAOS3Sampler, uv, sharedOffset) * float4(LandscapeTexture3PBRParams.x, 1, 1, LandscapeTexture3PBRParams.z);
+				landRMAOS3 = StochasticEffect(TexLandRMAOS3Sampler, SampLandRMAOS3Sampler, uv, sharedOffset, dx, dy) * float4(LandscapeTexture3PBRParams.x, 1, 1, LandscapeTexture3PBRParams.z);
 			}
 			else
 			{
@@ -1620,7 +1639,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landColor4;
 		[branch] if (useTerrainVariation)
 		{
-			landColor4 = StochasticEffect(screenNoise, TexLandColor4Sampler, SampLandColor4Sampler, uv, sharedOffset, dx, dy);
+			landColor4 = StochasticEffect(TexLandColor4Sampler, SampLandColor4Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1644,7 +1663,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landNormal4;
 		[branch] if (useTerrainVariation)
 		{
-			landNormal4 = StochasticEffect(screenNoise, TexLandNormal4Sampler, SampLandNormal4Sampler, uv, sharedOffset, dx, dy);
+			landNormal4 = StochasticEffect(TexLandNormal4Sampler, SampLandNormal4Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1667,7 +1686,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TERRAIN_VARIATION)
 			[branch] if (useTerrainVariation)
 			{
-				landRMAOS4 = StochasticEffectNoHeight(TexLandRMAOS4Sampler, SampLandRMAOS4Sampler, uv, sharedOffset) * float4(LandscapeTexture4PBRParams.x, 1, 1, LandscapeTexture4PBRParams.z);
+				landRMAOS4 = StochasticEffect(TexLandRMAOS4Sampler, SampLandRMAOS4Sampler, uv, sharedOffset, dx, dy) * float4(LandscapeTexture4PBRParams.x, 1, 1, LandscapeTexture4PBRParams.z);
 			}
 			else
 			{
@@ -1700,7 +1719,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landColor5;
 		[branch] if (useTerrainVariation)
 		{
-			landColor5 = StochasticEffect(screenNoise, TexLandColor5Sampler, SampLandColor5Sampler, uv, sharedOffset, dx, dy);
+			landColor5 = StochasticEffect(TexLandColor5Sampler, SampLandColor5Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1724,7 +1743,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landNormal5;
 		[branch] if (useTerrainVariation)
 		{
-			landNormal5 = StochasticEffect(screenNoise, TexLandNormal5Sampler, SampLandNormal5Sampler, uv, sharedOffset, dx, dy);
+			landNormal5 = StochasticEffect(TexLandNormal5Sampler, SampLandNormal5Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1748,7 +1767,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TERRAIN_VARIATION)
 			[branch] if (useTerrainVariation)
 			{
-				landRMAOS5 = StochasticEffectNoHeight(TexLandRMAOS5Sampler, SampLandRMAOS5Sampler, uv, sharedOffset) * float4(LandscapeTexture5PBRParams.x, 1, 1, LandscapeTexture5PBRParams.z);
+				landRMAOS5 = StochasticEffect(TexLandRMAOS5Sampler, SampLandRMAOS5Sampler, uv, sharedOffset, dx, dy) * float4(LandscapeTexture5PBRParams.x, 1, 1, LandscapeTexture5PBRParams.z);
 			}
 			else
 			{
@@ -1781,7 +1800,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landColor6;
 		[branch] if (useTerrainVariation)
 		{
-			landColor6 = StochasticEffect(screenNoise, TexLandColor6Sampler, SampLandColor6Sampler, uv, sharedOffset, dx, dy);
+			landColor6 = StochasticEffect(TexLandColor6Sampler, SampLandColor6Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1805,7 +1824,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float4 landNormal6;
 		[branch] if (useTerrainVariation)
 		{
-			landNormal6 = StochasticEffect(screenNoise, TexLandNormal6Sampler, SampLandNormal6Sampler, uv, sharedOffset, dx, dy);
+			landNormal6 = StochasticEffect(TexLandNormal6Sampler, SampLandNormal6Sampler, uv, sharedOffset, dx, dy);
 		}
 		else
 		{
@@ -1817,7 +1836,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float3 landNormalRGB6 = landNormal6.rgb;
 		float landNormalAlpha6 = landNormal6.a;
 #		if defined(SNOW) && !defined(TRUE_PBR)
-		landSnowMask += LandscapeTexture5to6IsSnow.y * input.LandBlendWeights2.y * landSnowMask6;
+		landSnowMask += LandscapeTexture5to6IsSnow.y * 	input.LandBlendWeights2.y * landSnowMask6;
 #		endif  // SNOW
 
 		// Sample RMAOS texture for layer 6
@@ -1828,7 +1847,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TERRAIN_VARIATION)
 			[branch] if (useTerrainVariation)
 			{
-				landRMAOS6 = StochasticEffectNoHeight(TexLandRMAOS6Sampler, SampLandRMAOS6Sampler, uv, sharedOffset) * float4(LandscapeTexture6PBRParams.x, 1, 1, LandscapeTexture6PBRParams.z);
+				landRMAOS6 = StochasticEffect(TexLandRMAOS6Sampler, SampLandRMAOS6Sampler, uv, sharedOffset, dx, dy) * float4(LandscapeTexture6PBRParams.x, 1, 1, LandscapeTexture6PBRParams.z);
 			}
 			else
 			{

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -10,7 +10,6 @@
 #include "Features/CloudShadows.h"
 #include "Features/TerrainBlending.h"
 #include "Features/TerrainHelper.h"
-#include "Features/TerrainVariation.h"
 #include "Menu.h"
 #include "ShaderCache.h"
 #include "Streamline.h"
@@ -726,17 +725,6 @@ void State::UpdateSharedData(bool a_inWorld, bool a_prepass)
 			data.MipBias = std::log2f(renderSize.x / screenSize.x) - 1.0f;
 		} else {
 			data.MipBias = 0;
-		}
-
-		// Apply TAA-equivalent mip bias when terrain variation is enabled and TAA is disabled to prevent texture blurring
-		auto terrainVariation = globals::features::terrainVariation;
-		if (terrainVariation && terrainVariation->loaded && terrainVariation->settings.enableTilingFix) {
-			if (!bTAA) {
-				// Apply same sharpening calculation as TAA when TAA is disabled
-				auto renderSize = Util::ConvertToDynamic(screenSize);
-				data.MipBias = std::log2f(renderSize.x / screenSize.x) - 1.0f;
-			}
-			// When TAA is enabled, keep the existing TAA mip bias calculation
 		}
 
 		sharedDataCB->Update(data);

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -10,6 +10,7 @@
 #include "Features/CloudShadows.h"
 #include "Features/TerrainBlending.h"
 #include "Features/TerrainHelper.h"
+#include "Features/TerrainVariation.h"
 #include "Menu.h"
 #include "ShaderCache.h"
 #include "Streamline.h"
@@ -725,6 +726,17 @@ void State::UpdateSharedData(bool a_inWorld, bool a_prepass)
 			data.MipBias = std::log2f(renderSize.x / screenSize.x) - 1.0f;
 		} else {
 			data.MipBias = 0;
+		}
+
+		// Apply TAA-equivalent mip bias when terrain variation is enabled and TAA is disabled to prevent texture blurring
+		auto terrainVariation = globals::features::terrainVariation;
+		if (terrainVariation && terrainVariation->loaded && terrainVariation->settings.enableTilingFix) {
+			if (!bTAA) {
+				// Apply same sharpening calculation as TAA when TAA is disabled
+				auto renderSize = Util::ConvertToDynamic(screenSize);
+				data.MipBias = std::log2f(renderSize.x / screenSize.x) - 1.0f;
+			}
+			// When TAA is enabled, keep the existing TAA mip bias calculation
 		}
 
 		sharedDataCB->Update(data);


### PR DESCRIPTION
Reworked Terrain Variation system to have more consistent mipmapping. Uses a custom GPU-based MipLevel function within StochasticEffect instead of trying to work with the MipLevels made for parallax from ExtendedMaterials.hlsli.

- Updated RMAOS sampling to use StochasticEffect, not StochasticEffectNoHeight.

- Separated StochasticEffectNoHeight and renamed to StochasticEffectParallax for clarity. Uses EMAT MipLevels.

- GPU-Based Mipmapping should result in better compatability across manufacturers, reducing issues where single-sample early exit is executed unintentionally.

- Removed all early exit/single sample functions from StochasticEffectParallax, as parallax fade out can handle this instead.

- Results in a significant performance increase over current dev.


<img width="1499" height="943" alt="image" src="https://github.com/user-attachments/assets/711a39a5-f29e-40b8-af96-2d78097e5485" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of mip level adjustments for terrain and extended materials, ensuring more accurate texture sampling in various scenarios, including VR and TAA.
  * Updated comments for better clarity on how mip bias is applied in different rendering modes.
* **New Features**
  * Introduced a new terrain sampling method enhancing blending and parallax effects for terrain variation.
  * Simplified and centralized mip level computation for improved rendering consistency and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->