### PR TITLE
perf: RTTI optimisation

### DIFF
--- a/src/Features/ExtendedTranslucency.cpp
+++ b/src/Features/ExtendedTranslucency.cpp
@@ -24,9 +24,7 @@ void ExtendedTranslucency::BSLightingShader_SetupGeometry(RE::BSRenderPass* pass
 	globals::state->currentExtraFeatureDescriptor &= ~(ExtraFeatureDescriptorMask << ExtraFeatureDescriptorShift);
 	// TODO: PERFORMANCE: Caching the feature descriptor in map<RE::BSGeometry*, uint> if this get more complex
 	if (auto* data = pass->geometry->GetExtraData(NiExtraDataName_AnisotropicAlphaMaterial)) {
-		static const REL::Relocation<const RE::NiRTTI*> NiIntegerExtraDataRTTI{ RE::NiIntegerExtraData::Ni_RTTI };
-		// netimmerse_cast<RE::NiIntegerExtraData*>(data) seems not working here
-		if (data->GetRTTI() == NiIntegerExtraDataRTTI.get()) {
+		if (data->GetRTTI() == globals::rtti::NiIntegerExtraDataRTTI.get()) {
 			uint32_t material = static_cast<uint32_t>(static_cast<RE::NiIntegerExtraData*>(data)->value) & ExtraFeatureDescriptorMask;
 			if (material == MaterialModel::Disabled) {
 				// MaterialModel::Disabled (0) is the flag when this extra does not exist

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -492,7 +492,7 @@ LightLimitFix::ParticleLightReference LightLimitFix::GetParticleLightConfigs(RE:
 				if (auto material = shaderProperty->GetMaterial()) {
 					// Check if it's a valid particle light
 					bool billboard = false;
-					if (a_pass->geometry->GetRTTI() != globals::rtti::NiParticleSystemRTTI.get()){
+					if (a_pass->geometry->GetRTTI() != globals::rtti::NiParticleSystemRTTI.get()) {
 						if (auto parent = a_pass->geometry->parent) {
 							if (auto billboardNode = parent->GetRTTI() == globals::rtti::NiBillboardNodeRTTI.get() ? static_cast<RE::NiBillboardNode*>(parent) : nullptr) {
 								billboard = true;

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -487,14 +487,14 @@ LightLimitFix::ParticleLightReference LightLimitFix::GetParticleLightConfigs(RE:
 
 	// see https://www.nexusmods.com/skyrimspecialedition/articles/1391
 	if (settings.EnableParticleLights) {
-		if (auto shaderProperty = netimmerse_cast<RE::BSEffectShaderProperty*>(a_pass->shaderProperty)) {
+		if (auto shaderProperty = a_pass->shaderProperty->GetRTTI() == globals::rtti::BSEffectShaderPropertyRTTI.get() ? static_cast<RE::BSEffectShaderProperty*>(a_pass->shaderProperty) : nullptr) {
 			if (!shaderProperty->lightData) {
 				if (auto material = shaderProperty->GetMaterial()) {
 					// Check if it's a valid particle light
 					bool billboard = false;
-					if (!netimmerse_cast<RE::NiParticleSystem*>(a_pass->geometry)) {
+					if (a_pass->geometry->GetRTTI() != globals::rtti::NiParticleSystemRTTI.get()){
 						if (auto parent = a_pass->geometry->parent) {
-							if (auto billboardNode = netimmerse_cast<RE::NiBillboardNode*>(parent)) {
+							if (auto billboardNode = parent->GetRTTI() == globals::rtti::NiBillboardNodeRTTI.get() ? static_cast<RE::NiBillboardNode*>(parent) : nullptr) {
 								billboard = true;
 							} else {
 								return { false };

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -194,7 +194,6 @@ namespace globals
 			perFrame = { REL::RelocationID(524768, 411384) };
 		}
 
-
 		{
 			using namespace rtti;
 			NiIntegerExtraDataRTTI = { RE::NiIntegerExtraData::Ni_RTTI };

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -194,6 +194,16 @@ namespace globals
 			perFrame = { REL::RelocationID(524768, 411384) };
 		}
 
+
+		{
+			using namespace rtti;
+			NiIntegerExtraDataRTTI = { RE::NiIntegerExtraData::Ni_RTTI };
+			BSLightingShaderPropertyRTTI = { RE::BSLightingShaderProperty::Ni_RTTI };
+			BSEffectShaderPropertyRTTI = { RE::BSEffectShaderProperty::Ni_RTTI };
+			NiParticleSystemRTTI = { RE::NiParticleSystem::Ni_RTTI };
+			NiBillboardNodeRTTI = { RE::NiBillboardNode::Ni_RTTI };
+		}
+
 		d3d::device = reinterpret_cast<ID3D11Device*>(game::renderer->GetRuntimeData().forwarder);
 		d3d::context = reinterpret_cast<ID3D11DeviceContext*>(game::renderer->GetRuntimeData().context);
 		d3d::swapChain = reinterpret_cast<IDXGISwapChain*>(game::renderer->GetRuntimeData().renderWindows->swapChain);

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -116,6 +116,15 @@ namespace globals
 		extern REL::Relocation<ID3D11Buffer**> perFrame;
 	}
 
+	namespace rtti
+	{
+		extern REL::Relocation<const RE::NiRTTI*> NiIntegerExtraDataRTTI;
+		extern REL::Relocation<const RE::NiRTTI*> BSLightingShaderPropertyRTTI;
+		extern REL::Relocation<const RE::NiRTTI*> BSEffectShaderPropertyRTTI;
+		extern REL::Relocation<const RE::NiRTTI*> NiParticleSystemRTTI;
+		extern REL::Relocation<const RE::NiRTTI*> NiBillboardNodeRTTI;
+	}
+
 	extern State* state;
 	extern Deferred* deferred;
 	extern TruePBR* truePBR;

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -1232,8 +1232,8 @@ struct BSTempEffectSimpleDecal_SetupGeometry
 	{
 		func(decal, geometry, textureSet, blended);
 		auto* singleton = globals::truePBR;
-		auto property = geometry->GetGeometryRuntimeData().properties[1].get();
-		if (auto shaderProperty = property->GetRTTI() == globals::rtti::BSLightingShaderPropertyRTTI.get() ? static_cast<RE::BSLightingShaderProperty*>(geometry->GetGeometryRuntimeData().properties[1].get()) : nullptr;
+		auto uncastedProperty = geometry->GetGeometryRuntimeData().properties[1].get();
+		if (auto shaderProperty = uncastedProperty->GetRTTI() == globals::rtti::BSLightingShaderPropertyRTTI.get() ? static_cast<RE::BSLightingShaderProperty*>(uncastedProperty) : nullptr;
 			shaderProperty != nullptr && singleton->IsPBRTextureSet(textureSet)) {
 			{
 				BSLightingShaderMaterialPBR srcMaterial;

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -1232,8 +1232,8 @@ struct BSTempEffectSimpleDecal_SetupGeometry
 	{
 		func(decal, geometry, textureSet, blended);
 		auto* singleton = globals::truePBR;
-		auto uncastedProperty = geometry->GetGeometryRuntimeData().properties[1].get();
-		if (auto shaderProperty = uncastedProperty->GetRTTI() == globals::rtti::BSLightingShaderPropertyRTTI.get() ? static_cast<RE::BSLightingShaderProperty*>(uncastedProperty) : nullptr;
+		auto unknownProperty = geometry->GetGeometryRuntimeData().properties[1].get();
+		if (auto shaderProperty = unknownProperty->GetRTTI() == globals::rtti::BSLightingShaderPropertyRTTI.get() ? static_cast<RE::BSLightingShaderProperty*>(unknownProperty) : nullptr;
 			shaderProperty != nullptr && singleton->IsPBRTextureSet(textureSet)) {
 			{
 				BSLightingShaderMaterialPBR srcMaterial;

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -1232,8 +1232,8 @@ struct BSTempEffectSimpleDecal_SetupGeometry
 	{
 		func(decal, geometry, textureSet, blended);
 		auto* singleton = globals::truePBR;
-
-		if (auto* shaderProperty = netimmerse_cast<RE::BSLightingShaderProperty*>(geometry->GetGeometryRuntimeData().properties[1].get());
+		auto property = geometry->GetGeometryRuntimeData().properties[1].get();
+		if (auto shaderProperty = property->GetRTTI() == globals::rtti::BSLightingShaderPropertyRTTI.get() ? static_cast<RE::BSLightingShaderProperty*>(geometry->GetGeometryRuntimeData().properties[1].get()) : nullptr;
 			shaderProperty != nullptr && singleton->IsPBRTextureSet(textureSet)) {
 			{
 				BSLightingShaderMaterialPBR srcMaterial;


### PR DESCRIPTION
optimisations where netimmerse_cast was used before. instead of querying an expensive function it now can just directly check the RTTI using globals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type checking and casting mechanisms for shader and geometry properties, enhancing reliability and safety.
  * Introduced global runtime type information (RTTI) references for more consistent type validation across features.

* **Chores**
  * Added new global RTTI variables and initialization logic for internal use. No impact on user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->