### PR TITLE
perf(extended translucency): enable only on alpha blended materials

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -3318,7 +3318,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 			float AlphaMaterialReduction = 0.f;
 			float AlphaMaterialSoftness = 0.f;
 			float AlphaMaterialStrength = 0.f;
-			
+
 			if (AlphaMaterialModel == ExtendedTranslucency::MaterialModel::Default) {
 				AlphaMaterialModel = SharedData::extendedTranslucencySettings.MaterialModel;
 				AlphaMaterialReduction = SharedData::extendedTranslucencySettings.Reduction;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -3312,19 +3312,20 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		if defined(ANISOTROPIC_ALPHA)
 	// Uniform alpha material settings
 	uint AlphaMaterialModel = ExtendedTranslucency::GetMaterialModelFromDescriptor(Permutation::ExtraFeatureDescriptor);
-	float AlphaMaterialReduction = 0.f;
-	float AlphaMaterialSoftness = 0.f;
-	float AlphaMaterialStrength = 0.f;
-	if (AlphaMaterialModel == ExtendedTranslucency::MaterialModel::Default) {
-		AlphaMaterialModel = SharedData::extendedTranslucencySettings.MaterialModel;
-		AlphaMaterialReduction = SharedData::extendedTranslucencySettings.Reduction;
-		AlphaMaterialSoftness = SharedData::extendedTranslucencySettings.Softness;
-		AlphaMaterialStrength = SharedData::extendedTranslucencySettings.Strength;
-	}
-
 	[branch] if (ExtendedTranslucency::IsValidMaterial(AlphaMaterialModel))
 	{
 		if (alpha >= 0.0156862754 && alpha < 1.0) {
+			float AlphaMaterialReduction = 0.f;
+			float AlphaMaterialSoftness = 0.f;
+			float AlphaMaterialStrength = 0.f;
+			
+			if (AlphaMaterialModel == ExtendedTranslucency::MaterialModel::Default) {
+				AlphaMaterialModel = SharedData::extendedTranslucencySettings.MaterialModel;
+				AlphaMaterialReduction = SharedData::extendedTranslucencySettings.Reduction;
+				AlphaMaterialSoftness = SharedData::extendedTranslucencySettings.Softness;
+				AlphaMaterialStrength = SharedData::extendedTranslucencySettings.Strength;
+			}
+
 			float originalAlpha = alpha;
 			alpha = alpha * (1.0 - AlphaMaterialReduction);
 			[branch] if (AlphaMaterialModel == ExtendedTranslucency::MaterialModel::AnisotropicFabric)

--- a/src/Features/ExtendedTranslucency.cpp
+++ b/src/Features/ExtendedTranslucency.cpp
@@ -25,7 +25,7 @@ void ExtendedTranslucency::BSLightingShader_SetupGeometry(RE::BSRenderPass* pass
 	// TODO: PERFORMANCE: Caching the feature descriptor in map<RE::BSGeometry*, uint> if this get more complex
 	auto& unknownProperty = pass->geometry->GetGeometryRuntimeData().properties[RE::BSGeometry::States::kProperty];
 	static const REL::Relocation<const RE::NiRTTI*> NiAlphaPropertyRTTI{ RE::NiAlphaProperty::Ni_RTTI };
-	auto alphaProperty = unknownProperty->GetRTTI() == NiAlphaPropertyRTTI.get() ? static_cast<RE::NiAlphaProperty*>(unknownProperty.get()) : nullptr;
+	auto alphaProperty = unknownProperty && unknownProperty->GetRTTI() == NiAlphaPropertyRTTI.get() ? static_cast<RE::NiAlphaProperty*>(unknownProperty.get()) : nullptr;
 	// Check alpha property exists and blending is enabled
 	if (alphaProperty && alphaProperty->GetAlphaBlending()){
 		if (auto* data = pass->geometry->GetExtraData(NiExtraDataName_AnisotropicAlphaMaterial)) {

--- a/src/Features/ExtendedTranslucency.cpp
+++ b/src/Features/ExtendedTranslucency.cpp
@@ -27,7 +27,7 @@ void ExtendedTranslucency::BSLightingShader_SetupGeometry(RE::BSRenderPass* pass
 	static const REL::Relocation<const RE::NiRTTI*> NiAlphaPropertyRTTI{ RE::NiAlphaProperty::Ni_RTTI };
 	auto alphaProperty = unknownProperty->GetRTTI() == NiAlphaPropertyRTTI.get() ? static_cast<RE::NiAlphaProperty*>(unknownProperty.get()) : nullptr;
 	// Check alpha property exists and blending is enabled
-	if (alphaProperty && alphaProperty->GetAlphaBlending()){
+	if (alphaProperty && alphaProperty->GetAlphaBlending()) {
 		if (auto* data = pass->geometry->GetExtraData(NiExtraDataName_AnisotropicAlphaMaterial)) {
 			static const REL::Relocation<const RE::NiRTTI*> NiIntegerExtraDataRTTI{ RE::NiIntegerExtraData::Ni_RTTI };
 			if (data->GetRTTI() == NiIntegerExtraDataRTTI.get()) {

--- a/src/Features/ExtendedTranslucency.cpp
+++ b/src/Features/ExtendedTranslucency.cpp
@@ -23,23 +23,30 @@ void ExtendedTranslucency::BSLightingShader_SetupGeometry(RE::BSRenderPass* pass
 {
 	globals::state->currentExtraFeatureDescriptor &= ~(ExtraFeatureDescriptorMask << ExtraFeatureDescriptorShift);
 	// TODO: PERFORMANCE: Caching the feature descriptor in map<RE::BSGeometry*, uint> if this get more complex
-	if (auto* data = pass->geometry->GetExtraData(NiExtraDataName_AnisotropicAlphaMaterial)) {
-		static const REL::Relocation<const RE::NiRTTI*> NiIntegerExtraDataRTTI{ RE::NiIntegerExtraData::Ni_RTTI };
-		// netimmerse_cast<RE::NiIntegerExtraData*>(data) seems not working here
-		if (data->GetRTTI() == NiIntegerExtraDataRTTI.get()) {
-			uint32_t material = static_cast<uint32_t>(static_cast<RE::NiIntegerExtraData*>(data)->value) & ExtraFeatureDescriptorMask;
-			if (material == MaterialModel::Disabled) {
-				// MaterialModel::Disabled (0) is the flag when this extra does not exist
-				// And it will let the effect use default settings instead of force disable it
-				// Ensure this is disabled by using the ForceDisabled flag
-				material = MaterialModel::ForceDisabled;
-			}
-			globals::state->currentExtraFeatureDescriptor |= (material << ExtraFeatureDescriptorShift);
+	auto& unknownProperty = pass->geometry->GetGeometryRuntimeData().properties[RE::BSGeometry::States::kProperty];
+	static const REL::Relocation<const RE::NiRTTI*> NiAlphaPropertyRTTI{ RE::NiAlphaProperty::Ni_RTTI };
+	auto alphaProperty = unknownProperty->GetRTTI() == NiAlphaPropertyRTTI.get() ? static_cast<RE::NiAlphaProperty*>(unknownProperty.get()) : nullptr;
+	// Check alpha property exists and blending is enabled
+	if (alphaProperty && alphaProperty->GetAlphaBlending()){
+		if (auto* data = pass->geometry->GetExtraData(NiExtraDataName_AnisotropicAlphaMaterial)) {
+			static const REL::Relocation<const RE::NiRTTI*> NiIntegerExtraDataRTTI{ RE::NiIntegerExtraData::Ni_RTTI };
+			if (data->GetRTTI() == NiIntegerExtraDataRTTI.get()) {
+				uint32_t material = static_cast<uint32_t>(static_cast<RE::NiIntegerExtraData*>(data)->value) & ExtraFeatureDescriptorMask;
+				if (material == MaterialModel::Disabled) {
+					// MaterialModel::Disabled (0) is the flag when this extra does not exist
+					// And it will let the effect use default settings instead of force disable it
+					// Ensure this is disabled by using the ForceDisabled flag
+					material = MaterialModel::ForceDisabled;
+				}
+				globals::state->currentExtraFeatureDescriptor |= (material << ExtraFeatureDescriptorShift);
 
-			// TODO: Per-material settings from Nif
-			// Mods supporting this feature should adjust their alpha value in texture already
-			// And the texture should be adjusted based on full strength param
+				// TODO: Per-material settings from Nif
+				// Mods supporting this feature should adjust their alpha value in texture already
+				// And the texture should be adjusted based on full strength param
+			}
 		}
+	} else {
+		globals::state->currentExtraFeatureDescriptor |= ((MaterialModel::ForceDisabled) << ExtraFeatureDescriptorShift);
 	}
 }
 

--- a/src/Features/ExtendedTranslucency.h
+++ b/src/Features/ExtendedTranslucency.h
@@ -35,7 +35,7 @@ struct ExtendedTranslucency final : Feature
 		RimLight = 1,           // Similar effect like rim light
 		IsotropicFabric = 2,    // 1D fabric model, respect normal map
 		AnisotropicFabric = 3,  // 2D fabric model alone tangent and binormal, ignores normal map
-		ForceDisabled = 7,      // In ExtraFeatureDescriptor, value >= 4 means 'Disabled'
+		ForceDisabled = 4,      // In ExtraFeatureDescriptor, value >= 4 means 'Disabled'
 	};
 
 	static constexpr uint32_t ExtraFeatureDescriptorShift = 6;


### PR DESCRIPTION
Prevents running useless code when alpha blending is off. Fixes ForceDisabled being the wrong value on the CPU.

@ArcEarth 