### PR TITLE
feat(perfoverlay): add frame time and a/b testing stats

### DIFF
--- a/features/Performance Overlay/Shaders/Features/PerformanceOverlay.ini
+++ b/features/Performance Overlay/Shaders/Features/PerformanceOverlay.ini
@@ -1,0 +1,2 @@
+[Info]
+Version = 1-0-0

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -14,6 +14,7 @@
 #include "Features/InverseSquareLighting.h"
 #include "Features/LODBlending.h"
 #include "Features/LightLimitFix.h"
+#include "Features/PerformanceOverlay.h"
 #include "Features/ScreenSpaceGI.h"
 #include "Features/ScreenSpaceShadows.h"
 #include "Features/SkySync.h"
@@ -206,6 +207,7 @@ const std::vector<Feature*>& Feature::GetFeatureList()
 		globals::features::cloudShadows,
 		globals::features::waterEffects,
 		globals::features::weatherPicker,
+		globals::features::performanceOverlay,
 		globals::features::subsurfaceScattering,
 		globals::features::terrainShadows,
 		globals::features::screenSpaceGI,

--- a/src/Features/OverlayFeature.h
+++ b/src/Features/OverlayFeature.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "Feature.h"
+
+/**
+ * @brief Abstract base class for all features that provide an in-game overlay.
+ *
+ * Inherit from OverlayFeature if your feature draws an ImGui overlay that can be toggled
+ * globally and/or individually. This interface allows the menu system to manage overlays
+ * in a generic way.
+ */
+struct OverlayFeature : Feature
+{
+	/**
+     * @brief Draw the overlay for this feature.
+     *
+     * This method should render the overlay UI using ImGui. It will only be called if
+     * IsOverlayVisible() returns true and the global overlay toggle is enabled.
+     */
+	virtual void DrawOverlay() = 0;
+
+	/**
+     * @brief Whether this overlay should be visible when the global overlay is enabled.
+     *
+     * Typically, this should return the value of a per-feature setting (e.g., ShowInOverlay).
+     * If false, the overlay will not be drawn even if the global overlay is enabled.
+     */
+	virtual bool IsOverlayVisible() const = 0;
+
+	/**
+     * @brief Get the category for UI grouping. Overlays default to "Debug".
+     *
+     * Subclasses may override this to provide a different category.
+     */
+	virtual std::string_view GetCategory() const override { return "Debug"; }
+};

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -1,10 +1,32 @@
+/**
+ * @file PerformanceOverlay.cpp
+ * @brief Real-time performance monitoring system for Skyrim Community Shaders
+ *
+ * This module provides comprehensive performance monitoring capabilities including:
+ * - Real-time FPS and frame time tracking with configurable update intervals
+ * - Interactive draw call analysis with per-shader type performance breakdown
+ * - VRAM usage monitoring with visual progress bars
+ * - Frame time graphs for pre and post-frame generation analysis
+ * - A/B testing support for performance comparison between configurations
+ * - Color-coded performance metrics with customizable thresholds
+ * - Movable overlay window with persistent positioning
+ *
+ * The overlay integrates with the A/B testing system to provide live performance
+ * comparisons between different shader configurations, helping users optimize
+ * their setup for maximum performance while maintaining visual quality.
+ *
+ */
+
 #include "PerformanceOverlay.h"
 #include "Feature.h"
+#include "Features/PerformanceOverlay/ABTesting/ABTestAggregator.h"
+#include "Features/PerformanceOverlay/ABTesting/ABTesting.h"
 #include "FidelityFX.h"
 #include "Globals.h"
 #include "Menu.h"
 #include "State.h"
 #include "Upscaling.h"
+#include "Utils/FileSystem.h"
 #include "Utils/Game.h"
 #include "Utils/UI.h"
 #include <nlohmann/json.hpp>
@@ -12,12 +34,81 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <filesystem>
 #include <format>
+#include <fstream>
 #include <imgui.h>
 #include <imgui_internal.h>
 #include <imgui_stdlib.h>
 #include <magic_enum.hpp>
+#include <map>
 #include <numeric>
+
+// --- Constants ---
+constexpr float kDefaultFPS = 60.0f;
+constexpr float kDefaultFrameTimeMs = 1000.0f / kDefaultFPS;
+
+// --- Helper Structures and Functions ---
+struct ColumnConfig
+{
+	std::string header;
+	std::function<void(const DrawCallRow&, int colIdx)> cellRender;
+	std::function<bool(const DrawCallRow&, const DrawCallRow&, bool)> sortFunc;
+	std::function<void()> headerTooltip;
+};
+
+// Helper function to create metric columns with consistent formatting
+auto MakeMetricColumn(const auto& theme, auto valueGetter, auto colorGetter, auto formatter, const Util::ColoredTextLines& legend, const Util::ColoredTextLines* cellLegend = nullptr)
+{
+	return [theme, valueGetter, colorGetter, formatter, legend, cellLegend](const DrawCallRow& row, int) {
+		using ValueType = decltype(valueGetter(row));
+		if constexpr (std::is_same_v<ValueType, std::optional<float>>) {
+			if (!valueGetter(row).has_value()) {
+				ImGui::TextDisabled("-");
+				return;
+			}
+			float value = *valueGetter(row);
+			ImVec4 color = colorGetter(theme, value, row);
+			std::string valueStr = formatter(value, row);
+			ImGui::PushStyleColor(ImGuiCol_Text, color);
+			ImGui::Text("%s", valueStr.c_str());
+			ImGui::PopStyleColor();
+		} else {
+			float value = valueGetter(row);
+			ImVec4 color = colorGetter(theme, value, row);
+			std::string valueStr = formatter(value, row);
+			ImGui::PushStyleColor(ImGuiCol_Text, color);
+			ImGui::Text("%s", valueStr.c_str());
+			ImGui::PopStyleColor();
+		}
+		if (ImGui::IsItemHovered()) {
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				const Util::ColoredTextLines& useLegend = cellLegend ? *cellLegend : legend;
+				Util::DrawColoredMultiLineTooltip(useLegend);
+			}
+		}
+	};
+}
+
+// --- Static variables for A/B testing ---
+static std::vector<SettingsDiffEntry> abSettingsDiff;
+static bool abSettingsDiffLoaded = false;
+
+// --- Helper Functions ---
+/**
+ * @brief Calculates summary data (Other frame time, percentages, cost per call) from measured sum
+ * @param smoothedFrameTime The total smoothed frame time
+ * @param measuredSum The sum of measured frame times
+ * @return Tuple of (otherFrameTime, otherPercent, totalCostPerCall)
+ */
+static std::tuple<float, float, float> CalculateSummaryData(float smoothedFrameTime, float measuredSum)
+{
+	float totalSmoothedDrawCalls = globals::state->GetTotalSmoothedDrawCalls();
+	float otherFrameTime = Util::CalculateOtherFrameTime(smoothedFrameTime, measuredSum);
+	float otherPercent = Util::CalculatePercentage(otherFrameTime, smoothedFrameTime);
+	float totalCostPerCall = Util::CalculateCostPerCall(smoothedFrameTime, totalSmoothedDrawCalls);
+	return { otherFrameTime, otherPercent, totalCostPerCall };
+}
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	PerformanceOverlay::PerfOverlaySettings,
@@ -48,42 +139,535 @@ static const std::unordered_map<RE::BSShader::Type, std::string> kShaderTypeTool
 	{ RE::BSShader::Type::ImageSpace, "Draw calls for image space post-processing effects." }
 };
 
+// --- ABTestAggregator integration ---
+ABTestAggregator& PerformanceOverlay::GetABTestAggregator()
+{
+	auto* abTestingManager = ABTestingManager::GetSingleton();
+	return abTestingManager->GetAggregator();
+}
+
+/**
+ * @brief Draws the A/B test results table with comprehensive performance comparison
+ *
+ * This function renders a detailed table showing performance metrics for both Variant A (USER config)
+ * and Variant B (TEST config), including:
+ * - Average and median frame times for each shader type
+ * - Performance deltas and percentage differences
+ * - Color-coded indicators for better/worse performance
+ * - Statistical validity assessment with tooltips
+ * - Sortable columns for easy analysis
+ *
+ * The table provides both main rows (individual shader types) and summary rows (Total, Other)
+ * to give users a complete picture of performance differences between configurations.
+ *
+ * @note This function requires an active A/B test with aggregated results
+ */
+void PerformanceOverlay::DrawABTestResultsTable()
+{
+	auto* abTestingManager = ABTestingManager::GetSingleton();
+	auto& aggregator = abTestingManager->GetAggregator();
+	auto results = aggregator.GetAggregatedResults();
+	if (results.empty())
+		return;
+
+	auto* menu = Menu::GetSingleton();
+	const auto& theme = menu->GetTheme();
+
+	// Test statistics header
+	float totalDuration = aggregator.GetTotalTestDuration();
+	int totalFrames = aggregator.GetTotalFrameCount();
+	int excludedFrames = 0;
+	for (const auto& interval : aggregator.GetIntervals()) {
+		excludedFrames += interval.excludedFrames;
+	}
+	int validFrames = totalFrames;
+	int totalWithExcluded = totalFrames + excludedFrames;
+	float validPercent = (totalWithExcluded > 0) ? (100.0f * validFrames / totalWithExcluded) : 100.0f;
+
+	// Statistical validity assessment
+	bool hasEnoughSamples = validFrames >= kMinimumSamplesForValidity;
+	bool hasGoodDuration = totalDuration >= kMinimumTestDuration;
+	bool hasLowExclusionRate = validPercent >= kMinimumValidFramesPercent;
+	bool isStatisticallyValid = hasEnoughSamples && hasGoodDuration && hasLowExclusionRate;
+
+	// Color coding for statistical validity
+	ImVec4 validityColor = theme.Palette.Text;
+	if (isStatisticallyValid) {
+		validityColor = theme.StatusPalette.SuccessColor;  // Green for valid
+	} else if (validFrames >= kMinimumSamplesForMarginal && totalDuration >= kMinimumDurationForMarginal) {
+		validityColor = theme.StatusPalette.Warning;  // Yellow for marginal
+	} else {
+		validityColor = theme.StatusPalette.Error;  // Red for insufficient
+	}
+
+	ImGui::PushStyleColor(ImGuiCol_Text, validityColor);
+	ImGui::Text("Test Duration: %.1f seconds | Valid Frames: %d/%d (%.1f%%) | Excluded: %d",
+		totalDuration, validFrames, totalWithExcluded, validPercent, excludedFrames);
+	ImGui::PopStyleColor();
+	if (ImGui::IsItemHovered()) {
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			char validStr[128], marginalStr[128];
+			snprintf(validStr, sizeof(validStr), "Statistically valid (>%d samples, >%.0fs duration, >%.0f%% valid)", kMinimumSamplesForValidity, static_cast<float>(kMinimumTestDuration), kMinimumValidFramesPercent);
+			snprintf(marginalStr, sizeof(marginalStr), "Marginal validity (>%d samples, >%.0fs duration)", kMinimumSamplesForMarginal, static_cast<float>(kMinimumDurationForMarginal));
+			Util::ColoredTextLines validityLegend = {
+				{ "Valid frames are those not excluded as outliers.\nA low percentage may indicate instability or test interruptions.\nExcluded frames are those with frame times > 3x median or > 100ms.\nThis removes shader compilation spikes, JSON loading overhead, and other anomalies\nthat would skew the performance comparison.", theme.Palette.Text },
+				{ "", theme.Palette.Text },
+				{ validStr, theme.StatusPalette.SuccessColor },
+				{ marginalStr, theme.StatusPalette.Warning },
+				{ "Insufficient data for reliable results", theme.StatusPalette.Error }
+			};
+			Util::DrawColoredMultiLineTooltip(validityLegend);
+		}
+	}
+
+	// Convert to DrawCallRow format for proper sorting and footer handling
+	std::vector<DrawCallRow> mainRows;
+	std::vector<DrawCallRow> summaryRows;
+
+	for (const auto& stat : results) {
+		DrawCallRow row;
+		row.label = stat.label;
+		row.shaderType = stat.shaderType;  // Just assign the int directly
+		row.frameTime = stat.meanA;        // Use A as primary frame time
+		row.percent = (stat.meanA > 0.0f) ? (stat.meanA / (stat.meanA + stat.meanB) * 100.0f) : 0.0f;
+		row.costPerCall = stat.medianA;  // Use A median as primary cost per call
+		row.enabled = true;
+
+		// Store B values in test data fields for comparison
+		row.testFrameTime = stat.meanB;
+		row.testCostPerCall = stat.medianB;  // Store B median in testCostPerCall field
+
+		// Add tooltip based on shader type
+		if (row.shaderType >= 0) {
+			// Regular shader type
+			auto shaderType = static_cast<RE::BSShader::Type>(row.shaderType);
+			auto tipIt = kShaderTypeTooltips.find(shaderType);
+			if (tipIt != kShaderTypeTooltips.end()) {
+				row.tooltip = tipIt->second;
+			} else {
+				row.tooltip = "Draw calls for this shader type.";
+			}
+		} else {
+			// Special shader type (Total or Other)
+			if (row.shaderType == static_cast<int>(SpecialShaderType::Total)) {
+				row.tooltip = "Total frame time.";
+			} else if (row.shaderType == static_cast<int>(SpecialShaderType::Other)) {
+				row.tooltip = "Frame time not attributed to any measured shader type. This includes UI, post-processing, engine work, and any GPU activity not directly measured by the overlay.";
+			}
+		}
+
+		// Separate main rows from summary rows
+		if (row.shaderType < 0) {
+			summaryRows.push_back(row);
+		} else {
+			mainRows.push_back(row);
+		}
+	}
+
+	// --- BUILD LEGENDS ---
+	const Util::ColoredTextLines aAvgLegend = {
+		{ "A Avg (ms): Average frame time for Variant A (USER config).", theme.Palette.Text },
+		{ "", theme.Palette.Text },
+		{ "Color Legend (compared to Variant B):", theme.Palette.Text },
+		{ "  Better (lower than B)", theme.StatusPalette.SuccessColor },
+		{ "  Worse (higher than B)", theme.StatusPalette.Error },
+		{ "  Same as B", theme.Palette.Text }
+	};
+	const Util::ColoredTextLines bAvgLegend = {
+		{ "B Avg (ms): Average frame time for Variant B (TEST config).", theme.Palette.Text },
+		{ "", theme.Palette.Text },
+		{ "Color Legend (compared to Variant A):", theme.Palette.Text },
+		{ "  Better (lower than A)", theme.StatusPalette.SuccessColor },
+		{ "  Worse (higher than A)", theme.StatusPalette.Error },
+		{ "  Same as A", theme.Palette.Text }
+	};
+	const Util::ColoredTextLines deltaLegend = {
+		{ "Delta (ms): Difference between Variant B and Variant A (B - A).", theme.Palette.Text },
+		{ "Negative values indicate Variant B is better (lower frame time).", theme.Palette.Text },
+		{ "Positive values indicate Variant A is better (lower frame time).", theme.Palette.Text },
+		{ "Percentage shows relative performance difference.", theme.Palette.Text },
+		{ "", theme.Palette.Text },
+		{ "Color Legend:", theme.Palette.Text },
+		{ "  Negative (B better)", theme.StatusPalette.SuccessColor },
+		{ "  Positive (A better)", theme.StatusPalette.Error },
+		{ "  Zero (same)", theme.Palette.Text }
+	};
+	const Util::ColoredTextLines aMedianLegend = {
+		{ "A Median: Median frame time for Variant A (USER config).", theme.Palette.Text },
+		{ "Median is less sensitive to outliers than average.", theme.Palette.Text },
+		{ "", theme.Palette.Text },
+		{ "Color Legend (compared to Variant B median):", theme.Palette.Text },
+		{ "  Better (lower than B)", theme.StatusPalette.SuccessColor },
+		{ "  Worse (higher than B)", theme.StatusPalette.Error },
+		{ "  Same as B", theme.Palette.Text }
+	};
+	const Util::ColoredTextLines bMedianLegend = {
+		{ "B Median: Median frame time for Variant B (TEST config).", theme.Palette.Text },
+		{ "Median is less sensitive to outliers than average.", theme.Palette.Text },
+		{ "", theme.Palette.Text },
+		{ "Color Legend (compared to Variant A median):", theme.Palette.Text },
+		{ "  Better (lower than A)", theme.StatusPalette.SuccessColor },
+		{ "  Worse (higher than A)", theme.StatusPalette.Error },
+		{ "  Same as A", theme.Palette.Text }
+	};
+	const Util::ColoredTextLines medianDeltaLegend = {
+		{ "Median Delta: Difference between Variant B and Variant A medians (B - A).", theme.Palette.Text },
+		{ "Negative values indicate Variant B is better (lower median).", theme.Palette.Text },
+		{ "Positive values indicate Variant A is better (lower median).", theme.Palette.Text },
+		{ "", theme.Palette.Text },
+		{ "Color Legend:", theme.Palette.Text },
+		{ "  Negative (B better)", theme.StatusPalette.SuccessColor },
+		{ "  Positive (A better)", theme.StatusPalette.Error },
+		{ "  Zero (same)", theme.Palette.Text }
+	};
+
+	// --- BUILD HEADERS AND CONFIG ---
+	std::vector<ColumnConfig> columns = {
+		{ "Shader Type",
+			[theme](const DrawCallRow& row, int) {
+				ImGui::TextUnformatted(row.label.c_str());
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::TextUnformatted(row.tooltip.c_str());
+						// Add FPS for Total row
+						if (row.label == "Total:") {
+							float fps = row.frameTime > 0.0f ? 1000.0f / row.frameTime : 0.0f;
+							ImGui::Text("FPS: %.2f", fps);
+						}
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.label < b.label) : (a.label > b.label); },
+			nullptr },
+		{ "A Avg (ms)",
+			[theme, aAvgLegend](const DrawCallRow& row, int) {
+				float value = row.frameTime;
+				// Color A relative to B
+				ImVec4 color = theme.Palette.Text;
+				if (row.testFrameTime.has_value()) {
+					if (value < *row.testFrameTime) {
+						color = theme.StatusPalette.SuccessColor;  // A is better (lower) than B
+					} else if (value > *row.testFrameTime) {
+						color = theme.StatusPalette.Error;  // A is worse (higher) than B
+					}
+				}
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				ImGui::Text("%s", Util::FormatMilliseconds(value).c_str());
+				ImGui::PopStyleColor();
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						if (row.label == "Total:") {
+							ImGui::Text("A (USER) FPS: %.2f", Util::CalcFPS(value));
+						} else {
+							Util::DrawColoredMultiLineTooltip(aAvgLegend);
+						}
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.frameTime < b.frameTime) : (a.frameTime > b.frameTime); },
+			[aAvgLegend]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						Util::DrawColoredMultiLineTooltip(aAvgLegend);
+					}
+				}
+			} },
+		{ "B Avg (ms)",
+			[theme, bAvgLegend](const DrawCallRow& row, int) {
+				if (!row.testFrameTime.has_value()) {
+					ImGui::TextDisabled("-");
+					return;
+				}
+				float value = *row.testFrameTime;
+				// Color B relative to A
+				ImVec4 color = theme.Palette.Text;
+				if (value < row.frameTime) {
+					color = theme.StatusPalette.SuccessColor;  // B is better (lower) than A
+				} else if (value > row.frameTime) {
+					color = theme.StatusPalette.Error;  // B is worse (higher) than A
+				}
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				ImGui::Text("%s", Util::FormatMilliseconds(value).c_str());
+				ImGui::PopStyleColor();
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						if (row.label == "Total:") {
+							ImGui::Text("B (TEST) FPS: %.2f", Util::CalcFPS(value));
+						} else {
+							Util::DrawColoredMultiLineTooltip(bAvgLegend);
+						}
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+				float aVal = a.testFrameTime.value_or(FLT_MAX);
+				float bVal = b.testFrameTime.value_or(FLT_MAX);
+				return asc ? (aVal < bVal) : (aVal > bVal);
+			},
+			[bAvgLegend]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						Util::DrawColoredMultiLineTooltip(bAvgLegend);
+					}
+				}
+			} },
+		{ "Delta (ms)",
+			[theme, deltaLegend](const DrawCallRow& row, int) {
+				if (!row.testFrameTime.has_value()) {
+					ImGui::TextDisabled("-");
+					return;
+				}
+				float delta = *row.testFrameTime - row.frameTime;
+				// Color based on delta
+				ImVec4 color = theme.Palette.Text;
+				if (delta < 0.0f) {
+					color = theme.StatusPalette.SuccessColor;  // Better performance (negative delta)
+				} else if (delta > 0.0f) {
+					color = theme.StatusPalette.Error;  // Worse performance (positive delta)
+				}
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				ImGui::Text("%s", Util::FormatDeltaWithPercent(row.frameTime, *row.testFrameTime, PerformanceOverlay::PerfOverlayState::kPercentDisplayThreshold).c_str());
+				ImGui::PopStyleColor();
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						if (row.testFrameTime.has_value()) {
+							// Show detailed values for rows with test data
+							if (row.label == "Total:") {
+								ImGui::TextUnformatted("Delta (B - A):");
+								ImGui::Separator();
+								ImGui::Text("A (USER) FPS: %.2f", Util::CalcFPS(row.frameTime));
+								ImGui::Text("B (TEST) FPS: %.2f", Util::CalcFPS(*row.testFrameTime));
+							} else {
+								ImGui::TextUnformatted("Delta (B - A):");
+								ImGui::Separator();
+								ImGui::Text("A (USER): %.3f ms", row.frameTime);
+								ImGui::Text("B (TEST): %.3f ms", *row.testFrameTime);
+							}
+							ImGui::Separator();
+						}
+						// Always show the delta legend for explanation
+						Util::DrawColoredMultiLineTooltip(deltaLegend);
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+				float aDelta = a.testFrameTime.value_or(0.0f) - a.frameTime;
+				float bDelta = b.testFrameTime.value_or(0.0f) - b.frameTime;
+				return asc ? (aDelta < bDelta) : (aDelta > bDelta);
+			},
+			[deltaLegend]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						Util::DrawColoredMultiLineTooltip(deltaLegend);
+					}
+				}
+			} },
+		{ "A Median",
+			[theme, aMedianLegend](const DrawCallRow& row, int) {
+				float value = row.costPerCall;
+				// Color A median relative to B median (stored in testCostPerCall for now)
+				ImVec4 color = theme.Palette.Text;
+				if (row.testCostPerCall.has_value()) {
+					if (value < *row.testCostPerCall) {
+						color = theme.StatusPalette.SuccessColor;  // A is better (lower) than B
+					} else if (value > *row.testCostPerCall) {
+						color = theme.StatusPalette.Error;  // A is worse (higher) than B
+					}
+				}
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				ImGui::Text("%s", Util::FormatMilliseconds(value).c_str());
+				ImGui::PopStyleColor();
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						if (row.label == "Total:") {
+							Util::ColoredTextLines fpsTooltip{
+								{ std::format("A (USER) Median FPS: {:.2f}", Util::CalcFPS(value)), ImVec4(1.0f, 1.0f, 1.0f, 1.0f) }
+							};
+							Util::DrawColoredMultiLineTooltip(fpsTooltip);
+						} else {
+							Util::DrawColoredMultiLineTooltip(aMedianLegend);
+						}
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall); },
+			[aMedianLegend]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						Util::DrawColoredMultiLineTooltip(aMedianLegend);
+					}
+				}
+			} },
+		{ "B Median",
+			[theme, bMedianLegend](const DrawCallRow& row, int) {
+				if (!row.testCostPerCall.has_value()) {
+					ImGui::TextDisabled("-");
+					return;
+				}
+				float value = *row.testCostPerCall;
+				// Color B median relative to A median
+				ImVec4 color = theme.Palette.Text;
+				if (value < row.costPerCall) {
+					color = theme.StatusPalette.SuccessColor;  // B is better (lower) than A
+				} else if (value > row.costPerCall) {
+					color = theme.StatusPalette.Error;  // B is worse (higher) than A
+				}
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				ImGui::Text("%s", Util::FormatMilliseconds(value).c_str());
+				ImGui::PopStyleColor();
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						if (row.label == "Total:") {
+							Util::ColoredTextLines fpsTooltip{
+								{ std::format("B (TEST) Median FPS: {:.2f}", Util::CalcFPS(value)), ImVec4(1.0f, 1.0f, 1.0f, 1.0f) }
+							};
+							Util::DrawColoredMultiLineTooltip(fpsTooltip);
+						} else {
+							Util::DrawColoredMultiLineTooltip(bMedianLegend);
+						}
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+				float aVal = a.testCostPerCall.value_or(FLT_MAX);
+				float bVal = b.testCostPerCall.value_or(FLT_MAX);
+				return asc ? (aVal < bVal) : (aVal > bVal);
+			},
+			[bMedianLegend]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						Util::DrawColoredMultiLineTooltip(bMedianLegend);
+					}
+				}
+			} },
+		{ "Median Delta",
+			[theme, medianDeltaLegend](const DrawCallRow& row, int) {
+				if (!row.testCostPerCall.has_value()) {
+					ImGui::TextDisabled("-");
+					return;
+				}
+				float delta = *row.testCostPerCall - row.costPerCall;
+				// Color based on delta
+				ImVec4 color = theme.Palette.Text;
+				if (delta < 0.0f) {
+					color = theme.StatusPalette.SuccessColor;  // Better performance (negative delta)
+				} else if (delta > 0.0f) {
+					color = theme.StatusPalette.Error;  // Worse performance (positive delta)
+				}
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				std::string deltaStr = (delta > 0.0f) ? "+" + Util::FormatMilliseconds(delta) : Util::FormatMilliseconds(delta);
+				ImGui::Text("%s", deltaStr.c_str());
+				ImGui::PopStyleColor();
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						if (row.label == "Total:" && row.testCostPerCall.has_value()) {
+							Util::ColoredTextLines fpsTooltip{
+								{ "Median Delta (B - A):", ImVec4(1.0f, 1.0f, 1.0f, 1.0f) },
+								{ "", ImVec4(1.0f, 1.0f, 1.0f, 1.0f) },
+								{ std::format("A (USER) Median FPS: {:.2f}", Util::CalcFPS(row.costPerCall)), ImVec4(1.0f, 1.0f, 1.0f, 1.0f) },
+								{ std::format("B (TEST) Median FPS: {:.2f}", Util::CalcFPS(*row.testCostPerCall)), ImVec4(1.0f, 1.0f, 1.0f, 1.0f) },
+								{ "", ImVec4(1.0f, 1.0f, 1.0f, 1.0f) },
+								{ "Median is less sensitive to outliers than average.", ImVec4(1.0f, 1.0f, 1.0f, 1.0f) }
+							};
+							Util::DrawColoredMultiLineTooltip(fpsTooltip);
+						} else {
+							Util::DrawColoredMultiLineTooltip(medianDeltaLegend);
+						}
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+				float aDelta = a.testCostPerCall.value_or(0.0f) - a.costPerCall;
+				float bDelta = b.testCostPerCall.value_or(0.0f) - b.costPerCall;
+				return asc ? (aDelta < bDelta) : (aDelta > bDelta);
+			},
+			[medianDeltaLegend]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						Util::DrawColoredMultiLineTooltip(medianDeltaLegend);
+					}
+				}
+			} }
+	};
+
+	// --- TABLE RENDER: MAIN ROWS + FOOTER ROWS ---
+	std::vector<std::function<bool(const DrawCallRow&, const DrawCallRow&, bool)>> sorters;
+	for (const auto& col : columns) sorters.push_back(col.sortFunc);
+
+	std::vector<DrawCallRow> mainRowsCopy = mainRows;
+	std::vector<DrawCallRow> summaryRowsCopy = summaryRows;
+
+	Util::ShowSortedStringTable<DrawCallRow>(
+		"ABTestResultsTable",
+		[&columns]() { std::vector<std::string> h; for (const auto& c : columns) h.push_back(c.header); return h; }(),
+		mainRowsCopy,
+		0,     // Default sort column (Shader Type)
+		true,  // Default ascending
+		sorters,
+		[&columns](int rowIdx, int colIdx, const DrawCallRow& row) {
+			(void)rowIdx;
+			columns[colIdx].cellRender(row, colIdx);
+		},
+		summaryRowsCopy);
+}
+
 // Static test data state
 PerformanceOverlay::TestDataSource PerformanceOverlay::s_testDataSource = PerformanceOverlay::TestDataSource::None;
 std::chrono::steady_clock::time_point PerformanceOverlay::s_testDataLastUpdated;
 std::unordered_map<int, PerformanceOverlay::TestData> PerformanceOverlay::s_testData;
 
 // Implement static member functions
+/**
+ * @brief Updates test data for a specific shader type during manual shader toggling
+ *
+ * This function captures performance data for a shader type when it's manually disabled,
+ * allowing users to compare performance with/without specific shaders enabled.
+ *
+ * @param shaderType The shader type index to update test data for
+ * @param frameTime The frame time contribution of this shader type (ms)
+ * @param costPerCall The cost per draw call for this shader type (ms/call)
+ *
+ * @note This function also updates the Total and Other summary rows to maintain
+ *       consistency with the current performance state
+ */
 void PerformanceOverlay::UpdateShaderTestData(int shaderType, float frameTime, float costPerCall)
 {
-	s_testData[shaderType] = { frameTime, costPerCall };
+	UpdateShaderTestDataEntry(shaderType, frameTime, costPerCall);
+
 	float smoothedFrameTime = static_cast<float>(GetSingleton()->perfOverlayState.smoothFrameTimeMs);
 	float measuredSum = 0.0f;
 	for (const auto& [type, data] : s_testData) {
 		if (type >= 0)
 			measuredSum += data.frameTime;
 	}
-	float otherFrameTime = smoothedFrameTime - measuredSum;
-	float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
-	s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
-	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
-	float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
-	s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+
+	auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
+	UpdateSummaryTestData(smoothedFrameTime, otherFrameTime, otherPercent, totalCostPerCall);
 
 	s_testDataSource = TestDataSource::ManualShaderToggle;
 	s_testDataLastUpdated = std::chrono::steady_clock::now();
 }
 
+/**
+ * @brief Updates test data for all shader types during A/B test Variant B execution
+ *
+ * This function captures comprehensive performance data for all shader types when
+ * running in A/B test mode with Variant B (test config) active. It ensures that
+ * all shader types, including Total and Other summary rows, have current test data
+ * for accurate performance comparison.
+ *
+ * @note This function only captures data when A/B testing is enabled and using
+ *       Variant B (test config). It does nothing in manual shader toggle mode.
+ */
 void PerformanceOverlay::UpdateAllShaderTestData()
 {
 	// Check if all shaders are disabled
 	bool allDisabled = true;
-	for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
-		if (globals::state->enabledClasses[i]) {
+	globals::state->ForEachShaderTypeWithIndex([&allDisabled]([[maybe_unused]] auto type, int classIndex) {
+		if (globals::state->enabledClasses[classIndex]) {
 			allDisabled = false;
-			break;
 		}
-	}
+	});
 	if (allDisabled) {
 		s_testData.clear();
 		s_testDataSource = TestDataSource::None;
@@ -91,7 +675,8 @@ void PerformanceOverlay::UpdateAllShaderTestData()
 	}
 
 	// Only capture test data if we're in A/B test mode AND using Variant B (test config)
-	bool abTest = Menu::GetSingleton() && Menu::GetSingleton()->abTestingEnabled && Menu::GetSingleton()->usingTestConfig;
+	auto* abTestingManager = ABTestingManager::GetSingleton();
+	bool abTest = abTestingManager && abTestingManager->IsEnabled() && abTestingManager->IsUsingTestConfig();
 	if (!abTest) {
 		// If not in A/B test Variant B, don't capture test data
 		return;
@@ -99,23 +684,14 @@ void PerformanceOverlay::UpdateAllShaderTestData()
 
 	float smoothedFrameTime = static_cast<float>(GetSingleton()->perfOverlayState.smoothFrameTimeMs);
 	float measuredSum = 0.0f;
-	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
-	for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
-		if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
-			continue;
-		int typeIndex = magic_enum::enum_integer(type);
-		float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
-		float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
-		float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
-		float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
-		s_testData[typeIndex] = { frameTime, costPerCall, percent };
+
+	globals::state->ForEachShaderTypeWithMetrics([&measuredSum, smoothedFrameTime]([[maybe_unused]] auto type, int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, float percent, float costPerCall) {
+		UpdateShaderTestDataEntry(typeIndex, frameTime, costPerCall, percent);
 		measuredSum += frameTime;
-	}
-	float otherFrameTime = smoothedFrameTime - measuredSum;
-	float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
-	s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
-	float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
-	s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+	});
+
+	auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
+	UpdateSummaryTestData(smoothedFrameTime, otherFrameTime, otherPercent, totalCostPerCall);
 	s_testDataSource = TestDataSource::ABTest_VariantB;
 	s_testDataLastUpdated = std::chrono::steady_clock::now();
 }
@@ -215,7 +791,7 @@ void PerformanceOverlay::DrawSettings()
 
 			ImGui::SliderFloat("Background Opacity", &this->settings.BackgroundOpacity, 0.0f, 1.0f, "%.2f");
 			ImGui::Checkbox("Show Border", &this->settings.ShowBorder);
-			ImGui::SliderFloat("Update Interval", &this->settings.UpdateInterval, 0.001f, 2.0f, "%.2f seconds");
+			ImGui::SliderFloat("Update Interval", &this->settings.UpdateInterval, 0.001f, PerformanceOverlay::PerfOverlayState::kMaxUpdateInterval, "%.2f seconds");
 			ImGui::SliderInt("Frame History Size", &this->settings.FrameHistorySize,
 				this->settings.kMinFrameHistorySize, this->settings.kMaxFrameHistorySize);
 
@@ -235,26 +811,26 @@ void PerformanceOverlay::DrawOverlay()
 {
 	auto* menu = Menu::GetSingleton();
 
-	// Defensive: Check for required global state and ImGui context
 	if (!globals::state || !menu) {
 		return;
 	}
-	// Check global overlay visibility
 	if (!menu->overlayVisible) {
 		return;
 	}
-	// Defensive: Check for upscaling if you use it
-	// (Not strictly needed here, but safe for future use)
 	if (this->settings.ShowVRAM && (!menu->GetDXGIAdapter3())) {
 		return;
 	}
-	// Defensive: Check ImGui context
 	if (!ImGui::GetCurrentContext()) {
 		return;
 	}
 	if (!this->settings.ShowInOverlay) {
 		return;
 	}
+
+	// Build draw call rows ONCE per frame and reuse
+	auto [mainRows, summaryRows] = this->BuildDrawCallRows();
+	std::vector<DrawCallRow> allRows = mainRows;
+	allRows.insert(allRows.end(), summaryRows.begin(), summaryRows.end());
 
 	// Set window flags - no decoration and only movable when ShowBorder is true
 	ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize;
@@ -285,8 +861,8 @@ void PerformanceOverlay::DrawOverlay()
 
 	// Set initial position if not already set
 	if (!this->settings.PositionSet) {
-		ImGui::SetNextWindowPos(ImVec2(10.0f, 10.0f));
-		this->settings.Position = ImVec2(10.0f, 10.0f);
+		ImGui::SetNextWindowPos(ImVec2(PerformanceOverlay::PerfOverlayState::kDefaultWindowPadding, PerformanceOverlay::PerfOverlayState::kDefaultWindowPadding));
+		this->settings.Position = ImVec2(PerformanceOverlay::PerfOverlayState::kDefaultWindowPadding, PerformanceOverlay::PerfOverlayState::kDefaultWindowPadding);
 		this->settings.PositionSet = true;
 	} else {
 		ImGui::SetNextWindowPos(this->settings.Position, ImGuiCond_FirstUseEver);
@@ -296,8 +872,33 @@ void PerformanceOverlay::DrawOverlay()
 	this->perfOverlayState.hasGraphs = this->settings.ShowPreFGFrameTimeGraph ||
 	                                   (this->settings.ShowPostFGFrameTimeGraph && this->perfOverlayState.isFrameGenerationActive);
 	if (!this->perfOverlayState.hasGraphs) {
-		float fixedWidth = 325.0f * this->perfOverlayState.textScale;
-		ImGui::SetNextWindowSize(ImVec2(fixedWidth, 0), ImGuiCond_Always);
+		// Calculate minimum width needed based on actual content
+		float minWidth = 0.0f;
+
+		// Calculate width needed for each enabled section
+		if (this->settings.ShowFPS) {
+			// Measure FPS text width
+			std::string fpsText = std::format("{:.1f} ({:.2f} ms)", this->perfOverlayState.smoothFps, this->perfOverlayState.smoothFrameTimeMs);
+			if (this->perfOverlayState.isFrameGenerationActive) {
+				fpsText = std::format("Raw FPS: {:.1f} ({:.2f} ms)", this->perfOverlayState.smoothFps, this->perfOverlayState.smoothFrameTimeMs);
+			}
+			float fpsWidth = ImGui::CalcTextSize(fpsText.c_str()).x;
+			minWidth = std::max(minWidth, fpsWidth + PerformanceOverlay::PerfOverlayState::kLabelPadding);  // Add padding for labels
+		}
+		if (this->settings.ShowDrawCalls) {
+			// Draw calls table needs significant width for all columns
+			minWidth = std::max(minWidth, PerformanceOverlay::PerfOverlayState::kDrawCallsTableWidth * this->perfOverlayState.textScale);
+		}
+		if (this->settings.ShowVRAM && menu->GetDXGIAdapter3()) {
+			// VRAM section needs width for the progress bar and text
+			minWidth = std::max(minWidth, PerformanceOverlay::PerfOverlayState::kVRAMSectionWidth * this->perfOverlayState.textScale);
+		}
+
+		// Add some padding for window borders and spacing
+		minWidth += PerformanceOverlay::PerfOverlayState::kWindowBorderPadding;
+
+		// Set minimum width, but allow auto-resize for larger content
+		ImGui::SetNextWindowSize(ImVec2(minWidth, 0), ImGuiCond_FirstUseEver);
 	}
 
 	// Create the window
@@ -354,30 +955,53 @@ void PerformanceOverlay::DrawOverlay()
 			this->perfOverlayState.UpdateFGFrameTime();
 		}
 
+		// Check if we should show collapsible sections (menu open or should swallow input)
+		bool showCollapsibleSections = Menu::GetSingleton()->ShouldSwallowInput() ||
+		                               (globals::game::ui && globals::game::ui->IsMenuOpen(RE::CursorMenu::MENU_NAME));
+
 		// Show FPS counter if enabled
 		if (this->settings.ShowFPS) {
-			DrawFPS();
+			static bool fpsExpanded = true;
+			if (showCollapsibleSections) {
+				Util::DrawSectionHeader("FPS & Frame Time", false, true, &fpsExpanded);
+			}
+			if (fpsExpanded) {
+				DrawFPS();
+			}
 		}
+
+		// Show Draw Calls if enabled
+		if (this->settings.ShowDrawCalls) {
+			static bool drawCallsExpanded = true;
+			if (showCollapsibleSections) {
+				Util::DrawSectionHeader("Draw Calls & Shader Performance", false, true, &drawCallsExpanded);
+			}
+			if (drawCallsExpanded) {
+				DrawDrawCallsTable(mainRows, summaryRows);
+			}
+		}
+
+		// VRAM & GPU Usage
+		if (this->settings.ShowVRAM && menu->GetDXGIAdapter3()) {
+			static bool vramExpanded = true;
+			if (showCollapsibleSections) {
+				Util::DrawSectionHeader("VRAM Usage", false, true, &vramExpanded);
+			}
+			if (vramExpanded) {
+				DrawVRAM();
+			}
+		}
+
+		ImGui::PopStyleVar();             // ItemSpacing
+		ImGui::SetWindowFontScale(1.0f);  // Reset font scale
+
+		// --- A/B Test Section ---
+		DrawABTestSection(allRows, showCollapsibleSections);
+
+		ImGui::End();
+		ImGui::PopStyleVar();    // WindowBorderSize
+		ImGui::PopStyleColor();  // WindowBg
 	}
-
-	// Show Draw Calls if enabled
-	if (this->settings.ShowDrawCalls) {
-		ImGui::Separator();
-		DrawDrawCalls();
-		ImGui::Separator();
-	}
-
-	// VRAM & GPU Usage
-	if (this->settings.ShowVRAM && menu->GetDXGIAdapter3()) {
-		DrawVRAM();
-	}
-
-	ImGui::PopStyleVar();             // ItemSpacing
-	ImGui::SetWindowFontScale(1.0f);  // Reset font scale
-
-	ImGui::End();
-	ImGui::PopStyleVar();    // WindowBorderSize
-	ImGui::PopStyleColor();  // WindowBg
 }
 
 void PerformanceOverlay::PerfOverlayState::UpdateFGFrameTime()
@@ -405,8 +1029,8 @@ void PerformanceOverlay::PerfOverlayState::UpdateFGFrameTime()
 		overlay->perfOverlayState.postFGFrameTimeHistoryIndex = (overlay->perfOverlayState.postFGFrameTimeHistoryIndex + 1) % overlay->settings.FrameHistorySize;
 	} else {
 		// Fallback if FG time is not available
-		overlay->perfOverlayState.postFGFrameTimeMs = overlay->perfOverlayState.frameTimeMs / 2.0f;
-		overlay->perfOverlayState.postFGFps = overlay->perfOverlayState.fps * 2.0f;
+		overlay->perfOverlayState.postFGFrameTimeMs = overlay->perfOverlayState.frameTimeMs / PerformanceOverlay::PerfOverlayState::kFrameGenerationMultiplier;
+		overlay->perfOverlayState.postFGFps = overlay->perfOverlayState.fps * PerformanceOverlay::PerfOverlayState::kFrameGenerationMultiplier;
 
 		if (overlay->perfOverlayState.updateTimer <= 0.0f) {
 			overlay->perfOverlayState.postFGSmoothFps = overlay->perfOverlayState.postFGFps;
@@ -594,59 +1218,37 @@ void PerformanceOverlay::PerfOverlayState::DrawPostFGFrameTimeGraph()
 // Test data is only cleared by the "Clear Test Data" button or if all shaders are disabled (rare edge case).
 void PerformanceOverlay::CaptureTestData()
 {
-	auto* menu = Menu::GetSingleton();
-	bool abTestActive = (menu && menu->abTestingEnabled && menu->usingTestConfig);
+	auto* abTestingManager = ABTestingManager::GetSingleton();
+	bool abTestActive = (abTestingManager && abTestingManager->IsEnabled() && abTestingManager->IsUsingTestConfig());
 	bool anyShaderDisabled = false;
-	for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
-		if (!globals::state->enabledClasses[i]) {
+	globals::state->ForEachShaderTypeWithIndex([&anyShaderDisabled]([[maybe_unused]] auto type, int classIndex) {
+		if (!globals::state->enabledClasses[classIndex]) {
 			anyShaderDisabled = true;
-			break;
 		}
-	}
+	});
 	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.smoothFrameTimeMs);
 	float measuredSum = 0.0f;
-	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
 	if (abTestActive) {
 		measuredSum = 0.0f;
-		for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
-			if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
-				continue;
-			int typeIndex = magic_enum::enum_integer(type);
-			float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
-			float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
-			float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
-			float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
-			s_testData[typeIndex] = { frameTime, costPerCall, percent };
+		globals::state->ForEachShaderTypeWithMetrics([&measuredSum, smoothedFrameTime]([[maybe_unused]] auto type, int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, float percent, float costPerCall) {
+			UpdateShaderTestDataEntry(typeIndex, frameTime, costPerCall, percent);
 			measuredSum += frameTime;
-		}
-		float otherFrameTime = smoothedFrameTime - measuredSum;
-		float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
-		s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
-		float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
-		s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+		});
+		auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
+		UpdateSummaryTestData(smoothedFrameTime, otherFrameTime, otherPercent, totalCostPerCall);
 		s_testDataSource = TestDataSource::ABTest_VariantB;
 		s_testDataLastUpdated = std::chrono::steady_clock::now();
 	} else if (anyShaderDisabled) {
 		measuredSum = 0.0f;
-		for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
-			if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
-				continue;
-			int typeIndex = magic_enum::enum_integer(type);
+		globals::state->ForEachShaderTypeWithMetrics([&measuredSum, smoothedFrameTime]([[maybe_unused]] auto type, int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, float percent, float costPerCall) {
 			bool enabled = globals::state->enabledClasses[typeIndex - 1];
 			if (!enabled) {
-				float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
-				float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
-				float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
-				float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
-				s_testData[typeIndex] = { frameTime, costPerCall, percent };
+				UpdateShaderTestDataEntry(typeIndex, frameTime, costPerCall, percent);
 			}
-			measuredSum += static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
-		}
-		float otherFrameTime = smoothedFrameTime - measuredSum;
-		float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
-		s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
-		float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
-		s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+			measuredSum += frameTime;
+		});
+		auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
+		UpdateSummaryTestData(smoothedFrameTime, otherFrameTime, otherPercent, totalCostPerCall);
 		s_testDataSource = TestDataSource::ManualShaderToggle;
 		s_testDataLastUpdated = std::chrono::steady_clock::now();
 	}
@@ -663,14 +1265,8 @@ std::pair<std::vector<DrawCallRow>, std::vector<DrawCallRow>> PerformanceOverlay
 	std::vector<DrawCallRow> mainRows;
 	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.smoothFrameTimeMs);
 	float measuredSum = 0.0f;
-	for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
-		if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
-			continue;
-		int typeIndex = magic_enum::enum_integer(type);
-		float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
-		float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
-		float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
-		float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
+
+	globals::state->ForEachShaderTypeWithMetrics([&mainRows, &measuredSum, smoothedFrameTime](auto type, int typeIndex, float drawCalls, float frameTime, float percent, float costPerCall) {
 		bool enabled = globals::state->enabledClasses[typeIndex - 1];
 		std::optional<float> testFrameTime, testCostPerCall;
 		auto it = s_testData.find(typeIndex);
@@ -686,370 +1282,42 @@ std::pair<std::vector<DrawCallRow>, std::vector<DrawCallRow>> PerformanceOverlay
 		}
 		mainRows.push_back({ label, typeIndex, static_cast<int>(drawCalls), frameTime, percent, costPerCall, tooltip, enabled, testFrameTime, testCostPerCall });
 		measuredSum += frameTime;
-	}
-	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
-	float otherFrameTime = smoothedFrameTime - measuredSum;
+	});
+
+	auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
 	if (std::abs(otherFrameTime) < 1e-4f)
 		otherFrameTime = 0.0f;
 	std::optional<float> otherTestFrameTime, otherTestCostPerCall, totalTestFrameTime, totalTestCostPerCall;
-	auto itOther = s_testData.find(-2);
+	auto itOther = s_testData.find(static_cast<int>(SpecialShaderType::Other));
 	if (itOther != s_testData.end()) {
 		otherTestFrameTime = itOther->second.frameTime;
 		otherTestCostPerCall = itOther->second.costPerCall;
 	}
-	auto itTotal = s_testData.find(-1);
+	auto itTotal = s_testData.find(static_cast<int>(SpecialShaderType::Total));
 	if (itTotal != s_testData.end()) {
 		totalTestFrameTime = itTotal->second.frameTime;
 		totalTestCostPerCall = itTotal->second.costPerCall;
 	}
 	DrawCallRow otherRow = {
-		"Other:", -2, 0, otherFrameTime,
-		(smoothedFrameTime > 0.0f ? static_cast<float>((otherFrameTime / smoothedFrameTime) * 100.0f) : 0.0f),
+		"Other:", static_cast<int>(SpecialShaderType::Other), 0, otherFrameTime, otherPercent,
 		0.0f,
 		std::string("Frame time not attributed to any measured shader type. This includes UI, post-processing, engine work, and any GPU activity not directly measured by the overlay."),
 		true, otherTestFrameTime, otherTestCostPerCall
 	};
+	// Always use the actual total frame time for live data
+	float totalFrameTime = smoothedFrameTime;
+	float totalPercent = 100.0f;  // Total is always 100% of total
+
 	DrawCallRow totalRow = {
-		"Total:", -1, static_cast<int>(totalSmoothedDrawCalls), smoothedFrameTime, 100.0f,
-		(totalSmoothedDrawCalls > 0.0f ? static_cast<float>(smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f),
-		std::string("Sum of all measured shader types. Click to enable or disable all shaders."),
+		"Total:", static_cast<int>(SpecialShaderType::Total), static_cast<int>(globals::state->GetTotalSmoothedDrawCalls()), totalFrameTime, totalPercent,
+		totalCostPerCall,
+		std::string("Total frame time."),
 		true, totalTestFrameTime, totalTestCostPerCall
 	};
-	std::vector<DrawCallRow> summaryRows = { otherRow, totalRow };
+	std::vector<DrawCallRow> summaryRows;
+	summaryRows.push_back(otherRow);
+	summaryRows.push_back(totalRow);
 	return { mainRows, summaryRows };
-}
-
-void PerformanceOverlay::DrawDrawCalls()
-{
-	static bool clearTestDataRequested = false;
-	auto* menu = Menu::GetSingleton();
-	const auto& theme = menu->GetTheme();
-
-	// --- COLUMN CONFIG ---
-	using ColoredTextLines = Util::ColoredTextLines;
-
-	// --- BUILD LEGENDS ---
-	const ColoredTextLines frameTimeLegend = {
-		{ "Frame Time: Time spent on this shader type (ms and % of total frame time).", theme.Palette.Text },
-		{ "", theme.Palette.Text },
-		{ "Performance Color Legend (ms):", theme.Palette.Text },
-		{ "  <= 2 ms", theme.StatusPalette.SuccessColor },
-		{ "  > 2 ms and <= 5 ms", theme.StatusPalette.Warning },
-		{ "  > 5 ms", theme.StatusPalette.Error }
-	};
-	const ColoredTextLines costPerCallLegend = {
-		{ "Cost/Call: Average time per draw call for this shader type.", theme.Palette.Text },
-		{ "", theme.Palette.Text },
-		{ "Color Legend (ms/call):", theme.Palette.Text },
-		{ "  <= 0.05 ms/call", theme.StatusPalette.SuccessColor },
-		{ "  > 0.05 ms and <= 0.2 ms/call", theme.StatusPalette.Warning },
-		{ "  > 0.2 ms/call", theme.StatusPalette.Error }
-	};
-	const ColoredTextLines testFrameTimeLegend = {
-		{ PerformanceOverlay::GetTestDataTooltip(), theme.Palette.Text },
-		{ "", theme.Palette.Text },
-		{ "Color Legend (compared to live data):", theme.Palette.Text },
-		{ "  Better (lower than live)", theme.StatusPalette.SuccessColor },
-		{ "  Worse (higher than live)", theme.StatusPalette.Error },
-		{ "  Same as live", theme.Palette.Text }
-	};
-	const ColoredTextLines testCostPerCallLegend = testFrameTimeLegend;
-
-	// --- COLUMN HELPERS ---
-	auto makeMetricColumn = [&](auto valueGetter, auto colorGetter, auto formatter, const ColoredTextLines& legend, const ColoredTextLines* cellLegend = nullptr) {
-		return [theme, valueGetter, colorGetter, formatter, legend, cellLegend](const DrawCallRow& row, int) {
-			using ValueType = decltype(valueGetter(row));
-			if constexpr (std::is_same_v<ValueType, std::optional<float>>) {
-				if (!valueGetter(row).has_value()) {
-					ImGui::TextDisabled("-");
-					return;
-				}
-				float value = *valueGetter(row);
-				ImVec4 color = colorGetter(theme, value, row);
-				std::string valueStr = formatter(value, row);
-				ImGui::PushStyleColor(ImGuiCol_Text, color);
-				ImGui::Text("%s", valueStr.c_str());
-				ImGui::PopStyleColor();
-			} else {
-				float value = valueGetter(row);
-				ImVec4 color = colorGetter(theme, value, row);
-				std::string valueStr = formatter(value, row);
-				ImGui::PushStyleColor(ImGuiCol_Text, color);
-				ImGui::Text("%s", valueStr.c_str());
-				ImGui::PopStyleColor();
-			}
-			if (ImGui::IsItemHovered()) {
-				if (auto _tt = Util::HoverTooltipWrapper()) {
-					const ColoredTextLines& useLegend = cellLegend ? *cellLegend : legend;
-					Util::DrawColoredMultiLineTooltip(useLegend);
-				}
-			}
-		};
-	};
-
-	this->CaptureTestData();
-
-	bool anyTestData = !s_testData.empty();
-	if (anyTestData) {
-		if (ImGui::Button("Clear Test Data")) {
-			clearTestDataRequested = true;
-		}
-	}
-
-	// --- COLUMN CONFIG ---
-	struct ColumnConfig
-	{
-		std::string header;
-		std::function<void(const DrawCallRow&, int colIdx)> cellRender;
-		std::function<bool(const DrawCallRow&, const DrawCallRow&, bool)> sortFunc;
-		std::function<void()> headerTooltip;
-	};
-
-	// --- BUILD HEADERS AND CONFIG ---
-	std::vector<ColumnConfig> columns = {
-		{ "Shader Type",
-			[theme](const DrawCallRow& row, int) {
-				if (!row.enabled)
-					ImGui::PushStyleColor(ImGuiCol_Text, theme.StatusPalette.Disable);
-				bool wasEnabled = row.enabled;
-				if (ImGui::Selectable(row.label.c_str(), false)) {
-					auto maybeType = magic_enum::enum_cast<RE::BSShader::Type>(row.shaderType);
-					if (maybeType.has_value()) {
-						auto classIndex = magic_enum::enum_integer(*maybeType) - 1;
-						if (classIndex >= 0 && classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1) {
-							bool isDisabling = wasEnabled;
-							float prevFrameTime = row.frameTime;
-							float prevCostPerCall = row.costPerCall;
-							// Capture live data for Total and Other before toggling
-							float smoothedFrameTime = static_cast<float>(PerformanceOverlay::GetSingleton()->perfOverlayState.smoothFrameTimeMs);
-							float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
-							float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
-							float measuredSum = 0.0f;
-							for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
-								if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
-									continue;
-								int typeIndex = magic_enum::enum_integer(type);
-								measuredSum += static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
-							}
-							float otherFrameTime = smoothedFrameTime - measuredSum;
-							float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
-							globals::state->enabledClasses[classIndex] = !wasEnabled;
-							if (isDisabling) {
-								// Save the last live value before disabling
-								UpdateShaderTestData(row.shaderType, prevFrameTime, prevCostPerCall);
-								// Save Total and Other test data as well
-								PerformanceOverlay::s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
-								PerformanceOverlay::s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
-								PerformanceOverlay::s_testDataSource = PerformanceOverlay::TestDataSource::ManualShaderToggle;
-								PerformanceOverlay::s_testDataLastUpdated = std::chrono::steady_clock::now();
-							}
-						}
-					}
-				}
-				if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup | ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::TextUnformatted(row.tooltip.c_str());
-					}
-				}
-				if (!row.enabled)
-					ImGui::PopStyleColor();
-			},
-			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.label < b.label) : (a.label > b.label); },
-			nullptr },
-		{ "Draw Calls",
-			[](const DrawCallRow& row, int) {
-				ImGui::Text("%d", row.drawCalls);
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::TextUnformatted("Draw Calls: Number of draw calls for this shader type in the current frame.");
-					}
-				}
-			},
-			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.drawCalls < b.drawCalls) : (a.drawCalls > b.drawCalls); },
-			[]() {
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::TextUnformatted("Draw Calls: Number of draw calls for this shader type in the current frame.");
-					}
-				}
-			} }
-
-	};
-	columns.push_back(ColumnConfig{
-		"Frame Time (%)",
-		makeMetricColumn(
-			[](const DrawCallRow& row) { return row.frameTime; },
-			[](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, 2.0f, 5.0f, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); },
-			[](float /*value*/, const DrawCallRow& row) {
-				return Util::FormatMilliseconds(row.frameTime) + " (" + Util::FormatPercent(row.percent) + ")";
-			},
-			frameTimeLegend),
-		[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.percent < b.percent) : (a.percent > b.percent); },
-		[frameTimeLegend]() {
-			if (ImGui::IsItemHovered()) {
-				if (auto _tt = Util::HoverTooltipWrapper()) {
-					Util::DrawColoredMultiLineTooltip(frameTimeLegend);
-				}
-			}
-		} });
-
-	columns.push_back(ColumnConfig{
-		"Cost/Call",
-		makeMetricColumn(
-			[](const DrawCallRow& row) { return row.costPerCall; },
-			[](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, 0.05f, 0.2f, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); },
-			[](float value, const DrawCallRow&) { return (value < 0.01f && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); },
-			costPerCallLegend),
-		[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall); },
-		[costPerCallLegend]() {
-			if (ImGui::IsItemHovered()) {
-				if (auto _tt = Util::HoverTooltipWrapper()) {
-					Util::DrawColoredMultiLineTooltip(costPerCallLegend);
-				}
-			}
-		} });
-
-	// Add test columns if present
-	if (anyTestData) {
-		columns.push_back(ColumnConfig{
-			"Test Frame Time (%)",
-			makeMetricColumn(
-				[](const DrawCallRow& row) { return row.testFrameTime; },
-				[](const auto& theme, float value, const DrawCallRow& row) {
-					if (value < row.frameTime)
-						return theme.StatusPalette.SuccessColor;
-					if (value > row.frameTime)
-						return theme.StatusPalette.Error;
-					return theme.Palette.Text;
-				},
-				[](float value, const DrawCallRow& row) { return Util::FormatMilliseconds(value) + " (" + Util::FormatPercent(PerformanceOverlay::s_testData[row.shaderType].percent) + ")"; },
-				testFrameTimeLegend),
-			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
-				float aVal = a.testFrameTime.value_or(FLT_MAX);
-				float bVal = b.testFrameTime.value_or(FLT_MAX);
-				return asc ? (aVal < bVal) : (aVal > bVal);
-			},
-			[testFrameTimeLegend]() {
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::TextUnformatted(PerformanceOverlay::GetTestDataTooltip().c_str());
-						ImGui::Separator();
-						Util::DrawColoredMultiLineTooltip(testFrameTimeLegend);
-					}
-				}
-			} });
-
-		columns.push_back(ColumnConfig{
-			"Test Cost/Call",
-			makeMetricColumn(
-				[](const DrawCallRow& row) { return row.testCostPerCall; },
-				[](const auto& theme, float value, const DrawCallRow& row) {
-					if (value < row.costPerCall)
-						return theme.StatusPalette.SuccessColor;
-					if (value > row.costPerCall)
-						return theme.StatusPalette.Error;
-					return theme.Palette.Text;
-				},
-				[](float value, const DrawCallRow&) { return (value < 0.01f && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); },
-				testCostPerCallLegend),
-			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
-				float aVal = a.testCostPerCall.value_or(FLT_MAX);
-				float bVal = b.testCostPerCall.value_or(FLT_MAX);
-				return asc ? (aVal < bVal) : (aVal > bVal);
-			},
-			[testCostPerCallLegend]() {
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::TextUnformatted(PerformanceOverlay::GetTestDataTooltip().c_str());
-						ImGui::Separator();
-						Util::DrawColoredMultiLineTooltip(testCostPerCallLegend);
-					}
-				}
-			} });
-	}
-
-	// --- BUILD ROWS ---
-	auto [mainRows, summaryRows] = this->BuildDrawCallRows();
-
-	// --- TABLE RENDER: MAIN ROWS + FOOTER ROWS ---
-	std::vector<std::function<bool(const DrawCallRow&, const DrawCallRow&, bool)>> sorters;
-	for (const auto& col : columns) sorters.push_back(col.sortFunc);
-	Util::ShowSortedStringTable<DrawCallRow>(
-		"DrawCallOverlayTable",
-		[&columns]() { std::vector<std::string> h; for (const auto& c : columns) h.push_back(c.header); return h; }(),
-		mainRows,
-		0,
-		true,
-		sorters,
-		[&columns](int rowIdx, int colIdx, const DrawCallRow& row) {
-			(void)rowIdx;
-			// Special handling for summary rows
-			if ((row.label == "Total:" || row.label == "Other:") && colIdx == 0) {
-				if (row.label == "Total:") {
-					if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
-						bool anyDisabled = false;
-						for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
-							if (!globals::state->enabledClasses[i]) {
-								anyDisabled = true;
-								break;
-							}
-						}
-						for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
-							globals::state->enabledClasses[i] = anyDisabled;
-						}
-						// Update test data and timestamp for manual toggling (not just A/B test mode)
-						bool abTest = Menu::GetSingleton() && Menu::GetSingleton()->abTestingEnabled && Menu::GetSingleton()->usingTestConfig;
-						if (abTest) {
-							UpdateAllShaderTestData();
-						} else {
-							// Manual toggle: update test data and timestamp
-							float smoothedFrameTime = static_cast<float>(PerformanceOverlay::GetSingleton()->perfOverlayState.smoothFrameTimeMs);
-							float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
-							float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
-							float measuredSum = 0.0f;
-							for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
-								if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
-									continue;
-								int typeIndex = magic_enum::enum_integer(type);
-								measuredSum += static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
-							}
-							float otherFrameTime = smoothedFrameTime - measuredSum;
-							float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
-							PerformanceOverlay::s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
-							PerformanceOverlay::s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
-							PerformanceOverlay::s_testDataSource = PerformanceOverlay::TestDataSource::ManualShaderToggle;
-							PerformanceOverlay::s_testDataLastUpdated = std::chrono::steady_clock::now();
-						}
-					}
-					if (ImGui::IsItemHovered()) {
-						if (auto _tt = Util::HoverTooltipWrapper()) {
-							ImGui::TextUnformatted(row.tooltip.c_str());
-							float _fps = row.frameTime > 0.0f ? 1000.0f / row.frameTime : 0.0f;
-							ImGui::Text("FPS: %.2f", _fps);
-						}
-					}
-				} else if (row.label == "Other:") {
-					ImGui::TextUnformatted(row.label.c_str());
-					if (!row.tooltip.empty() && ImGui::IsItemHovered()) {
-						if (auto _tt = Util::HoverTooltipWrapper()) {
-							ImGui::TextUnformatted(row.tooltip.c_str());
-						}
-					}
-				}
-			} else if (row.label == "Total:" || row.label == "Other:") {
-				// No tooltip for summary rows in non-label columns
-				columns[colIdx].cellRender(row, colIdx);
-			} else {
-				// Normal row: ensure tooltips never modify cell content
-				columns[colIdx].cellRender(row, colIdx);
-			}
-		},
-		summaryRows);
-
-	if (clearTestDataRequested) {  // clear after all drawing complete.
-		ClearTestData();
-		clearTestDataRequested = false;
-	}
 }
 
 void PerformanceOverlay::DrawVRAM()
@@ -1121,10 +1389,10 @@ void PerformanceOverlay::PerfOverlayState::UpdateGraphValues()
 	// Calculate mean and standard deviation for normalized graph range
 	if (frameTimeHistory.empty()) {
 		// Default to 60 FPS
-		avgFrameTime = 16.67f;
+		avgFrameTime = kDefaultFrameTimeMs;
 		stdDev = 0.0f;
 		graphMin = 0.0f;
-		graphMax = 33.0f;
+		graphMax = PerformanceOverlay::PerfOverlayState::kGraphSpreadMultiplier * kDefaultFrameTimeMs;
 	} else {
 		// Calculate average frame time
 		avgFrameTime = std::accumulate(frameTimeHistory.begin(), frameTimeHistory.end(), 0.0f) / frameTimeHistory.size();
@@ -1139,7 +1407,7 @@ void PerformanceOverlay::PerfOverlayState::UpdateGraphValues()
 		stdDev = std::sqrt(variance);
 
 		// Calculate graph range
-		float spread = std::clamp(stdDev * 2.0f, 2.0f, 20.0f);
+		float spread = std::clamp(stdDev * PerformanceOverlay::PerfOverlayState::kGraphSpreadMultiplier, PerformanceOverlay::PerfOverlayState::kGraphMinSpread, PerformanceOverlay::PerfOverlayState::kGraphMaxSpread);
 		graphMin = std::max(0.0f, avgFrameTime - spread);
 		graphMax = avgFrameTime + spread;
 	}
@@ -1147,4 +1415,441 @@ void PerformanceOverlay::PerfOverlayState::UpdateGraphValues()
 	// Exponential smoothing for stable graph scaling
 	smoothedMinFrameTime += kSmoothingFactor * (graphMin - smoothedMinFrameTime);
 	smoothedMaxFrameTime += kSmoothingFactor * (graphMax - smoothedMaxFrameTime);
+}
+
+// Private helper for table rendering
+void PerformanceOverlay::DrawDrawCallsTable(const std::vector<DrawCallRow>& mainRows, const std::vector<DrawCallRow>& summaryRows)
+{
+	static bool clearTestDataRequested = false;
+	auto* menu = Menu::GetSingleton();
+	const auto& theme = menu->GetTheme();
+
+	// --- COLUMN CONFIG ---
+	using ColoredTextLines = Util::ColoredTextLines;
+
+	// --- BUILD LEGENDS ---
+	const ColoredTextLines frameTimeLegend = {
+		{ "Frame Time: Time spent on this shader type (ms and % of total frame time).", theme.Palette.Text },
+		{ "", theme.Palette.Text },
+		{ "Performance Color Legend (ms):", theme.Palette.Text },
+		{ "  <= 2 ms", theme.StatusPalette.SuccessColor },
+		{ "  > 2 ms and <= 5 ms", theme.StatusPalette.Warning },
+		{ "  > 5 ms", theme.StatusPalette.Error }
+	};
+	const ColoredTextLines costPerCallLegend = {
+		{ "Cost/Call: Average time per draw call for this shader type.", theme.Palette.Text },
+		{ "", theme.Palette.Text },
+		{ "Color Legend (ms/call):", theme.Palette.Text },
+		{ "  <= 0.05 ms/call", theme.StatusPalette.SuccessColor },
+		{ "  > 0.05 ms and <= 0.2 ms/call", theme.StatusPalette.Warning },
+		{ "  > 0.2 ms/call", theme.StatusPalette.Error }
+	};
+	const ColoredTextLines testFrameTimeLegend = {
+		{ PerformanceOverlay::GetTestDataTooltip(), theme.Palette.Text },
+		{ "", theme.Palette.Text },
+		{ "Color Legend (compared to live data):", theme.Palette.Text },
+		{ "  Better (lower than live)", theme.StatusPalette.SuccessColor },
+		{ "  Worse (higher than live)", theme.StatusPalette.Error },
+		{ "  Same as live", theme.Palette.Text }
+	};
+	const Util::ColoredTextLines testCostPerCallLegend = testFrameTimeLegend;
+
+	this->CaptureTestData();
+
+	bool anyTestData = !s_testData.empty();
+	if (anyTestData) {
+		if (ImGui::Button("Clear Test Data")) {
+			clearTestDataRequested = true;
+		}
+	}
+
+	// --- BUILD HEADERS AND CONFIG ---
+	std::vector<ColumnConfig> columns = {
+		{ "Shader Type",
+			[theme](const DrawCallRow& row, int) {
+				if (!row.enabled)
+					ImGui::PushStyleColor(ImGuiCol_Text, theme.StatusPalette.Disable);
+				bool wasEnabled = row.enabled;
+				if (ImGui::Selectable(row.label.c_str(), false)) {
+					auto maybeType = magic_enum::enum_cast<RE::BSShader::Type>(row.shaderType);
+					if (maybeType.has_value()) {
+						auto classIndex = magic_enum::enum_integer(*maybeType) - 1;
+						if (classIndex >= 0 && classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1) {
+							bool isDisabling = wasEnabled;
+							float prevFrameTime = row.frameTime;
+							float prevCostPerCall = row.costPerCall;
+							// Capture live data for Total and Other before toggling
+							float smoothedFrameTime = static_cast<float>(PerformanceOverlay::GetSingleton()->perfOverlayState.smoothFrameTimeMs);
+							float measuredSum = 0.0f;
+							globals::state->ForEachShaderTypeWithMetrics([&measuredSum]([[maybe_unused]] auto type, [[maybe_unused]] int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, [[maybe_unused]] float percent, [[maybe_unused]] float costPerCall) {
+								measuredSum += frameTime;
+							});
+							auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
+							globals::state->enabledClasses[classIndex] = !wasEnabled;
+							if (isDisabling) {
+								// Save the last live value before disabling
+								UpdateShaderTestData(row.shaderType, prevFrameTime, prevCostPerCall);
+								// Save Total and Other test data as well
+								PerformanceOverlay::s_testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+								PerformanceOverlay::s_testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
+								PerformanceOverlay::s_testDataSource = PerformanceOverlay::TestDataSource::ManualShaderToggle;
+								PerformanceOverlay::s_testDataLastUpdated = std::chrono::steady_clock::now();
+							}
+						}
+					}
+				}
+				if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup | ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::TextUnformatted(row.tooltip.c_str());
+					}
+				}
+				if (!row.enabled)
+					ImGui::PopStyleColor();
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.label < b.label) : (a.label > b.label); },
+			nullptr },
+		{ "Draw Calls",
+			[](const DrawCallRow& row, int) {
+				ImGui::Text("%d", row.drawCalls);
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::TextUnformatted("Draw Calls: Number of draw calls for this shader type in the current frame.");
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.drawCalls < b.drawCalls) : (a.drawCalls > b.drawCalls); },
+			[]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::TextUnformatted("Draw Calls: Number of draw calls for this shader type in the current frame.");
+					}
+				}
+			} }
+	};
+	columns.push_back(ColumnConfig{
+		"Frame Time (%)",
+		MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.frameTime; }, [](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, PerformanceOverlay::PerfOverlayState::kFrameTimeGoodThreshold, PerformanceOverlay::PerfOverlayState::kFrameTimeWarningThreshold, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); }, [](float /*value*/, const DrawCallRow& row) { return Util::FormatMilliseconds(row.frameTime) + " (" + Util::FormatPercent(row.percent) + ")"; }, frameTimeLegend), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.percent < b.percent) : (a.percent > b.percent); }, [frameTimeLegend]() {
+			if (ImGui::IsItemHovered()) {
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					Util::DrawColoredMultiLineTooltip(frameTimeLegend);
+				}
+			} } });
+
+	columns.push_back(ColumnConfig{
+		"Cost/Call",
+		MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.costPerCall; }, [](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, PerformanceOverlay::PerfOverlayState::kCostPerCallGoodThreshold, PerformanceOverlay::PerfOverlayState::kCostPerCallWarningThreshold, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); }, [](float value, const DrawCallRow&) { return (value < PerformanceOverlay::PerfOverlayState::kMicrosecondThreshold && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); }, costPerCallLegend), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall); }, [costPerCallLegend]() {
+			if (ImGui::IsItemHovered()) {
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					Util::DrawColoredMultiLineTooltip(costPerCallLegend);
+				}
+			} } });
+
+	// Add test columns if present
+	if (anyTestData) {
+		columns.push_back(ColumnConfig{
+			"Test Frame Time (%)",
+			MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.testFrameTime; }, [](const auto& theme, float value, const DrawCallRow& row) {
+					if (value < row.frameTime)
+						return theme.StatusPalette.SuccessColor;
+					if (value > row.frameTime)
+						return theme.StatusPalette.Error;
+					return theme.Palette.Text; }, [](float value, const DrawCallRow& row) { return Util::FormatMilliseconds(value) + " (" + Util::FormatPercent(PerformanceOverlay::s_testData[row.shaderType].percent) + ")"; }, testFrameTimeLegend), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+				float aVal = a.testFrameTime.value_or(FLT_MAX);
+				float bVal = b.testFrameTime.value_or(FLT_MAX);
+				return asc ? (aVal < bVal) : (aVal > bVal); }, [testFrameTimeLegend]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::TextUnformatted(PerformanceOverlay::GetTestDataTooltip().c_str());
+						ImGui::Separator();
+						Util::DrawColoredMultiLineTooltip(testFrameTimeLegend);
+					}
+				} } });
+
+		columns.push_back(ColumnConfig{
+			"Test Cost/Call",
+			MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.testCostPerCall; }, [](const auto& theme, float value, const DrawCallRow& row) {
+					if (value < row.costPerCall)
+						return theme.StatusPalette.SuccessColor;
+					if (value > row.costPerCall)
+						return theme.StatusPalette.Error;
+					return theme.Palette.Text; }, [](float value, const DrawCallRow&) { return (value < PerformanceOverlay::PerfOverlayState::kMicrosecondThreshold && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); }, testCostPerCallLegend), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+				float aVal = a.testCostPerCall.value_or(FLT_MAX);
+				float bVal = b.testCostPerCall.value_or(FLT_MAX);
+				return asc ? (aVal < bVal) : (aVal > bVal); }, [testCostPerCallLegend]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::TextUnformatted(PerformanceOverlay::GetTestDataTooltip().c_str());
+						ImGui::Separator();
+						Util::DrawColoredMultiLineTooltip(testCostPerCallLegend);
+					}
+				} } });
+	}
+
+	// --- TABLE RENDER: MAIN ROWS + FOOTER ROWS ---
+	std::vector<std::function<bool(const DrawCallRow&, const DrawCallRow&, bool)>> sorters;
+	for (const auto& col : columns) sorters.push_back(col.sortFunc);
+
+	// Create non-const copies for the table function
+	std::vector<DrawCallRow> mainRowsCopy = mainRows;
+	std::vector<DrawCallRow> summaryRowsCopy = summaryRows;
+
+	Util::ShowSortedStringTable<DrawCallRow>(
+		"DrawCallOverlayTable",
+		[&columns]() { std::vector<std::string> h; for (const auto& c : columns) h.push_back(c.header); return h; }(),
+		mainRowsCopy,
+		0,     // Default sort column (Shader Type)
+		true,  // Default ascending
+		sorters,
+		[&columns](int rowIdx, int colIdx, const DrawCallRow& row) {
+			(void)rowIdx;
+			// Special handling for summary rows
+			if ((row.label == "Total:" || row.label == "Other:") && colIdx == 0) {
+				if (row.label == "Total:") {
+					if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
+						bool anyDisabled = false;
+						globals::state->ForEachShaderTypeWithIndex([&anyDisabled]([[maybe_unused]] auto type, int classIndex) {
+							if (!globals::state->enabledClasses[classIndex]) {
+								anyDisabled = true;
+							}
+						});
+						globals::state->ForEachShaderTypeWithIndex([&anyDisabled]([[maybe_unused]] auto type, int classIndex) {
+							globals::state->enabledClasses[classIndex] = anyDisabled;
+						});
+						// Update test data and timestamp for manual toggling (not just A/B test mode)
+						auto* abTestingManager = ABTestingManager::GetSingleton();
+						bool abTest = abTestingManager && abTestingManager->IsEnabled() && abTestingManager->IsUsingTestConfig();
+						if (abTest) {
+							UpdateAllShaderTestData();
+						} else {
+							// Manual toggle: update test data and timestamp
+							float smoothedFrameTime = static_cast<float>(PerformanceOverlay::GetSingleton()->perfOverlayState.smoothFrameTimeMs);
+							float measuredSum = 0.0f;
+							globals::state->ForEachShaderTypeWithMetrics([&measuredSum]([[maybe_unused]] auto type, [[maybe_unused]] int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, [[maybe_unused]] float percent, [[maybe_unused]] float costPerCall) {
+								measuredSum += frameTime;
+							});
+							auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
+							PerformanceOverlay::s_testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+							PerformanceOverlay::s_testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
+							PerformanceOverlay::s_testDataSource = PerformanceOverlay::TestDataSource::ManualShaderToggle;
+							PerformanceOverlay::s_testDataLastUpdated = std::chrono::steady_clock::now();
+						}
+					}
+					if (ImGui::IsItemHovered()) {
+						if (auto _tt = Util::HoverTooltipWrapper()) {
+							ImGui::TextUnformatted(row.tooltip.c_str());
+							float _fps = row.frameTime > 0.0f ? 1000.0f / row.frameTime : 0.0f;
+							ImGui::Text("FPS: %.2f", _fps);
+						}
+					}
+				} else if (row.label == "Other:") {
+					ImGui::TextUnformatted(row.label.c_str());
+					if (!row.tooltip.empty() && ImGui::IsItemHovered()) {
+						if (auto _tt = Util::HoverTooltipWrapper()) {
+							ImGui::TextUnformatted(row.tooltip.c_str());
+						}
+					}
+				}
+			} else if (row.label == "Total:" || row.label == "Other:") {
+				// No tooltip for summary rows in non-label columns
+				columns[colIdx].cellRender(row, colIdx);
+			} else {
+				// Normal row: ensure tooltips never modify cell content
+				columns[colIdx].cellRender(row, colIdx);
+			}
+		},
+		summaryRowsCopy);
+
+	if (clearTestDataRequested) {
+		this->ClearTestData();
+		clearTestDataRequested = false;
+	}
+}
+
+/**
+ * @brief Draws the A/B testing section of the performance overlay
+ *
+ * This function handles all A/B testing related UI including:
+ * - A/B test state management and data collection
+ * - Display of aggregated A/B test results
+ * - Settings difference comparison table
+ * - A/B test controls (clear results, show/hide settings diff)
+ *
+ * @param allRows The current draw call rows for data collection
+ * @param showCollapsibleSections Whether to show collapsible section headers
+ */
+void PerformanceOverlay::DrawABTestSection(const std::vector<DrawCallRow>& allRows, bool showCollapsibleSections)
+{
+	auto* menu = Menu::GetSingleton();
+	auto* abTestingManager = ABTestingManager::GetSingleton();
+	bool abTestingEnabled = abTestingManager && abTestingManager->IsEnabled();
+	static ABVariant lastVariant = ABVariant::A;
+	static bool lastUsingTestConfig = false;
+	static bool wasAbTestActive = false;
+	bool currentUsingTestConfig = abTestingManager && abTestingManager->IsUsingTestConfig();
+	static std::string lastSettingsA, lastSettingsB;
+	std::string currentSettingsA, currentSettingsB;
+	auto& aggregator = abTestingManager->GetAggregator();
+	if (abTestingEnabled) {
+		// Serialize current settings for A and B from the aggregator
+		if (aggregator.HasSettingsA())
+			currentSettingsA = aggregator.GetSettingsA().dump();
+		if (aggregator.HasSettingsB())
+			currentSettingsB = aggregator.GetSettingsB().dump();
+	}
+	// Detect A/B test start/stop and variant switches
+	bool settingsChanged = (currentSettingsA != lastSettingsA) || (currentSettingsB != lastSettingsB);
+	if (abTestingEnabled && (!wasAbTestActive || settingsChanged)) {
+		aggregator.Clear();
+		aggregator.OnABSwitch(currentUsingTestConfig ? ABVariant::B : ABVariant::A);
+		lastSettingsA = currentSettingsA;
+		lastSettingsB = currentSettingsB;
+	}
+	if (abTestingEnabled && (currentUsingTestConfig != lastUsingTestConfig)) {
+		aggregator.OnABSwitch(currentUsingTestConfig ? ABVariant::B : ABVariant::A);
+	}
+	if (!abTestingEnabled && wasAbTestActive) {
+		aggregator.OnTestEnd();
+	}
+	wasAbTestActive = abTestingEnabled;
+	lastUsingTestConfig = currentUsingTestConfig;
+
+	// --- A/B Test Data Collection ---
+	if (abTestingEnabled) {
+		aggregator.OnFrame(allRows);  // Pass both main and summary rows
+	}
+
+	// Display A/B test results if available
+	if (aggregator.HasResults()) {
+		static bool abResultsExpanded = true;
+		if (showCollapsibleSections) {
+			Util::DrawSectionHeader("Aggregated A/B Test Results", false, true, &abResultsExpanded);
+		}
+		if (abResultsExpanded) {
+			this->DrawABTestResultsTable();
+			ImGui::Separator();
+			// --- A/B Results Controls ---
+			static bool showSettingsDiff = false;
+			ImGui::BeginGroup();
+			if (ImGui::Button(showSettingsDiff ? "Hide Settings Diff" : "Show Settings Diff")) {
+				showSettingsDiff = !showSettingsDiff;
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("Clear A/B Test Results")) {
+				aggregator.Clear();
+				abSettingsDiff.clear();
+				abSettingsDiffLoaded = false;
+				showSettingsDiff = false;
+				ImGui::EndGroup();
+				ImGui::Separator();
+				return;
+			}
+			ImGui::EndGroup();
+			// --- Settings diff section (inline, toggled) ---
+			if (showSettingsDiff) {
+				if (!abSettingsDiffLoaded) {
+					std::filesystem::path userPath = Util::PathHelpers::GetDataPath() / "SKSE/Plugins/CommunityShaders/SettingsUser.json";
+					std::filesystem::path testPath = Util::PathHelpers::GetDataPath() / "SKSE/Plugins/CommunityShaders/SettingsTest.json";
+					abSettingsDiff = Util::FileSystem::LoadJsonDiff(userPath, testPath);
+					abSettingsDiffLoaded = true;
+				}
+				static bool settingsDiffExpanded = true;
+				if (showCollapsibleSections) {
+					Util::DrawSectionHeader("A/B Test Settings Differences", false, true, &settingsDiffExpanded);
+				}
+				if (settingsDiffExpanded) {
+					ImGui::TextUnformatted("Differences between USER (A) and TEST (B) configs:");
+					if (abSettingsDiff.empty()) {
+						ImGui::TextUnformatted("No setting changes detected between USER (A) and TEST (B) configs.");
+					} else if (ImGui::BeginTable("ABSettingsDiffTable", 3, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable)) {
+						ImGui::TableSetupColumn("Setting Path", ImGuiTableColumnFlags_DefaultSort);
+						ImGui::TableSetupColumn("A Value");
+						ImGui::TableSetupColumn("B Value");
+						ImGui::TableHeadersRow();
+
+						// Determine which variant performed better based on Total row
+						bool variantABetter = false;
+						bool variantBBetter = false;
+						auto results = aggregator.GetAggregatedResults();
+						for (const auto& stat : results) {
+							if (stat.shaderType == static_cast<int>(SpecialShaderType::Total)) {  // Total row
+								if (stat.meanA < stat.meanB) {
+									variantABetter = true;  // A has lower frame time (better)
+								} else if (stat.meanB < stat.meanA) {
+									variantBBetter = true;  // B has lower frame time (better)
+								}
+								break;
+							}
+						}
+
+						// Get theme for color coding
+						const auto& theme = menu->GetTheme();
+
+						// Sort the settings diff if needed
+						std::vector<SettingsDiffEntry> sortedDiff = abSettingsDiff;
+						if (const ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs()) {
+							if (sortSpecs->SpecsCount > 0) {
+								int sortCol = sortSpecs->Specs->ColumnIndex;
+								bool sortAsc = sortSpecs->Specs->SortDirection == ImGuiSortDirection_Ascending;
+								std::sort(sortedDiff.begin(), sortedDiff.end(), [sortCol, sortAsc](const SettingsDiffEntry& a, const SettingsDiffEntry& b) {
+									if (sortCol == 0)
+										return sortAsc ? (a.path < b.path) : (a.path > b.path);
+									if (sortCol == 1)
+										return sortAsc ? (a.aValue < b.aValue) : (a.aValue > b.aValue);
+									if (sortCol == 2)
+										return sortAsc ? (a.bValue < b.bValue) : (a.bValue > b.bValue);
+									return false;
+								});
+							}
+						}
+						for (const auto& entry : sortedDiff) {
+							ImGui::TableNextRow();
+							ImGui::TableSetColumnIndex(0);
+							ImGui::TextUnformatted(entry.path.c_str());
+							// Only show the path as text, no custom tooltip guessing
+							ImGui::TableSetColumnIndex(1);
+							// Color A value based on performance
+							if (variantABetter) {
+								ImGui::PushStyleColor(ImGuiCol_Text, theme.StatusPalette.SuccessColor);
+								ImGui::TextUnformatted(entry.aValue.c_str());
+								ImGui::PopStyleColor();
+							} else if (variantBBetter) {
+								ImGui::PushStyleColor(ImGuiCol_Text, theme.StatusPalette.Error);
+								ImGui::TextUnformatted(entry.aValue.c_str());
+								ImGui::PopStyleColor();
+							} else {
+								ImGui::TextUnformatted(entry.aValue.c_str());
+							}
+							ImGui::TableSetColumnIndex(2);
+							// Color B value based on performance
+							if (variantBBetter) {
+								ImGui::PushStyleColor(ImGuiCol_Text, theme.StatusPalette.SuccessColor);
+								ImGui::TextUnformatted(entry.bValue.c_str());
+								ImGui::PopStyleColor();
+							} else if (variantABetter) {
+								ImGui::PushStyleColor(ImGuiCol_Text, theme.StatusPalette.Error);
+								ImGui::TextUnformatted(entry.bValue.c_str());
+								ImGui::PopStyleColor();
+							} else {
+								ImGui::TextUnformatted(entry.bValue.c_str());
+							}
+						}
+						ImGui::EndTable();
+					}
+				}
+				ImGui::Separator();
+			}
+		}
+	}
+}
+
+// Static helper method implementations
+void PerformanceOverlay::UpdateShaderTestDataEntry(int shaderType, float frameTime, float costPerCall, float percent)
+{
+	s_testData[shaderType] = { frameTime, costPerCall, percent };
+}
+
+void PerformanceOverlay::UpdateSummaryTestData(float smoothedFrameTime, float otherFrameTime, float otherPercent, float totalCostPerCall)
+{
+	s_testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
+	s_testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
 }

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -278,7 +278,8 @@ void PerformanceOverlay::DrawOverlay()
 			this->settings.BackgroundOpacity));
 
 	// Set text size based on user preference
-	this->perfOverlayState.SetTextScale(this->perfOverlayState.SetTextScale());
+	float scale = this->perfOverlayState.CalculateTextScale();
+	this->perfOverlayState.SetTextScale(scale);
 
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, this->settings.ShowBorder ? 1.0f : 0.0f);
 
@@ -704,10 +705,16 @@ void PerformanceOverlay::ConvertABTestResultsToRows(const std::vector<Aggregated
 				row.tooltip = "Draw calls for this shader type.";
 			}
 		} else {
-			if (row.shaderType == static_cast<int>(SpecialShaderType::Total)) {
-				row.tooltip = "Total frame time.";
-			} else if (row.shaderType == static_cast<int>(SpecialShaderType::Other)) {
-				row.tooltip = "Frame time not attributed to any measured shader type. This includes UI, post-processing, engine work, and any GPU activity not directly measured by the overlay.";
+			auto maybeSpecialType = magic_enum::enum_cast<SpecialShaderType>(row.shaderType);
+			if (maybeSpecialType.has_value()) {
+				switch (*maybeSpecialType) {
+				case SpecialShaderType::Total:
+					row.tooltip = "Total frame time.";
+					break;
+				case SpecialShaderType::Other:
+					row.tooltip = "Frame time not attributed to any measured shader type. This includes UI, post-processing, engine work, and any GPU activity not directly measured by the overlay.";
+					break;
+				}
 			}
 		}
 		if (row.shaderType < 0) {
@@ -1204,7 +1211,8 @@ void PerformanceOverlay::DrawABTestSection(const std::vector<DrawCallRow>& allRo
 						bool variantBBetter = false;
 						auto results = aggregator.GetAggregatedResults();
 						for (const auto& stat : results) {
-							if (stat.shaderType == static_cast<int>(SpecialShaderType::Total)) {  // Total row
+							auto maybeSpecialType = magic_enum::enum_cast<SpecialShaderType>(stat.shaderType);
+							if (maybeSpecialType.has_value() && *maybeSpecialType == SpecialShaderType::Total) {  // Total row
 								if (stat.meanA < stat.meanB) {
 									variantABetter = true;  // A has lower frame time (better)
 								} else if (stat.meanB < stat.meanA) {
@@ -1423,10 +1431,18 @@ std::vector<ColumnConfig> PerformanceOverlay::BuildDrawCallTableColumns(const Me
 			} },
 		{ legends.drawCalls.header,
 			[](const DrawCallRow& row, int) {
-				ImGui::Text("%d", row.drawCalls);
+				if (row.drawCalls == kDrawCallsNotApplicable) {
+					ImGui::TextDisabled("-");
+				} else {
+					ImGui::Text("%d", row.drawCalls);
+				}
 				if (ImGui::IsItemHovered()) {
 					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::TextUnformatted("Draw Calls: Number of draw calls for this shader type in the current frame.");
+						if (row.drawCalls == kDrawCallsNotApplicable) {
+							ImGui::TextUnformatted("Draw Calls: Not applicable for unmeasured GPU time.");
+						} else {
+							ImGui::TextUnformatted("Draw Calls: Number of draw calls for this shader type in the current frame.");
+						}
 					}
 				}
 			},
@@ -1526,18 +1542,18 @@ std::pair<std::vector<DrawCallRow>, std::vector<DrawCallRow>> PerformanceOverlay
 	if (std::abs(otherFrameTime) < 1e-4f)
 		otherFrameTime = 0.0f;
 	std::optional<float> otherTestFrameTime, otherTestCostPerCall, totalTestFrameTime, totalTestCostPerCall;
-	auto itOther = this->testData.find(static_cast<int>(SpecialShaderType::Other));
+	auto itOther = this->testData.find(magic_enum::enum_integer(SpecialShaderType::Other));
 	if (itOther != this->testData.end()) {
 		otherTestFrameTime = itOther->second.frameTime;
 		otherTestCostPerCall = itOther->second.costPerCall;
 	}
-	auto itTotal = this->testData.find(static_cast<int>(SpecialShaderType::Total));
+	auto itTotal = this->testData.find(magic_enum::enum_integer(SpecialShaderType::Total));
 	if (itTotal != this->testData.end()) {
 		totalTestFrameTime = itTotal->second.frameTime;
 		totalTestCostPerCall = itTotal->second.costPerCall;
 	}
 	DrawCallRow otherRow = {
-		"Other:", static_cast<int>(SpecialShaderType::Other), 0, otherFrameTime, otherPercent,
+		"Other:", magic_enum::enum_integer(SpecialShaderType::Other), kDrawCallsNotApplicable, otherFrameTime, otherPercent,
 		0.0f,
 		std::string("Frame time not attributed to any measured shader type. This includes UI, post-processing, engine work, and any GPU activity not directly measured by the overlay."),
 		true, otherTestFrameTime, otherTestCostPerCall
@@ -1547,7 +1563,7 @@ std::pair<std::vector<DrawCallRow>, std::vector<DrawCallRow>> PerformanceOverlay
 	float totalPercent = 100.0f;  // Total is always 100% of total
 
 	DrawCallRow totalRow = {
-		"Total:", static_cast<int>(SpecialShaderType::Total), static_cast<int>(globals::state->GetTotalSmoothedDrawCalls()), totalFrameTime, totalPercent,
+		"Total:", magic_enum::enum_integer(SpecialShaderType::Total), static_cast<int>(globals::state->GetTotalSmoothedDrawCalls()), totalFrameTime, totalPercent,
 		totalCostPerCall,
 		std::string("Total frame time."),
 		true, totalTestFrameTime, totalTestCostPerCall
@@ -1649,8 +1665,8 @@ void PerformanceOverlay::HandleShaderToggle(const DrawCallRow& row, bool wasEnab
 		// Save the last live value before disabling
 		this->UpdateShaderTestData(row.shaderType, prevFrameTime, prevCostPerCall);
 		// Save Total and Other test data as well
-		this->testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
-		this->testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
+		this->testData[magic_enum::enum_integer(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+		this->testData[magic_enum::enum_integer(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
 		this->testDataSource = TestDataSource::ManualShaderToggle;
 		this->testDataLastUpdated = std::chrono::steady_clock::now();
 	}
@@ -1688,8 +1704,8 @@ void PerformanceOverlay::HandleTotalRowToggle()
 			measuredSum += frameTime;
 		});
 		auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
-		this->testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
-		this->testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
+		this->testData[magic_enum::enum_integer(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+		this->testData[magic_enum::enum_integer(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
 		this->testDataSource = TestDataSource::ManualShaderToggle;
 		this->testDataLastUpdated = std::chrono::steady_clock::now();
 	}
@@ -1853,8 +1869,8 @@ void PerformanceOverlay::UpdateShaderTestDataEntry(int shaderType, float frameTi
 
 void PerformanceOverlay::UpdateSummaryTestData(float smoothedFrameTime, float otherFrameTime, float otherPercent, float totalCostPerCall)
 {
-	testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
-	testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+	testData[magic_enum::enum_integer(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
+	testData[magic_enum::enum_integer(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
 }
 // ============================================================================
 // PERFORMANCE OVERLAY STATE MANAGEMENT
@@ -1933,7 +1949,7 @@ void PerformanceOverlay::PerfOverlayState::UpdateMaxFrameTime()
 	overlay->perfOverlayState.SetMaxFrameTime(*std::max_element(overlay->perfOverlayState.GetFrameTimeHistory().begin(), overlay->perfOverlayState.GetFrameTimeHistory().end()));
 }
 
-float PerformanceOverlay::PerfOverlayState::SetTextScale()
+float PerformanceOverlay::PerfOverlayState::CalculateTextScale()
 {
 	auto* overlay = GetSingleton();
 	switch (overlay->settings.Size) {

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -460,7 +460,7 @@ void PerformanceOverlay::DrawABTestResultsTable()
 					}
 				}
 			} },
-		{ "A Median",
+		{ "A Median (ms)",
 			[theme, aMedianLegend](const DrawCallRow& row, int) {
 				float value = row.costPerCall;
 				// Color A median relative to B median (stored in testCostPerCall for now)
@@ -496,7 +496,7 @@ void PerformanceOverlay::DrawABTestResultsTable()
 					}
 				}
 			} },
-		{ "B Median",
+		{ "B Median (ms)",
 			[theme, bMedianLegend](const DrawCallRow& row, int) {
 				if (!row.testCostPerCall.has_value()) {
 					ImGui::TextDisabled("-");
@@ -538,7 +538,7 @@ void PerformanceOverlay::DrawABTestResultsTable()
 					}
 				}
 			} },
-		{ "Median Delta",
+		{ "Median Delta (ms)",
 			[theme, medianDeltaLegend](const DrawCallRow& row, int) {
 				if (!row.testCostPerCall.has_value()) {
 					ImGui::TextDisabled("-");

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -49,13 +49,6 @@ constexpr float kDefaultFPS = 60.0f;
 constexpr float kDefaultFrameTimeMs = 1000.0f / kDefaultFPS;
 
 // --- Helper Structures and Functions ---
-struct ColumnConfig
-{
-	std::string header;
-	std::function<void(const DrawCallRow&, int colIdx)> cellRender;
-	std::function<bool(const DrawCallRow&, const DrawCallRow&, bool)> sortFunc;
-	std::function<void()> headerTooltip;
-};
 
 // Helper function to create metric columns with consistent formatting
 auto MakeMetricColumn(const auto& theme, auto valueGetter, auto colorGetter, auto formatter, const Util::ColoredTextLines& legend, const Util::ColoredTextLines* cellLegend = nullptr)
@@ -91,14 +84,12 @@ auto MakeMetricColumn(const auto& theme, auto valueGetter, auto colorGetter, aut
 }
 
 // --- Helper Functions ---
-
-// --- Helper Functions ---
 /**
- * @brief Calculates summary data (Other frame time, percentages, cost per call) from measured sum
- * @param smoothedFrameTime The total smoothed frame time
- * @param measuredSum The sum of measured frame times
- * @return Tuple of (otherFrameTime, otherPercent, totalCostPerCall)
- */
+  * @brief Calculates summary data (Other frame time, percentages, cost per call) from measured sum
+  * @param smoothedFrameTime The total smoothed frame time
+  * @param measuredSum The sum of measured frame times
+  * @return Tuple of (otherFrameTime, otherPercent, totalCostPerCall)
+  */
 static std::tuple<float, float, float> CalculateSummaryData(float smoothedFrameTime, float measuredSum)
 {
 	float totalSmoothedDrawCalls = globals::state->GetTotalSmoothedDrawCalls();
@@ -136,580 +127,9 @@ static const std::unordered_map<RE::BSShader::Type, std::string> kShaderTypeTool
 	{ RE::BSShader::Type::BloodSplatter, "Draw calls for blood splatter effects." },
 	{ RE::BSShader::Type::ImageSpace, "Draw calls for image space post-processing effects." }
 };
-
-// --- ABTestAggregator integration ---
-ABTestAggregator& PerformanceOverlay::GetABTestAggregator()
-{
-	auto* abTestingManager = ABTestingManager::GetSingleton();
-	return abTestingManager->GetAggregator();
-}
-
-/**
- * @brief Draws the A/B test results table with comprehensive performance comparison
- *
- * This function renders a detailed table showing performance metrics for both Variant A (USER config)
- * and Variant B (TEST config), including:
- * - Average and median frame times for each shader type
- * - Performance deltas and percentage differences
- * - Color-coded indicators for better/worse performance
- * - Statistical validity assessment with tooltips
- * - Sortable columns for easy analysis
- *
- * The table provides both main rows (individual shader types) and summary rows (Total, Other)
- * to give users a complete picture of performance differences between configurations.
- *
- * @note This function requires an active A/B test with aggregated results
- */
-void PerformanceOverlay::DrawABTestResultsTable()
-{
-	auto* abTestingManager = ABTestingManager::GetSingleton();
-	auto& aggregator = abTestingManager->GetAggregator();
-	auto results = aggregator.GetAggregatedResults();
-	if (results.empty())
-		return;
-
-	auto* menu = Menu::GetSingleton();
-	const auto& theme = menu->GetTheme();
-
-	// Test statistics header
-	float totalDuration = aggregator.GetTotalTestDuration();
-	int totalFrames = aggregator.GetTotalFrameCount();
-	int excludedFrames = 0;
-	for (const auto& interval : aggregator.GetIntervals()) {
-		excludedFrames += interval.excludedFrames;
-	}
-	int validFrames = totalFrames;
-	int totalWithExcluded = totalFrames + excludedFrames;
-	float validPercent = (totalWithExcluded > 0) ? (100.0f * validFrames / totalWithExcluded) : 100.0f;
-
-	// Statistical validity assessment
-	bool hasEnoughSamples = validFrames >= kMinimumSamplesForValidity;
-	bool hasGoodDuration = totalDuration >= kMinimumTestDuration;
-	bool hasLowExclusionRate = validPercent >= kMinimumValidFramesPercent;
-	bool isStatisticallyValid = hasEnoughSamples && hasGoodDuration && hasLowExclusionRate;
-
-	// Color coding for statistical validity
-	ImVec4 validityColor = theme.Palette.Text;
-	if (isStatisticallyValid) {
-		validityColor = theme.StatusPalette.SuccessColor;  // Green for valid
-	} else if (validFrames >= kMinimumSamplesForMarginal && totalDuration >= kMinimumDurationForMarginal) {
-		validityColor = theme.StatusPalette.Warning;  // Yellow for marginal
-	} else {
-		validityColor = theme.StatusPalette.Error;  // Red for insufficient
-	}
-
-	ImGui::PushStyleColor(ImGuiCol_Text, validityColor);
-	ImGui::Text("Test Duration: %.1f seconds | Valid Frames: %d/%d (%.1f%%) | Excluded: %d",
-		totalDuration, validFrames, totalWithExcluded, validPercent, excludedFrames);
-	ImGui::PopStyleColor();
-	if (ImGui::IsItemHovered()) {
-		if (auto _tt = Util::HoverTooltipWrapper()) {
-			char validStr[128], marginalStr[128];
-			snprintf(validStr, sizeof(validStr), "Statistically valid (>%d samples, >%.0fs duration, >%.0f%% valid)", kMinimumSamplesForValidity, static_cast<float>(kMinimumTestDuration), kMinimumValidFramesPercent);
-			snprintf(marginalStr, sizeof(marginalStr), "Marginal validity (>%d samples, >%.0fs duration)", kMinimumSamplesForMarginal, static_cast<float>(kMinimumDurationForMarginal));
-			Util::ColoredTextLines validityLegend = {
-				{ "Valid frames are those not excluded as outliers.\nA low percentage may indicate instability or test interruptions.\nExcluded frames are those with frame times > 3x median or > 100ms.\nThis removes shader compilation spikes, JSON loading overhead, and other anomalies\nthat would skew the performance comparison.", theme.Palette.Text },
-				{ "", theme.Palette.Text },
-				{ validStr, theme.StatusPalette.SuccessColor },
-				{ marginalStr, theme.StatusPalette.Warning },
-				{ "Insufficient data for reliable results", theme.StatusPalette.Error }
-			};
-			Util::DrawColoredMultiLineTooltip(validityLegend);
-		}
-	}
-
-	// Convert to DrawCallRow format for proper sorting and footer handling
-	std::vector<DrawCallRow> mainRows;
-	std::vector<DrawCallRow> summaryRows;
-
-	for (const auto& stat : results) {
-		DrawCallRow row;
-		row.label = stat.label;
-		row.shaderType = stat.shaderType;  // Just assign the int directly
-		row.frameTime = stat.meanA;        // Use A as primary frame time
-		row.percent = (stat.meanA > 0.0f) ? (stat.meanA / (stat.meanA + stat.meanB) * 100.0f) : 0.0f;
-		row.costPerCall = stat.medianA;  // Use A median as primary cost per call
-		row.enabled = true;
-
-		// Store B values in test data fields for comparison
-		row.testFrameTime = stat.meanB;
-		row.testCostPerCall = stat.medianB;  // Store B median in testCostPerCall field
-
-		// Add tooltip based on shader type
-		if (row.shaderType >= 0) {
-			// Regular shader type
-			auto shaderType = static_cast<RE::BSShader::Type>(row.shaderType);
-			auto tipIt = kShaderTypeTooltips.find(shaderType);
-			if (tipIt != kShaderTypeTooltips.end()) {
-				row.tooltip = tipIt->second;
-			} else {
-				row.tooltip = "Draw calls for this shader type.";
-			}
-		} else {
-			// Special shader type (Total or Other)
-			if (row.shaderType == static_cast<int>(SpecialShaderType::Total)) {
-				row.tooltip = "Total frame time.";
-			} else if (row.shaderType == static_cast<int>(SpecialShaderType::Other)) {
-				row.tooltip = "Frame time not attributed to any measured shader type. This includes UI, post-processing, engine work, and any GPU activity not directly measured by the overlay.";
-			}
-		}
-
-		// Separate main rows from summary rows
-		if (row.shaderType < 0) {
-			summaryRows.push_back(row);
-		} else {
-			mainRows.push_back(row);
-		}
-	}
-
-	// --- BUILD LEGENDS ---
-	const Util::ColoredTextLines aAvgLegend = {
-		{ "A Avg (ms): Average frame time for Variant A (USER config).", theme.Palette.Text },
-		{ "", theme.Palette.Text },
-		{ "Color Legend (compared to Variant B):", theme.Palette.Text },
-		{ "  Better (lower than B)", theme.StatusPalette.SuccessColor },
-		{ "  Worse (higher than B)", theme.StatusPalette.Error },
-		{ "  Same as B", theme.Palette.Text }
-	};
-	const Util::ColoredTextLines bAvgLegend = {
-		{ "B Avg (ms): Average frame time for Variant B (TEST config).", theme.Palette.Text },
-		{ "", theme.Palette.Text },
-		{ "Color Legend (compared to Variant A):", theme.Palette.Text },
-		{ "  Better (lower than A)", theme.StatusPalette.SuccessColor },
-		{ "  Worse (higher than A)", theme.StatusPalette.Error },
-		{ "  Same as A", theme.Palette.Text }
-	};
-	const Util::ColoredTextLines deltaLegend = {
-		{ "Delta (ms): Difference between Variant B and Variant A (B - A).", theme.Palette.Text },
-		{ "Negative values indicate Variant B is better (lower frame time).", theme.Palette.Text },
-		{ "Positive values indicate Variant A is better (lower frame time).", theme.Palette.Text },
-		{ "Percentage shows relative performance difference.", theme.Palette.Text },
-		{ "", theme.Palette.Text },
-		{ "Color Legend:", theme.Palette.Text },
-		{ "  Negative (B better)", theme.StatusPalette.SuccessColor },
-		{ "  Positive (A better)", theme.StatusPalette.Error },
-		{ "  Zero (same)", theme.Palette.Text }
-	};
-	const Util::ColoredTextLines aMedianLegend = {
-		{ "A Median: Median frame time for Variant A (USER config).", theme.Palette.Text },
-		{ "Median is less sensitive to outliers than average.", theme.Palette.Text },
-		{ "", theme.Palette.Text },
-		{ "Color Legend (compared to Variant B median):", theme.Palette.Text },
-		{ "  Better (lower than B)", theme.StatusPalette.SuccessColor },
-		{ "  Worse (higher than B)", theme.StatusPalette.Error },
-		{ "  Same as B", theme.Palette.Text }
-	};
-	const Util::ColoredTextLines bMedianLegend = {
-		{ "B Median: Median frame time for Variant B (TEST config).", theme.Palette.Text },
-		{ "Median is less sensitive to outliers than average.", theme.Palette.Text },
-		{ "", theme.Palette.Text },
-		{ "Color Legend (compared to Variant A median):", theme.Palette.Text },
-		{ "  Better (lower than A)", theme.StatusPalette.SuccessColor },
-		{ "  Worse (higher than A)", theme.StatusPalette.Error },
-		{ "  Same as A", theme.Palette.Text }
-	};
-	const Util::ColoredTextLines medianDeltaLegend = {
-		{ "Median Delta: Difference between Variant B and Variant A medians (B - A).", theme.Palette.Text },
-		{ "Negative values indicate Variant B is better (lower median).", theme.Palette.Text },
-		{ "Positive values indicate Variant A is better (lower median).", theme.Palette.Text },
-		{ "", theme.Palette.Text },
-		{ "Color Legend:", theme.Palette.Text },
-		{ "  Negative (B better)", theme.StatusPalette.SuccessColor },
-		{ "  Positive (A better)", theme.StatusPalette.Error },
-		{ "  Zero (same)", theme.Palette.Text }
-	};
-
-	// --- BUILD HEADERS AND CONFIG ---
-	std::vector<ColumnConfig> columns = {
-		{ "Shader Type",
-			[theme](const DrawCallRow& row, int) {
-				ImGui::TextUnformatted(row.label.c_str());
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::TextUnformatted(row.tooltip.c_str());
-						// Add FPS for Total row
-						if (row.label == "Total:") {
-							float fps = row.frameTime > 0.0f ? 1000.0f / row.frameTime : 0.0f;
-							ImGui::Text("FPS: %.2f", fps);
-						}
-					}
-				}
-			},
-			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.label < b.label) : (a.label > b.label); },
-			nullptr },
-		{ "A Avg (ms)",
-			[theme, aAvgLegend](const DrawCallRow& row, int) {
-				float value = row.frameTime;
-				// Color A relative to B
-				ImVec4 color = theme.Palette.Text;
-				if (row.testFrameTime.has_value()) {
-					if (value < *row.testFrameTime) {
-						color = theme.StatusPalette.SuccessColor;  // A is better (lower) than B
-					} else if (value > *row.testFrameTime) {
-						color = theme.StatusPalette.Error;  // A is worse (higher) than B
-					}
-				}
-				ImGui::PushStyleColor(ImGuiCol_Text, color);
-				ImGui::Text("%s", Util::FormatMilliseconds(value).c_str());
-				ImGui::PopStyleColor();
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						if (row.label == "Total:") {
-							ImGui::Text("A (USER) FPS: %.2f", Util::CalcFPS(value));
-						} else {
-							Util::DrawColoredMultiLineTooltip(aAvgLegend);
-						}
-					}
-				}
-			},
-			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.frameTime < b.frameTime) : (a.frameTime > b.frameTime); },
-			[aAvgLegend]() {
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						Util::DrawColoredMultiLineTooltip(aAvgLegend);
-					}
-				}
-			} },
-		{ "B Avg (ms)",
-			[theme, bAvgLegend](const DrawCallRow& row, int) {
-				if (!row.testFrameTime.has_value()) {
-					ImGui::TextDisabled("-");
-					return;
-				}
-				float value = *row.testFrameTime;
-				// Color B relative to A
-				ImVec4 color = theme.Palette.Text;
-				if (value < row.frameTime) {
-					color = theme.StatusPalette.SuccessColor;  // B is better (lower) than A
-				} else if (value > row.frameTime) {
-					color = theme.StatusPalette.Error;  // B is worse (higher) than A
-				}
-				ImGui::PushStyleColor(ImGuiCol_Text, color);
-				ImGui::Text("%s", Util::FormatMilliseconds(value).c_str());
-				ImGui::PopStyleColor();
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						if (row.label == "Total:") {
-							ImGui::Text("B (TEST) FPS: %.2f", Util::CalcFPS(value));
-						} else {
-							Util::DrawColoredMultiLineTooltip(bAvgLegend);
-						}
-					}
-				}
-			},
-			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
-				float aVal = a.testFrameTime.value_or(FLT_MAX);
-				float bVal = b.testFrameTime.value_or(FLT_MAX);
-				return asc ? (aVal < bVal) : (aVal > bVal);
-			},
-			[bAvgLegend]() {
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						Util::DrawColoredMultiLineTooltip(bAvgLegend);
-					}
-				}
-			} },
-		{ "Delta (ms)",
-			[theme, deltaLegend](const DrawCallRow& row, int) {
-				if (!row.testFrameTime.has_value()) {
-					ImGui::TextDisabled("-");
-					return;
-				}
-				float delta = *row.testFrameTime - row.frameTime;
-				// Color based on delta
-				ImVec4 color = theme.Palette.Text;
-				if (delta < 0.0f) {
-					color = theme.StatusPalette.SuccessColor;  // Better performance (negative delta)
-				} else if (delta > 0.0f) {
-					color = theme.StatusPalette.Error;  // Worse performance (positive delta)
-				}
-				ImGui::PushStyleColor(ImGuiCol_Text, color);
-				ImGui::Text("%s", Util::FormatDeltaWithPercent(row.frameTime, *row.testFrameTime, PerformanceOverlay::PerfOverlayState::kPercentDisplayThreshold).c_str());
-				ImGui::PopStyleColor();
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						if (row.testFrameTime.has_value()) {
-							// Show detailed values for rows with test data
-							if (row.label == "Total:") {
-								ImGui::TextUnformatted("Delta (B - A):");
-								ImGui::Separator();
-								ImGui::Text("A (USER) FPS: %.2f", Util::CalcFPS(row.frameTime));
-								ImGui::Text("B (TEST) FPS: %.2f", Util::CalcFPS(*row.testFrameTime));
-							} else {
-								ImGui::TextUnformatted("Delta (B - A):");
-								ImGui::Separator();
-								ImGui::Text("A (USER): %.3f ms", row.frameTime);
-								ImGui::Text("B (TEST): %.3f ms", *row.testFrameTime);
-							}
-							ImGui::Separator();
-						}
-						// Always show the delta legend for explanation
-						Util::DrawColoredMultiLineTooltip(deltaLegend);
-					}
-				}
-			},
-			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
-				float aDelta = a.testFrameTime.value_or(0.0f) - a.frameTime;
-				float bDelta = b.testFrameTime.value_or(0.0f) - b.frameTime;
-				return asc ? (aDelta < bDelta) : (aDelta > bDelta);
-			},
-			[deltaLegend]() {
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						Util::DrawColoredMultiLineTooltip(deltaLegend);
-					}
-				}
-			} },
-		{ "A Median (ms)",
-			[theme, aMedianLegend](const DrawCallRow& row, int) {
-				float value = row.costPerCall;
-				// Color A median relative to B median (stored in testCostPerCall for now)
-				ImVec4 color = theme.Palette.Text;
-				if (row.testCostPerCall.has_value()) {
-					if (value < *row.testCostPerCall) {
-						color = theme.StatusPalette.SuccessColor;  // A is better (lower) than B
-					} else if (value > *row.testCostPerCall) {
-						color = theme.StatusPalette.Error;  // A is worse (higher) than B
-					}
-				}
-				ImGui::PushStyleColor(ImGuiCol_Text, color);
-				ImGui::Text("%s", Util::FormatMilliseconds(value).c_str());
-				ImGui::PopStyleColor();
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						if (row.label == "Total:") {
-							Util::ColoredTextLines fpsTooltip{
-								{ std::format("A (USER) Median FPS: {:.2f}", Util::CalcFPS(value)), ImVec4(1.0f, 1.0f, 1.0f, 1.0f) }
-							};
-							Util::DrawColoredMultiLineTooltip(fpsTooltip);
-						} else {
-							Util::DrawColoredMultiLineTooltip(aMedianLegend);
-						}
-					}
-				}
-			},
-			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall); },
-			[aMedianLegend]() {
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						Util::DrawColoredMultiLineTooltip(aMedianLegend);
-					}
-				}
-			} },
-		{ "B Median (ms)",
-			[theme, bMedianLegend](const DrawCallRow& row, int) {
-				if (!row.testCostPerCall.has_value()) {
-					ImGui::TextDisabled("-");
-					return;
-				}
-				float value = *row.testCostPerCall;
-				// Color B median relative to A median
-				ImVec4 color = theme.Palette.Text;
-				if (value < row.costPerCall) {
-					color = theme.StatusPalette.SuccessColor;  // B is better (lower) than A
-				} else if (value > row.costPerCall) {
-					color = theme.StatusPalette.Error;  // B is worse (higher) than A
-				}
-				ImGui::PushStyleColor(ImGuiCol_Text, color);
-				ImGui::Text("%s", Util::FormatMilliseconds(value).c_str());
-				ImGui::PopStyleColor();
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						if (row.label == "Total:") {
-							Util::ColoredTextLines fpsTooltip{
-								{ std::format("B (TEST) Median FPS: {:.2f}", Util::CalcFPS(value)), ImVec4(1.0f, 1.0f, 1.0f, 1.0f) }
-							};
-							Util::DrawColoredMultiLineTooltip(fpsTooltip);
-						} else {
-							Util::DrawColoredMultiLineTooltip(bMedianLegend);
-						}
-					}
-				}
-			},
-			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
-				float aVal = a.testCostPerCall.value_or(FLT_MAX);
-				float bVal = b.testCostPerCall.value_or(FLT_MAX);
-				return asc ? (aVal < bVal) : (aVal > bVal);
-			},
-			[bMedianLegend]() {
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						Util::DrawColoredMultiLineTooltip(bMedianLegend);
-					}
-				}
-			} },
-		{ "Median Delta (ms)",
-			[theme, medianDeltaLegend](const DrawCallRow& row, int) {
-				if (!row.testCostPerCall.has_value()) {
-					ImGui::TextDisabled("-");
-					return;
-				}
-				float delta = *row.testCostPerCall - row.costPerCall;
-				// Color based on delta
-				ImVec4 color = theme.Palette.Text;
-				if (delta < 0.0f) {
-					color = theme.StatusPalette.SuccessColor;  // Better performance (negative delta)
-				} else if (delta > 0.0f) {
-					color = theme.StatusPalette.Error;  // Worse performance (positive delta)
-				}
-				ImGui::PushStyleColor(ImGuiCol_Text, color);
-				std::string deltaStr = (delta > 0.0f) ? "+" + Util::FormatMilliseconds(delta) : Util::FormatMilliseconds(delta);
-				ImGui::Text("%s", deltaStr.c_str());
-				ImGui::PopStyleColor();
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						if (row.label == "Total:" && row.testCostPerCall.has_value()) {
-							Util::ColoredTextLines fpsTooltip{
-								{ "Median Delta (B - A):", ImVec4(1.0f, 1.0f, 1.0f, 1.0f) },
-								{ "", ImVec4(1.0f, 1.0f, 1.0f, 1.0f) },
-								{ std::format("A (USER) Median FPS: {:.2f}", Util::CalcFPS(row.costPerCall)), ImVec4(1.0f, 1.0f, 1.0f, 1.0f) },
-								{ std::format("B (TEST) Median FPS: {:.2f}", Util::CalcFPS(*row.testCostPerCall)), ImVec4(1.0f, 1.0f, 1.0f, 1.0f) },
-								{ "", ImVec4(1.0f, 1.0f, 1.0f, 1.0f) },
-								{ "Median is less sensitive to outliers than average.", ImVec4(1.0f, 1.0f, 1.0f, 1.0f) }
-							};
-							Util::DrawColoredMultiLineTooltip(fpsTooltip);
-						} else {
-							Util::DrawColoredMultiLineTooltip(medianDeltaLegend);
-						}
-					}
-				}
-			},
-			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
-				float aDelta = a.testCostPerCall.value_or(0.0f) - a.costPerCall;
-				float bDelta = b.testCostPerCall.value_or(0.0f) - b.costPerCall;
-				return asc ? (aDelta < bDelta) : (aDelta > bDelta);
-			},
-			[medianDeltaLegend]() {
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						Util::DrawColoredMultiLineTooltip(medianDeltaLegend);
-					}
-				}
-			} }
-	};
-
-	// --- TABLE RENDER: MAIN ROWS + FOOTER ROWS ---
-	std::vector<std::function<bool(const DrawCallRow&, const DrawCallRow&, bool)>> sorters;
-	for (const auto& col : columns) sorters.push_back(col.sortFunc);
-
-	std::vector<DrawCallRow> mainRowsCopy = mainRows;
-	std::vector<DrawCallRow> summaryRowsCopy = summaryRows;
-
-	Util::ShowSortedStringTable<DrawCallRow>(
-		"ABTestResultsTable",
-		[&columns]() { std::vector<std::string> h; for (const auto& c : columns) h.push_back(c.header); return h; }(),
-		mainRowsCopy,
-		0,     // Default sort column (Shader Type)
-		true,  // Default ascending
-		sorters,
-		[&columns](int rowIdx, int colIdx, const DrawCallRow& row) {
-			(void)rowIdx;
-			columns[colIdx].cellRender(row, colIdx);
-		},
-		summaryRowsCopy);
-}
-
-// Static test data state
-
-// Implement static member functions
-/**
- * @brief Updates test data for a specific shader type during manual shader toggling
- *
- * This function captures performance data for a shader type when it's manually disabled,
- * allowing users to compare performance with/without specific shaders enabled.
- *
- * @param shaderType The shader type index to update test data for
- * @param frameTime The frame time contribution of this shader type (ms)
- * @param costPerCall The cost per draw call for this shader type (ms/call)
- *
- * @note This function also updates the Total and Other summary rows to maintain
- *       consistency with the current performance state
- */
-void PerformanceOverlay::UpdateShaderTestData(int shaderType, float frameTime, float costPerCall)
-{
-	UpdateShaderTestDataEntry(shaderType, frameTime, costPerCall);
-
-	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.GetSmoothFrameTimeMs());
-	float measuredSum = 0.0f;
-	for (const auto& [type, data] : testData) {
-		if (type >= 0)
-			measuredSum += data.frameTime;
-	}
-
-	auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
-	UpdateSummaryTestData(smoothedFrameTime, otherFrameTime, otherPercent, totalCostPerCall);
-
-	testDataSource = TestDataSource::ManualShaderToggle;
-	testDataLastUpdated = std::chrono::steady_clock::now();
-}
-
-/**
- * @brief Updates test data for all shader types during A/B test Variant B execution
- *
- * This function captures comprehensive performance data for all shader types when
- * running in A/B test mode with Variant B (test config) active. It ensures that
- * all shader types, including Total and Other summary rows, have current test data
- * for accurate performance comparison.
- *
- * @note This function only captures data when A/B testing is enabled and using
- *       Variant B (test config). It does nothing in manual shader toggle mode.
- */
-void PerformanceOverlay::UpdateAllShaderTestData()
-{
-	// Check if all shaders are disabled
-	bool allDisabled = true;
-	globals::state->ForEachShaderTypeWithIndex([&allDisabled]([[maybe_unused]] auto type, int classIndex) {
-		if (globals::state->enabledClasses[classIndex]) {
-			allDisabled = false;
-		}
-	});
-	if (allDisabled) {
-		testData.clear();
-		testDataSource = TestDataSource::None;
-		return;
-	}
-
-	// Only capture test data if we're in A/B test mode AND using Variant B (test config)
-	auto* abTestingManager = ABTestingManager::GetSingleton();
-	bool abTest = abTestingManager && abTestingManager->IsEnabled() && abTestingManager->IsUsingTestConfig();
-	if (!abTest) {
-		// If not in A/B test Variant B, don't capture test data
-		return;
-	}
-
-	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.GetSmoothFrameTimeMs());
-	float measuredSum = 0.0f;
-
-	globals::state->ForEachShaderTypeWithMetrics([&measuredSum, smoothedFrameTime, this]([[maybe_unused]] auto type, int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, float percent, float costPerCall) {
-		this->UpdateShaderTestDataEntry(typeIndex, frameTime, costPerCall, percent);
-		measuredSum += frameTime;
-	});
-
-	auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
-	UpdateSummaryTestData(smoothedFrameTime, otherFrameTime, otherPercent, totalCostPerCall);
-	testDataSource = TestDataSource::ABTest_VariantB;
-	testDataLastUpdated = std::chrono::steady_clock::now();
-}
-
-std::string PerformanceOverlay::GetTestDataTooltip()
-{
-	switch (testDataSource) {
-	case TestDataSource::ABTest_VariantB:
-		return std::string("Test data from Test (Variant B).\nLast updated: ") + Util::TimeAgoString(testDataLastUpdated) + " ago.";
-	case TestDataSource::ManualShaderToggle:
-		return std::string("Test data from manual shader toggle.\nLast updated: ") + Util::TimeAgoString(testDataLastUpdated) + " ago.";
-	default:
-		return "No test data available.";
-	}
-}
-
-void PerformanceOverlay::DataLoaded()
-{
-	// Initialize performance overlay state
-	this->perfOverlayState.SetInitialized(false);
-	this->perfOverlayState.ResizeFrameTimeHistory(this->settings.FrameHistorySize, 0.0f);
-	this->perfOverlayState.ResizePostFGFrameTimeHistory(this->settings.FrameHistorySize, 0.0f);
-}
+// ============================================================================
+// VIRTUAL OVERRIDES (Feature.h interface)
+// ============================================================================
 
 std::pair<std::string, std::vector<std::string>> PerformanceOverlay::GetFeatureSummary()
 {
@@ -800,6 +220,14 @@ void PerformanceOverlay::DrawSettings()
 		}
 		ImGui::Unindent();
 	}
+}
+
+void PerformanceOverlay::DataLoaded()
+{
+	// Initialize performance overlay state
+	this->perfOverlayState.SetInitialized(false);
+	this->perfOverlayState.ResizeFrameTimeHistory(this->settings.FrameHistorySize, 0.0f);
+	this->perfOverlayState.ResizePostFGFrameTimeHistory(this->settings.FrameHistorySize, 0.0f);
 }
 
 void PerformanceOverlay::DrawOverlay()
@@ -998,93 +426,9 @@ void PerformanceOverlay::DrawOverlay()
 		ImGui::PopStyleColor();  // WindowBg
 	}
 }
-
-void PerformanceOverlay::PerfOverlayState::UpdateFGFrameTime()
-{
-	// Defensive: Check for upscaling pointer
-	if (!globals::upscaling)
-		return;
-
-	auto* overlay = GetSingleton();
-
-	// Get frametime directly from the Frame Generation system
-	float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
-	if (fgDeltaTime > 0.0f) {
-		overlay->perfOverlayState.SetPostFGFrameTimeMs(fgDeltaTime * 1000.0f);
-		overlay->perfOverlayState.SetPostFGFps(1000.0f / overlay->perfOverlayState.GetPostFGFrameTimeMs());
-
-		// Update post-FG smooth values when timer elapses
-		if (overlay->perfOverlayState.GetUpdateTimer() <= 0.0f) {
-			overlay->perfOverlayState.SetPostFGSmoothFps(overlay->perfOverlayState.GetPostFGFps());
-			overlay->perfOverlayState.SetPostFGSmoothFrameTimeMs(overlay->perfOverlayState.GetPostFGFrameTimeMs());
-		}
-
-		// Update post-FG frametime history
-		overlay->perfOverlayState.GetPostFGFrameTimeHistoryRef()[overlay->perfOverlayState.GetPostFGFrameTimeHistoryIndex()] = overlay->perfOverlayState.GetPostFGFrameTimeMs();
-		overlay->perfOverlayState.SetPostFGFrameTimeHistoryIndex((overlay->perfOverlayState.GetPostFGFrameTimeHistoryIndex() + 1) % overlay->settings.FrameHistorySize);
-	} else {
-		// Fallback if FG time is not available
-		overlay->perfOverlayState.SetPostFGFrameTimeMs(overlay->perfOverlayState.GetFrameTimeMs() / PerformanceOverlay::PerfOverlayState::kFrameGenerationMultiplier);
-		overlay->perfOverlayState.SetPostFGFps(overlay->perfOverlayState.GetFps() * PerformanceOverlay::PerfOverlayState::kFrameGenerationMultiplier);
-
-		if (overlay->perfOverlayState.GetUpdateTimer() <= 0.0f) {
-			overlay->perfOverlayState.SetPostFGSmoothFps(overlay->perfOverlayState.GetPostFGFps());
-			overlay->perfOverlayState.SetPostFGSmoothFrameTimeMs(overlay->perfOverlayState.GetPostFGFrameTimeMs());
-		}
-
-		overlay->perfOverlayState.GetPostFGFrameTimeHistoryRef()[overlay->perfOverlayState.GetPostFGFrameTimeHistoryIndex()] = overlay->perfOverlayState.GetPostFGFrameTimeMs();
-		overlay->perfOverlayState.SetPostFGFrameTimeHistoryIndex((overlay->perfOverlayState.GetPostFGFrameTimeHistoryIndex() + 1) % overlay->settings.FrameHistorySize);
-	}
-}
-
-void PerformanceOverlay::PerfOverlayState::UpdateFrameTimeHistorySizes()
-{
-	auto* overlay = GetSingleton();
-
-	overlay->settings.FrameHistorySize = std::clamp(
-		overlay->settings.FrameHistorySize,
-		overlay->settings.kMinFrameHistorySize,
-		overlay->settings.kMaxFrameHistorySize);
-
-	if (overlay->perfOverlayState.GetFrameTimeHistory().size() != static_cast<size_t>(overlay->settings.FrameHistorySize)) {
-		overlay->perfOverlayState.ResizeFrameTimeHistory(overlay->settings.FrameHistorySize, 0.0f);
-		if (overlay->perfOverlayState.GetFrameTimeHistoryIndex() >= overlay->settings.FrameHistorySize) {
-			overlay->perfOverlayState.SetFrameTimeHistoryIndex(0);
-		}
-	}
-	if (overlay->perfOverlayState.GetPostFGFrameTimeHistory().size() != static_cast<size_t>(overlay->settings.FrameHistorySize)) {
-		overlay->perfOverlayState.ResizePostFGFrameTimeHistory(overlay->settings.FrameHistorySize, 0.0f);
-		if (overlay->perfOverlayState.GetPostFGFrameTimeHistoryIndex() >= overlay->settings.FrameHistorySize) {
-			overlay->perfOverlayState.SetPostFGFrameTimeHistoryIndex(0);
-		}
-	}
-}
-
-void PerformanceOverlay::PerfOverlayState::UpdateMinFrameTime()
-{
-	auto* overlay = GetSingleton();
-	overlay->perfOverlayState.SetMinFrameTime(*std::min_element(overlay->perfOverlayState.GetFrameTimeHistory().begin(), overlay->perfOverlayState.GetFrameTimeHistory().end()));
-}
-
-void PerformanceOverlay::PerfOverlayState::UpdateMaxFrameTime()
-{
-	auto* overlay = GetSingleton();
-	overlay->perfOverlayState.SetMaxFrameTime(*std::max_element(overlay->perfOverlayState.GetFrameTimeHistory().begin(), overlay->perfOverlayState.GetFrameTimeHistory().end()));
-}
-
-float PerformanceOverlay::PerfOverlayState::SetTextScale()
-{
-	auto* overlay = GetSingleton();
-	switch (overlay->settings.Size) {
-	case PerfOverlaySettings::TextSize::Small:
-		return 0.8f;
-	case PerfOverlaySettings::TextSize::Medium:
-		return 1.0f;
-	case PerfOverlaySettings::TextSize::Large:
-		return 1.2f;
-	}
-	return 1.0f;
-}
+// ============================================================================
+// CORE PERFORMANCE DISPLAY FUNCTIONS
+// ============================================================================
 
 void PerformanceOverlay::DrawFPS()
 {
@@ -1164,157 +508,6 @@ void PerformanceOverlay::DrawFPS()
 	}
 }
 
-void PerformanceOverlay::PerfOverlayState::DrawPostFGFrameTimeGraph()
-{
-	// Prepare overlay text
-	char overlay_text[128];
-	snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
-		"Post-FG: %.2f ms (%.1f FPS)",
-		GetPostFGSmoothFrameTimeMs(), GetPostFGSmoothFps());
-
-	// Set graph colors - blue for post-FG
-	ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
-
-	// Draw the graph
-	float graphWidth = ImGui::GetWindowWidth() * 0.9f;
-	ImGui::PlotLines("##postfgframetime",
-		GetPostFGFrameTimeHistory().data(),
-		PerformanceOverlay::GetSingleton()->settings.FrameHistorySize,
-		GetPostFGFrameTimeHistoryIndex(),
-		overlay_text,
-		GetSmoothedMinFrameTime(), GetSmoothedMaxFrameTime(),
-		ImVec2(graphWidth, 50.0f * GetTextScale()));
-
-	ImGui::PopStyleColor();
-
-	// Draw frametime target reference lines
-	if (ImGui::BeginTable("PostFGFrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
-		ImGui::TableNextColumn();
-		ImGui::Text("30 FPS: 33.3 ms");
-
-		ImGui::TableNextColumn();
-		ImGui::Text("60 FPS: 16.7 ms");
-
-		ImGui::TableNextColumn();
-		ImGui::Text("120 FPS: 8.3 ms");
-
-		ImGui::EndTable();
-	}
-}
-
-// --- TEST DATA CAPTURE LOGIC ---
-// Test data is captured in two scenarios:
-// 1. A/B Test Mode (Variant B): If abTestingEnabled && usingTestConfig, we continuously capture test data
-//    for all shader types, "Other", and "Total" every frame. This allows live comparison between
-//    Variant A (user config) and Variant B (test config).
-// 2. Manual Shader Toggle: If any shader is disabled, we capture test data for the disabled shaders
-//    (and summary rows) at the moment of disabling, and keep it until cleared. This allows users to
-//    compare performance with/without specific shaders enabled.
-// Test data is only cleared by the "Clear Test Data" button or if all shaders are disabled (rare edge case).
-void PerformanceOverlay::CaptureTestData()
-{
-	auto* abTestingManager = ABTestingManager::GetSingleton();
-	bool abTestActive = (abTestingManager && abTestingManager->IsEnabled() && abTestingManager->IsUsingTestConfig());
-	bool anyShaderDisabled = false;
-	globals::state->ForEachShaderTypeWithIndex([&anyShaderDisabled]([[maybe_unused]] auto type, int classIndex) {
-		if (!globals::state->enabledClasses[classIndex]) {
-			anyShaderDisabled = true;
-		}
-	});
-	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.GetSmoothFrameTimeMs());
-	float measuredSum = 0.0f;
-	if (abTestActive) {
-		measuredSum = 0.0f;
-		globals::state->ForEachShaderTypeWithMetrics([&measuredSum, smoothedFrameTime, this]([[maybe_unused]] auto type, int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, float percent, float costPerCall) {
-			this->UpdateShaderTestDataEntry(typeIndex, frameTime, costPerCall, percent);
-			measuredSum += frameTime;
-		});
-		auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
-		UpdateSummaryTestData(smoothedFrameTime, otherFrameTime, otherPercent, totalCostPerCall);
-		testDataSource = TestDataSource::ABTest_VariantB;
-		testDataLastUpdated = std::chrono::steady_clock::now();
-	} else if (anyShaderDisabled) {
-		measuredSum = 0.0f;
-		globals::state->ForEachShaderTypeWithMetrics([&measuredSum, smoothedFrameTime, this]([[maybe_unused]] auto type, int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, float percent, float costPerCall) {
-			bool enabled = globals::state->enabledClasses[typeIndex - 1];
-			if (!enabled) {
-				this->UpdateShaderTestDataEntry(typeIndex, frameTime, costPerCall, percent);
-			}
-			measuredSum += frameTime;
-		});
-		auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
-		UpdateSummaryTestData(smoothedFrameTime, otherFrameTime, otherPercent, totalCostPerCall);
-		testDataSource = TestDataSource::ManualShaderToggle;
-		testDataLastUpdated = std::chrono::steady_clock::now();
-	}
-}
-
-void PerformanceOverlay::ClearTestData()
-{
-	testData.clear();
-	testDataSource = TestDataSource::None;
-}
-
-std::pair<std::vector<DrawCallRow>, std::vector<DrawCallRow>> PerformanceOverlay::BuildDrawCallRows() const
-{
-	std::vector<DrawCallRow> mainRows;
-	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.GetSmoothFrameTimeMs());
-	float measuredSum = 0.0f;
-
-	globals::state->ForEachShaderTypeWithMetrics([&mainRows, &measuredSum, smoothedFrameTime, this](auto type, int typeIndex, float drawCalls, float frameTime, float percent, float costPerCall) {
-		bool enabled = globals::state->enabledClasses[typeIndex - 1];
-		std::optional<float> testFrameTime, testCostPerCall;
-		auto it = this->testData.find(typeIndex);
-		if (it != this->testData.end()) {
-			testFrameTime = it->second.frameTime;
-			testCostPerCall = it->second.costPerCall;
-		}
-		std::string label = std::string(magic_enum::enum_name(type)) + ":";
-		std::string tooltip = "Draw calls for this shader type.";
-		auto tipIt = kShaderTypeTooltips.find(type);
-		if (tipIt != kShaderTypeTooltips.end()) {
-			tooltip = tipIt->second;
-		}
-		mainRows.push_back({ label, typeIndex, static_cast<int>(drawCalls), frameTime, percent, costPerCall, tooltip, enabled, testFrameTime, testCostPerCall });
-		measuredSum += frameTime;
-	});
-
-	auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
-	if (std::abs(otherFrameTime) < 1e-4f)
-		otherFrameTime = 0.0f;
-	std::optional<float> otherTestFrameTime, otherTestCostPerCall, totalTestFrameTime, totalTestCostPerCall;
-	auto itOther = this->testData.find(static_cast<int>(SpecialShaderType::Other));
-	if (itOther != this->testData.end()) {
-		otherTestFrameTime = itOther->second.frameTime;
-		otherTestCostPerCall = itOther->second.costPerCall;
-	}
-	auto itTotal = this->testData.find(static_cast<int>(SpecialShaderType::Total));
-	if (itTotal != this->testData.end()) {
-		totalTestFrameTime = itTotal->second.frameTime;
-		totalTestCostPerCall = itTotal->second.costPerCall;
-	}
-	DrawCallRow otherRow = {
-		"Other:", static_cast<int>(SpecialShaderType::Other), 0, otherFrameTime, otherPercent,
-		0.0f,
-		std::string("Frame time not attributed to any measured shader type. This includes UI, post-processing, engine work, and any GPU activity not directly measured by the overlay."),
-		true, otherTestFrameTime, otherTestCostPerCall
-	};
-	// Always use the actual total frame time for live data
-	float totalFrameTime = smoothedFrameTime;
-	float totalPercent = 100.0f;  // Total is always 100% of total
-
-	DrawCallRow totalRow = {
-		"Total:", static_cast<int>(SpecialShaderType::Total), static_cast<int>(globals::state->GetTotalSmoothedDrawCalls()), totalFrameTime, totalPercent,
-		totalCostPerCall,
-		std::string("Total frame time."),
-		true, totalTestFrameTime, totalTestCostPerCall
-	};
-	std::vector<DrawCallRow> summaryRows;
-	summaryRows.push_back(otherRow);
-	summaryRows.push_back(totalRow);
-	return { mainRows, summaryRows };
-}
-
 void PerformanceOverlay::DrawVRAM()
 {
 	auto menu = Menu::GetSingleton();
@@ -1355,324 +548,568 @@ void PerformanceOverlay::DrawVRAM()
 		ImGui::Text("VRAM Usage: Not available");
 	}
 }
+// ============================================================================
+// A/B TESTING FUNCTIONS
+// ============================================================================
 
-void PerformanceOverlay::PerfOverlayState::UpdateGraphValues()
+// --- ABTestAggregator integration ---
+ABTestAggregator& PerformanceOverlay::GetABTestAggregator()
 {
-	// Get settings from the singleton
-	const auto& overlaySettings = PerformanceOverlay::GetSingleton()->settings;
-
-	// Sync frame history buffer size with user settings
-	UpdateFrameTimeHistorySizes();
-
-	// Insert latest frame time into circular buffer
-	float oldFrameTime = GetFrameTimeHistory()[GetFrameTimeHistoryIndex()];
-	GetFrameTimeHistoryRef()[GetFrameTimeHistoryIndex()] = GetFrameTimeMs();
-	SetFrameTimeHistoryIndex((GetFrameTimeHistoryIndex() + 1) % overlaySettings.FrameHistorySize);
-
-	// Maintain instantaneous min/max tracking
-	if (GetFrameTimeMs() > GetMaxFrameTime()) {
-		SetMaxFrameTime(GetFrameTimeMs());
-	} else if (GetFrameTimeMs() < GetMinFrameTime()) {
-		SetMinFrameTime(GetFrameTimeMs());
-	} else if (oldFrameTime == GetMinFrameTime()) {
-		UpdateMinFrameTime();
-	} else if (oldFrameTime == GetMaxFrameTime()) {
-		UpdateMaxFrameTime();
-	}
-
-	float avgFrameTime, stdDev, graphMin, graphMax;
-	// Calculate mean and standard deviation for normalized graph range
-	if (GetFrameTimeHistory().empty()) {
-		// Default to 60 FPS
-		avgFrameTime = kDefaultFrameTimeMs;
-		stdDev = 0.0f;
-		graphMin = 0.0f;
-		graphMax = PerformanceOverlay::PerfOverlayState::kGraphSpreadMultiplier * kDefaultFrameTimeMs;
-	} else {
-		// Calculate average frame time
-		avgFrameTime = std::accumulate(GetFrameTimeHistory().begin(), GetFrameTimeHistory().end(), 0.0f) / GetFrameTimeHistory().size();
-
-		// Calculate standard deviation
-		float variance = 0.0f;
-		for (float ft : GetFrameTimeHistory()) {
-			float diff = ft - avgFrameTime;
-			variance += diff * diff;
-		}
-		variance /= GetFrameTimeHistory().size();
-		stdDev = std::sqrt(variance);
-
-		// Calculate graph range
-		float spread = std::clamp(stdDev * PerformanceOverlay::PerfOverlayState::kGraphSpreadMultiplier, PerformanceOverlay::PerfOverlayState::kGraphMinSpread, PerformanceOverlay::PerfOverlayState::kGraphMaxSpread);
-		graphMin = std::max(0.0f, avgFrameTime - spread);
-		graphMax = avgFrameTime + spread;
-	}
-
-	// Exponential smoothing for stable graph scaling
-	SetSmoothedMinFrameTime(GetSmoothedMinFrameTime() + kSmoothingFactor * (graphMin - GetSmoothedMinFrameTime()));
-	SetSmoothedMaxFrameTime(GetSmoothedMaxFrameTime() + kSmoothingFactor * (graphMax - GetSmoothedMaxFrameTime()));
+	auto* abTestingManager = ABTestingManager::GetSingleton();
+	return abTestingManager->GetAggregator();
 }
 
-// Private helper for table rendering
-void PerformanceOverlay::DrawDrawCallsTable(const std::vector<DrawCallRow>& mainRows, const std::vector<DrawCallRow>& summaryRows)
+/**
+  * @brief Draws the A/B test results table with comprehensive performance comparison
+  *
+  * This function renders a detailed table showing performance metrics for both Variant A (USER config)
+  * and Variant B (TEST config), including:
+  * - Average and median frame times for each shader type
+  * - Performance deltas and percentage differences
+  * - Color-coded indicators for better/worse performance
+  * - Statistical validity assessment with tooltips
+  * - Sortable columns for easy analysis
+  *
+  * The table provides both main rows (individual shader types) and summary rows (Total, Other)
+  * to give users a complete picture of performance differences between configurations.
+  *
+  * @note This function requires an active A/B test with aggregated results
+  */
+void PerformanceOverlay::DrawABTestResultsTable()
 {
-	static bool clearTestDataRequested = false;
-	auto* overlay = PerformanceOverlay::GetSingleton();
+	auto* abTestingManager = ABTestingManager::GetSingleton();
+	auto& aggregator = abTestingManager->GetAggregator();
+	auto results = aggregator.GetAggregatedResults();
+	if (results.empty())
+		return;
+
 	auto* menu = Menu::GetSingleton();
 	const auto& theme = menu->GetTheme();
 
-	// --- COLUMN CONFIG ---
-	using ColoredTextLines = Util::ColoredTextLines;
+	DrawABTestStatisticalValidity(theme, aggregator);
 
-	// --- BUILD LEGENDS ---
-	const ColoredTextLines frameTimeLegend = {
-		{ "Frame Time: Time spent on this shader type (ms and % of total frame time).", theme.Palette.Text },
-		{ "", theme.Palette.Text },
-		{ "Performance Color Legend (ms):", theme.Palette.Text },
-		{ "  <= 2 ms", theme.StatusPalette.SuccessColor },
-		{ "  > 2 ms and <= 5 ms", theme.StatusPalette.Warning },
-		{ "  > 5 ms", theme.StatusPalette.Error }
-	};
-	const ColoredTextLines costPerCallLegend = {
-		{ "Cost/Call: Average time per draw call for this shader type.", theme.Palette.Text },
-		{ "", theme.Palette.Text },
-		{ "Color Legend (ms/call):", theme.Palette.Text },
-		{ "  <= 0.05 ms/call", theme.StatusPalette.SuccessColor },
-		{ "  > 0.05 ms and <= 0.2 ms/call", theme.StatusPalette.Warning },
-		{ "  > 0.2 ms/call", theme.StatusPalette.Error }
-	};
-	const ColoredTextLines testFrameTimeLegend = {
-		{ PerformanceOverlay::GetTestDataTooltip(), theme.Palette.Text },
-		{ "", theme.Palette.Text },
-		{ "Color Legend (compared to live data):", theme.Palette.Text },
-		{ "  Better (lower than live)", theme.StatusPalette.SuccessColor },
-		{ "  Worse (higher than live)", theme.StatusPalette.Error },
-		{ "  Same as live", theme.Palette.Text }
-	};
-	const Util::ColoredTextLines testCostPerCallLegend = testFrameTimeLegend;
+	std::vector<DrawCallRow> mainRows, summaryRows;
+	ConvertABTestResultsToRows(results, mainRows, summaryRows);
 
-	overlay->CaptureTestData();
+	ABTestLegends legends = BuildABTestLegends(theme);
 
-	bool anyTestData = !overlay->testData.empty();
-	if (anyTestData) {
-		if (ImGui::Button("Clear Test Data")) {
-			clearTestDataRequested = true;
-		}
-	}
+	auto columns = BuildABTestResultsTableColumns(theme, legends);
 
-	// --- BUILD HEADERS AND CONFIG ---
-	std::vector<ColumnConfig> columns = {
-		{ "Shader Type",
-			[theme](const DrawCallRow& row, int) {
-				if (!row.enabled)
-					ImGui::PushStyleColor(ImGuiCol_Text, theme.StatusPalette.Disable);
-				bool wasEnabled = row.enabled;
-				if (ImGui::Selectable(row.label.c_str(), false)) {
-					auto maybeType = magic_enum::enum_cast<RE::BSShader::Type>(row.shaderType);
-					if (maybeType.has_value()) {
-						auto classIndex = magic_enum::enum_integer(*maybeType) - 1;
-						if (classIndex >= 0 && classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1) {
-							bool isDisabling = wasEnabled;
-							float prevFrameTime = row.frameTime;
-							float prevCostPerCall = row.costPerCall;
-							// Capture live data for Total and Other before toggling
-							float smoothedFrameTime = static_cast<float>(PerformanceOverlay::GetSingleton()->perfOverlayState.GetSmoothFrameTimeMs());
-							float measuredSum = 0.0f;
-							globals::state->ForEachShaderTypeWithMetrics([&measuredSum]([[maybe_unused]] auto type, [[maybe_unused]] int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, [[maybe_unused]] float percent, [[maybe_unused]] float costPerCall) {
-								measuredSum += frameTime;
-							});
-							auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
-							globals::state->enabledClasses[classIndex] = !wasEnabled;
-							if (isDisabling) {
-								// Save the last live value before disabling
-								PerformanceOverlay::GetSingleton()->UpdateShaderTestData(row.shaderType, prevFrameTime, prevCostPerCall);
-								// Save Total and Other test data as well
-								PerformanceOverlay::GetSingleton()->testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
-								PerformanceOverlay::GetSingleton()->testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
-								PerformanceOverlay::GetSingleton()->testDataSource = PerformanceOverlay::TestDataSource::ManualShaderToggle;
-								PerformanceOverlay::GetSingleton()->testDataLastUpdated = std::chrono::steady_clock::now();
-							}
-						}
-					}
-				}
-				if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup | ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::TextUnformatted(row.tooltip.c_str());
-					}
-				}
-				if (!row.enabled)
-					ImGui::PopStyleColor();
-			},
-			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.label < b.label) : (a.label > b.label); },
-			nullptr },
-		{ "Draw Calls",
-			[](const DrawCallRow& row, int) {
-				ImGui::Text("%d", row.drawCalls);
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::TextUnformatted("Draw Calls: Number of draw calls for this shader type in the current frame.");
-					}
-				}
-			},
-			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.drawCalls < b.drawCalls) : (a.drawCalls > b.drawCalls); },
-			[]() {
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::TextUnformatted("Draw Calls: Number of draw calls for this shader type in the current frame.");
-					}
-				}
-			} }
-	};
-	columns.push_back(ColumnConfig{
-		"Frame Time (%)",
-		MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.frameTime; }, [](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, PerformanceOverlay::PerfOverlayState::kFrameTimeGoodThreshold, PerformanceOverlay::PerfOverlayState::kFrameTimeWarningThreshold, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); }, [](float /*value*/, const DrawCallRow& row) { return Util::FormatMilliseconds(row.frameTime) + " (" + Util::FormatPercent(row.percent) + ")"; }, frameTimeLegend), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.percent < b.percent) : (a.percent > b.percent); }, [frameTimeLegend]() {
-			if (ImGui::IsItemHovered()) {
-				if (auto _tt = Util::HoverTooltipWrapper()) {
-					Util::DrawColoredMultiLineTooltip(frameTimeLegend);
-				}
-			} } });
-
-	columns.push_back(ColumnConfig{
-		"Cost/Call",
-		MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.costPerCall; }, [](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, PerformanceOverlay::PerfOverlayState::kCostPerCallGoodThreshold, PerformanceOverlay::PerfOverlayState::kCostPerCallWarningThreshold, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); }, [](float value, const DrawCallRow&) { return (value < PerformanceOverlay::PerfOverlayState::kMicrosecondThreshold && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); }, costPerCallLegend), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall); }, [costPerCallLegend]() {
-			if (ImGui::IsItemHovered()) {
-				if (auto _tt = Util::HoverTooltipWrapper()) {
-					Util::DrawColoredMultiLineTooltip(costPerCallLegend);
-				}
-			} } });
-
-	// Add test columns if present
-	if (anyTestData) {
-		columns.push_back(ColumnConfig{
-			"Test Frame Time (%)",
-			MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.testFrameTime; }, [](const auto& theme, float value, const DrawCallRow& row) {
-					if (value < row.frameTime)
-						return theme.StatusPalette.SuccessColor;
-					if (value > row.frameTime)
-						return theme.StatusPalette.Error;
-					return theme.Palette.Text; }, [overlay](float value, const DrawCallRow& row) { return Util::FormatMilliseconds(value) + " (" + Util::FormatPercent(overlay->testData[row.shaderType].percent) + ")"; }, testFrameTimeLegend), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
-				float aVal = a.testFrameTime.value_or(FLT_MAX);
-				float bVal = b.testFrameTime.value_or(FLT_MAX);
-				return asc ? (aVal < bVal) : (aVal > bVal); }, [overlay, testFrameTimeLegend]() {
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::TextUnformatted(overlay->GetTestDataTooltip().c_str());
-						ImGui::Separator();
-						Util::DrawColoredMultiLineTooltip(testFrameTimeLegend);
-					}
-				} } });
-
-		columns.push_back(ColumnConfig{
-			"Test Cost/Call",
-			MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.testCostPerCall; }, [](const auto& theme, float value, const DrawCallRow& row) {
-					if (value < row.costPerCall)
-						return theme.StatusPalette.SuccessColor;
-					if (value > row.costPerCall)
-						return theme.StatusPalette.Error;
-					return theme.Palette.Text; }, [](float value, const DrawCallRow&) { return (value < PerformanceOverlay::PerfOverlayState::kMicrosecondThreshold && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); }, testCostPerCallLegend), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
-				float aVal = a.testCostPerCall.value_or(FLT_MAX);
-				float bVal = b.testCostPerCall.value_or(FLT_MAX);
-				return asc ? (aVal < bVal) : (aVal > bVal); }, [overlay, testCostPerCallLegend]() {
-				if (ImGui::IsItemHovered()) {
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::TextUnformatted(overlay->GetTestDataTooltip().c_str());
-						ImGui::Separator();
-						Util::DrawColoredMultiLineTooltip(testCostPerCallLegend);
-					}
-				} } });
-	}
-
-	// --- TABLE RENDER: MAIN ROWS + FOOTER ROWS ---
 	std::vector<std::function<bool(const DrawCallRow&, const DrawCallRow&, bool)>> sorters;
 	for (const auto& col : columns) sorters.push_back(col.sortFunc);
-
-	// Create non-const copies for the table function
 	std::vector<DrawCallRow> mainRowsCopy = mainRows;
 	std::vector<DrawCallRow> summaryRowsCopy = summaryRows;
-
 	Util::ShowSortedStringTable<DrawCallRow>(
-		"DrawCallOverlayTable",
+		"ABTestResultsTable",
 		[&columns]() { std::vector<std::string> h; for (const auto& c : columns) h.push_back(c.header); return h; }(),
 		mainRowsCopy,
 		0,     // Default sort column (Shader Type)
 		true,  // Default ascending
 		sorters,
-		[&columns, overlay](int rowIdx, int colIdx, const DrawCallRow& row) {
+		[&columns](int rowIdx, int colIdx, const DrawCallRow& row) {
 			(void)rowIdx;
-			// Special handling for summary rows
-			if ((row.label == "Total:" || row.label == "Other:") && colIdx == 0) {
-				if (row.label == "Total:") {
-					if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
-						bool anyDisabled = false;
-						globals::state->ForEachShaderTypeWithIndex([&anyDisabled]([[maybe_unused]] auto type, int classIndex) {
-							if (!globals::state->enabledClasses[classIndex]) {
-								anyDisabled = true;
-							}
-						});
-						globals::state->ForEachShaderTypeWithIndex([&anyDisabled]([[maybe_unused]] auto type, int classIndex) {
-							globals::state->enabledClasses[classIndex] = anyDisabled;
-						});
-						// Update test data and timestamp for manual toggling (not just A/B test mode)
-						auto* abTestingManager = ABTestingManager::GetSingleton();
-						bool abTest = abTestingManager && abTestingManager->IsEnabled() && abTestingManager->IsUsingTestConfig();
-						if (abTest) {
-							overlay->UpdateAllShaderTestData();
-						} else {
-							// Manual toggle: update test data and timestamp
-							float smoothedFrameTime = static_cast<float>(overlay->perfOverlayState.GetSmoothFrameTimeMs());
-							float measuredSum = 0.0f;
-							globals::state->ForEachShaderTypeWithMetrics([&measuredSum]([[maybe_unused]] auto type, [[maybe_unused]] int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, [[maybe_unused]] float percent, [[maybe_unused]] float costPerCall) {
-								measuredSum += frameTime;
-							});
-							auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
-							overlay->testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
-							overlay->testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
-							overlay->testDataSource = PerformanceOverlay::TestDataSource::ManualShaderToggle;
-							overlay->testDataLastUpdated = std::chrono::steady_clock::now();
-						}
-					}
-					if (ImGui::IsItemHovered()) {
-						if (auto _tt = Util::HoverTooltipWrapper()) {
-							ImGui::TextUnformatted(row.tooltip.c_str());
-							float _fps = row.frameTime > 0.0f ? 1000.0f / row.frameTime : 0.0f;
-							ImGui::Text("FPS: %.2f", _fps);
-						}
-					}
-				} else if (row.label == "Other:") {
-					ImGui::TextUnformatted(row.label.c_str());
-					if (!row.tooltip.empty() && ImGui::IsItemHovered()) {
-						if (auto _tt = Util::HoverTooltipWrapper()) {
-							ImGui::TextUnformatted(row.tooltip.c_str());
-						}
-					}
-				}
-			} else if (row.label == "Total:" || row.label == "Other:") {
-				// No tooltip for summary rows in non-label columns
-				columns[colIdx].cellRender(row, colIdx);
-			} else {
-				// Normal row: ensure tooltips never modify cell content
-				columns[colIdx].cellRender(row, colIdx);
-			}
+			columns[colIdx].cellRender(row, colIdx);
 		},
 		summaryRowsCopy);
+}
 
-	if (clearTestDataRequested) {
-		overlay->ClearTestData();
-		clearTestDataRequested = false;
+/**
+  * @brief Draws statistical validity information for A/B test results
+  *
+  * This function displays test duration, valid frame counts, and exclusion rates
+  * with color-coded indicators for statistical validity. It helps users understand
+  * whether the A/B test results are reliable and statistically significant.
+  *
+  * @param theme The current UI theme settings
+  * @param aggregator The A/B test aggregator containing test statistics
+  */
+void PerformanceOverlay::DrawABTestStatisticalValidity(const Menu::ThemeSettings& theme, const ABTestAggregator& aggregator) const
+{
+	float totalDuration = aggregator.GetTotalTestDuration();
+	int totalFrames = aggregator.GetTotalFrameCount();
+	int excludedFrames = 0;
+	for (const auto& interval : aggregator.GetIntervals()) {
+		excludedFrames += interval.excludedFrames;
+	}
+	int validFrames = totalFrames;
+	int totalWithExcluded = totalFrames + excludedFrames;
+	float validPercent = (totalWithExcluded > 0) ? (100.0f * validFrames / totalWithExcluded) : 100.0f;
+
+	bool hasEnoughSamples = validFrames >= kMinimumSamplesForValidity;
+	bool hasGoodDuration = totalDuration >= kMinimumTestDuration;
+	bool hasLowExclusionRate = validPercent >= kMinimumValidFramesPercent;
+	bool isStatisticallyValid = hasEnoughSamples && hasGoodDuration && hasLowExclusionRate;
+
+	ImVec4 validityColor = theme.Palette.Text;
+	if (isStatisticallyValid) {
+		validityColor = theme.StatusPalette.SuccessColor;
+	} else if (validFrames >= kMinimumSamplesForMarginal && totalDuration >= kMinimumDurationForMarginal) {
+		validityColor = theme.StatusPalette.Warning;
+	} else {
+		validityColor = theme.StatusPalette.Error;
+	}
+
+	ImGui::PushStyleColor(ImGuiCol_Text, validityColor);
+	ImGui::Text("Test Duration: %.1f seconds | Valid Frames: %d/%d (%.1f%%) | Excluded: %d",
+		totalDuration, validFrames, totalWithExcluded, validPercent, excludedFrames);
+	ImGui::PopStyleColor();
+	if (ImGui::IsItemHovered()) {
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			char validStr[128], marginalStr[128];
+			snprintf(validStr, sizeof(validStr), "Statistically valid (>%d samples, >%.0fs duration, >%.0f%% valid)", kMinimumSamplesForValidity, static_cast<float>(kMinimumTestDuration), kMinimumValidFramesPercent);
+			snprintf(marginalStr, sizeof(marginalStr), "Marginal validity (>%d samples, >%.0fs duration)", kMinimumSamplesForMarginal, static_cast<float>(kMinimumDurationForMarginal));
+			Util::ColoredTextLines validityLegend = {
+				{ "Valid frames are those not excluded as outliers.\nA low percentage may indicate instability or test interruptions.\nExcluded frames are those with frame times > 3x median or > 100ms.\nThis removes shader compilation spikes, JSON loading overhead, and other anomalies\nthat would skew the performance comparison.", theme.Palette.Text },
+				{ "", theme.Palette.Text },
+				{ validStr, theme.StatusPalette.SuccessColor },
+				{ marginalStr, theme.StatusPalette.Warning },
+				{ "Insufficient data for reliable results", theme.StatusPalette.Error }
+			};
+			Util::DrawColoredMultiLineTooltip(validityLegend);
+		}
 	}
 }
 
 /**
- * @brief Draws the A/B testing section of the performance overlay
- *
- * This function handles all A/B testing related UI including:
- * - A/B test state management and data collection
- * - Display of aggregated A/B test results
- * - Settings difference comparison table
- * - A/B test controls (clear results, show/hide settings diff)
- *
- * @param allRows The current draw call rows for data collection
- * @param showCollapsibleSections Whether to show collapsible section headers
- */
+  * @brief Converts A/B test aggregated results into table rows
+  *
+  * This function transforms aggregated A/B test statistics into DrawCallRow structures
+  * suitable for display in the performance overlay table. It separates main shader type
+  * rows from summary rows (Total, Other) and assigns appropriate tooltips.
+  *
+  * @param results The aggregated A/B test results
+  * @param mainRows Output vector for individual shader type rows
+  * @param summaryRows Output vector for summary rows (Total, Other)
+  */
+void PerformanceOverlay::ConvertABTestResultsToRows(const std::vector<AggregatedDrawCallStats>& results, std::vector<DrawCallRow>& mainRows, std::vector<DrawCallRow>& summaryRows) const
+{
+	mainRows.clear();
+	summaryRows.clear();
+	for (const auto& stat : results) {
+		DrawCallRow row;
+		row.label = stat.label;
+		row.shaderType = stat.shaderType;
+		row.frameTime = stat.meanA;
+		row.percent = (stat.meanA > 0.0f) ? (stat.meanA / (stat.meanA + stat.meanB) * 100.0f) : 0.0f;
+		row.costPerCall = stat.medianA;
+		row.enabled = true;
+		row.testFrameTime = stat.meanB;
+		row.testCostPerCall = stat.medianB;
+		if (row.shaderType >= 0) {
+			auto shaderType = static_cast<RE::BSShader::Type>(row.shaderType);
+			auto tipIt = kShaderTypeTooltips.find(shaderType);
+			if (tipIt != kShaderTypeTooltips.end()) {
+				row.tooltip = tipIt->second;
+			} else {
+				row.tooltip = "Draw calls for this shader type.";
+			}
+		} else {
+			if (row.shaderType == static_cast<int>(SpecialShaderType::Total)) {
+				row.tooltip = "Total frame time.";
+			} else if (row.shaderType == static_cast<int>(SpecialShaderType::Other)) {
+				row.tooltip = "Frame time not attributed to any measured shader type. This includes UI, post-processing, engine work, and any GPU activity not directly measured by the overlay.";
+			}
+		}
+		if (row.shaderType < 0) {
+			summaryRows.push_back(row);
+		} else {
+			mainRows.push_back(row);
+		}
+	}
+}
+
+/**
+  * @brief Builds color-coded legends for A/B test table columns
+  *
+  * This function creates comprehensive tooltip legends for each A/B test column,
+  * explaining the meaning of colors and values. The legends help users understand
+  * performance comparisons between Variant A (USER) and Variant B (TEST) configurations.
+  *
+  * @param theme The current UI theme settings
+  * @return ABTestLegends structure containing all column legends
+  */
+ABTestLegends PerformanceOverlay::BuildABTestLegends(const Menu::ThemeSettings& theme) const
+{
+	ABTestLegends legends;
+
+	legends.shaderType = {
+		"Shader Type",
+		{ { "Shader Type: The type of shader being measured.", theme.Palette.Text },
+			{ "Click to toggle shader on/off for performance testing.", theme.Palette.Text } }
+	};
+
+	legends.aAvg = {
+		"A Avg (ms)",
+		{ { "A Avg (ms): Average frame time for Variant A (USER config).", theme.Palette.Text },
+			{ "", theme.Palette.Text },
+			{ "Color Legend (compared to Variant B):", theme.Palette.Text },
+			{ "  Better (lower than B)", theme.StatusPalette.SuccessColor },
+			{ "  Worse (higher than B)", theme.StatusPalette.Error },
+			{ "  Same as B", theme.Palette.Text } }
+	};
+
+	legends.bAvg = {
+		"B Avg (ms)",
+		{ { "B Avg (ms): Average frame time for Variant B (TEST config).", theme.Palette.Text },
+			{ "", theme.Palette.Text },
+			{ "Color Legend (compared to Variant A):", theme.Palette.Text },
+			{ "  Better (lower than A)", theme.StatusPalette.SuccessColor },
+			{ "  Worse (higher than A)", theme.StatusPalette.Error },
+			{ "  Same as A", theme.Palette.Text } }
+	};
+
+	legends.delta = {
+		"Delta (ms)",
+		{ { "Delta (ms): Difference between Variant B and Variant A (B - A).", theme.Palette.Text },
+			{ "Negative values indicate Variant B is better (lower frame time).", theme.Palette.Text },
+			{ "Positive values indicate Variant A is better (lower frame time).", theme.Palette.Text },
+			{ "Percentage shows relative performance difference.", theme.Palette.Text },
+			{ "", theme.Palette.Text },
+			{ "Color Legend:", theme.Palette.Text },
+			{ "  Negative (B better)", theme.StatusPalette.SuccessColor },
+			{ "  Positive (A better)", theme.StatusPalette.Error },
+			{ "  Zero (same)", theme.Palette.Text } }
+	};
+
+	legends.aMedian = {
+		"A Median (ms)",
+		{ { "A Median: Median frame time for Variant A (USER config).", theme.Palette.Text },
+			{ "Median is less sensitive to outliers than average.", theme.Palette.Text },
+			{ "", theme.Palette.Text },
+			{ "Color Legend (compared to Variant B median):", theme.Palette.Text },
+			{ "  Better (lower than B)", theme.StatusPalette.SuccessColor },
+			{ "  Worse (higher than B)", theme.StatusPalette.Error },
+			{ "  Same as B", theme.Palette.Text } }
+	};
+
+	legends.bMedian = {
+		"B Median (ms)",
+		{ { "B Median: Median frame time for Variant B (TEST config).", theme.Palette.Text },
+			{ "Median is less sensitive to outliers than average.", theme.Palette.Text },
+			{ "", theme.Palette.Text },
+			{ "Color Legend (compared to Variant A median):", theme.Palette.Text },
+			{ "  Better (lower than A)", theme.StatusPalette.SuccessColor },
+			{ "  Worse (higher than A)", theme.StatusPalette.Error },
+			{ "  Same as A", theme.Palette.Text } }
+	};
+
+	legends.medianDelta = {
+		"Median Delta (ms)",
+		{ { "Median Delta: Difference between Variant B and Variant A medians (B - A).", theme.Palette.Text },
+			{ "Negative values indicate Variant B is better (lower median).", theme.Palette.Text },
+			{ "Positive values indicate Variant A is better (lower median).", theme.Palette.Text },
+			{ "", theme.Palette.Text },
+			{ "Color Legend:", theme.Palette.Text },
+			{ "  Negative (B better)", theme.StatusPalette.SuccessColor },
+			{ "  Positive (A better)", theme.StatusPalette.Error },
+			{ "  Zero (same)", theme.Palette.Text } }
+	};
+
+	return legends;
+}
+
+/**
+  * @brief Builds column configurations for the A/B test results table
+  *
+  * This function creates column configurations for displaying A/B test results,
+  * including average and median frame times for both variants, performance deltas,
+  * and color-coded indicators for better/worse performance comparisons.
+  *
+  * @param theme The current UI theme settings
+  * @param legends The color-coded legends for tooltips
+  * @return Vector of column configurations for the table
+  */
+std::vector<ColumnConfig> PerformanceOverlay::BuildABTestResultsTableColumns(const Menu::ThemeSettings& theme, const ABTestLegends& legends) const
+{
+	std::vector<ColumnConfig> columns = {
+		{ legends.shaderType.header,
+			[theme](const DrawCallRow& row, int) {
+				ImGui::TextUnformatted(row.label.c_str());
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::TextUnformatted(row.tooltip.c_str());
+						// Add FPS for Total row
+						if (row.label == "Total:") {
+							float fps = row.frameTime > 0.0f ? 1000.0f / row.frameTime : 0.0f;
+							ImGui::Text("FPS: %.2f", fps);
+						}
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.label < b.label) : (a.label > b.label); },
+			[legends]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						Util::DrawColoredMultiLineTooltip(legends.shaderType.tooltip);
+					}
+				}
+			} },
+		{ legends.aAvg.header,
+			[theme, legends](const DrawCallRow& row, int) {
+				float value = row.frameTime;
+				// Color A relative to B
+				ImVec4 color = theme.Palette.Text;
+				if (row.testFrameTime.has_value()) {
+					if (value < *row.testFrameTime) {
+						color = theme.StatusPalette.SuccessColor;  // A is better (lower) than B
+					} else if (value > *row.testFrameTime) {
+						color = theme.StatusPalette.Error;  // A is worse (higher) than B
+					}
+				}
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				ImGui::Text("%s", Util::FormatMilliseconds(value).c_str());
+				ImGui::PopStyleColor();
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						if (row.label == "Total:") {
+							ImGui::Text("A (USER) FPS: %.2f", Util::CalcFPS(value));
+						} else {
+							Util::DrawColoredMultiLineTooltip(legends.aAvg.tooltip);
+						}
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.frameTime < b.frameTime) : (a.frameTime > b.frameTime); },
+			[legends]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						Util::DrawColoredMultiLineTooltip(legends.aAvg.tooltip);
+					}
+				}
+			} },
+		{ legends.bAvg.header,
+			[theme, legends](const DrawCallRow& row, int) {
+				if (!row.testFrameTime.has_value()) {
+					ImGui::TextDisabled("-");
+					return;
+				}
+				float value = *row.testFrameTime;
+				// Color B relative to A
+				ImVec4 color = theme.Palette.Text;
+				if (value < row.frameTime) {
+					color = theme.StatusPalette.SuccessColor;  // B is better (lower) than A
+				} else if (value > row.frameTime) {
+					color = theme.StatusPalette.Error;  // B is worse (higher) than A
+				}
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				ImGui::Text("%s", Util::FormatMilliseconds(value).c_str());
+				ImGui::PopStyleColor();
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						if (row.label == "Total:") {
+							ImGui::Text("B (TEST) FPS: %.2f", Util::CalcFPS(value));
+						} else {
+							Util::DrawColoredMultiLineTooltip(legends.bAvg.tooltip);
+						}
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+				float aVal = a.testFrameTime.value_or(FLT_MAX);
+				float bVal = b.testFrameTime.value_or(FLT_MAX);
+				return asc ? (aVal < bVal) : (aVal > bVal);
+			},
+			[legends]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						Util::DrawColoredMultiLineTooltip(legends.bAvg.tooltip);
+					}
+				}
+			} },
+		{ legends.delta.header,
+			[theme, legends](const DrawCallRow& row, int) {
+				if (!row.testFrameTime.has_value()) {
+					ImGui::TextDisabled("-");
+					return;
+				}
+				float delta = *row.testFrameTime - row.frameTime;
+				// Color based on delta
+				ImVec4 color = theme.Palette.Text;
+				if (delta < 0.0f) {
+					color = theme.StatusPalette.SuccessColor;  // Better performance (negative delta)
+				} else if (delta > 0.0f) {
+					color = theme.StatusPalette.Error;  // Worse performance (positive delta)
+				}
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				ImGui::Text("%s", Util::FormatDeltaWithPercent(row.frameTime, *row.testFrameTime, PerformanceOverlay::PerfOverlayState::kPercentDisplayThreshold).c_str());
+				ImGui::PopStyleColor();
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						if (row.testFrameTime.has_value()) {
+							// Show detailed values for rows with test data
+							if (row.label == "Total:") {
+								ImGui::TextUnformatted("Delta (B - A):");
+								ImGui::Separator();
+								ImGui::Text("A (USER) FPS: %.2f", Util::CalcFPS(row.frameTime));
+								ImGui::Text("B (TEST) FPS: %.2f", Util::CalcFPS(*row.testFrameTime));
+							} else {
+								ImGui::TextUnformatted("Delta (B - A):");
+								ImGui::Separator();
+								ImGui::Text("A (USER): %.3f ms", row.frameTime);
+								ImGui::Text("B (TEST): %.3f ms", *row.testFrameTime);
+							}
+							ImGui::Separator();
+						}
+						// Always show the delta legend for explanation
+						Util::DrawColoredMultiLineTooltip(legends.delta.tooltip);
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+				float aDelta = a.testFrameTime.value_or(0.0f) - a.frameTime;
+				float bDelta = b.testFrameTime.value_or(0.0f) - b.frameTime;
+				return asc ? (aDelta < bDelta) : (aDelta > bDelta);
+			},
+			[legends]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						Util::DrawColoredMultiLineTooltip(legends.delta.tooltip);
+					}
+				}
+			} },
+		{ legends.aMedian.header,
+			[theme, legends](const DrawCallRow& row, int) {
+				float value = row.costPerCall;
+				// Color A median relative to B median (stored in testCostPerCall for now)
+				ImVec4 color = theme.Palette.Text;
+				if (row.testCostPerCall.has_value()) {
+					if (value < *row.testCostPerCall) {
+						color = theme.StatusPalette.SuccessColor;  // A is better (lower) than B
+					} else if (value > *row.testCostPerCall) {
+						color = theme.StatusPalette.Error;  // A is worse (higher) than B
+					}
+				}
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				ImGui::Text("%s", Util::FormatMilliseconds(value).c_str());
+				ImGui::PopStyleColor();
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						if (row.label == "Total:") {
+							Util::ColoredTextLines fpsTooltip{
+								{ std::format("A (USER) Median FPS: {:.2f}", Util::CalcFPS(value)), ImVec4(1.0f, 1.0f, 1.0f, 1.0f) }
+							};
+							Util::DrawColoredMultiLineTooltip(fpsTooltip);
+						} else {
+							Util::DrawColoredMultiLineTooltip(legends.aMedian.tooltip);
+						}
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall); },
+			[legends]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						Util::DrawColoredMultiLineTooltip(legends.aMedian.tooltip);
+					}
+				}
+			} },
+		{ legends.bMedian.header,
+			[theme, legends](const DrawCallRow& row, int) {
+				if (!row.testCostPerCall.has_value()) {
+					ImGui::TextDisabled("-");
+					return;
+				}
+				float value = *row.testCostPerCall;
+				// Color B median relative to A median
+				ImVec4 color = theme.Palette.Text;
+				if (value < row.costPerCall) {
+					color = theme.StatusPalette.SuccessColor;  // B is better (lower) than A
+				} else if (value > row.costPerCall) {
+					color = theme.StatusPalette.Error;  // B is worse (higher) than A
+				}
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				ImGui::Text("%s", Util::FormatMilliseconds(value).c_str());
+				ImGui::PopStyleColor();
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						if (row.label == "Total:") {
+							Util::ColoredTextLines fpsTooltip{
+								{ std::format("B (TEST) Median FPS: {:.2f}", Util::CalcFPS(value)), ImVec4(1.0f, 1.0f, 1.0f, 1.0f) }
+							};
+							Util::DrawColoredMultiLineTooltip(fpsTooltip);
+						} else {
+							Util::DrawColoredMultiLineTooltip(legends.bMedian.tooltip);
+						}
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+				float aVal = a.testCostPerCall.value_or(FLT_MAX);
+				float bVal = b.testCostPerCall.value_or(FLT_MAX);
+				return asc ? (aVal < bVal) : (aVal > bVal);
+			},
+			[legends]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						Util::DrawColoredMultiLineTooltip(legends.bMedian.tooltip);
+					}
+				}
+			} },
+		{ legends.medianDelta.header,
+			[theme, legends](const DrawCallRow& row, int) {
+				if (!row.testCostPerCall.has_value()) {
+					ImGui::TextDisabled("-");
+					return;
+				}
+				float delta = *row.testCostPerCall - row.costPerCall;
+				// Color based on delta
+				ImVec4 color = theme.Palette.Text;
+				if (delta < 0.0f) {
+					color = theme.StatusPalette.SuccessColor;  // Better performance (negative delta)
+				} else if (delta > 0.0f) {
+					color = theme.StatusPalette.Error;  // Worse performance (positive delta)
+				}
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				std::string deltaStr = (delta > 0.0f) ? "+" + Util::FormatMilliseconds(delta) : Util::FormatMilliseconds(delta);
+				ImGui::Text("%s", deltaStr.c_str());
+				ImGui::PopStyleColor();
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						if (row.label == "Total:" && row.testCostPerCall.has_value()) {
+							Util::ColoredTextLines fpsTooltip{
+								{ "Median Delta (B - A):", ImVec4(1.0f, 1.0f, 1.0f, 1.0f) },
+								{ "", ImVec4(1.0f, 1.0f, 1.0f, 1.0f) },
+								{ std::format("A (USER) Median FPS: {:.2f}", Util::CalcFPS(row.costPerCall)), ImVec4(1.0f, 1.0f, 1.0f, 1.0f) },
+								{ std::format("B (TEST) Median FPS: {:.2f}", Util::CalcFPS(*row.testCostPerCall)), ImVec4(1.0f, 1.0f, 1.0f, 1.0f) },
+								{ "", ImVec4(1.0f, 1.0f, 1.0f, 1.0f) },
+								{ "Median is less sensitive to outliers than average.", ImVec4(1.0f, 1.0f, 1.0f, 1.0f) }
+							};
+							Util::DrawColoredMultiLineTooltip(fpsTooltip);
+						} else {
+							Util::DrawColoredMultiLineTooltip(legends.medianDelta.tooltip);
+						}
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+				float aDelta = a.testCostPerCall.value_or(0.0f) - a.costPerCall;
+				float bDelta = b.testCostPerCall.value_or(0.0f) - b.costPerCall;
+				return asc ? (aDelta < bDelta) : (aDelta > bDelta);
+			},
+			[legends]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						Util::DrawColoredMultiLineTooltip(legends.medianDelta.tooltip);
+					}
+				}
+			} }
+	};
+
+	return columns;
+}
+
+/**
+  * @brief Draws the A/B testing section of the performance overlay
+  *
+  * This function handles all A/B testing related UI including:
+  * - A/B test state management and data collection
+  * - Display of aggregated A/B test results
+  * - Settings difference comparison table
+  * - A/B test controls (clear results, show/hide settings diff)
+  *
+  * @param allRows The current draw call rows for data collection
+  * @param showCollapsibleSections Whether to show collapsible section headers
+  */
 void PerformanceOverlay::DrawABTestSection(const std::vector<DrawCallRow>& allRows, bool showCollapsibleSections)
 {
 	auto* menu = Menu::GetSingleton();
@@ -1837,6 +1274,576 @@ void PerformanceOverlay::DrawABTestSection(const std::vector<DrawCallRow>& allRo
 		}
 	}
 }
+// ============================================================================
+// TABLE BUILDING AND RENDERING FUNCTIONS
+// ============================================================================
+
+// Private helper for table rendering
+void PerformanceOverlay::DrawDrawCallsTable(const std::vector<DrawCallRow>& mainRows, const std::vector<DrawCallRow>& summaryRows)
+{
+	static bool clearTestDataRequested = false;
+	auto* overlay = PerformanceOverlay::GetSingleton();
+	auto* menu = Menu::GetSingleton();
+	const auto& theme = menu->GetTheme();
+
+	// Capture test data and handle clear button
+	overlay->CaptureTestData();
+	bool anyTestData = !overlay->testData.empty();
+	if (anyTestData) {
+		if (ImGui::Button("Clear Test Data")) {
+			clearTestDataRequested = true;
+		}
+	}
+
+	// Build legends and column configurations
+	auto legends = overlay->BuildDrawCallLegends(theme, anyTestData, overlay);
+	auto columns = overlay->BuildDrawCallTableColumns(theme, legends, anyTestData, overlay);
+
+	// Build sorters
+	std::vector<std::function<bool(const DrawCallRow&, const DrawCallRow&, bool)>> sorters;
+	for (const auto& col : columns) sorters.push_back(col.sortFunc);
+
+	// Create non-const copies for the table function
+	std::vector<DrawCallRow> mainRowsCopy = mainRows;
+	std::vector<DrawCallRow> summaryRowsCopy = summaryRows;
+
+	// Create table row handler
+	auto rowHandler = overlay->CreateTableRowHandler(columns, overlay);
+
+	// Render the table
+	Util::ShowSortedStringTable<DrawCallRow>(
+		"DrawCallOverlayTable",
+		[&columns]() { std::vector<std::string> h; for (const auto& c : columns) h.push_back(c.header); return h; }(),
+		mainRowsCopy,
+		0,     // Default sort column (Shader Type)
+		true,  // Default ascending
+		sorters,
+		rowHandler,
+		summaryRowsCopy);
+
+	// Handle clear test data request
+	if (clearTestDataRequested) {
+		overlay->ClearTestData();
+		clearTestDataRequested = false;
+	}
+}
+
+DrawCallLegends PerformanceOverlay::BuildDrawCallLegends(const Menu::ThemeSettings& theme, bool anyTestData, PerformanceOverlay* overlay) const
+{
+	(void)anyTestData;
+	DrawCallLegends legends;
+
+	legends.shaderType = {
+		"Shader Type",
+		{ { "Shader Type: The type of shader being measured.", theme.Palette.Text },
+			{ "Click to toggle shader on/off for performance testing.", theme.Palette.Text } }
+	};
+
+	legends.drawCalls = {
+		"Draw Calls",
+		{ { "Draw Calls: Number of draw calls for this shader type in the current frame.", theme.Palette.Text } }
+	};
+
+	legends.frameTime = {
+		"Frame Time (%)",
+		{ { overlay->GetTestDataTooltip(), theme.Palette.Text },
+			{ "", theme.Palette.Text },
+			{ "Performance Color Legend (ms):", theme.Palette.Text },
+			{ "  <= 2 ms", theme.StatusPalette.SuccessColor },
+			{ "  > 2 ms and <= 5 ms", theme.StatusPalette.Warning },
+			{ "  > 5 ms", theme.StatusPalette.Error } }
+	};
+
+	legends.costPerCall = {
+		"Cost/Call",
+		{ { "Cost/Call: Average time per draw call for this shader type.", theme.Palette.Text },
+			{ "", theme.Palette.Text },
+			{ "Color Legend (ms/call):", theme.Palette.Text },
+			{ "  <= 0.05 ms/call", theme.StatusPalette.SuccessColor },
+			{ "  > 0.05 ms and <= 0.2 ms/call", theme.StatusPalette.Warning },
+			{ "  > 0.2 ms/call", theme.StatusPalette.Error } }
+	};
+
+	legends.testFrameTime = {
+		"Test Frame Time (%)",
+		{ { overlay->GetTestDataTooltip(), theme.Palette.Text },
+			{ "", theme.Palette.Text },
+			{ "Color Legend (compared to live data):", theme.Palette.Text },
+			{ "  Better (lower than live)", theme.StatusPalette.SuccessColor },
+			{ "  Worse (higher than live)", theme.StatusPalette.Error },
+			{ "  Same as live", theme.Palette.Text } }
+	};
+
+	legends.testCostPerCall = {
+		"Test Cost/Call",
+		{ { overlay->GetTestDataTooltip(), theme.Palette.Text },
+			{ "", theme.Palette.Text },
+			{ "Color Legend (compared to live data):", theme.Palette.Text },
+			{ "  Better (lower than live)", theme.StatusPalette.SuccessColor },
+			{ "  Worse (higher than live)", theme.StatusPalette.Error },
+			{ "  Same as live", theme.Palette.Text } }
+	};
+
+	return legends;
+}
+
+std::vector<ColumnConfig> PerformanceOverlay::BuildDrawCallTableColumns(const Menu::ThemeSettings& theme, const DrawCallLegends& legends, bool anyTestData, PerformanceOverlay* overlay)
+{
+	// Build column configurations
+	std::vector<ColumnConfig> columns = {
+		{ legends.shaderType.header,
+			[theme](const DrawCallRow& row, int) {
+				if (!row.enabled)
+					ImGui::PushStyleColor(ImGuiCol_Text, theme.StatusPalette.Disable);
+				bool wasEnabled = row.enabled;
+				if (ImGui::Selectable(row.label.c_str(), false)) {
+					auto maybeType = magic_enum::enum_cast<RE::BSShader::Type>(row.shaderType);
+					if (maybeType.has_value()) {
+						auto classIndex = magic_enum::enum_integer(*maybeType) - 1;
+						if (classIndex >= 0 && classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1) {
+							PerformanceOverlay::GetSingleton()->HandleShaderToggle(row, wasEnabled);
+						}
+					}
+				}
+				if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup | ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::TextUnformatted(row.tooltip.c_str());
+					}
+				}
+				if (!row.enabled)
+					ImGui::PopStyleColor();
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.label < b.label) : (a.label > b.label); },
+			[legends]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						Util::DrawColoredMultiLineTooltip(legends.shaderType.tooltip);
+					}
+				}
+			} },
+		{ legends.drawCalls.header,
+			[](const DrawCallRow& row, int) {
+				ImGui::Text("%d", row.drawCalls);
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::TextUnformatted("Draw Calls: Number of draw calls for this shader type in the current frame.");
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.drawCalls < b.drawCalls) : (a.drawCalls > b.drawCalls); },
+			[legends]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						Util::DrawColoredMultiLineTooltip(legends.drawCalls.tooltip);
+					}
+				}
+			} }
+	};
+
+	columns.push_back(ColumnConfig{
+		legends.frameTime.header,
+		MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.frameTime; }, [](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, PerformanceOverlay::PerfOverlayState::kFrameTimeGoodThreshold, PerformanceOverlay::PerfOverlayState::kFrameTimeWarningThreshold, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); }, [](float /*value*/, const DrawCallRow& row) { return Util::FormatMilliseconds(row.frameTime) + " (" + Util::FormatPercent(row.percent) + ")"; }, legends.frameTime.tooltip), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.percent < b.percent) : (a.percent > b.percent); }, [legends]() {
+			 if (ImGui::IsItemHovered()) {
+				 if (auto _tt = Util::HoverTooltipWrapper()) {
+					 Util::DrawColoredMultiLineTooltip(legends.frameTime.tooltip);
+				 }
+			 } } });
+
+	columns.push_back(ColumnConfig{
+		legends.costPerCall.header,
+		MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.costPerCall; }, [](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, PerformanceOverlay::PerfOverlayState::kCostPerCallGoodThreshold, PerformanceOverlay::PerfOverlayState::kCostPerCallWarningThreshold, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); }, [](float value, const DrawCallRow&) { return (value < PerformanceOverlay::PerfOverlayState::kMicrosecondThreshold && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); }, legends.costPerCall.tooltip), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall); }, [legends]() {
+			 if (ImGui::IsItemHovered()) {
+				 if (auto _tt = Util::HoverTooltipWrapper()) {
+					 Util::DrawColoredMultiLineTooltip(legends.costPerCall.tooltip);
+				 }
+			 } } });
+
+	// Add test columns if present
+	if (anyTestData) {
+		columns.push_back(ColumnConfig{
+			legends.testFrameTime.header,
+			MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.testFrameTime; }, [](const auto& theme, float value, const DrawCallRow& row) {
+					 if (value < row.frameTime)
+						 return theme.StatusPalette.SuccessColor;
+					 if (value > row.frameTime)
+						 return theme.StatusPalette.Error;
+					 return theme.Palette.Text; }, [overlay](float value, const DrawCallRow& row) { return Util::FormatMilliseconds(value) + " (" + Util::FormatPercent(overlay->testData[row.shaderType].percent) + ")"; }, legends.testFrameTime.tooltip), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+				 float aVal = a.testFrameTime.value_or(FLT_MAX);
+				 float bVal = b.testFrameTime.value_or(FLT_MAX);
+				 return asc ? (aVal < bVal) : (aVal > bVal); }, [legends]() {
+				 if (ImGui::IsItemHovered()) {
+					 if (auto _tt = Util::HoverTooltipWrapper()) {
+						 Util::DrawColoredMultiLineTooltip(legends.testFrameTime.tooltip);
+					 }
+				 } } });
+
+		columns.push_back(ColumnConfig{
+			legends.testCostPerCall.header,
+			MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.testCostPerCall; }, [](const auto& theme, float value, const DrawCallRow& row) {
+					 if (value < row.costPerCall)
+						 return theme.StatusPalette.SuccessColor;
+					 if (value > row.costPerCall)
+						 return theme.StatusPalette.Error;
+					 return theme.Palette.Text; }, [](float value, const DrawCallRow&) { return (value < PerformanceOverlay::PerfOverlayState::kMicrosecondThreshold && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); }, legends.testCostPerCall.tooltip), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+				 float aVal = a.testCostPerCall.value_or(FLT_MAX);
+				 float bVal = b.testCostPerCall.value_or(FLT_MAX);
+				 return asc ? (aVal < bVal) : (aVal > bVal); }, [legends]() {
+				 if (ImGui::IsItemHovered()) {
+					 if (auto _tt = Util::HoverTooltipWrapper()) {
+						 Util::DrawColoredMultiLineTooltip(legends.testCostPerCall.tooltip);
+					 }
+				 } } });
+	}
+
+	return columns;
+}
+
+std::pair<std::vector<DrawCallRow>, std::vector<DrawCallRow>> PerformanceOverlay::BuildDrawCallRows() const
+{
+	std::vector<DrawCallRow> mainRows;
+	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.GetSmoothFrameTimeMs());
+	float measuredSum = 0.0f;
+
+	globals::state->ForEachShaderTypeWithMetrics([&mainRows, &measuredSum, smoothedFrameTime, this](auto type, int typeIndex, float drawCalls, float frameTime, float percent, float costPerCall) {
+		bool enabled = globals::state->enabledClasses[typeIndex - 1];
+		std::optional<float> testFrameTime, testCostPerCall;
+		auto it = this->testData.find(typeIndex);
+		if (it != this->testData.end()) {
+			testFrameTime = it->second.frameTime;
+			testCostPerCall = it->second.costPerCall;
+		}
+		std::string label = std::string(magic_enum::enum_name(type)) + ":";
+		std::string tooltip = "Draw calls for this shader type.";
+		auto tipIt = kShaderTypeTooltips.find(type);
+		if (tipIt != kShaderTypeTooltips.end()) {
+			tooltip = tipIt->second;
+		}
+		mainRows.push_back({ label, typeIndex, static_cast<int>(drawCalls), frameTime, percent, costPerCall, tooltip, enabled, testFrameTime, testCostPerCall });
+		measuredSum += frameTime;
+	});
+
+	auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
+	if (std::abs(otherFrameTime) < 1e-4f)
+		otherFrameTime = 0.0f;
+	std::optional<float> otherTestFrameTime, otherTestCostPerCall, totalTestFrameTime, totalTestCostPerCall;
+	auto itOther = this->testData.find(static_cast<int>(SpecialShaderType::Other));
+	if (itOther != this->testData.end()) {
+		otherTestFrameTime = itOther->second.frameTime;
+		otherTestCostPerCall = itOther->second.costPerCall;
+	}
+	auto itTotal = this->testData.find(static_cast<int>(SpecialShaderType::Total));
+	if (itTotal != this->testData.end()) {
+		totalTestFrameTime = itTotal->second.frameTime;
+		totalTestCostPerCall = itTotal->second.costPerCall;
+	}
+	DrawCallRow otherRow = {
+		"Other:", static_cast<int>(SpecialShaderType::Other), 0, otherFrameTime, otherPercent,
+		0.0f,
+		std::string("Frame time not attributed to any measured shader type. This includes UI, post-processing, engine work, and any GPU activity not directly measured by the overlay."),
+		true, otherTestFrameTime, otherTestCostPerCall
+	};
+	// Always use the actual total frame time for live data
+	float totalFrameTime = smoothedFrameTime;
+	float totalPercent = 100.0f;  // Total is always 100% of total
+
+	DrawCallRow totalRow = {
+		"Total:", static_cast<int>(SpecialShaderType::Total), static_cast<int>(globals::state->GetTotalSmoothedDrawCalls()), totalFrameTime, totalPercent,
+		totalCostPerCall,
+		std::string("Total frame time."),
+		true, totalTestFrameTime, totalTestCostPerCall
+	};
+	std::vector<DrawCallRow> summaryRows;
+	summaryRows.push_back(otherRow);
+	summaryRows.push_back(totalRow);
+	return { mainRows, summaryRows };
+}
+
+/**
+  * @brief Creates a table row handler for the draw calls table
+  *
+  * This function creates a lambda that handles rendering individual table rows,
+  * including special handling for summary rows (Total, Other) and normal shader
+  * type rows. It ensures proper tooltip display and click handling for each row type.
+  *
+  * @param columns The column configurations for the table
+  * @param overlay Pointer to the performance overlay instance
+  * @return Function that handles row rendering and interaction
+  */
+std::function<void(int, int, const DrawCallRow&)> PerformanceOverlay::CreateTableRowHandler(const std::vector<ColumnConfig>& columns, PerformanceOverlay* overlay)
+{
+	return [&columns, overlay](int rowIdx, int colIdx, const DrawCallRow& row) {
+		(void)rowIdx;
+		// Special handling for summary rows
+		if ((row.label == "Total:" || row.label == "Other:") && colIdx == 0) {
+			if (row.label == "Total:") {
+				if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
+					overlay->HandleTotalRowToggle();
+				}
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::TextUnformatted(row.tooltip.c_str());
+						float _fps = row.frameTime > 0.0f ? 1000.0f / row.frameTime : 0.0f;
+						ImGui::Text("FPS: %.2f", _fps);
+					}
+				}
+			} else if (row.label == "Other:") {
+				ImGui::TextUnformatted(row.label.c_str());
+				if (!row.tooltip.empty() && ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::TextUnformatted(row.tooltip.c_str());
+					}
+				}
+			}
+		} else if (row.label == "Total:" || row.label == "Other:") {
+			// No tooltip for summary rows in non-label columns
+			columns[colIdx].cellRender(row, colIdx);
+		} else {
+			// Normal row: ensure tooltips never modify cell content
+			columns[colIdx].cellRender(row, colIdx);
+		}
+	};
+}
+// ============================================================================
+// EVENT HANDLING FUNCTIONS
+// ============================================================================
+
+/**
+  * @brief Handles shader type toggle functionality
+  *
+  * This function processes user clicks on shader type rows in the performance table.
+  * When a shader is disabled, it captures the current performance data as test data
+  * for comparison. This allows users to see the performance impact of disabling
+  * specific shader types.
+  *
+  * @param row The draw call row that was clicked
+  * @param wasEnabled Whether the shader was enabled before the click
+  */
+void PerformanceOverlay::HandleShaderToggle(const DrawCallRow& row, bool wasEnabled)
+{
+	auto maybeType = magic_enum::enum_cast<RE::BSShader::Type>(row.shaderType);
+	if (!maybeType.has_value()) {
+		return;
+	}
+
+	auto classIndex = magic_enum::enum_integer(*maybeType) - 1;
+	if (classIndex < 0 || classIndex >= magic_enum::enum_integer(RE::BSShader::Type::Total) - 1) {
+		return;
+	}
+
+	bool isDisabling = wasEnabled;
+	float prevFrameTime = row.frameTime;
+	float prevCostPerCall = row.costPerCall;
+
+	// Capture live data for Total and Other before toggling
+	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.GetSmoothFrameTimeMs());
+	float measuredSum = 0.0f;
+	globals::state->ForEachShaderTypeWithMetrics([&measuredSum]([[maybe_unused]] auto type, [[maybe_unused]] int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, [[maybe_unused]] float percent, [[maybe_unused]] float costPerCall) {
+		measuredSum += frameTime;
+	});
+	auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
+
+	// Toggle the shader
+	globals::state->enabledClasses[classIndex] = !wasEnabled;
+
+	if (isDisabling) {
+		// Save the last live value before disabling
+		this->UpdateShaderTestData(row.shaderType, prevFrameTime, prevCostPerCall);
+		// Save Total and Other test data as well
+		this->testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+		this->testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
+		this->testDataSource = TestDataSource::ManualShaderToggle;
+		this->testDataLastUpdated = std::chrono::steady_clock::now();
+	}
+}
+
+/**
+  * @brief Handles the Total row toggle functionality
+  *
+  * This function processes clicks on the Total row in the performance table.
+  * It toggles all shader types on/off simultaneously, allowing users to quickly
+  * enable or disable all shaders for performance testing.
+  */
+void PerformanceOverlay::HandleTotalRowToggle()
+{
+	bool anyDisabled = false;
+	globals::state->ForEachShaderTypeWithIndex([&anyDisabled]([[maybe_unused]] auto type, int classIndex) {
+		if (!globals::state->enabledClasses[classIndex]) {
+			anyDisabled = true;
+		}
+	});
+	globals::state->ForEachShaderTypeWithIndex([&anyDisabled]([[maybe_unused]] auto type, int classIndex) {
+		globals::state->enabledClasses[classIndex] = anyDisabled;
+	});
+
+	// Update test data and timestamp for manual toggling (not just A/B test mode)
+	auto* abTestingManager = ABTestingManager::GetSingleton();
+	bool abTest = abTestingManager && abTestingManager->IsEnabled() && abTestingManager->IsUsingTestConfig();
+	if (abTest) {
+		this->UpdateAllShaderTestData();
+	} else {
+		// Manual toggle: update test data and timestamp
+		float smoothedFrameTime = static_cast<float>(this->perfOverlayState.GetSmoothFrameTimeMs());
+		float measuredSum = 0.0f;
+		globals::state->ForEachShaderTypeWithMetrics([&measuredSum]([[maybe_unused]] auto type, [[maybe_unused]] int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, [[maybe_unused]] float percent, [[maybe_unused]] float costPerCall) {
+			measuredSum += frameTime;
+		});
+		auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
+		this->testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+		this->testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
+		this->testDataSource = TestDataSource::ManualShaderToggle;
+		this->testDataLastUpdated = std::chrono::steady_clock::now();
+	}
+}
+// ============================================================================
+// TEST DATA MANAGEMENT FUNCTIONS
+// ============================================================================
+
+// Static test data state
+
+// Implement static member functions
+/**
+  * @brief Updates test data for a specific shader type during manual shader toggling
+  *
+  * This function captures performance data for a shader type when it's manually disabled,
+  * allowing users to compare performance with/without specific shaders enabled.
+  *
+  * @param shaderType The shader type index to update test data for
+  * @param frameTime The frame time contribution of this shader type (ms)
+  * @param costPerCall The cost per draw call for this shader type (ms/call)
+  *
+  * @note This function also updates the Total and Other summary rows to maintain
+  *       consistency with the current performance state
+  */
+void PerformanceOverlay::UpdateShaderTestData(int shaderType, float frameTime, float costPerCall)
+{
+	UpdateShaderTestDataEntry(shaderType, frameTime, costPerCall);
+
+	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.GetSmoothFrameTimeMs());
+	float measuredSum = 0.0f;
+	for (const auto& [type, data] : testData) {
+		if (type >= 0)
+			measuredSum += data.frameTime;
+	}
+
+	auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
+	UpdateSummaryTestData(smoothedFrameTime, otherFrameTime, otherPercent, totalCostPerCall);
+
+	testDataSource = TestDataSource::ManualShaderToggle;
+	testDataLastUpdated = std::chrono::steady_clock::now();
+}
+
+/**
+  * @brief Updates test data for all shader types during A/B test Variant B execution
+  *
+  * This function captures comprehensive performance data for all shader types when
+  * running in A/B test mode with Variant B (test config) active. It ensures that
+  * all shader types, including Total and Other summary rows, have current test data
+  * for accurate performance comparison.
+  *
+  * @note This function only captures data when A/B testing is enabled and using
+  *       Variant B (test config). It does nothing in manual shader toggle mode.
+  */
+void PerformanceOverlay::UpdateAllShaderTestData()
+{
+	// Check if all shaders are disabled
+	bool allDisabled = true;
+	globals::state->ForEachShaderTypeWithIndex([&allDisabled]([[maybe_unused]] auto type, int classIndex) {
+		if (globals::state->enabledClasses[classIndex]) {
+			allDisabled = false;
+		}
+	});
+	if (allDisabled) {
+		testData.clear();
+		testDataSource = TestDataSource::None;
+		return;
+	}
+
+	// Only capture test data if we're in A/B test mode AND using Variant B (test config)
+	auto* abTestingManager = ABTestingManager::GetSingleton();
+	bool abTest = abTestingManager && abTestingManager->IsEnabled() && abTestingManager->IsUsingTestConfig();
+	if (!abTest) {
+		// If not in A/B test Variant B, don't capture test data
+		return;
+	}
+
+	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.GetSmoothFrameTimeMs());
+	float measuredSum = 0.0f;
+
+	globals::state->ForEachShaderTypeWithMetrics([&measuredSum, smoothedFrameTime, this]([[maybe_unused]] auto type, int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, float percent, float costPerCall) {
+		this->UpdateShaderTestDataEntry(typeIndex, frameTime, costPerCall, percent);
+		measuredSum += frameTime;
+	});
+
+	auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
+	UpdateSummaryTestData(smoothedFrameTime, otherFrameTime, otherPercent, totalCostPerCall);
+	testDataSource = TestDataSource::ABTest_VariantB;
+	testDataLastUpdated = std::chrono::steady_clock::now();
+}
+
+std::string PerformanceOverlay::GetTestDataTooltip()
+{
+	switch (testDataSource) {
+	case TestDataSource::ABTest_VariantB:
+		return std::string("Test data from Test (Variant B).\nLast updated: ") + Util::TimeAgoString(testDataLastUpdated) + " ago.";
+	case TestDataSource::ManualShaderToggle:
+		return std::string("Test data from manual shader toggle.\nLast updated: ") + Util::TimeAgoString(testDataLastUpdated) + " ago.";
+	default:
+		return "No test data available.";
+	}
+}
+
+// --- TEST DATA CAPTURE LOGIC ---
+// Test data is captured in two scenarios:
+// 1. A/B Test Mode (Variant B): If abTestingEnabled && usingTestConfig, we continuously capture test data
+//    for all shader types, "Other", and "Total" every frame. This allows live comparison between
+//    Variant A (user config) and Variant B (test config).
+// 2. Manual Shader Toggle: If any shader is disabled, we capture test data for the disabled shaders
+//    (and summary rows) at the moment of disabling, and keep it until cleared. This allows users to
+//    compare performance with/without specific shaders enabled.
+// Test data is only cleared by the "Clear Test Data" button or if all shaders are disabled (rare edge case).
+void PerformanceOverlay::CaptureTestData()
+{
+	auto* abTestingManager = ABTestingManager::GetSingleton();
+	bool abTestActive = (abTestingManager && abTestingManager->IsEnabled() && abTestingManager->IsUsingTestConfig());
+	bool anyShaderDisabled = false;
+	globals::state->ForEachShaderTypeWithIndex([&anyShaderDisabled]([[maybe_unused]] auto type, int classIndex) {
+		if (!globals::state->enabledClasses[classIndex]) {
+			anyShaderDisabled = true;
+		}
+	});
+	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.GetSmoothFrameTimeMs());
+	float measuredSum = 0.0f;
+	if (abTestActive) {
+		measuredSum = 0.0f;
+		globals::state->ForEachShaderTypeWithMetrics([&measuredSum, smoothedFrameTime, this]([[maybe_unused]] auto type, int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, float percent, float costPerCall) {
+			this->UpdateShaderTestDataEntry(typeIndex, frameTime, costPerCall, percent);
+			measuredSum += frameTime;
+		});
+		auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
+		UpdateSummaryTestData(smoothedFrameTime, otherFrameTime, otherPercent, totalCostPerCall);
+		testDataSource = TestDataSource::ABTest_VariantB;
+		testDataLastUpdated = std::chrono::steady_clock::now();
+	} else if (anyShaderDisabled) {
+		measuredSum = 0.0f;
+		globals::state->ForEachShaderTypeWithMetrics([&measuredSum, smoothedFrameTime, this]([[maybe_unused]] auto type, int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, float percent, float costPerCall) {
+			bool enabled = globals::state->enabledClasses[typeIndex - 1];
+			if (!enabled) {
+				this->UpdateShaderTestDataEntry(typeIndex, frameTime, costPerCall, percent);
+			}
+			measuredSum += frameTime;
+		});
+		auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
+		UpdateSummaryTestData(smoothedFrameTime, otherFrameTime, otherPercent, totalCostPerCall);
+		testDataSource = TestDataSource::ManualShaderToggle;
+		testDataLastUpdated = std::chrono::steady_clock::now();
+	}
+}
+
+void PerformanceOverlay::ClearTestData()
+{
+	testData.clear();
+	testDataSource = TestDataSource::None;
+}
 
 // Static helper method implementations
 void PerformanceOverlay::UpdateShaderTestDataEntry(int shaderType, float frameTime, float costPerCall, float percent)
@@ -1848,4 +1855,188 @@ void PerformanceOverlay::UpdateSummaryTestData(float smoothedFrameTime, float ot
 {
 	testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
 	testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+}
+// ============================================================================
+// PERFORMANCE OVERLAY STATE MANAGEMENT
+// ============================================================================
+
+void PerformanceOverlay::PerfOverlayState::UpdateFGFrameTime()
+{
+	// Defensive: Check for upscaling pointer
+	if (!globals::upscaling)
+		return;
+
+	auto* overlay = GetSingleton();
+
+	// Get frametime directly from the Frame Generation system
+	float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
+	if (fgDeltaTime > 0.0f) {
+		overlay->perfOverlayState.SetPostFGFrameTimeMs(fgDeltaTime * 1000.0f);
+		overlay->perfOverlayState.SetPostFGFps(1000.0f / overlay->perfOverlayState.GetPostFGFrameTimeMs());
+
+		// Update post-FG smooth values when timer elapses
+		if (overlay->perfOverlayState.GetUpdateTimer() <= 0.0f) {
+			overlay->perfOverlayState.SetPostFGSmoothFps(overlay->perfOverlayState.GetPostFGFps());
+			overlay->perfOverlayState.SetPostFGSmoothFrameTimeMs(overlay->perfOverlayState.GetPostFGFrameTimeMs());
+		}
+
+		// Update post-FG frametime history
+		overlay->perfOverlayState.GetPostFGFrameTimeHistoryRef()[overlay->perfOverlayState.GetPostFGFrameTimeHistoryIndex()] = overlay->perfOverlayState.GetPostFGFrameTimeMs();
+		overlay->perfOverlayState.SetPostFGFrameTimeHistoryIndex((overlay->perfOverlayState.GetPostFGFrameTimeHistoryIndex() + 1) % overlay->settings.FrameHistorySize);
+	} else {
+		// Fallback if FG time is not available
+		overlay->perfOverlayState.SetPostFGFrameTimeMs(overlay->perfOverlayState.GetFrameTimeMs() / PerformanceOverlay::PerfOverlayState::kFrameGenerationMultiplier);
+		overlay->perfOverlayState.SetPostFGFps(overlay->perfOverlayState.GetFps() * PerformanceOverlay::PerfOverlayState::kFrameGenerationMultiplier);
+
+		if (overlay->perfOverlayState.GetUpdateTimer() <= 0.0f) {
+			overlay->perfOverlayState.SetPostFGSmoothFps(overlay->perfOverlayState.GetPostFGFps());
+			overlay->perfOverlayState.SetPostFGSmoothFrameTimeMs(overlay->perfOverlayState.GetPostFGFrameTimeMs());
+		}
+
+		overlay->perfOverlayState.GetPostFGFrameTimeHistoryRef()[overlay->perfOverlayState.GetPostFGFrameTimeHistoryIndex()] = overlay->perfOverlayState.GetPostFGFrameTimeMs();
+		overlay->perfOverlayState.SetPostFGFrameTimeHistoryIndex((overlay->perfOverlayState.GetPostFGFrameTimeHistoryIndex() + 1) % overlay->settings.FrameHistorySize);
+	}
+}
+
+void PerformanceOverlay::PerfOverlayState::UpdateFrameTimeHistorySizes()
+{
+	auto* overlay = GetSingleton();
+
+	overlay->settings.FrameHistorySize = std::clamp(
+		overlay->settings.FrameHistorySize,
+		overlay->settings.kMinFrameHistorySize,
+		overlay->settings.kMaxFrameHistorySize);
+
+	if (overlay->perfOverlayState.GetFrameTimeHistory().size() != static_cast<size_t>(overlay->settings.FrameHistorySize)) {
+		overlay->perfOverlayState.ResizeFrameTimeHistory(overlay->settings.FrameHistorySize, 0.0f);
+		if (overlay->perfOverlayState.GetFrameTimeHistoryIndex() >= overlay->settings.FrameHistorySize) {
+			overlay->perfOverlayState.SetFrameTimeHistoryIndex(0);
+		}
+	}
+	if (overlay->perfOverlayState.GetPostFGFrameTimeHistory().size() != static_cast<size_t>(overlay->settings.FrameHistorySize)) {
+		overlay->perfOverlayState.ResizePostFGFrameTimeHistory(overlay->settings.FrameHistorySize, 0.0f);
+		if (overlay->perfOverlayState.GetPostFGFrameTimeHistoryIndex() >= overlay->settings.FrameHistorySize) {
+			overlay->perfOverlayState.SetPostFGFrameTimeHistoryIndex(0);
+		}
+	}
+}
+
+void PerformanceOverlay::PerfOverlayState::UpdateMinFrameTime()
+{
+	auto* overlay = GetSingleton();
+	overlay->perfOverlayState.SetMinFrameTime(*std::min_element(overlay->perfOverlayState.GetFrameTimeHistory().begin(), overlay->perfOverlayState.GetFrameTimeHistory().end()));
+}
+
+void PerformanceOverlay::PerfOverlayState::UpdateMaxFrameTime()
+{
+	auto* overlay = GetSingleton();
+	overlay->perfOverlayState.SetMaxFrameTime(*std::max_element(overlay->perfOverlayState.GetFrameTimeHistory().begin(), overlay->perfOverlayState.GetFrameTimeHistory().end()));
+}
+
+float PerformanceOverlay::PerfOverlayState::SetTextScale()
+{
+	auto* overlay = GetSingleton();
+	switch (overlay->settings.Size) {
+	case PerfOverlaySettings::TextSize::Small:
+		return 0.8f;
+	case PerfOverlaySettings::TextSize::Medium:
+		return 1.0f;
+	case PerfOverlaySettings::TextSize::Large:
+		return 1.2f;
+	}
+	return 1.0f;
+}
+
+void PerformanceOverlay::PerfOverlayState::UpdateGraphValues()
+{
+	// Get settings from the singleton
+	const auto& overlaySettings = PerformanceOverlay::GetSingleton()->settings;
+
+	// Sync frame history buffer size with user settings
+	UpdateFrameTimeHistorySizes();
+
+	// Insert latest frame time into circular buffer
+	float oldFrameTime = GetFrameTimeHistory()[GetFrameTimeHistoryIndex()];
+	GetFrameTimeHistoryRef()[GetFrameTimeHistoryIndex()] = GetFrameTimeMs();
+	SetFrameTimeHistoryIndex((GetFrameTimeHistoryIndex() + 1) % overlaySettings.FrameHistorySize);
+
+	// Maintain instantaneous min/max tracking
+	if (GetFrameTimeMs() > GetMaxFrameTime()) {
+		SetMaxFrameTime(GetFrameTimeMs());
+	} else if (GetFrameTimeMs() < GetMinFrameTime()) {
+		SetMinFrameTime(GetFrameTimeMs());
+	} else if (oldFrameTime == GetMinFrameTime()) {
+		UpdateMinFrameTime();
+	} else if (oldFrameTime == GetMaxFrameTime()) {
+		UpdateMaxFrameTime();
+	}
+
+	float avgFrameTime, stdDev, graphMin, graphMax;
+	// Calculate mean and standard deviation for normalized graph range
+	if (GetFrameTimeHistory().empty()) {
+		// Default to 60 FPS
+		avgFrameTime = kDefaultFrameTimeMs;
+		stdDev = 0.0f;
+		graphMin = 0.0f;
+		graphMax = PerformanceOverlay::PerfOverlayState::kGraphSpreadMultiplier * kDefaultFrameTimeMs;
+	} else {
+		// Calculate average frame time
+		avgFrameTime = std::accumulate(GetFrameTimeHistory().begin(), GetFrameTimeHistory().end(), 0.0f) / GetFrameTimeHistory().size();
+
+		// Calculate standard deviation
+		float variance = 0.0f;
+		for (float ft : GetFrameTimeHistory()) {
+			float diff = ft - avgFrameTime;
+			variance += diff * diff;
+		}
+		variance /= GetFrameTimeHistory().size();
+		stdDev = std::sqrt(variance);
+
+		// Calculate graph range
+		float spread = std::clamp(stdDev * PerformanceOverlay::PerfOverlayState::kGraphSpreadMultiplier, PerformanceOverlay::PerfOverlayState::kGraphMinSpread, PerformanceOverlay::PerfOverlayState::kGraphMaxSpread);
+		graphMin = std::max(0.0f, avgFrameTime - spread);
+		graphMax = avgFrameTime + spread;
+	}
+
+	// Exponential smoothing for stable graph scaling
+	SetSmoothedMinFrameTime(GetSmoothedMinFrameTime() + kSmoothingFactor * (graphMin - GetSmoothedMinFrameTime()));
+	SetSmoothedMaxFrameTime(GetSmoothedMaxFrameTime() + kSmoothingFactor * (graphMax - GetSmoothedMaxFrameTime()));
+}
+
+void PerformanceOverlay::PerfOverlayState::DrawPostFGFrameTimeGraph()
+{
+	// Prepare overlay text
+	char overlay_text[128];
+	snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
+		"Post-FG: %.2f ms (%.1f FPS)",
+		GetPostFGSmoothFrameTimeMs(), GetPostFGSmoothFps());
+
+	// Set graph colors - blue for post-FG
+	ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
+
+	// Draw the graph
+	float graphWidth = ImGui::GetWindowWidth() * 0.9f;
+	ImGui::PlotLines("##postfgframetime",
+		GetPostFGFrameTimeHistory().data(),
+		PerformanceOverlay::GetSingleton()->settings.FrameHistorySize,
+		GetPostFGFrameTimeHistoryIndex(),
+		overlay_text,
+		GetSmoothedMinFrameTime(), GetSmoothedMaxFrameTime(),
+		ImVec2(graphWidth, 50.0f * GetTextScale()));
+
+	ImGui::PopStyleColor();
+
+	// Draw frametime target reference lines
+	if (ImGui::BeginTable("PostFGFrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
+		ImGui::TableNextColumn();
+		ImGui::Text("30 FPS: 33.3 ms");
+
+		ImGui::TableNextColumn();
+		ImGui::Text("60 FPS: 16.7 ms");
+
+		ImGui::TableNextColumn();
+		ImGui::Text("120 FPS: 8.3 ms");
+
+		ImGui::EndTable();
+	}
 }

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -1,0 +1,1127 @@
+#include "PerformanceOverlay.h"
+#include "Feature.h"
+#include "FidelityFX.h"
+#include "Globals.h"
+#include "Menu.h"
+#include "State.h"
+#include "Upscaling.h"
+#include "Utils/Game.h"
+#include "Utils/UI.h"
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <format>
+#include <imgui.h>
+#include <imgui_internal.h>
+#include <imgui_stdlib.h>
+#include <magic_enum.hpp>
+#include <numeric>
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+	PerformanceOverlay::PerfOverlaySettings,
+	ShowInOverlay,
+	ShowDrawCalls,
+	ShowVRAM,
+	ShowFPS,
+	ShowPreFGFrameTimeGraph,
+	ShowPostFGFrameTimeGraph,
+	UpdateInterval,
+	FrameHistorySize,
+	Size,
+	BackgroundOpacity,
+	ShowBorder,
+	Position,
+	PositionSet)
+
+// Static test data state
+// Remove global static variables and functions for test data
+// Add static member variable definitions
+PerformanceOverlay::TestDataSource PerformanceOverlay::s_testDataSource = PerformanceOverlay::TestDataSource::None;
+std::chrono::steady_clock::time_point PerformanceOverlay::s_testDataLastUpdated;
+std::unordered_map<int, PerformanceOverlay::TestData> PerformanceOverlay::s_testData;
+
+// Implement static member functions
+void PerformanceOverlay::UpdateShaderTestData(int shaderType, float frameTime, float costPerCall)
+{
+	s_testData[shaderType] = { frameTime, costPerCall };
+	float smoothedFrameTime = static_cast<float>(GetSingleton()->perfOverlayState.smoothFrameTimeMs);
+	float measuredSum = 0.0f;
+	for (const auto& [type, data] : s_testData) {
+		if (type >= 0)
+			measuredSum += data.frameTime;
+	}
+	float otherFrameTime = smoothedFrameTime - measuredSum;
+	float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
+	s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
+	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
+	float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
+	s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+
+	s_testDataSource = TestDataSource::ManualShaderToggle;
+	s_testDataLastUpdated = std::chrono::steady_clock::now();
+}
+
+void PerformanceOverlay::UpdateAllShaderTestData()
+{
+	if (!(Menu::GetSingleton() && Menu::GetSingleton()->abTestingEnabled && Menu::GetSingleton()->usingTestConfig))
+		return;
+	float smoothedFrameTime = static_cast<float>(GetSingleton()->perfOverlayState.smoothFrameTimeMs);
+	float measuredSum = 0.0f;
+	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
+	for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
+		if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
+			continue;
+		int typeIndex = magic_enum::enum_integer(type);
+		float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
+		float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
+		float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
+		float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
+		s_testData[typeIndex] = { frameTime, costPerCall, percent };
+		measuredSum += frameTime;
+	}
+	float otherFrameTime = smoothedFrameTime - measuredSum;
+	float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
+	s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
+	float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
+	s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+	s_testDataSource = TestDataSource::ABTest_VariantB;
+	s_testDataLastUpdated = std::chrono::steady_clock::now();
+}
+
+std::string PerformanceOverlay::GetTestDataTooltip()
+{
+	switch (s_testDataSource) {
+	case TestDataSource::ABTest_VariantB:
+		return std::string("Test data from Test (Variant B).\nLast updated: ") + Util::TimeAgoString(s_testDataLastUpdated) + " ago.";
+	case TestDataSource::ManualShaderToggle:
+		return std::string("Test data from manual shader toggle.\nLast updated: ") + Util::TimeAgoString(s_testDataLastUpdated) + " ago.";
+	default:
+		return "No test data available.";
+	}
+}
+
+void PerformanceOverlay::DataLoaded()
+{
+	// Initialize performance overlay state
+	this->perfOverlayState.initialized = false;
+	this->perfOverlayState.frameTimeHistory.resize(this->settings.FrameHistorySize, 0.0f);
+	this->perfOverlayState.postFGFrameTimeHistory.resize(this->settings.FrameHistorySize, 0.0f);
+}
+
+std::pair<std::string, std::vector<std::string>> PerformanceOverlay::GetFeatureSummary()
+{
+	std::string description = "Real-time performance monitoring system that displays FPS, frame times, draw calls, VRAM usage, and detailed shader performance analysis.";
+
+	std::vector<std::string> keyFeatures = {
+		"Real-time FPS and frame time monitoring with configurable update intervals",
+		"Interactive draw call analysis with per-shader type performance breakdown",
+		"VRAM usage monitoring with visual progress bars",
+		"Frame time graphs for pre and post-frame generation analysis",
+		"A/B testing support for performance comparison between configurations",
+		"Color-coded performance metrics with customizable thresholds",
+		"Movable overlay window with persistent positioning"
+	};
+
+	return { description, keyFeatures };
+}
+
+void PerformanceOverlay::DrawSettings()
+{
+	auto menu = Menu::GetSingleton();
+	const auto& themeSettings = menu->GetTheme();
+	const auto& menuSettings = menu->GetSettings();
+	ImGui::Checkbox("Show in Overlay", &this->settings.ShowInOverlay);
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text("Opens performance overlay in a separate window that stays open\neven when the main menu is closed. ");
+		ImGui::Text("Toggle with ");
+		ImGui::SameLine();
+		ImGui::TextColored(themeSettings.StatusPalette.CurrentHotkey, "%s", Menu::KeyIdToString(menuSettings.OverlayToggleKey));
+	}
+
+	if (this->settings.ShowInOverlay) {
+		ImGui::Indent();
+
+		// Display options
+		if (ImGui::CollapsingHeader("Display Options", ImGuiTreeNodeFlags_DefaultOpen)) {
+			ImGui::Indent();
+
+			ImGui::Checkbox("Show FPS Counter", &this->settings.ShowFPS);
+			ImGui::Checkbox("Show Draw Calls", &this->settings.ShowDrawCalls);
+			ImGui::Checkbox("Show VRAM Usage", &this->settings.ShowVRAM);
+
+			bool isFrameGenerationActive = globals::upscaling && globals::upscaling->IsFrameGenerationActive();
+			if (this->settings.ShowFPS && isFrameGenerationActive) {
+				ImGui::Checkbox("Show Pre-FG Frametime Graph", &this->settings.ShowPreFGFrameTimeGraph);
+
+				bool isFSRFrameGen = globals::fidelityFX && globals::fidelityFX->isFrameGenActive;
+				if (isFSRFrameGen) {
+					ImGui::BeginDisabled();
+					ImGui::Checkbox("Show Post-FG Frametime Graph", &this->settings.ShowPostFGFrameTimeGraph);
+					ImGui::EndDisabled();
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::Text("Post-FG timing not available with AMD FSR Frame Generation.\nThis option is only available with NVIDIA DLSS Frame Generation.");
+					}
+				} else {
+					ImGui::Checkbox("Show Post-FG Frametime Graph", &this->settings.ShowPostFGFrameTimeGraph);
+				}
+			} else if (this->settings.ShowFPS) {
+				ImGui::Checkbox("Show Frametime Graph", &this->settings.ShowPreFGFrameTimeGraph);
+			}
+
+			ImGui::Unindent();
+		}
+
+		// Appearance settings
+		if (ImGui::CollapsingHeader("Appearance", ImGuiTreeNodeFlags_DefaultOpen)) {
+			ImGui::Indent();
+
+			const char* sizes[] = { "Small", "Medium", "Large" };
+			int currentSize = static_cast<int>(this->settings.Size);
+			if (ImGui::Combo("Text Size", &currentSize, sizes, IM_ARRAYSIZE(sizes))) {
+				this->settings.Size = static_cast<PerfOverlaySettings::TextSize>(currentSize);
+			}
+
+			ImGui::SliderFloat("Background Opacity", &this->settings.BackgroundOpacity, 0.0f, 1.0f, "%.2f");
+			ImGui::Checkbox("Show Border", &this->settings.ShowBorder);
+			ImGui::SliderFloat("Update Interval", &this->settings.UpdateInterval, 0.001f, 2.0f, "%.2f seconds");
+			ImGui::SliderInt("Frame History Size", &this->settings.FrameHistorySize,
+				this->settings.kMinFrameHistorySize, this->settings.kMaxFrameHistorySize);
+
+			ImGui::Separator();
+			ImGui::Text("Position:");
+			if (ImGui::Button("Reset Position")) {
+				this->settings.PositionSet = false;
+			}
+
+			ImGui::Unindent();
+		}
+		ImGui::Unindent();
+	}
+}
+
+void PerformanceOverlay::DrawOverlay()
+{
+	// Defensive: Check for required global state and ImGui context
+	if (!globals::state || !Menu::GetSingleton()) {
+		return;
+	}
+	// Check global overlay visibility
+	if (!Menu::GetSingleton()->overlayVisible) {
+		return;
+	}
+	// Defensive: Check for upscaling if you use it
+	// (Not strictly needed here, but safe for future use)
+	if (this->settings.ShowVRAM && (!Menu::GetSingleton()->GetDXGIAdapter3())) {
+		return;
+	}
+	// Defensive: Check ImGui context
+	if (!ImGui::GetCurrentContext()) {
+		return;
+	}
+	if (!this->settings.ShowInOverlay) {
+		return;
+	}
+
+	// Set window flags - no decoration and only movable when ShowBorder is true
+	ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize;
+
+	// Only allow mouse interaction when the main menu is open
+	if (!PerformanceOverlay::GetSingleton()->settings.ShowInOverlay) {
+		windowFlags |= ImGuiWindowFlags_NoInputs;
+	}
+
+	if (!this->settings.ShowBorder) {
+		windowFlags |= ImGuiWindowFlags_NoBackground;
+	} else {
+		windowFlags &= ~ImGuiWindowFlags_NoDecoration;
+		windowFlags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize;
+	}
+
+	// Set background opacity
+	ImGui::PushStyleColor(ImGuiCol_WindowBg,
+		ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_WindowBg).x,
+			ImGui::GetStyleColorVec4(ImGuiCol_WindowBg).y,
+			ImGui::GetStyleColorVec4(ImGuiCol_WindowBg).z,
+			this->settings.BackgroundOpacity));
+
+	// Set text size based on user preference
+	this->perfOverlayState.textScale = this->perfOverlayState.SetTextScale();
+
+	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, this->settings.ShowBorder ? 1.0f : 0.0f);
+
+	// Set initial position if not already set
+	if (!this->settings.PositionSet) {
+		ImGui::SetNextWindowPos(ImVec2(10.0f, 10.0f));
+		this->settings.Position = ImVec2(10.0f, 10.0f);
+		this->settings.PositionSet = true;
+	} else {
+		ImGui::SetNextWindowPos(this->settings.Position, ImGuiCond_FirstUseEver);
+	}
+
+	// Set window size based on whether graphs are shown, was rapidly changing size based on text
+	this->perfOverlayState.hasGraphs = this->settings.ShowPreFGFrameTimeGraph ||
+	                                   (this->settings.ShowPostFGFrameTimeGraph && this->perfOverlayState.isFrameGenerationActive);
+	if (!this->perfOverlayState.hasGraphs) {
+		float fixedWidth = 325.0f * this->perfOverlayState.textScale;
+		ImGui::SetNextWindowSize(ImVec2(fixedWidth, 0), ImGuiCond_Always);
+	}
+
+	// Create the window
+	ImGui::Begin("Performance Overlay", NULL, windowFlags);
+
+	// Remember window position for next frame
+	if (ImGui::IsWindowAppearing()) {
+		ImGui::SetWindowPos(this->settings.Position);
+	}
+
+	// Track if window has been moved
+	ImVec2 currentPos = ImGui::GetWindowPos();
+	if (currentPos.x != this->settings.Position.x || currentPos.y != this->settings.Position.y) {
+		this->settings.Position = currentPos;
+	}
+
+	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4.0f, 1.0f));  // Tighter spacing
+	ImGui::SetWindowFontScale(this->perfOverlayState.textScale);
+
+	// Initialize Performance Counter if necessary
+	if (!this->perfOverlayState.initialized) {
+		REX::W32::QueryPerformanceFrequency(&this->perfOverlayState.frequency);
+		REX::W32::QueryPerformanceCounter(&this->perfOverlayState.lastFrameCounter);
+		this->perfOverlayState.initialized = true;
+	} else {
+		REX::W32::QueryPerformanceCounter(&this->perfOverlayState.currentFrameCounter);
+		int64_t elapsedCounter = this->perfOverlayState.currentFrameCounter - this->perfOverlayState.lastFrameCounter;
+		this->perfOverlayState.lastFrameCounter = this->perfOverlayState.currentFrameCounter;
+
+		// Calculate frametime and fps
+		this->perfOverlayState.frameTimeMs = Util::performanceOverlay.CalcFrameTime(elapsedCounter, this->perfOverlayState.frequency);
+		this->perfOverlayState.fps = Util::performanceOverlay.CalcFPS(this->perfOverlayState.frameTimeMs);
+
+		// Calculate smooth values for display using the user-defined update interval
+		auto now = std::chrono::steady_clock::now();
+		float deltaTime = std::chrono::duration<float>(now - this->perfOverlayState.lastUpdateTime).count();
+		this->perfOverlayState.lastUpdateTime = now;
+
+		// Update graph values
+		this->perfOverlayState.UpdateGraphValues();
+
+		// Update smooth values with user-specified interval
+		this->perfOverlayState.updateTimer += deltaTime;
+		if (this->perfOverlayState.updateTimer >= this->settings.UpdateInterval) {
+			this->perfOverlayState.smoothFps = this->perfOverlayState.fps;
+			this->perfOverlayState.smoothFrameTimeMs = this->perfOverlayState.frameTimeMs;
+			this->perfOverlayState.updateTimer = 0.0f;
+		}
+
+		// Check if Frame Generation is active
+		this->perfOverlayState.isFrameGenerationActive = globals::upscaling && globals::upscaling->IsFrameGenerationActive();
+
+		if (this->perfOverlayState.isFrameGenerationActive) {
+			this->perfOverlayState.UpdateFGFrameTime();
+		}
+
+		// Show FPS counter if enabled
+		if (this->settings.ShowFPS) {
+			DrawFPS();
+		}
+	}
+
+	// Show Draw Calls if enabled
+	if (this->settings.ShowDrawCalls) {
+		ImGui::Separator();
+		DrawDrawCalls();
+		ImGui::Separator();
+	}
+
+	// VRAM & GPU Usage
+	if (this->settings.ShowVRAM && Menu::GetSingleton()->GetDXGIAdapter3()) {
+		DrawVRAM();
+	}
+
+	ImGui::PopStyleVar();             // ItemSpacing
+	ImGui::SetWindowFontScale(1.0f);  // Reset font scale
+
+	ImGui::End();
+	ImGui::PopStyleVar();    // WindowBorderSize
+	ImGui::PopStyleColor();  // WindowBg
+}
+
+void PerformanceOverlay::PerfOverlayState::UpdateFGFrameTime()
+{
+	// Defensive: Check for upscaling pointer
+	if (!globals::upscaling)
+		return;
+
+	// Get frametime directly from the Frame Generation system
+	float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
+	if (fgDeltaTime > 0.0f) {
+		GetSingleton()->perfOverlayState.postFGFrameTimeMs = fgDeltaTime * 1000.0f;
+		GetSingleton()->perfOverlayState.postFGFps = 1000.0f / GetSingleton()->perfOverlayState.postFGFrameTimeMs;
+
+		// Update post-FG smooth values when timer elapses
+		if (GetSingleton()->perfOverlayState.updateTimer <= 0.0f) {
+			GetSingleton()->perfOverlayState.postFGSmoothFps = GetSingleton()->perfOverlayState.postFGFps;
+			GetSingleton()->perfOverlayState.postFGSmoothFrameTimeMs = GetSingleton()->perfOverlayState.postFGFrameTimeMs;
+		}
+
+		// Update post-FG frametime history
+		GetSingleton()->perfOverlayState.postFGFrameTimeHistory[GetSingleton()->perfOverlayState.postFGFrameTimeHistoryIndex] = GetSingleton()->perfOverlayState.postFGFrameTimeMs;
+		GetSingleton()->perfOverlayState.postFGFrameTimeHistoryIndex = (GetSingleton()->perfOverlayState.postFGFrameTimeHistoryIndex + 1) % GetSingleton()->settings.FrameHistorySize;
+	} else {
+		// Fallback if FG time is not available
+		GetSingleton()->perfOverlayState.postFGFrameTimeMs = GetSingleton()->perfOverlayState.frameTimeMs / 2.0f;
+		GetSingleton()->perfOverlayState.postFGFps = GetSingleton()->perfOverlayState.fps * 2.0f;
+
+		if (GetSingleton()->perfOverlayState.updateTimer <= 0.0f) {
+			GetSingleton()->perfOverlayState.postFGSmoothFps = GetSingleton()->perfOverlayState.postFGFps;
+			GetSingleton()->perfOverlayState.postFGSmoothFrameTimeMs = GetSingleton()->perfOverlayState.postFGFrameTimeMs;
+		}
+
+		GetSingleton()->perfOverlayState.postFGFrameTimeHistory[GetSingleton()->perfOverlayState.postFGFrameTimeHistoryIndex] = GetSingleton()->perfOverlayState.postFGFrameTimeMs;
+		GetSingleton()->perfOverlayState.postFGFrameTimeHistoryIndex = (GetSingleton()->perfOverlayState.postFGFrameTimeHistoryIndex + 1) % GetSingleton()->settings.FrameHistorySize;
+	}
+}
+
+void PerformanceOverlay::PerfOverlayState::UpdateFrameTimeHistorySizes()
+{
+	GetSingleton()->settings.FrameHistorySize = std::clamp(
+		GetSingleton()->settings.FrameHistorySize,
+		GetSingleton()->settings.kMinFrameHistorySize,
+		GetSingleton()->settings.kMaxFrameHistorySize);
+
+	if (GetSingleton()->perfOverlayState.frameTimeHistory.size() != static_cast<size_t>(GetSingleton()->settings.FrameHistorySize)) {
+		GetSingleton()->perfOverlayState.frameTimeHistory.resize(GetSingleton()->settings.FrameHistorySize, 0.0f);
+		if (GetSingleton()->perfOverlayState.frameTimeHistoryIndex >= GetSingleton()->settings.FrameHistorySize) {
+			GetSingleton()->perfOverlayState.frameTimeHistoryIndex = 0;
+		}
+	}
+	if (GetSingleton()->perfOverlayState.postFGFrameTimeHistory.size() != static_cast<size_t>(GetSingleton()->settings.FrameHistorySize)) {
+		GetSingleton()->perfOverlayState.postFGFrameTimeHistory.resize(GetSingleton()->settings.FrameHistorySize, 0.0f);
+		if (GetSingleton()->perfOverlayState.postFGFrameTimeHistoryIndex >= GetSingleton()->settings.FrameHistorySize) {
+			GetSingleton()->perfOverlayState.postFGFrameTimeHistoryIndex = 0;
+		}
+	}
+}
+
+void PerformanceOverlay::PerfOverlayState::UpdateMinFrameTime()
+{
+	GetSingleton()->perfOverlayState.minFrameTime = *std::min_element(GetSingleton()->perfOverlayState.frameTimeHistory.begin(), GetSingleton()->perfOverlayState.frameTimeHistory.end());
+}
+
+void PerformanceOverlay::PerfOverlayState::UpdateMaxFrameTime()
+{
+	GetSingleton()->perfOverlayState.maxFrameTime = *std::max_element(GetSingleton()->perfOverlayState.frameTimeHistory.begin(), GetSingleton()->perfOverlayState.frameTimeHistory.end());
+}
+
+float PerformanceOverlay::PerfOverlayState::SetTextScale()
+{
+	switch (GetSingleton()->settings.Size) {
+	case PerfOverlaySettings::TextSize::Small:
+		return 0.8f;
+	case PerfOverlaySettings::TextSize::Medium:
+		return 1.0f;
+	case PerfOverlaySettings::TextSize::Large:
+		return 1.2f;
+	}
+	return 1.0f;
+}
+
+void PerformanceOverlay::DrawFPS()
+{
+	if (ImGui::BeginTable("FrametimeTargets", 2, ImGuiTableFlags_SizingStretchProp)) {
+		ImGui::TableSetupColumn("##prop", ImGuiTableColumnFlags_WidthFixed, ImGui::GetTextLineHeight() * 5);
+		ImGui::TableSetupColumn("##value");
+
+		ImGui::TableNextColumn();
+		ImGui::Text(this->perfOverlayState.isFrameGenerationActive ? "Raw FPS:" : "FPS:");
+		ImGui::TableNextColumn();
+		ImGui::Text("%.1f (%.2f ms)", this->perfOverlayState.smoothFps, this->perfOverlayState.smoothFrameTimeMs);
+
+		if (this->perfOverlayState.isFrameGenerationActive) {
+			ImGui::TableNextColumn();
+			ImGui::Text("Post-FG FPS:");
+			ImGui::TableNextColumn();
+			ImGui::Text("%.1f (%.2f ms)", this->perfOverlayState.postFGSmoothFps, this->perfOverlayState.postFGSmoothFrameTimeMs);
+		}
+
+		ImGui::EndTable();
+	}
+
+	// Show Pre-FG frametime graph if enabled
+	if (this->settings.ShowPreFGFrameTimeGraph) {
+		// Prepare overlay text
+		char overlay_text[128];
+		snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
+			"%s%.2f ms (%.1f FPS)",
+			this->perfOverlayState.isFrameGenerationActive ? "Pre-FG: " : "",
+			this->perfOverlayState.smoothFrameTimeMs, this->perfOverlayState.smoothFps);
+
+		// Set graph colors
+		ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));  // Green line
+
+		// Draw the graph
+		float graphWidth = ImGui::GetWindowWidth() * 0.9f;
+		ImGui::PlotLines("##frametime",
+			this->perfOverlayState.frameTimeHistory.data(),
+			this->settings.FrameHistorySize,
+			this->perfOverlayState.frameTimeHistoryIndex,
+			overlay_text,
+			this->perfOverlayState.smoothedMinFrameTime, this->perfOverlayState.smoothedMaxFrameTime,
+			ImVec2(graphWidth, 50.0f * this->perfOverlayState.textScale));
+
+		ImGui::PopStyleColor();
+
+		// Draw frametime target reference lines
+		if (ImGui::BeginTable("FrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
+			ImGui::TableNextColumn();
+			ImGui::Text("30 FPS: 33.3 ms");
+
+			ImGui::TableNextColumn();
+			ImGui::Text("60 FPS: 16.7 ms");
+
+			ImGui::TableNextColumn();
+			ImGui::Text("120 FPS: 8.3 ms");
+
+			ImGui::EndTable();
+		}
+	}
+
+	// Show Post-FG frametime graph if enabled
+	if (this->settings.ShowPostFGFrameTimeGraph && this->perfOverlayState.isFrameGenerationActive) {
+		// Check if FSR frame generation is active (FSR doesn't provide timing data)
+		bool isFSRFrameGen = globals::fidelityFX && globals::fidelityFX->isFrameGenActive;
+
+		if (isFSRFrameGen) {
+			// Show note that post-FG timing isn't available with FSR
+			ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f), "Post-FG timing not available with FSR3 Framegen");
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text("AMD FSR Frame Generation doesn't provide internal timing data.\nPost-FG performance metrics are only available with NVIDIA DLSS Frame Generation.");
+			}
+		} else {
+			// Show post-FG graph for DLSS
+			this->perfOverlayState.DrawPostFGFrameTimeGraph();
+		}
+	}
+}
+
+void PerformanceOverlay::PerfOverlayState::DrawPostFGFrameTimeGraph()
+{
+	// Prepare overlay text
+	char overlay_text[128];
+	snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
+		"Post-FG: %.2f ms (%.1f FPS)",
+		postFGSmoothFrameTimeMs, postFGSmoothFps);
+
+	// Set graph colors - blue for post-FG
+	ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
+
+	// Draw the graph
+	float graphWidth = ImGui::GetWindowWidth() * 0.9f;
+	ImGui::PlotLines("##postfgframetime",
+		postFGFrameTimeHistory.data(),
+		PerformanceOverlay::GetSingleton()->settings.FrameHistorySize,
+		postFGFrameTimeHistoryIndex,
+		overlay_text,
+		smoothedMinFrameTime, smoothedMaxFrameTime,
+		ImVec2(graphWidth, 50.0f * textScale));
+
+	ImGui::PopStyleColor();
+
+	// Draw frametime target reference lines
+	if (ImGui::BeginTable("PostFGFrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
+		ImGui::TableNextColumn();
+		ImGui::Text("30 FPS: 33.3 ms");
+
+		ImGui::TableNextColumn();
+		ImGui::Text("60 FPS: 16.7 ms");
+
+		ImGui::TableNextColumn();
+		ImGui::Text("120 FPS: 8.3 ms");
+
+		ImGui::EndTable();
+	}
+}
+
+void PerformanceOverlay::DrawDrawCalls()
+{
+	static bool clearTestDataRequested = false;
+	bool abTestActive = (Menu::GetSingleton() && Menu::GetSingleton()->abTestingEnabled && Menu::GetSingleton()->usingTestConfig);
+	bool anyShaderDisabled = false;
+	for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
+		if (!globals::state->enabledClasses[i]) {
+			anyShaderDisabled = true;
+			break;
+		}
+	}
+	if (!s_testData.empty()) {
+		if (ImGui::Button("Clear Test Data")) {
+			clearTestDataRequested = true;
+		}
+		ImGui::SameLine();
+		ImGui::TextDisabled("Test columns are shown only when test data is present.");
+	}
+
+	// Build headers and column count dynamically
+	std::vector<std::string> headers = { "Shader Type", "Draw Calls", "Frame Time (%)", "Cost/Call" };
+	bool anyTestData = !s_testData.empty();
+	if (anyTestData) {
+		headers.push_back("Test Frame Time (%)");
+		headers.push_back("Test Cost/Call");
+	}
+	int columnCount = static_cast<int>(headers.size());
+
+	// Tooltip map for shader types
+	static const std::unordered_map<RE::BSShader::Type, std::string> kShaderTypeTooltips = {
+		{ RE::BSShader::Type::Grass, "Draw calls using the Grass shader. Typically many, but each is usually cheap." },
+		{ RE::BSShader::Type::Sky, "Draw calls for the sky dome, clouds, and related effects." },
+		{ RE::BSShader::Type::Water, "Draw calls for water surfaces and effects." },
+		{ RE::BSShader::Type::Lighting, "Draw calls for dynamic and static lighting passes." },
+		{ RE::BSShader::Type::Effect, "Draw calls for special effects, particles, and post-processing." },
+		{ RE::BSShader::Type::Utility, "Draw calls for utility passes, such as shadow masks or G-buffer fills." },
+		{ RE::BSShader::Type::DistantTree, "Draw calls for distant tree rendering (LOD vegetation)." },
+		{ RE::BSShader::Type::Particle, "Draw calls for particle systems (smoke, sparks, etc.)." },
+		{ RE::BSShader::Type::BloodSplatter, "Draw calls for blood splatter effects." },
+		{ RE::BSShader::Type::ImageSpace, "Draw calls for image space post-processing effects." }
+	};
+	std::vector<ShaderRow> shaderTypes;
+	for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
+		if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
+			continue;
+		std::string label = std::string(magic_enum::enum_name(type)) + ":";
+		auto it = kShaderTypeTooltips.find(type);
+		std::string tooltip = (it != kShaderTypeTooltips.end()) ? it->second : "Draw calls for this shader type.";
+		tooltip += "\nClick to ";
+		tooltip += (globals::state->enabledClasses[magic_enum::enum_integer(type) - 1]) ? "disable" : "enable";
+		tooltip += " this shader.";
+		shaderTypes.push_back({ label, type, tooltip });
+	}
+
+	// Sorting state (declare all at the top)
+	static int sortColumn = 0;
+	static bool sortAscending = false;
+	static bool isSorted = false;
+	static std::vector<DrawCallRow> originalRows;
+
+	// Use the smoothed frame time for all calculations
+	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.smoothFrameTimeMs);
+	float measuredSum = 0.0f;
+	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
+
+	// --- TEST DATA SNAPSHOT LOGIC ---
+	if (abTestActive) {
+		measuredSum = 0.0f;
+		for (const auto& row : shaderTypes) {
+			auto typeIndex = magic_enum::enum_integer(static_cast<RE::BSShader::Type>(row.type));
+			float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
+			float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
+			float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
+			float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
+			s_testData[typeIndex] = { frameTime, costPerCall, percent };
+			measuredSum += frameTime;
+		}
+		float otherFrameTime = smoothedFrameTime - measuredSum;
+		float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
+		s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
+		float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
+		s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+	} else if (anyShaderDisabled) {
+		measuredSum = 0.0f;
+		for (const auto& row : shaderTypes) {
+			auto typeIndex = magic_enum::enum_integer(static_cast<RE::BSShader::Type>(row.type));
+			bool enabled = globals::state->enabledClasses[typeIndex - 1];
+			if (!enabled) {
+				float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
+				float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
+				float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
+				float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
+				s_testData[typeIndex] = { frameTime, costPerCall, percent };
+			}
+			measuredSum += static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
+		}
+		float otherFrameTime = smoothedFrameTime - measuredSum;
+		float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
+		s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
+		float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
+		s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+	}
+
+	// Build main rows: all shader types
+	std::vector<DrawCallRow> mainRows;
+	measuredSum = 0.0f;
+	for (const auto& row : shaderTypes) {
+		auto typeIndex = magic_enum::enum_integer(static_cast<RE::BSShader::Type>(row.type));
+		float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
+		float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
+		float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
+		float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
+		// Clamp small negative values to zero
+		if (std::abs(frameTime) < 1e-4f)
+			frameTime = 0.0f;
+		if (std::abs(costPerCall) < 1e-6f)
+			costPerCall = 0.0f;
+		bool enabled = globals::state->enabledClasses[typeIndex - 1];
+		std::optional<float> testFrameTime, testCostPerCall;
+		auto it = s_testData.find(typeIndex);
+		if (it != s_testData.end()) {
+			testFrameTime = it->second.frameTime;
+			testCostPerCall = it->second.costPerCall;
+			anyTestData = true;
+		}
+		DrawCallRow rowObj{ row.label, typeIndex, static_cast<int>(drawCalls), frameTime, percent, costPerCall, row.tooltip, enabled, testFrameTime, testCostPerCall };
+		mainRows.push_back(rowObj);
+		measuredSum += frameTime;
+	}
+
+	// Add summary rows (not part of main sorting)
+	float otherFrameTime = smoothedFrameTime - measuredSum;
+	if (std::abs(otherFrameTime) < 1e-4f)
+		otherFrameTime = 0.0f;
+
+	DrawCallRow otherRow = {
+		"Other:", -2, 0, otherFrameTime,
+		(smoothedFrameTime > 0.0f ? static_cast<float>((otherFrameTime / smoothedFrameTime) * 100.0f) : 0.0f),
+		0.0f,
+		std::string("Frame time not attributed to any measured shader type. This includes UI, post-processing, engine work, and any GPU activity not directly measured by the overlay.")
+	};
+
+	DrawCallRow totalRow = {
+		"Total:", -1, static_cast<int>(totalSmoothedDrawCalls), smoothedFrameTime, 100.0f,
+		(totalSmoothedDrawCalls > 0.0f ? static_cast<float>(smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f),
+		std::string("Sum of all measured shader types.\nClick to enable or disable all shaders.")
+	};
+
+	// Always start the main table sorted alphabetically by label on first display
+	static bool firstTableDisplay = true;
+	if (firstTableDisplay) {
+		std::sort(mainRows.begin(), mainRows.end(), [](const DrawCallRow& a, const DrawCallRow& b) {
+			return a.label < b.label;
+		});
+		firstTableDisplay = false;
+	}
+
+	// Handle sorting: only sort mainRows, never summary rows
+	if (ImGui::BeginTable("DrawCallOverlayTable##", columnCount, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable)) {
+		// --- HEADER SETUP WITH TOOLTIP ---
+		for (int i = 0; i < headers.size(); ++i) {
+			ImGui::TableSetupColumn(headers[i].c_str());
+			if (anyTestData && (headers[i] == "Test Frame Time" || headers[i] == "Test Cost/Call")) {
+				if (ImGui::IsItemHovered()) {
+					ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
+				}
+			}
+		}
+		ImGui::TableHeadersRow();
+
+		if (const ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs()) {
+			if (sortSpecs->SpecsCount > 0) {
+				sortColumn = sortSpecs->Specs->ColumnIndex;
+				sortAscending = sortSpecs->Specs->SortDirection == ImGuiSortDirection_Ascending;
+				switch (sortColumn) {
+				case Col_Label:
+					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
+						return sortAscending ? (a.label < b.label) : (a.label > b.label);
+					});
+					break;
+				case Col_DrawCalls:
+					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
+						return sortAscending ? (a.drawCalls < b.drawCalls) : (a.drawCalls > b.drawCalls);
+					});
+					break;
+				case Col_FrameTime:
+					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
+						return sortAscending ? (a.percent < b.percent) : (a.percent > b.percent);
+					});
+					break;
+				case Col_CostPerCall:
+					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
+						return sortAscending ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall);
+					});
+					break;
+				case Col_TestFrameTime:
+					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
+						float aVal = a.testFrameTime.value_or(FLT_MAX);
+						float bVal = b.testFrameTime.value_or(FLT_MAX);
+						return sortAscending ? (aVal < bVal) : (aVal > bVal);
+					});
+					break;
+				case Col_TestCostPerCall:
+					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
+						float aVal = a.testCostPerCall.value_or(FLT_MAX);
+						float bVal = b.testCostPerCall.value_or(FLT_MAX);
+						return sortAscending ? (aVal < bVal) : (aVal > bVal);
+					});
+					break;
+				}
+			}
+		}
+
+		// --- Main table cell rendering switch: renders each cell based on column ---
+		for (size_t rowIdx = 0; rowIdx < mainRows.size(); ++rowIdx) {
+			const auto& row = mainRows[rowIdx];
+			ImGui::TableNextRow();
+			int colIdx = 0;
+			// Label
+			ImGui::TableSetColumnIndex(colIdx++);
+			if (!row.enabled) {
+				ImGui::PushStyleColor(ImGuiCol_Text, Menu::GetSingleton()->GetTheme().StatusPalette.Disable);
+			}
+			bool wasEnabled = row.enabled;
+			if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
+				auto maybeType = magic_enum::enum_cast<RE::BSShader::Type>(row.shaderType);
+				if (maybeType.has_value()) {
+					auto classIndex = magic_enum::enum_integer(*maybeType) - 1;
+					if (classIndex >= 0 && classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1) {
+						globals::state->enabledClasses[classIndex] = !wasEnabled;
+						// Also update test data when toggled
+						UpdateShaderTestData(row.shaderType, row.frameTime, row.costPerCall);
+					}
+				}
+			}
+			if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup | ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
+				ImGui::SetTooltip("%s", row.tooltip.c_str());
+			}
+			if (!row.enabled) {
+				ImGui::PopStyleColor();
+			}
+			// Draw Calls
+			ImGui::TableSetColumnIndex(colIdx++);
+			ImGui::Text("%d", row.drawCalls);
+			// Frame Time (%)
+			ImGui::TableSetColumnIndex(colIdx++);
+			{
+				std::string frameTimeStr = Util::FormatMilliseconds(row.frameTime) + " (" + Util::FormatPercent(row.percent) + ")";
+				ImVec4 color = Util::GetThresholdColor(row.percent, 30.0f, 60.0f,
+					Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor,
+					Menu::GetSingleton()->GetTheme().StatusPalette.Warning,
+					Menu::GetSingleton()->GetTheme().StatusPalette.Error);
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				ImGui::Text("%s", frameTimeStr.c_str());
+				ImGui::PopStyleColor();
+			}
+			// Cost/Call
+			ImGui::TableSetColumnIndex(colIdx++);
+			{
+				ImVec4 color = Util::GetThresholdColor(row.costPerCall, 0.05f, 0.2f,
+					Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor,
+					Menu::GetSingleton()->GetTheme().StatusPalette.Warning,
+					Menu::GetSingleton()->GetTheme().StatusPalette.Error);
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				if (row.costPerCall < 0.01f && row.costPerCall > 0.0f)
+					ImGui::Text("%s", Util::FormatMicroseconds(row.costPerCall * 1000.0f).c_str());
+				else
+					ImGui::Text("%s", Util::FormatMilliseconds(row.costPerCall).c_str());
+				ImGui::PopStyleColor();
+			}
+			// Test columns if present
+			if (anyTestData) {
+				// Test Frame Time
+				ImGui::TableSetColumnIndex(colIdx++);
+				if (row.testFrameTime.has_value()) {
+					ImVec4 testColor = Util::GetThresholdColor(*row.testFrameTime, row.frameTime, row.frameTime + 0.01f,
+						Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor,
+						Menu::GetSingleton()->GetTheme().StatusPalette.Warning,
+						Menu::GetSingleton()->GetTheme().StatusPalette.Error);
+					ImGui::PushStyleColor(ImGuiCol_Text, testColor);
+					std::string testFrameTimeStr = Util::FormatMilliseconds(*row.testFrameTime) + " (" + Util::FormatPercent(s_testData[row.shaderType].percent) + ")";
+					ImGui::Text("%s", testFrameTimeStr.c_str());
+					ImGui::PopStyleColor();
+					if (ImGui::IsItemHovered()) {
+						ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
+					}
+				} else {
+					ImGui::TextDisabled("-");
+				}
+				// Test Cost/Call
+				ImGui::TableSetColumnIndex(colIdx++);
+				if (row.testCostPerCall.has_value()) {
+					ImVec4 testColor = Util::GetThresholdColor(*row.testCostPerCall, row.costPerCall, row.costPerCall + 0.01f,
+						Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor,
+						Menu::GetSingleton()->GetTheme().StatusPalette.Warning,
+						Menu::GetSingleton()->GetTheme().StatusPalette.Error);
+					ImGui::PushStyleColor(ImGuiCol_Text, testColor);
+					if (*row.testCostPerCall < 0.01f && *row.testCostPerCall > 0.0f)
+						ImGui::Text("%s", Util::FormatMicroseconds(*row.testCostPerCall * 1000.0f).c_str());
+					else
+						ImGui::Text("%s", Util::FormatMilliseconds(*row.testCostPerCall).c_str());
+					ImGui::PopStyleColor();
+					if (ImGui::IsItemHovered()) {
+						ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
+					}
+				} else {
+					ImGui::TextDisabled("-");
+				}
+			}
+		}
+		// Separator row (optional, for visual separation)
+		ImGui::TableNextRow(ImGuiTableRowFlags_None, 4.0f);
+		for (int col = 0; col < columnCount; ++col) {
+			ImGui::TableSetColumnIndex(col);
+			if (col == 0)
+				ImGui::Separator();
+		}
+		// Summary rows (Other, Total)
+		for (const DrawCallRow& row : { otherRow, totalRow }) {
+			ImGui::TableNextRow();
+			int colIdx = 0;
+			ImGui::TableSetColumnIndex(colIdx++);
+			if (row.label == std::string("Total:")) {
+				if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
+					bool anyDisabled = false;
+					for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
+						if (!globals::state->enabledClasses[i]) {
+							anyDisabled = true;
+							break;
+						}
+					}
+					for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
+						globals::state->enabledClasses[i] = anyDisabled;
+					}
+				}
+			} else {
+				ImGui::TextUnformatted(row.label.c_str());
+			}
+			if (!row.tooltip.empty() && ImGui::IsItemHovered()) {
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					ImGui::TextUnformatted(row.tooltip.c_str());
+				}
+			}
+			ImGui::TableSetColumnIndex(colIdx++);
+			if (row.label == "Other:" && row.drawCalls <= 0) {
+				ImGui::TextUnformatted("N/A");
+			} else {
+				ImGui::Text("%d", row.drawCalls);
+			}
+			ImGui::TableSetColumnIndex(colIdx++);
+			if (row.label == "Other:" && row.frameTime <= 0.0f) {
+				ImGui::TextUnformatted("N/A");
+			} else {
+				ImGui::Text("%.2f ms (%.1f%%)", row.frameTime, row.percent);
+				if (row.label == "Total:" && ImGui::IsItemHovered()) {
+					float _fps = row.frameTime > 0.0f ? 1000.0f / row.frameTime : 0.0f;
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::Text("FPS: %.2f", _fps);
+					}
+				}
+			}
+			ImGui::TableSetColumnIndex(colIdx++);
+			if (row.label == "Other:" && row.costPerCall <= 0.0f) {
+				ImGui::TextUnformatted("N/A");
+			} else if (row.costPerCall < 0.01f && row.costPerCall > 0.0f) {
+				ImGui::Text("%.2f us", row.costPerCall * 1000.0f);
+			} else {
+				ImGui::Text("%.3f ms", row.costPerCall);
+			}
+			if (anyTestData) {
+				ImGui::TableSetColumnIndex(colIdx++);
+				auto testIt = s_testData.find(row.shaderType);
+				if (testIt != s_testData.end()) {
+					ImVec4 testColor = ImGui::GetStyleColorVec4(ImGuiCol_Text);
+					if (testIt->second.frameTime < row.frameTime)
+						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
+					else if (testIt->second.frameTime > row.frameTime)
+						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
+					ImGui::PushStyleColor(ImGuiCol_Text, testColor);
+					ImGui::Text("%.2f ms (%.1f%%)", testIt->second.frameTime, testIt->second.percent);
+					ImGui::PopStyleColor();
+					if (ImGui::IsItemHovered()) {
+						ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
+						// Show FPS for test frame time
+						float _fps = testIt->second.frameTime > 0.0f ? 1000.0f / testIt->second.frameTime : 0.0f;
+						if (auto _tt = Util::HoverTooltipWrapper()) {
+							ImGui::Text("FPS: %.2f", _fps);
+						}
+					}
+				} else {
+					ImGui::TextUnformatted("N/A");
+				}
+				ImGui::TableSetColumnIndex(colIdx++);
+				if (testIt != s_testData.end()) {
+					ImVec4 testColor = ImGui::GetStyleColorVec4(ImGuiCol_Text);
+					if (testIt->second.costPerCall < row.costPerCall)
+						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
+					else if (testIt->second.costPerCall > row.costPerCall)
+						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
+					ImGui::PushStyleColor(ImGuiCol_Text, testColor);
+					if (testIt->second.costPerCall < 0.01f && testIt->second.costPerCall > 0.0f)
+						ImGui::Text("%.2f us", testIt->second.costPerCall * 1000.0f);
+					else
+						ImGui::Text("%.3f ms", testIt->second.costPerCall);
+					ImGui::PopStyleColor();
+					if (ImGui::IsItemHovered()) {
+						ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
+					}
+				} else {
+					ImGui::TextUnformatted("N/A");
+				}
+			}
+		}
+		ImGui::EndTable();
+	}
+
+	if (clearTestDataRequested) {
+		s_testData.clear();
+		clearTestDataRequested = false;
+		s_testDataSource = TestDataSource::None;
+	}
+}
+
+void PerformanceOverlay::DrawVRAM()
+{
+	auto menu = Menu::GetSingleton();
+	if (!menu)
+		return;
+	auto dxgiAdapter3 = menu->GetDXGIAdapter3();
+	if (!dxgiAdapter3)
+		return;
+	DXGI_QUERY_VIDEO_MEMORY_INFO videoMemoryInfo{};
+	HRESULT hr = dxgiAdapter3->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &videoMemoryInfo);
+
+	// Only proceed if the call succeeded and Budget is not zero
+	if (SUCCEEDED(hr) && videoMemoryInfo.Budget > 0) {
+		float currentGpuUsage = videoMemoryInfo.CurrentUsage / (1024.f * 1024.f * 1024.f);
+		float totalGpuMemory = videoMemoryInfo.Budget / (1024.f * 1024.f * 1024.f);
+		float percent = currentGpuUsage / totalGpuMemory;
+
+		// Center the VRAM text
+		ImGui::Text("VRAM Usage:");
+
+		// Use a centered text format for the numeric values
+		std::string vramText = std::format("{:.2f}GB/{:.2f}GB ({:.1f}%)", currentGpuUsage, totalGpuMemory, 100 * percent);
+		float textWidth = ImGui::CalcTextSize(vramText.c_str()).x;
+		float windowWidth = ImGui::GetWindowWidth();
+
+		// Center the text if it fits within the window
+		if (textWidth < windowWidth) {
+			ImGui::SetCursorPosX((windowWidth - textWidth) * 0.5f);
+			ImGui::Text("%s", vramText.c_str());
+		} else {
+			ImGui::Text("%s", vramText.c_str());
+		}
+
+		// Only move the progress bar, not the text
+		ImGui::ProgressBar(percent, ImVec2(ImGui::GetWindowWidth() * 0.9f, 0.0f), "");
+	} else {
+		// Display a fallback message if we couldn't get the VRAM info
+		ImGui::Text("VRAM Usage: Not available");
+	}
+}
+
+ImVec4 PerformanceOverlay::GetPerformanceColor(float value, float lowThreshold, float highThreshold)
+{
+	auto menu = Menu::GetSingleton();
+	const auto& theme = menu->GetTheme();
+
+	if (value <= lowThreshold) {
+		return theme.StatusPalette.SuccessColor;
+	} else if (value <= highThreshold) {
+		return theme.StatusPalette.Warning;
+	} else {
+		return theme.StatusPalette.Error;
+	}
+}
+
+ImVec4 PerformanceOverlay::GetPerformanceStatusColor(int status)
+{
+	auto menu = Menu::GetSingleton();
+	const auto& theme = menu->GetTheme();
+
+	switch (status) {
+	case 0:  // Good
+		return theme.StatusPalette.SuccessColor;
+	case 1:  // Warning
+		return theme.StatusPalette.Warning;
+	case 2:  // Error
+		return theme.StatusPalette.Error;
+	case 3:  // Info
+		return theme.StatusPalette.InfoColor;
+	default:
+		return theme.StatusPalette.InfoColor;
+	}
+}
+
+bool PerformanceOverlay::RenderColorCodedMetric(const char* label, float value, float lowThreshold, float highThreshold, const char* format)
+{
+	ImVec4 color = GetPerformanceColor(value, lowThreshold, highThreshold);
+	ImGui::PushStyleColor(ImGuiCol_Text, color);
+	ImGui::Text(label);
+	ImGui::SameLine();
+	ImGui::Text(format, value);
+	ImGui::PopStyleColor();
+	return ImGui::IsItemHovered();
+}
+
+/**
+ * @brief Updates all runtime state related to the performance overlay graph.
+ *
+ * This function synchronizes the frame time history buffer, tracks min/max frame times,
+ * and computes the normalized Y-axis range for the frame time graph using statistical analysis.
+ *
+ * Steps performed:
+ *   1. Resizes the frameTimeHistory buffer if the user has changed the setting.
+ *   2. Inserts the latest frame time into the circular history buffer.
+ *   3. Updates instantaneous min/max frame time values, with full rescans if necessary.
+ *   4. Calculates the average (mean) and standard deviation of frame times in the buffer.
+ *   5. Sets the graph Y-axis range to be centered on the average, with a spread of ±2 standard deviations,
+ *      clamped to user-friendly minimum and maximum values.
+ *   6. Smooths the min/max Y-axis values for visual stability using exponential smoothing.
+ *
+ *
+ * No parameters; uses settings from the singleton.
+ */
+void PerformanceOverlay::PerfOverlayState::UpdateGraphValues()
+{
+	// Get settings from the singleton
+	const auto& overlaySettings = PerformanceOverlay::GetSingleton()->settings;
+
+	// Sync frame history buffer size with user settings
+	UpdateFrameTimeHistorySizes();
+
+	// Insert latest frame time into circular buffer
+	float oldFrameTime = frameTimeHistory[frameTimeHistoryIndex];
+	frameTimeHistory[frameTimeHistoryIndex] = frameTimeMs;
+	frameTimeHistoryIndex = (frameTimeHistoryIndex + 1) % overlaySettings.FrameHistorySize;
+
+	// Maintain instantaneous min/max tracking
+	if (frameTimeMs > maxFrameTime) {
+		maxFrameTime = frameTimeMs;
+	} else if (frameTimeMs < minFrameTime) {
+		minFrameTime = frameTimeMs;
+	} else if (oldFrameTime == minFrameTime) {
+		UpdateMinFrameTime();
+	} else if (oldFrameTime == maxFrameTime) {
+		UpdateMaxFrameTime();
+	}
+
+	float avgFrameTime, stdDev, graphMin, graphMax;
+	// Calculate mean and standard deviation for normalized graph range
+	if (frameTimeHistory.empty()) {
+		// Default to 60 FPS
+		avgFrameTime = 16.67f;
+		stdDev = 0.0f;
+		graphMin = 0.0f;
+		graphMax = 33.0f;
+	} else {
+		// Calculate average frame time
+		avgFrameTime = std::accumulate(frameTimeHistory.begin(), frameTimeHistory.end(), 0.0f) / frameTimeHistory.size();
+
+		// Calculate standard deviation
+		float variance = 0.0f;
+		for (float ft : frameTimeHistory) {
+			float diff = ft - avgFrameTime;
+			variance += diff * diff;
+		}
+		variance /= frameTimeHistory.size();
+		stdDev = std::sqrt(variance);
+
+		// Calculate graph range
+		float spread = std::clamp(stdDev * 2.0f, 2.0f, 20.0f);
+		graphMin = std::max(0.0f, avgFrameTime - spread);
+		graphMax = avgFrameTime + spread;
+	}
+
+	// Exponential smoothing for stable graph scaling
+	smoothedMinFrameTime += kSmoothingFactor * (graphMin - smoothedMinFrameTime);
+	smoothedMaxFrameTime += kSmoothingFactor * (graphMax - smoothedMaxFrameTime);
+}

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -90,9 +90,7 @@ auto MakeMetricColumn(const auto& theme, auto valueGetter, auto colorGetter, aut
 	};
 }
 
-// --- Static variables for A/B testing ---
-static std::vector<SettingsDiffEntry> abSettingsDiff;
-static bool abSettingsDiffLoaded = false;
+// --- Helper Functions ---
 
 // --- Helper Functions ---
 /**
@@ -612,9 +610,6 @@ void PerformanceOverlay::DrawABTestResultsTable()
 }
 
 // Static test data state
-PerformanceOverlay::TestDataSource PerformanceOverlay::s_testDataSource = PerformanceOverlay::TestDataSource::None;
-std::chrono::steady_clock::time_point PerformanceOverlay::s_testDataLastUpdated;
-std::unordered_map<int, PerformanceOverlay::TestData> PerformanceOverlay::s_testData;
 
 // Implement static member functions
 /**
@@ -634,9 +629,9 @@ void PerformanceOverlay::UpdateShaderTestData(int shaderType, float frameTime, f
 {
 	UpdateShaderTestDataEntry(shaderType, frameTime, costPerCall);
 
-	float smoothedFrameTime = static_cast<float>(GetSingleton()->perfOverlayState.smoothFrameTimeMs);
+	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.GetSmoothFrameTimeMs());
 	float measuredSum = 0.0f;
-	for (const auto& [type, data] : s_testData) {
+	for (const auto& [type, data] : testData) {
 		if (type >= 0)
 			measuredSum += data.frameTime;
 	}
@@ -644,8 +639,8 @@ void PerformanceOverlay::UpdateShaderTestData(int shaderType, float frameTime, f
 	auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
 	UpdateSummaryTestData(smoothedFrameTime, otherFrameTime, otherPercent, totalCostPerCall);
 
-	s_testDataSource = TestDataSource::ManualShaderToggle;
-	s_testDataLastUpdated = std::chrono::steady_clock::now();
+	testDataSource = TestDataSource::ManualShaderToggle;
+	testDataLastUpdated = std::chrono::steady_clock::now();
 }
 
 /**
@@ -669,8 +664,8 @@ void PerformanceOverlay::UpdateAllShaderTestData()
 		}
 	});
 	if (allDisabled) {
-		s_testData.clear();
-		s_testDataSource = TestDataSource::None;
+		testData.clear();
+		testDataSource = TestDataSource::None;
 		return;
 	}
 
@@ -682,27 +677,27 @@ void PerformanceOverlay::UpdateAllShaderTestData()
 		return;
 	}
 
-	float smoothedFrameTime = static_cast<float>(GetSingleton()->perfOverlayState.smoothFrameTimeMs);
+	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.GetSmoothFrameTimeMs());
 	float measuredSum = 0.0f;
 
-	globals::state->ForEachShaderTypeWithMetrics([&measuredSum, smoothedFrameTime]([[maybe_unused]] auto type, int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, float percent, float costPerCall) {
-		UpdateShaderTestDataEntry(typeIndex, frameTime, costPerCall, percent);
+	globals::state->ForEachShaderTypeWithMetrics([&measuredSum, smoothedFrameTime, this]([[maybe_unused]] auto type, int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, float percent, float costPerCall) {
+		this->UpdateShaderTestDataEntry(typeIndex, frameTime, costPerCall, percent);
 		measuredSum += frameTime;
 	});
 
 	auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
 	UpdateSummaryTestData(smoothedFrameTime, otherFrameTime, otherPercent, totalCostPerCall);
-	s_testDataSource = TestDataSource::ABTest_VariantB;
-	s_testDataLastUpdated = std::chrono::steady_clock::now();
+	testDataSource = TestDataSource::ABTest_VariantB;
+	testDataLastUpdated = std::chrono::steady_clock::now();
 }
 
 std::string PerformanceOverlay::GetTestDataTooltip()
 {
-	switch (s_testDataSource) {
+	switch (testDataSource) {
 	case TestDataSource::ABTest_VariantB:
-		return std::string("Test data from Test (Variant B).\nLast updated: ") + Util::TimeAgoString(s_testDataLastUpdated) + " ago.";
+		return std::string("Test data from Test (Variant B).\nLast updated: ") + Util::TimeAgoString(testDataLastUpdated) + " ago.";
 	case TestDataSource::ManualShaderToggle:
-		return std::string("Test data from manual shader toggle.\nLast updated: ") + Util::TimeAgoString(s_testDataLastUpdated) + " ago.";
+		return std::string("Test data from manual shader toggle.\nLast updated: ") + Util::TimeAgoString(testDataLastUpdated) + " ago.";
 	default:
 		return "No test data available.";
 	}
@@ -711,9 +706,9 @@ std::string PerformanceOverlay::GetTestDataTooltip()
 void PerformanceOverlay::DataLoaded()
 {
 	// Initialize performance overlay state
-	this->perfOverlayState.initialized = false;
-	this->perfOverlayState.frameTimeHistory.resize(this->settings.FrameHistorySize, 0.0f);
-	this->perfOverlayState.postFGFrameTimeHistory.resize(this->settings.FrameHistorySize, 0.0f);
+	this->perfOverlayState.SetInitialized(false);
+	this->perfOverlayState.ResizeFrameTimeHistory(this->settings.FrameHistorySize, 0.0f);
+	this->perfOverlayState.ResizePostFGFrameTimeHistory(this->settings.FrameHistorySize, 0.0f);
 }
 
 std::pair<std::string, std::vector<std::string>> PerformanceOverlay::GetFeatureSummary()
@@ -855,7 +850,7 @@ void PerformanceOverlay::DrawOverlay()
 			this->settings.BackgroundOpacity));
 
 	// Set text size based on user preference
-	this->perfOverlayState.textScale = this->perfOverlayState.SetTextScale();
+	this->perfOverlayState.SetTextScale(this->perfOverlayState.SetTextScale());
 
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, this->settings.ShowBorder ? 1.0f : 0.0f);
 
@@ -869,29 +864,29 @@ void PerformanceOverlay::DrawOverlay()
 	}
 
 	// Set window size based on whether graphs are shown, was rapidly changing size based on text
-	this->perfOverlayState.hasGraphs = this->settings.ShowPreFGFrameTimeGraph ||
-	                                   (this->settings.ShowPostFGFrameTimeGraph && this->perfOverlayState.isFrameGenerationActive);
-	if (!this->perfOverlayState.hasGraphs) {
+	this->perfOverlayState.SetHasGraphs(this->settings.ShowPreFGFrameTimeGraph ||
+										(this->settings.ShowPostFGFrameTimeGraph && this->perfOverlayState.IsFrameGenerationActive()));
+	if (!this->perfOverlayState.HasGraphs()) {
 		// Calculate minimum width needed based on actual content
 		float minWidth = 0.0f;
 
 		// Calculate width needed for each enabled section
 		if (this->settings.ShowFPS) {
 			// Measure FPS text width
-			std::string fpsText = std::format("{:.1f} ({:.2f} ms)", this->perfOverlayState.smoothFps, this->perfOverlayState.smoothFrameTimeMs);
-			if (this->perfOverlayState.isFrameGenerationActive) {
-				fpsText = std::format("Raw FPS: {:.1f} ({:.2f} ms)", this->perfOverlayState.smoothFps, this->perfOverlayState.smoothFrameTimeMs);
+			std::string fpsText = std::format("{:.1f} ({:.2f} ms)", this->perfOverlayState.GetSmoothFps(), this->perfOverlayState.GetSmoothFrameTimeMs());
+			if (this->perfOverlayState.IsFrameGenerationActive()) {
+				fpsText = std::format("Raw FPS: {:.1f} ({:.2f} ms)", this->perfOverlayState.GetSmoothFps(), this->perfOverlayState.GetSmoothFrameTimeMs());
 			}
 			float fpsWidth = ImGui::CalcTextSize(fpsText.c_str()).x;
 			minWidth = std::max(minWidth, fpsWidth + PerformanceOverlay::PerfOverlayState::kLabelPadding);  // Add padding for labels
 		}
 		if (this->settings.ShowDrawCalls) {
 			// Draw calls table needs significant width for all columns
-			minWidth = std::max(minWidth, PerformanceOverlay::PerfOverlayState::kDrawCallsTableWidth * this->perfOverlayState.textScale);
+			minWidth = std::max(minWidth, PerformanceOverlay::PerfOverlayState::kDrawCallsTableWidth * this->perfOverlayState.GetTextScale());
 		}
 		if (this->settings.ShowVRAM && menu->GetDXGIAdapter3()) {
 			// VRAM section needs width for the progress bar and text
-			minWidth = std::max(minWidth, PerformanceOverlay::PerfOverlayState::kVRAMSectionWidth * this->perfOverlayState.textScale);
+			minWidth = std::max(minWidth, PerformanceOverlay::PerfOverlayState::kVRAMSectionWidth * this->perfOverlayState.GetTextScale());
 		}
 
 		// Add some padding for window borders and spacing
@@ -916,42 +911,42 @@ void PerformanceOverlay::DrawOverlay()
 	}
 
 	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4.0f, 1.0f));  // Tighter spacing
-	ImGui::SetWindowFontScale(this->perfOverlayState.textScale);
+	ImGui::SetWindowFontScale(this->perfOverlayState.GetTextScale());
 
 	// Initialize Performance Counter if necessary
-	if (!this->perfOverlayState.initialized) {
-		REX::W32::QueryPerformanceFrequency(&this->perfOverlayState.frequency);
-		REX::W32::QueryPerformanceCounter(&this->perfOverlayState.lastFrameCounter);
-		this->perfOverlayState.initialized = true;
+	if (!this->perfOverlayState.IsInitialized()) {
+		REX::W32::QueryPerformanceFrequency(&this->perfOverlayState.GetFrequencyRef());
+		REX::W32::QueryPerformanceCounter(&this->perfOverlayState.GetLastFrameCounterRef());
+		this->perfOverlayState.SetInitialized(true);
 	} else {
-		REX::W32::QueryPerformanceCounter(&this->perfOverlayState.currentFrameCounter);
-		int64_t elapsedCounter = this->perfOverlayState.currentFrameCounter - this->perfOverlayState.lastFrameCounter;
-		this->perfOverlayState.lastFrameCounter = this->perfOverlayState.currentFrameCounter;
+		REX::W32::QueryPerformanceCounter(&this->perfOverlayState.GetCurrentFrameCounterRef());
+		int64_t elapsedCounter = this->perfOverlayState.GetCurrentFrameCounter() - this->perfOverlayState.GetLastFrameCounter();
+		this->perfOverlayState.SetLastFrameCounter(this->perfOverlayState.GetCurrentFrameCounter());
 
 		// Calculate frametime and fps
-		this->perfOverlayState.frameTimeMs = Util::CalcFrameTime(elapsedCounter, this->perfOverlayState.frequency);
-		this->perfOverlayState.fps = Util::CalcFPS(this->perfOverlayState.frameTimeMs);
+		this->perfOverlayState.SetFrameTimeMs(Util::CalcFrameTime(elapsedCounter, this->perfOverlayState.GetFrequency()));
+		this->perfOverlayState.SetFps(Util::CalcFPS(this->perfOverlayState.GetFrameTimeMs()));
 
 		// Calculate smooth values for display using the user-defined update interval
 		auto now = std::chrono::steady_clock::now();
-		float deltaTime = std::chrono::duration<float>(now - this->perfOverlayState.lastUpdateTime).count();
-		this->perfOverlayState.lastUpdateTime = now;
+		float deltaTime = std::chrono::duration<float>(now - this->perfOverlayState.GetLastUpdateTime()).count();
+		this->perfOverlayState.SetLastUpdateTime(now);
 
 		// Update graph values
 		this->perfOverlayState.UpdateGraphValues();
 
 		// Update smooth values with user-specified interval
-		this->perfOverlayState.updateTimer += deltaTime;
-		if (this->perfOverlayState.updateTimer >= this->settings.UpdateInterval) {
-			this->perfOverlayState.smoothFps = this->perfOverlayState.fps;
-			this->perfOverlayState.smoothFrameTimeMs = this->perfOverlayState.frameTimeMs;
-			this->perfOverlayState.updateTimer = 0.0f;
+		this->perfOverlayState.SetUpdateTimer(this->perfOverlayState.GetUpdateTimer() + deltaTime);
+		if (this->perfOverlayState.GetUpdateTimer() >= this->settings.UpdateInterval) {
+			this->perfOverlayState.SetSmoothFps(this->perfOverlayState.GetFps());
+			this->perfOverlayState.SetSmoothFrameTimeMs(this->perfOverlayState.GetFrameTimeMs());
+			this->perfOverlayState.SetUpdateTimer(0.0f);
 		}
 
 		// Check if Frame Generation is active
-		this->perfOverlayState.isFrameGenerationActive = globals::upscaling && globals::upscaling->IsFrameGenerationActive();
+		this->perfOverlayState.SetFrameGenerationActive(globals::upscaling && globals::upscaling->IsFrameGenerationActive());
 
-		if (this->perfOverlayState.isFrameGenerationActive) {
+		if (this->perfOverlayState.IsFrameGenerationActive()) {
 			this->perfOverlayState.UpdateFGFrameTime();
 		}
 
@@ -1015,30 +1010,30 @@ void PerformanceOverlay::PerfOverlayState::UpdateFGFrameTime()
 	// Get frametime directly from the Frame Generation system
 	float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
 	if (fgDeltaTime > 0.0f) {
-		overlay->perfOverlayState.postFGFrameTimeMs = fgDeltaTime * 1000.0f;
-		overlay->perfOverlayState.postFGFps = 1000.0f / overlay->perfOverlayState.postFGFrameTimeMs;
+		overlay->perfOverlayState.SetPostFGFrameTimeMs(fgDeltaTime * 1000.0f);
+		overlay->perfOverlayState.SetPostFGFps(1000.0f / overlay->perfOverlayState.GetPostFGFrameTimeMs());
 
 		// Update post-FG smooth values when timer elapses
-		if (overlay->perfOverlayState.updateTimer <= 0.0f) {
-			overlay->perfOverlayState.postFGSmoothFps = overlay->perfOverlayState.postFGFps;
-			overlay->perfOverlayState.postFGSmoothFrameTimeMs = overlay->perfOverlayState.postFGFrameTimeMs;
+		if (overlay->perfOverlayState.GetUpdateTimer() <= 0.0f) {
+			overlay->perfOverlayState.SetPostFGSmoothFps(overlay->perfOverlayState.GetPostFGFps());
+			overlay->perfOverlayState.SetPostFGSmoothFrameTimeMs(overlay->perfOverlayState.GetPostFGFrameTimeMs());
 		}
 
 		// Update post-FG frametime history
-		overlay->perfOverlayState.postFGFrameTimeHistory[overlay->perfOverlayState.postFGFrameTimeHistoryIndex] = overlay->perfOverlayState.postFGFrameTimeMs;
-		overlay->perfOverlayState.postFGFrameTimeHistoryIndex = (overlay->perfOverlayState.postFGFrameTimeHistoryIndex + 1) % overlay->settings.FrameHistorySize;
+		overlay->perfOverlayState.GetPostFGFrameTimeHistoryRef()[overlay->perfOverlayState.GetPostFGFrameTimeHistoryIndex()] = overlay->perfOverlayState.GetPostFGFrameTimeMs();
+		overlay->perfOverlayState.SetPostFGFrameTimeHistoryIndex((overlay->perfOverlayState.GetPostFGFrameTimeHistoryIndex() + 1) % overlay->settings.FrameHistorySize);
 	} else {
 		// Fallback if FG time is not available
-		overlay->perfOverlayState.postFGFrameTimeMs = overlay->perfOverlayState.frameTimeMs / PerformanceOverlay::PerfOverlayState::kFrameGenerationMultiplier;
-		overlay->perfOverlayState.postFGFps = overlay->perfOverlayState.fps * PerformanceOverlay::PerfOverlayState::kFrameGenerationMultiplier;
+		overlay->perfOverlayState.SetPostFGFrameTimeMs(overlay->perfOverlayState.GetFrameTimeMs() / PerformanceOverlay::PerfOverlayState::kFrameGenerationMultiplier);
+		overlay->perfOverlayState.SetPostFGFps(overlay->perfOverlayState.GetFps() * PerformanceOverlay::PerfOverlayState::kFrameGenerationMultiplier);
 
-		if (overlay->perfOverlayState.updateTimer <= 0.0f) {
-			overlay->perfOverlayState.postFGSmoothFps = overlay->perfOverlayState.postFGFps;
-			overlay->perfOverlayState.postFGSmoothFrameTimeMs = overlay->perfOverlayState.postFGFrameTimeMs;
+		if (overlay->perfOverlayState.GetUpdateTimer() <= 0.0f) {
+			overlay->perfOverlayState.SetPostFGSmoothFps(overlay->perfOverlayState.GetPostFGFps());
+			overlay->perfOverlayState.SetPostFGSmoothFrameTimeMs(overlay->perfOverlayState.GetPostFGFrameTimeMs());
 		}
 
-		overlay->perfOverlayState.postFGFrameTimeHistory[overlay->perfOverlayState.postFGFrameTimeHistoryIndex] = overlay->perfOverlayState.postFGFrameTimeMs;
-		overlay->perfOverlayState.postFGFrameTimeHistoryIndex = (overlay->perfOverlayState.postFGFrameTimeHistoryIndex + 1) % overlay->settings.FrameHistorySize;
+		overlay->perfOverlayState.GetPostFGFrameTimeHistoryRef()[overlay->perfOverlayState.GetPostFGFrameTimeHistoryIndex()] = overlay->perfOverlayState.GetPostFGFrameTimeMs();
+		overlay->perfOverlayState.SetPostFGFrameTimeHistoryIndex((overlay->perfOverlayState.GetPostFGFrameTimeHistoryIndex() + 1) % overlay->settings.FrameHistorySize);
 	}
 }
 
@@ -1051,16 +1046,16 @@ void PerformanceOverlay::PerfOverlayState::UpdateFrameTimeHistorySizes()
 		overlay->settings.kMinFrameHistorySize,
 		overlay->settings.kMaxFrameHistorySize);
 
-	if (overlay->perfOverlayState.frameTimeHistory.size() != static_cast<size_t>(overlay->settings.FrameHistorySize)) {
-		overlay->perfOverlayState.frameTimeHistory.resize(overlay->settings.FrameHistorySize, 0.0f);
-		if (overlay->perfOverlayState.frameTimeHistoryIndex >= overlay->settings.FrameHistorySize) {
-			overlay->perfOverlayState.frameTimeHistoryIndex = 0;
+	if (overlay->perfOverlayState.GetFrameTimeHistory().size() != static_cast<size_t>(overlay->settings.FrameHistorySize)) {
+		overlay->perfOverlayState.ResizeFrameTimeHistory(overlay->settings.FrameHistorySize, 0.0f);
+		if (overlay->perfOverlayState.GetFrameTimeHistoryIndex() >= overlay->settings.FrameHistorySize) {
+			overlay->perfOverlayState.SetFrameTimeHistoryIndex(0);
 		}
 	}
-	if (overlay->perfOverlayState.postFGFrameTimeHistory.size() != static_cast<size_t>(overlay->settings.FrameHistorySize)) {
-		overlay->perfOverlayState.postFGFrameTimeHistory.resize(overlay->settings.FrameHistorySize, 0.0f);
-		if (overlay->perfOverlayState.postFGFrameTimeHistoryIndex >= overlay->settings.FrameHistorySize) {
-			overlay->perfOverlayState.postFGFrameTimeHistoryIndex = 0;
+	if (overlay->perfOverlayState.GetPostFGFrameTimeHistory().size() != static_cast<size_t>(overlay->settings.FrameHistorySize)) {
+		overlay->perfOverlayState.ResizePostFGFrameTimeHistory(overlay->settings.FrameHistorySize, 0.0f);
+		if (overlay->perfOverlayState.GetPostFGFrameTimeHistoryIndex() >= overlay->settings.FrameHistorySize) {
+			overlay->perfOverlayState.SetPostFGFrameTimeHistoryIndex(0);
 		}
 	}
 }
@@ -1068,13 +1063,13 @@ void PerformanceOverlay::PerfOverlayState::UpdateFrameTimeHistorySizes()
 void PerformanceOverlay::PerfOverlayState::UpdateMinFrameTime()
 {
 	auto* overlay = GetSingleton();
-	overlay->perfOverlayState.minFrameTime = *std::min_element(overlay->perfOverlayState.frameTimeHistory.begin(), overlay->perfOverlayState.frameTimeHistory.end());
+	overlay->perfOverlayState.SetMinFrameTime(*std::min_element(overlay->perfOverlayState.GetFrameTimeHistory().begin(), overlay->perfOverlayState.GetFrameTimeHistory().end()));
 }
 
 void PerformanceOverlay::PerfOverlayState::UpdateMaxFrameTime()
 {
 	auto* overlay = GetSingleton();
-	overlay->perfOverlayState.maxFrameTime = *std::max_element(overlay->perfOverlayState.frameTimeHistory.begin(), overlay->perfOverlayState.frameTimeHistory.end());
+	overlay->perfOverlayState.SetMaxFrameTime(*std::max_element(overlay->perfOverlayState.GetFrameTimeHistory().begin(), overlay->perfOverlayState.GetFrameTimeHistory().end()));
 }
 
 float PerformanceOverlay::PerfOverlayState::SetTextScale()
@@ -1098,15 +1093,15 @@ void PerformanceOverlay::DrawFPS()
 		ImGui::TableSetupColumn("##value");
 
 		ImGui::TableNextColumn();
-		ImGui::Text(this->perfOverlayState.isFrameGenerationActive ? "Raw FPS:" : "FPS:");
+		ImGui::Text(this->perfOverlayState.IsFrameGenerationActive() ? "Raw FPS:" : "FPS:");
 		ImGui::TableNextColumn();
-		ImGui::Text("%.1f (%.2f ms)", this->perfOverlayState.smoothFps, this->perfOverlayState.smoothFrameTimeMs);
+		ImGui::Text("%.1f (%.2f ms)", this->perfOverlayState.GetSmoothFps(), this->perfOverlayState.GetSmoothFrameTimeMs());
 
-		if (this->perfOverlayState.isFrameGenerationActive) {
+		if (this->perfOverlayState.IsFrameGenerationActive()) {
 			ImGui::TableNextColumn();
 			ImGui::Text("Post-FG FPS:");
 			ImGui::TableNextColumn();
-			ImGui::Text("%.1f (%.2f ms)", this->perfOverlayState.postFGSmoothFps, this->perfOverlayState.postFGSmoothFrameTimeMs);
+			ImGui::Text("%.1f (%.2f ms)", this->perfOverlayState.GetPostFGSmoothFps(), this->perfOverlayState.GetPostFGSmoothFrameTimeMs());
 		}
 
 		ImGui::EndTable();
@@ -1118,8 +1113,8 @@ void PerformanceOverlay::DrawFPS()
 		char overlay_text[128];
 		snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
 			"%s%.2f ms (%.1f FPS)",
-			this->perfOverlayState.isFrameGenerationActive ? "Pre-FG: " : "",
-			this->perfOverlayState.smoothFrameTimeMs, this->perfOverlayState.smoothFps);
+			this->perfOverlayState.IsFrameGenerationActive() ? "Pre-FG: " : "",
+			this->perfOverlayState.GetSmoothFrameTimeMs(), this->perfOverlayState.GetSmoothFps());
 
 		// Set graph colors
 		ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));  // Green line
@@ -1127,12 +1122,12 @@ void PerformanceOverlay::DrawFPS()
 		// Draw the graph
 		float graphWidth = ImGui::GetWindowWidth() * 0.9f;
 		ImGui::PlotLines("##frametime",
-			this->perfOverlayState.frameTimeHistory.data(),
+			this->perfOverlayState.GetFrameTimeHistory().data(),
 			this->settings.FrameHistorySize,
-			this->perfOverlayState.frameTimeHistoryIndex,
+			this->perfOverlayState.GetFrameTimeHistoryIndex(),
 			overlay_text,
-			this->perfOverlayState.smoothedMinFrameTime, this->perfOverlayState.smoothedMaxFrameTime,
-			ImVec2(graphWidth, 50.0f * this->perfOverlayState.textScale));
+			this->perfOverlayState.GetSmoothedMinFrameTime(), this->perfOverlayState.GetSmoothedMaxFrameTime(),
+			ImVec2(graphWidth, 50.0f * this->perfOverlayState.GetTextScale()));
 
 		ImGui::PopStyleColor();
 
@@ -1152,7 +1147,7 @@ void PerformanceOverlay::DrawFPS()
 	}
 
 	// Show Post-FG frametime graph if enabled
-	if (this->settings.ShowPostFGFrameTimeGraph && this->perfOverlayState.isFrameGenerationActive) {
+	if (this->settings.ShowPostFGFrameTimeGraph && this->perfOverlayState.IsFrameGenerationActive()) {
 		// Check if FSR frame generation is active (FSR doesn't provide timing data)
 		bool isFSRFrameGen = globals::fidelityFX && globals::fidelityFX->isFrameGenActive;
 
@@ -1175,7 +1170,7 @@ void PerformanceOverlay::PerfOverlayState::DrawPostFGFrameTimeGraph()
 	char overlay_text[128];
 	snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
 		"Post-FG: %.2f ms (%.1f FPS)",
-		postFGSmoothFrameTimeMs, postFGSmoothFps);
+		GetPostFGSmoothFrameTimeMs(), GetPostFGSmoothFps());
 
 	// Set graph colors - blue for post-FG
 	ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
@@ -1183,12 +1178,12 @@ void PerformanceOverlay::PerfOverlayState::DrawPostFGFrameTimeGraph()
 	// Draw the graph
 	float graphWidth = ImGui::GetWindowWidth() * 0.9f;
 	ImGui::PlotLines("##postfgframetime",
-		postFGFrameTimeHistory.data(),
+		GetPostFGFrameTimeHistory().data(),
 		PerformanceOverlay::GetSingleton()->settings.FrameHistorySize,
-		postFGFrameTimeHistoryIndex,
+		GetPostFGFrameTimeHistoryIndex(),
 		overlay_text,
-		smoothedMinFrameTime, smoothedMaxFrameTime,
-		ImVec2(graphWidth, 50.0f * textScale));
+		GetSmoothedMinFrameTime(), GetSmoothedMaxFrameTime(),
+		ImVec2(graphWidth, 50.0f * GetTextScale()));
 
 	ImGui::PopStyleColor();
 
@@ -1226,51 +1221,51 @@ void PerformanceOverlay::CaptureTestData()
 			anyShaderDisabled = true;
 		}
 	});
-	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.smoothFrameTimeMs);
+	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.GetSmoothFrameTimeMs());
 	float measuredSum = 0.0f;
 	if (abTestActive) {
 		measuredSum = 0.0f;
-		globals::state->ForEachShaderTypeWithMetrics([&measuredSum, smoothedFrameTime]([[maybe_unused]] auto type, int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, float percent, float costPerCall) {
-			UpdateShaderTestDataEntry(typeIndex, frameTime, costPerCall, percent);
+		globals::state->ForEachShaderTypeWithMetrics([&measuredSum, smoothedFrameTime, this]([[maybe_unused]] auto type, int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, float percent, float costPerCall) {
+			this->UpdateShaderTestDataEntry(typeIndex, frameTime, costPerCall, percent);
 			measuredSum += frameTime;
 		});
 		auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
 		UpdateSummaryTestData(smoothedFrameTime, otherFrameTime, otherPercent, totalCostPerCall);
-		s_testDataSource = TestDataSource::ABTest_VariantB;
-		s_testDataLastUpdated = std::chrono::steady_clock::now();
+		testDataSource = TestDataSource::ABTest_VariantB;
+		testDataLastUpdated = std::chrono::steady_clock::now();
 	} else if (anyShaderDisabled) {
 		measuredSum = 0.0f;
-		globals::state->ForEachShaderTypeWithMetrics([&measuredSum, smoothedFrameTime]([[maybe_unused]] auto type, int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, float percent, float costPerCall) {
+		globals::state->ForEachShaderTypeWithMetrics([&measuredSum, smoothedFrameTime, this]([[maybe_unused]] auto type, int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, float percent, float costPerCall) {
 			bool enabled = globals::state->enabledClasses[typeIndex - 1];
 			if (!enabled) {
-				UpdateShaderTestDataEntry(typeIndex, frameTime, costPerCall, percent);
+				this->UpdateShaderTestDataEntry(typeIndex, frameTime, costPerCall, percent);
 			}
 			measuredSum += frameTime;
 		});
 		auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
 		UpdateSummaryTestData(smoothedFrameTime, otherFrameTime, otherPercent, totalCostPerCall);
-		s_testDataSource = TestDataSource::ManualShaderToggle;
-		s_testDataLastUpdated = std::chrono::steady_clock::now();
+		testDataSource = TestDataSource::ManualShaderToggle;
+		testDataLastUpdated = std::chrono::steady_clock::now();
 	}
 }
 
 void PerformanceOverlay::ClearTestData()
 {
-	s_testData.clear();
-	s_testDataSource = TestDataSource::None;
+	testData.clear();
+	testDataSource = TestDataSource::None;
 }
 
 std::pair<std::vector<DrawCallRow>, std::vector<DrawCallRow>> PerformanceOverlay::BuildDrawCallRows() const
 {
 	std::vector<DrawCallRow> mainRows;
-	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.smoothFrameTimeMs);
+	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.GetSmoothFrameTimeMs());
 	float measuredSum = 0.0f;
 
-	globals::state->ForEachShaderTypeWithMetrics([&mainRows, &measuredSum, smoothedFrameTime](auto type, int typeIndex, float drawCalls, float frameTime, float percent, float costPerCall) {
+	globals::state->ForEachShaderTypeWithMetrics([&mainRows, &measuredSum, smoothedFrameTime, this](auto type, int typeIndex, float drawCalls, float frameTime, float percent, float costPerCall) {
 		bool enabled = globals::state->enabledClasses[typeIndex - 1];
 		std::optional<float> testFrameTime, testCostPerCall;
-		auto it = s_testData.find(typeIndex);
-		if (it != s_testData.end()) {
+		auto it = this->testData.find(typeIndex);
+		if (it != this->testData.end()) {
 			testFrameTime = it->second.frameTime;
 			testCostPerCall = it->second.costPerCall;
 		}
@@ -1288,13 +1283,13 @@ std::pair<std::vector<DrawCallRow>, std::vector<DrawCallRow>> PerformanceOverlay
 	if (std::abs(otherFrameTime) < 1e-4f)
 		otherFrameTime = 0.0f;
 	std::optional<float> otherTestFrameTime, otherTestCostPerCall, totalTestFrameTime, totalTestCostPerCall;
-	auto itOther = s_testData.find(static_cast<int>(SpecialShaderType::Other));
-	if (itOther != s_testData.end()) {
+	auto itOther = this->testData.find(static_cast<int>(SpecialShaderType::Other));
+	if (itOther != this->testData.end()) {
 		otherTestFrameTime = itOther->second.frameTime;
 		otherTestCostPerCall = itOther->second.costPerCall;
 	}
-	auto itTotal = s_testData.find(static_cast<int>(SpecialShaderType::Total));
-	if (itTotal != s_testData.end()) {
+	auto itTotal = this->testData.find(static_cast<int>(SpecialShaderType::Total));
+	if (itTotal != this->testData.end()) {
 		totalTestFrameTime = itTotal->second.frameTime;
 		totalTestCostPerCall = itTotal->second.costPerCall;
 	}
@@ -1370,24 +1365,24 @@ void PerformanceOverlay::PerfOverlayState::UpdateGraphValues()
 	UpdateFrameTimeHistorySizes();
 
 	// Insert latest frame time into circular buffer
-	float oldFrameTime = frameTimeHistory[frameTimeHistoryIndex];
-	frameTimeHistory[frameTimeHistoryIndex] = frameTimeMs;
-	frameTimeHistoryIndex = (frameTimeHistoryIndex + 1) % overlaySettings.FrameHistorySize;
+	float oldFrameTime = GetFrameTimeHistory()[GetFrameTimeHistoryIndex()];
+	GetFrameTimeHistoryRef()[GetFrameTimeHistoryIndex()] = GetFrameTimeMs();
+	SetFrameTimeHistoryIndex((GetFrameTimeHistoryIndex() + 1) % overlaySettings.FrameHistorySize);
 
 	// Maintain instantaneous min/max tracking
-	if (frameTimeMs > maxFrameTime) {
-		maxFrameTime = frameTimeMs;
-	} else if (frameTimeMs < minFrameTime) {
-		minFrameTime = frameTimeMs;
-	} else if (oldFrameTime == minFrameTime) {
+	if (GetFrameTimeMs() > GetMaxFrameTime()) {
+		SetMaxFrameTime(GetFrameTimeMs());
+	} else if (GetFrameTimeMs() < GetMinFrameTime()) {
+		SetMinFrameTime(GetFrameTimeMs());
+	} else if (oldFrameTime == GetMinFrameTime()) {
 		UpdateMinFrameTime();
-	} else if (oldFrameTime == maxFrameTime) {
+	} else if (oldFrameTime == GetMaxFrameTime()) {
 		UpdateMaxFrameTime();
 	}
 
 	float avgFrameTime, stdDev, graphMin, graphMax;
 	// Calculate mean and standard deviation for normalized graph range
-	if (frameTimeHistory.empty()) {
+	if (GetFrameTimeHistory().empty()) {
 		// Default to 60 FPS
 		avgFrameTime = kDefaultFrameTimeMs;
 		stdDev = 0.0f;
@@ -1395,15 +1390,15 @@ void PerformanceOverlay::PerfOverlayState::UpdateGraphValues()
 		graphMax = PerformanceOverlay::PerfOverlayState::kGraphSpreadMultiplier * kDefaultFrameTimeMs;
 	} else {
 		// Calculate average frame time
-		avgFrameTime = std::accumulate(frameTimeHistory.begin(), frameTimeHistory.end(), 0.0f) / frameTimeHistory.size();
+		avgFrameTime = std::accumulate(GetFrameTimeHistory().begin(), GetFrameTimeHistory().end(), 0.0f) / GetFrameTimeHistory().size();
 
 		// Calculate standard deviation
 		float variance = 0.0f;
-		for (float ft : frameTimeHistory) {
+		for (float ft : GetFrameTimeHistory()) {
 			float diff = ft - avgFrameTime;
 			variance += diff * diff;
 		}
-		variance /= frameTimeHistory.size();
+		variance /= GetFrameTimeHistory().size();
 		stdDev = std::sqrt(variance);
 
 		// Calculate graph range
@@ -1413,14 +1408,15 @@ void PerformanceOverlay::PerfOverlayState::UpdateGraphValues()
 	}
 
 	// Exponential smoothing for stable graph scaling
-	smoothedMinFrameTime += kSmoothingFactor * (graphMin - smoothedMinFrameTime);
-	smoothedMaxFrameTime += kSmoothingFactor * (graphMax - smoothedMaxFrameTime);
+	SetSmoothedMinFrameTime(GetSmoothedMinFrameTime() + kSmoothingFactor * (graphMin - GetSmoothedMinFrameTime()));
+	SetSmoothedMaxFrameTime(GetSmoothedMaxFrameTime() + kSmoothingFactor * (graphMax - GetSmoothedMaxFrameTime()));
 }
 
 // Private helper for table rendering
 void PerformanceOverlay::DrawDrawCallsTable(const std::vector<DrawCallRow>& mainRows, const std::vector<DrawCallRow>& summaryRows)
 {
 	static bool clearTestDataRequested = false;
+	auto* overlay = PerformanceOverlay::GetSingleton();
 	auto* menu = Menu::GetSingleton();
 	const auto& theme = menu->GetTheme();
 
@@ -1454,9 +1450,9 @@ void PerformanceOverlay::DrawDrawCallsTable(const std::vector<DrawCallRow>& main
 	};
 	const Util::ColoredTextLines testCostPerCallLegend = testFrameTimeLegend;
 
-	this->CaptureTestData();
+	overlay->CaptureTestData();
 
-	bool anyTestData = !s_testData.empty();
+	bool anyTestData = !overlay->testData.empty();
 	if (anyTestData) {
 		if (ImGui::Button("Clear Test Data")) {
 			clearTestDataRequested = true;
@@ -1479,7 +1475,7 @@ void PerformanceOverlay::DrawDrawCallsTable(const std::vector<DrawCallRow>& main
 							float prevFrameTime = row.frameTime;
 							float prevCostPerCall = row.costPerCall;
 							// Capture live data for Total and Other before toggling
-							float smoothedFrameTime = static_cast<float>(PerformanceOverlay::GetSingleton()->perfOverlayState.smoothFrameTimeMs);
+							float smoothedFrameTime = static_cast<float>(PerformanceOverlay::GetSingleton()->perfOverlayState.GetSmoothFrameTimeMs());
 							float measuredSum = 0.0f;
 							globals::state->ForEachShaderTypeWithMetrics([&measuredSum]([[maybe_unused]] auto type, [[maybe_unused]] int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, [[maybe_unused]] float percent, [[maybe_unused]] float costPerCall) {
 								measuredSum += frameTime;
@@ -1488,12 +1484,12 @@ void PerformanceOverlay::DrawDrawCallsTable(const std::vector<DrawCallRow>& main
 							globals::state->enabledClasses[classIndex] = !wasEnabled;
 							if (isDisabling) {
 								// Save the last live value before disabling
-								UpdateShaderTestData(row.shaderType, prevFrameTime, prevCostPerCall);
+								PerformanceOverlay::GetSingleton()->UpdateShaderTestData(row.shaderType, prevFrameTime, prevCostPerCall);
 								// Save Total and Other test data as well
-								PerformanceOverlay::s_testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
-								PerformanceOverlay::s_testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
-								PerformanceOverlay::s_testDataSource = PerformanceOverlay::TestDataSource::ManualShaderToggle;
-								PerformanceOverlay::s_testDataLastUpdated = std::chrono::steady_clock::now();
+								PerformanceOverlay::GetSingleton()->testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+								PerformanceOverlay::GetSingleton()->testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
+								PerformanceOverlay::GetSingleton()->testDataSource = PerformanceOverlay::TestDataSource::ManualShaderToggle;
+								PerformanceOverlay::GetSingleton()->testDataLastUpdated = std::chrono::steady_clock::now();
 							}
 						}
 					}
@@ -1553,13 +1549,13 @@ void PerformanceOverlay::DrawDrawCallsTable(const std::vector<DrawCallRow>& main
 						return theme.StatusPalette.SuccessColor;
 					if (value > row.frameTime)
 						return theme.StatusPalette.Error;
-					return theme.Palette.Text; }, [](float value, const DrawCallRow& row) { return Util::FormatMilliseconds(value) + " (" + Util::FormatPercent(PerformanceOverlay::s_testData[row.shaderType].percent) + ")"; }, testFrameTimeLegend), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+					return theme.Palette.Text; }, [overlay](float value, const DrawCallRow& row) { return Util::FormatMilliseconds(value) + " (" + Util::FormatPercent(overlay->testData[row.shaderType].percent) + ")"; }, testFrameTimeLegend), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
 				float aVal = a.testFrameTime.value_or(FLT_MAX);
 				float bVal = b.testFrameTime.value_or(FLT_MAX);
-				return asc ? (aVal < bVal) : (aVal > bVal); }, [testFrameTimeLegend]() {
+				return asc ? (aVal < bVal) : (aVal > bVal); }, [overlay, testFrameTimeLegend]() {
 				if (ImGui::IsItemHovered()) {
 					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::TextUnformatted(PerformanceOverlay::GetTestDataTooltip().c_str());
+						ImGui::TextUnformatted(overlay->GetTestDataTooltip().c_str());
 						ImGui::Separator();
 						Util::DrawColoredMultiLineTooltip(testFrameTimeLegend);
 					}
@@ -1575,10 +1571,10 @@ void PerformanceOverlay::DrawDrawCallsTable(const std::vector<DrawCallRow>& main
 					return theme.Palette.Text; }, [](float value, const DrawCallRow&) { return (value < PerformanceOverlay::PerfOverlayState::kMicrosecondThreshold && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); }, testCostPerCallLegend), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
 				float aVal = a.testCostPerCall.value_or(FLT_MAX);
 				float bVal = b.testCostPerCall.value_or(FLT_MAX);
-				return asc ? (aVal < bVal) : (aVal > bVal); }, [testCostPerCallLegend]() {
+				return asc ? (aVal < bVal) : (aVal > bVal); }, [overlay, testCostPerCallLegend]() {
 				if (ImGui::IsItemHovered()) {
 					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::TextUnformatted(PerformanceOverlay::GetTestDataTooltip().c_str());
+						ImGui::TextUnformatted(overlay->GetTestDataTooltip().c_str());
 						ImGui::Separator();
 						Util::DrawColoredMultiLineTooltip(testCostPerCallLegend);
 					}
@@ -1600,7 +1596,7 @@ void PerformanceOverlay::DrawDrawCallsTable(const std::vector<DrawCallRow>& main
 		0,     // Default sort column (Shader Type)
 		true,  // Default ascending
 		sorters,
-		[&columns](int rowIdx, int colIdx, const DrawCallRow& row) {
+		[&columns, overlay](int rowIdx, int colIdx, const DrawCallRow& row) {
 			(void)rowIdx;
 			// Special handling for summary rows
 			if ((row.label == "Total:" || row.label == "Other:") && colIdx == 0) {
@@ -1619,19 +1615,19 @@ void PerformanceOverlay::DrawDrawCallsTable(const std::vector<DrawCallRow>& main
 						auto* abTestingManager = ABTestingManager::GetSingleton();
 						bool abTest = abTestingManager && abTestingManager->IsEnabled() && abTestingManager->IsUsingTestConfig();
 						if (abTest) {
-							UpdateAllShaderTestData();
+							overlay->UpdateAllShaderTestData();
 						} else {
 							// Manual toggle: update test data and timestamp
-							float smoothedFrameTime = static_cast<float>(PerformanceOverlay::GetSingleton()->perfOverlayState.smoothFrameTimeMs);
+							float smoothedFrameTime = static_cast<float>(overlay->perfOverlayState.GetSmoothFrameTimeMs());
 							float measuredSum = 0.0f;
 							globals::state->ForEachShaderTypeWithMetrics([&measuredSum]([[maybe_unused]] auto type, [[maybe_unused]] int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, [[maybe_unused]] float percent, [[maybe_unused]] float costPerCall) {
 								measuredSum += frameTime;
 							});
 							auto [otherFrameTime, otherPercent, totalCostPerCall] = CalculateSummaryData(smoothedFrameTime, measuredSum);
-							PerformanceOverlay::s_testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
-							PerformanceOverlay::s_testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
-							PerformanceOverlay::s_testDataSource = PerformanceOverlay::TestDataSource::ManualShaderToggle;
-							PerformanceOverlay::s_testDataLastUpdated = std::chrono::steady_clock::now();
+							overlay->testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+							overlay->testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
+							overlay->testDataSource = PerformanceOverlay::TestDataSource::ManualShaderToggle;
+							overlay->testDataLastUpdated = std::chrono::steady_clock::now();
 						}
 					}
 					if (ImGui::IsItemHovered()) {
@@ -1660,7 +1656,7 @@ void PerformanceOverlay::DrawDrawCallsTable(const std::vector<DrawCallRow>& main
 		summaryRowsCopy);
 
 	if (clearTestDataRequested) {
-		this->ClearTestData();
+		overlay->ClearTestData();
 		clearTestDataRequested = false;
 	}
 }
@@ -1736,8 +1732,8 @@ void PerformanceOverlay::DrawABTestSection(const std::vector<DrawCallRow>& allRo
 			ImGui::SameLine();
 			if (ImGui::Button("Clear A/B Test Results")) {
 				aggregator.Clear();
-				abSettingsDiff.clear();
-				abSettingsDiffLoaded = false;
+				this->settingsDiff.clear();
+				this->settingsDiffLoaded = false;
 				showSettingsDiff = false;
 				ImGui::EndGroup();
 				ImGui::Separator();
@@ -1746,11 +1742,11 @@ void PerformanceOverlay::DrawABTestSection(const std::vector<DrawCallRow>& allRo
 			ImGui::EndGroup();
 			// --- Settings diff section (inline, toggled) ---
 			if (showSettingsDiff) {
-				if (!abSettingsDiffLoaded) {
+				if (!this->settingsDiffLoaded) {
 					std::filesystem::path userPath = Util::PathHelpers::GetDataPath() / "SKSE/Plugins/CommunityShaders/SettingsUser.json";
 					std::filesystem::path testPath = Util::PathHelpers::GetDataPath() / "SKSE/Plugins/CommunityShaders/SettingsTest.json";
-					abSettingsDiff = Util::FileSystem::LoadJsonDiff(userPath, testPath);
-					abSettingsDiffLoaded = true;
+					this->settingsDiff = Util::FileSystem::LoadJsonDiff(userPath, testPath);
+					this->settingsDiffLoaded = true;
 				}
 				static bool settingsDiffExpanded = true;
 				if (showCollapsibleSections) {
@@ -1758,7 +1754,7 @@ void PerformanceOverlay::DrawABTestSection(const std::vector<DrawCallRow>& allRo
 				}
 				if (settingsDiffExpanded) {
 					ImGui::TextUnformatted("Differences between USER (A) and TEST (B) configs:");
-					if (abSettingsDiff.empty()) {
+					if (this->settingsDiff.empty()) {
 						ImGui::TextUnformatted("No setting changes detected between USER (A) and TEST (B) configs.");
 					} else if (ImGui::BeginTable("ABSettingsDiffTable", 3, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable)) {
 						ImGui::TableSetupColumn("Setting Path", ImGuiTableColumnFlags_DefaultSort);
@@ -1785,7 +1781,7 @@ void PerformanceOverlay::DrawABTestSection(const std::vector<DrawCallRow>& allRo
 						const auto& theme = menu->GetTheme();
 
 						// Sort the settings diff if needed
-						std::vector<SettingsDiffEntry> sortedDiff = abSettingsDiff;
+						std::vector<SettingsDiffEntry> sortedDiff = this->settingsDiff;
 						if (const ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs()) {
 							if (sortSpecs->SpecsCount > 0) {
 								int sortCol = sortSpecs->Specs->ColumnIndex;
@@ -1845,11 +1841,11 @@ void PerformanceOverlay::DrawABTestSection(const std::vector<DrawCallRow>& allRo
 // Static helper method implementations
 void PerformanceOverlay::UpdateShaderTestDataEntry(int shaderType, float frameTime, float costPerCall, float percent)
 {
-	s_testData[shaderType] = { frameTime, costPerCall, percent };
+	testData[shaderType] = { frameTime, costPerCall, percent };
 }
 
 void PerformanceOverlay::UpdateSummaryTestData(float smoothedFrameTime, float otherFrameTime, float otherPercent, float totalCostPerCall)
 {
-	s_testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
-	s_testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+	testData[static_cast<int>(SpecialShaderType::Other)] = { otherFrameTime, 0.0f, otherPercent };
+	testData[static_cast<int>(SpecialShaderType::Total)] = { smoothedFrameTime, totalCostPerCall, 100.0f };
 }

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -35,9 +35,20 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	Position,
 	PositionSet)
 
+static const std::unordered_map<RE::BSShader::Type, std::string> kShaderTypeTooltips = {
+	{ RE::BSShader::Type::Grass, "Draw calls using the Grass shader. Typically many, but each is usually cheap." },
+	{ RE::BSShader::Type::Sky, "Draw calls for the sky dome, clouds, and related effects." },
+	{ RE::BSShader::Type::Water, "Draw calls for water surfaces and effects." },
+	{ RE::BSShader::Type::Lighting, "Draw calls for dynamic and static lighting passes." },
+	{ RE::BSShader::Type::Effect, "Draw calls for special effects, particles, and post-processing." },
+	{ RE::BSShader::Type::Utility, "Draw calls for utility passes, such as shadow masks or G-buffer fills." },
+	{ RE::BSShader::Type::DistantTree, "Draw calls for distant tree rendering (LOD vegetation)." },
+	{ RE::BSShader::Type::Particle, "Draw calls for particle systems (smoke, sparks, etc.)." },
+	{ RE::BSShader::Type::BloodSplatter, "Draw calls for blood splatter effects." },
+	{ RE::BSShader::Type::ImageSpace, "Draw calls for image space post-processing effects." }
+};
+
 // Static test data state
-// Remove global static variables and functions for test data
-// Add static member variable definitions
 PerformanceOverlay::TestDataSource PerformanceOverlay::s_testDataSource = PerformanceOverlay::TestDataSource::None;
 std::chrono::steady_clock::time_point PerformanceOverlay::s_testDataLastUpdated;
 std::unordered_map<int, PerformanceOverlay::TestData> PerformanceOverlay::s_testData;
@@ -65,8 +76,27 @@ void PerformanceOverlay::UpdateShaderTestData(int shaderType, float frameTime, f
 
 void PerformanceOverlay::UpdateAllShaderTestData()
 {
-	if (!(Menu::GetSingleton() && Menu::GetSingleton()->abTestingEnabled && Menu::GetSingleton()->usingTestConfig))
+	// Check if all shaders are disabled
+	bool allDisabled = true;
+	for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
+		if (globals::state->enabledClasses[i]) {
+			allDisabled = false;
+			break;
+		}
+	}
+	if (allDisabled) {
+		s_testData.clear();
+		s_testDataSource = TestDataSource::None;
 		return;
+	}
+
+	// Only capture test data if we're in A/B test mode AND using Variant B (test config)
+	bool abTest = Menu::GetSingleton() && Menu::GetSingleton()->abTestingEnabled && Menu::GetSingleton()->usingTestConfig;
+	if (!abTest) {
+		// If not in A/B test Variant B, don't capture test data
+		return;
+	}
+
 	float smoothedFrameTime = static_cast<float>(GetSingleton()->perfOverlayState.smoothFrameTimeMs);
 	float measuredSum = 0.0f;
 	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
@@ -203,17 +233,19 @@ void PerformanceOverlay::DrawSettings()
 
 void PerformanceOverlay::DrawOverlay()
 {
+	auto* menu = Menu::GetSingleton();
+
 	// Defensive: Check for required global state and ImGui context
-	if (!globals::state || !Menu::GetSingleton()) {
+	if (!globals::state || !menu) {
 		return;
 	}
 	// Check global overlay visibility
-	if (!Menu::GetSingleton()->overlayVisible) {
+	if (!menu->overlayVisible) {
 		return;
 	}
 	// Defensive: Check for upscaling if you use it
 	// (Not strictly needed here, but safe for future use)
-	if (this->settings.ShowVRAM && (!Menu::GetSingleton()->GetDXGIAdapter3())) {
+	if (this->settings.ShowVRAM && (!menu->GetDXGIAdapter3())) {
 		return;
 	}
 	// Defensive: Check ImGui context
@@ -228,7 +260,7 @@ void PerformanceOverlay::DrawOverlay()
 	ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize;
 
 	// Only allow mouse interaction when the main menu is open
-	if (!PerformanceOverlay::GetSingleton()->settings.ShowInOverlay) {
+	if (!this->settings.ShowInOverlay) {
 		windowFlags |= ImGuiWindowFlags_NoInputs;
 	}
 
@@ -296,8 +328,8 @@ void PerformanceOverlay::DrawOverlay()
 		this->perfOverlayState.lastFrameCounter = this->perfOverlayState.currentFrameCounter;
 
 		// Calculate frametime and fps
-		this->perfOverlayState.frameTimeMs = Util::performanceOverlay.CalcFrameTime(elapsedCounter, this->perfOverlayState.frequency);
-		this->perfOverlayState.fps = Util::performanceOverlay.CalcFPS(this->perfOverlayState.frameTimeMs);
+		this->perfOverlayState.frameTimeMs = Util::CalcFrameTime(elapsedCounter, this->perfOverlayState.frequency);
+		this->perfOverlayState.fps = Util::CalcFPS(this->perfOverlayState.frameTimeMs);
 
 		// Calculate smooth values for display using the user-defined update interval
 		auto now = std::chrono::steady_clock::now();
@@ -336,7 +368,7 @@ void PerformanceOverlay::DrawOverlay()
 	}
 
 	// VRAM & GPU Usage
-	if (this->settings.ShowVRAM && Menu::GetSingleton()->GetDXGIAdapter3()) {
+	if (this->settings.ShowVRAM && menu->GetDXGIAdapter3()) {
 		DrawVRAM();
 	}
 
@@ -354,70 +386,77 @@ void PerformanceOverlay::PerfOverlayState::UpdateFGFrameTime()
 	if (!globals::upscaling)
 		return;
 
+	auto* overlay = GetSingleton();
+
 	// Get frametime directly from the Frame Generation system
 	float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
 	if (fgDeltaTime > 0.0f) {
-		GetSingleton()->perfOverlayState.postFGFrameTimeMs = fgDeltaTime * 1000.0f;
-		GetSingleton()->perfOverlayState.postFGFps = 1000.0f / GetSingleton()->perfOverlayState.postFGFrameTimeMs;
+		overlay->perfOverlayState.postFGFrameTimeMs = fgDeltaTime * 1000.0f;
+		overlay->perfOverlayState.postFGFps = 1000.0f / overlay->perfOverlayState.postFGFrameTimeMs;
 
 		// Update post-FG smooth values when timer elapses
-		if (GetSingleton()->perfOverlayState.updateTimer <= 0.0f) {
-			GetSingleton()->perfOverlayState.postFGSmoothFps = GetSingleton()->perfOverlayState.postFGFps;
-			GetSingleton()->perfOverlayState.postFGSmoothFrameTimeMs = GetSingleton()->perfOverlayState.postFGFrameTimeMs;
+		if (overlay->perfOverlayState.updateTimer <= 0.0f) {
+			overlay->perfOverlayState.postFGSmoothFps = overlay->perfOverlayState.postFGFps;
+			overlay->perfOverlayState.postFGSmoothFrameTimeMs = overlay->perfOverlayState.postFGFrameTimeMs;
 		}
 
 		// Update post-FG frametime history
-		GetSingleton()->perfOverlayState.postFGFrameTimeHistory[GetSingleton()->perfOverlayState.postFGFrameTimeHistoryIndex] = GetSingleton()->perfOverlayState.postFGFrameTimeMs;
-		GetSingleton()->perfOverlayState.postFGFrameTimeHistoryIndex = (GetSingleton()->perfOverlayState.postFGFrameTimeHistoryIndex + 1) % GetSingleton()->settings.FrameHistorySize;
+		overlay->perfOverlayState.postFGFrameTimeHistory[overlay->perfOverlayState.postFGFrameTimeHistoryIndex] = overlay->perfOverlayState.postFGFrameTimeMs;
+		overlay->perfOverlayState.postFGFrameTimeHistoryIndex = (overlay->perfOverlayState.postFGFrameTimeHistoryIndex + 1) % overlay->settings.FrameHistorySize;
 	} else {
 		// Fallback if FG time is not available
-		GetSingleton()->perfOverlayState.postFGFrameTimeMs = GetSingleton()->perfOverlayState.frameTimeMs / 2.0f;
-		GetSingleton()->perfOverlayState.postFGFps = GetSingleton()->perfOverlayState.fps * 2.0f;
+		overlay->perfOverlayState.postFGFrameTimeMs = overlay->perfOverlayState.frameTimeMs / 2.0f;
+		overlay->perfOverlayState.postFGFps = overlay->perfOverlayState.fps * 2.0f;
 
-		if (GetSingleton()->perfOverlayState.updateTimer <= 0.0f) {
-			GetSingleton()->perfOverlayState.postFGSmoothFps = GetSingleton()->perfOverlayState.postFGFps;
-			GetSingleton()->perfOverlayState.postFGSmoothFrameTimeMs = GetSingleton()->perfOverlayState.postFGFrameTimeMs;
+		if (overlay->perfOverlayState.updateTimer <= 0.0f) {
+			overlay->perfOverlayState.postFGSmoothFps = overlay->perfOverlayState.postFGFps;
+			overlay->perfOverlayState.postFGSmoothFrameTimeMs = overlay->perfOverlayState.postFGFrameTimeMs;
 		}
 
-		GetSingleton()->perfOverlayState.postFGFrameTimeHistory[GetSingleton()->perfOverlayState.postFGFrameTimeHistoryIndex] = GetSingleton()->perfOverlayState.postFGFrameTimeMs;
-		GetSingleton()->perfOverlayState.postFGFrameTimeHistoryIndex = (GetSingleton()->perfOverlayState.postFGFrameTimeHistoryIndex + 1) % GetSingleton()->settings.FrameHistorySize;
+		overlay->perfOverlayState.postFGFrameTimeHistory[overlay->perfOverlayState.postFGFrameTimeHistoryIndex] = overlay->perfOverlayState.postFGFrameTimeMs;
+		overlay->perfOverlayState.postFGFrameTimeHistoryIndex = (overlay->perfOverlayState.postFGFrameTimeHistoryIndex + 1) % overlay->settings.FrameHistorySize;
 	}
 }
 
 void PerformanceOverlay::PerfOverlayState::UpdateFrameTimeHistorySizes()
 {
-	GetSingleton()->settings.FrameHistorySize = std::clamp(
-		GetSingleton()->settings.FrameHistorySize,
-		GetSingleton()->settings.kMinFrameHistorySize,
-		GetSingleton()->settings.kMaxFrameHistorySize);
+	auto* overlay = GetSingleton();
 
-	if (GetSingleton()->perfOverlayState.frameTimeHistory.size() != static_cast<size_t>(GetSingleton()->settings.FrameHistorySize)) {
-		GetSingleton()->perfOverlayState.frameTimeHistory.resize(GetSingleton()->settings.FrameHistorySize, 0.0f);
-		if (GetSingleton()->perfOverlayState.frameTimeHistoryIndex >= GetSingleton()->settings.FrameHistorySize) {
-			GetSingleton()->perfOverlayState.frameTimeHistoryIndex = 0;
+	overlay->settings.FrameHistorySize = std::clamp(
+		overlay->settings.FrameHistorySize,
+		overlay->settings.kMinFrameHistorySize,
+		overlay->settings.kMaxFrameHistorySize);
+
+	if (overlay->perfOverlayState.frameTimeHistory.size() != static_cast<size_t>(overlay->settings.FrameHistorySize)) {
+		overlay->perfOverlayState.frameTimeHistory.resize(overlay->settings.FrameHistorySize, 0.0f);
+		if (overlay->perfOverlayState.frameTimeHistoryIndex >= overlay->settings.FrameHistorySize) {
+			overlay->perfOverlayState.frameTimeHistoryIndex = 0;
 		}
 	}
-	if (GetSingleton()->perfOverlayState.postFGFrameTimeHistory.size() != static_cast<size_t>(GetSingleton()->settings.FrameHistorySize)) {
-		GetSingleton()->perfOverlayState.postFGFrameTimeHistory.resize(GetSingleton()->settings.FrameHistorySize, 0.0f);
-		if (GetSingleton()->perfOverlayState.postFGFrameTimeHistoryIndex >= GetSingleton()->settings.FrameHistorySize) {
-			GetSingleton()->perfOverlayState.postFGFrameTimeHistoryIndex = 0;
+	if (overlay->perfOverlayState.postFGFrameTimeHistory.size() != static_cast<size_t>(overlay->settings.FrameHistorySize)) {
+		overlay->perfOverlayState.postFGFrameTimeHistory.resize(overlay->settings.FrameHistorySize, 0.0f);
+		if (overlay->perfOverlayState.postFGFrameTimeHistoryIndex >= overlay->settings.FrameHistorySize) {
+			overlay->perfOverlayState.postFGFrameTimeHistoryIndex = 0;
 		}
 	}
 }
 
 void PerformanceOverlay::PerfOverlayState::UpdateMinFrameTime()
 {
-	GetSingleton()->perfOverlayState.minFrameTime = *std::min_element(GetSingleton()->perfOverlayState.frameTimeHistory.begin(), GetSingleton()->perfOverlayState.frameTimeHistory.end());
+	auto* overlay = GetSingleton();
+	overlay->perfOverlayState.minFrameTime = *std::min_element(overlay->perfOverlayState.frameTimeHistory.begin(), overlay->perfOverlayState.frameTimeHistory.end());
 }
 
 void PerformanceOverlay::PerfOverlayState::UpdateMaxFrameTime()
 {
-	GetSingleton()->perfOverlayState.maxFrameTime = *std::max_element(GetSingleton()->perfOverlayState.frameTimeHistory.begin(), GetSingleton()->perfOverlayState.frameTimeHistory.end());
+	auto* overlay = GetSingleton();
+	overlay->perfOverlayState.maxFrameTime = *std::max_element(overlay->perfOverlayState.frameTimeHistory.begin(), overlay->perfOverlayState.frameTimeHistory.end());
 }
 
 float PerformanceOverlay::PerfOverlayState::SetTextScale()
 {
-	switch (GetSingleton()->settings.Size) {
+	auto* overlay = GetSingleton();
+	switch (overlay->settings.Size) {
 	case PerfOverlaySettings::TextSize::Small:
 		return 0.8f;
 	case PerfOverlaySettings::TextSize::Medium:
@@ -544,10 +583,19 @@ void PerformanceOverlay::PerfOverlayState::DrawPostFGFrameTimeGraph()
 	}
 }
 
-void PerformanceOverlay::DrawDrawCalls()
+// --- TEST DATA CAPTURE LOGIC ---
+// Test data is captured in two scenarios:
+// 1. A/B Test Mode (Variant B): If abTestingEnabled && usingTestConfig, we continuously capture test data
+//    for all shader types, "Other", and "Total" every frame. This allows live comparison between
+//    Variant A (user config) and Variant B (test config).
+// 2. Manual Shader Toggle: If any shader is disabled, we capture test data for the disabled shaders
+//    (and summary rows) at the moment of disabling, and keep it until cleared. This allows users to
+//    compare performance with/without specific shaders enabled.
+// Test data is only cleared by the "Clear Test Data" button or if all shaders are disabled (rare edge case).
+void PerformanceOverlay::CaptureTestData()
 {
-	static bool clearTestDataRequested = false;
-	bool abTestActive = (Menu::GetSingleton() && Menu::GetSingleton()->abTestingEnabled && Menu::GetSingleton()->usingTestConfig);
+	auto* menu = Menu::GetSingleton();
+	bool abTestActive = (menu && menu->abTestingEnabled && menu->usingTestConfig);
 	bool anyShaderDisabled = false;
 	for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
 		if (!globals::state->enabledClasses[i]) {
@@ -555,65 +603,15 @@ void PerformanceOverlay::DrawDrawCalls()
 			break;
 		}
 	}
-	if (!s_testData.empty()) {
-		if (ImGui::Button("Clear Test Data")) {
-			clearTestDataRequested = true;
-		}
-		ImGui::SameLine();
-		ImGui::TextDisabled("Test columns are shown only when test data is present.");
-	}
-
-	// Build headers and column count dynamically
-	std::vector<std::string> headers = { "Shader Type", "Draw Calls", "Frame Time (%)", "Cost/Call" };
-	bool anyTestData = !s_testData.empty();
-	if (anyTestData) {
-		headers.push_back("Test Frame Time (%)");
-		headers.push_back("Test Cost/Call");
-	}
-	int columnCount = static_cast<int>(headers.size());
-
-	// Tooltip map for shader types
-	static const std::unordered_map<RE::BSShader::Type, std::string> kShaderTypeTooltips = {
-		{ RE::BSShader::Type::Grass, "Draw calls using the Grass shader. Typically many, but each is usually cheap." },
-		{ RE::BSShader::Type::Sky, "Draw calls for the sky dome, clouds, and related effects." },
-		{ RE::BSShader::Type::Water, "Draw calls for water surfaces and effects." },
-		{ RE::BSShader::Type::Lighting, "Draw calls for dynamic and static lighting passes." },
-		{ RE::BSShader::Type::Effect, "Draw calls for special effects, particles, and post-processing." },
-		{ RE::BSShader::Type::Utility, "Draw calls for utility passes, such as shadow masks or G-buffer fills." },
-		{ RE::BSShader::Type::DistantTree, "Draw calls for distant tree rendering (LOD vegetation)." },
-		{ RE::BSShader::Type::Particle, "Draw calls for particle systems (smoke, sparks, etc.)." },
-		{ RE::BSShader::Type::BloodSplatter, "Draw calls for blood splatter effects." },
-		{ RE::BSShader::Type::ImageSpace, "Draw calls for image space post-processing effects." }
-	};
-	std::vector<ShaderRow> shaderTypes;
-	for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
-		if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
-			continue;
-		std::string label = std::string(magic_enum::enum_name(type)) + ":";
-		auto it = kShaderTypeTooltips.find(type);
-		std::string tooltip = (it != kShaderTypeTooltips.end()) ? it->second : "Draw calls for this shader type.";
-		tooltip += "\nClick to ";
-		tooltip += (globals::state->enabledClasses[magic_enum::enum_integer(type) - 1]) ? "disable" : "enable";
-		tooltip += " this shader.";
-		shaderTypes.push_back({ label, type, tooltip });
-	}
-
-	// Sorting state (declare all at the top)
-	static int sortColumn = 0;
-	static bool sortAscending = false;
-	static bool isSorted = false;
-	static std::vector<DrawCallRow> originalRows;
-
-	// Use the smoothed frame time for all calculations
 	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.smoothFrameTimeMs);
 	float measuredSum = 0.0f;
 	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
-
-	// --- TEST DATA SNAPSHOT LOGIC ---
 	if (abTestActive) {
 		measuredSum = 0.0f;
-		for (const auto& row : shaderTypes) {
-			auto typeIndex = magic_enum::enum_integer(static_cast<RE::BSShader::Type>(row.type));
+		for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
+			if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
+				continue;
+			int typeIndex = magic_enum::enum_integer(type);
 			float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
 			float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
 			float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
@@ -626,10 +624,14 @@ void PerformanceOverlay::DrawDrawCalls()
 		s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
 		float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
 		s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+		s_testDataSource = TestDataSource::ABTest_VariantB;
+		s_testDataLastUpdated = std::chrono::steady_clock::now();
 	} else if (anyShaderDisabled) {
 		measuredSum = 0.0f;
-		for (const auto& row : shaderTypes) {
-			auto typeIndex = magic_enum::enum_integer(static_cast<RE::BSShader::Type>(row.type));
+		for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
+			if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
+				continue;
+			int typeIndex = magic_enum::enum_integer(type);
 			bool enabled = globals::state->enabledClasses[typeIndex - 1];
 			if (!enabled) {
 				float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
@@ -645,325 +647,366 @@ void PerformanceOverlay::DrawDrawCalls()
 		s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
 		float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
 		s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+		s_testDataSource = TestDataSource::ManualShaderToggle;
+		s_testDataLastUpdated = std::chrono::steady_clock::now();
 	}
+}
 
-	// Build main rows: all shader types
+void PerformanceOverlay::ClearTestData()
+{
+	s_testData.clear();
+	s_testDataSource = TestDataSource::None;
+}
+
+std::pair<std::vector<DrawCallRow>, std::vector<DrawCallRow>> PerformanceOverlay::BuildDrawCallRows() const
+{
 	std::vector<DrawCallRow> mainRows;
-	measuredSum = 0.0f;
-	for (const auto& row : shaderTypes) {
-		auto typeIndex = magic_enum::enum_integer(static_cast<RE::BSShader::Type>(row.type));
+	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.smoothFrameTimeMs);
+	float measuredSum = 0.0f;
+	for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
+		if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
+			continue;
+		int typeIndex = magic_enum::enum_integer(type);
 		float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
 		float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
 		float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
 		float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
-		// Clamp small negative values to zero
-		if (std::abs(frameTime) < 1e-4f)
-			frameTime = 0.0f;
-		if (std::abs(costPerCall) < 1e-6f)
-			costPerCall = 0.0f;
 		bool enabled = globals::state->enabledClasses[typeIndex - 1];
 		std::optional<float> testFrameTime, testCostPerCall;
 		auto it = s_testData.find(typeIndex);
 		if (it != s_testData.end()) {
 			testFrameTime = it->second.frameTime;
 			testCostPerCall = it->second.costPerCall;
-			anyTestData = true;
 		}
-		DrawCallRow rowObj{ row.label, typeIndex, static_cast<int>(drawCalls), frameTime, percent, costPerCall, row.tooltip, enabled, testFrameTime, testCostPerCall };
-		mainRows.push_back(rowObj);
+		std::string label = std::string(magic_enum::enum_name(type)) + ":";
+		std::string tooltip = "Draw calls for this shader type.";
+		auto tipIt = kShaderTypeTooltips.find(type);
+		if (tipIt != kShaderTypeTooltips.end()) {
+			tooltip = tipIt->second;
+		}
+		mainRows.push_back({ label, typeIndex, static_cast<int>(drawCalls), frameTime, percent, costPerCall, tooltip, enabled, testFrameTime, testCostPerCall });
 		measuredSum += frameTime;
 	}
-
-	// Add summary rows (not part of main sorting)
+	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
 	float otherFrameTime = smoothedFrameTime - measuredSum;
 	if (std::abs(otherFrameTime) < 1e-4f)
 		otherFrameTime = 0.0f;
-
+	std::optional<float> otherTestFrameTime, otherTestCostPerCall, totalTestFrameTime, totalTestCostPerCall;
+	auto itOther = s_testData.find(-2);
+	if (itOther != s_testData.end()) {
+		otherTestFrameTime = itOther->second.frameTime;
+		otherTestCostPerCall = itOther->second.costPerCall;
+	}
+	auto itTotal = s_testData.find(-1);
+	if (itTotal != s_testData.end()) {
+		totalTestFrameTime = itTotal->second.frameTime;
+		totalTestCostPerCall = itTotal->second.costPerCall;
+	}
 	DrawCallRow otherRow = {
 		"Other:", -2, 0, otherFrameTime,
 		(smoothedFrameTime > 0.0f ? static_cast<float>((otherFrameTime / smoothedFrameTime) * 100.0f) : 0.0f),
 		0.0f,
-		std::string("Frame time not attributed to any measured shader type. This includes UI, post-processing, engine work, and any GPU activity not directly measured by the overlay.")
+		std::string("Frame time not attributed to any measured shader type. This includes UI, post-processing, engine work, and any GPU activity not directly measured by the overlay."),
+		true, otherTestFrameTime, otherTestCostPerCall
 	};
-
 	DrawCallRow totalRow = {
 		"Total:", -1, static_cast<int>(totalSmoothedDrawCalls), smoothedFrameTime, 100.0f,
 		(totalSmoothedDrawCalls > 0.0f ? static_cast<float>(smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f),
-		std::string("Sum of all measured shader types.\nClick to enable or disable all shaders.")
+		std::string("Sum of all measured shader types. Click to enable or disable all shaders."),
+		true, totalTestFrameTime, totalTestCostPerCall
+	};
+	std::vector<DrawCallRow> summaryRows = { otherRow, totalRow };
+	return { mainRows, summaryRows };
+}
+
+void PerformanceOverlay::DrawDrawCalls()
+{
+	static bool clearTestDataRequested = false;
+	auto* menu = Menu::GetSingleton();
+	const auto& theme = menu->GetTheme();
+
+	// helper for creating columns
+	auto makeLiveMetricColumn = [&](auto valueGetter, auto colorGetter, auto formatter, const std::vector<std::string>& tooltipLines, const std::vector<ImVec4>& tooltipColors) {
+		return [theme, valueGetter, colorGetter, formatter, tooltipLines, tooltipColors](const DrawCallRow& row, int) {
+			float value = valueGetter(row);
+			ImVec4 color = colorGetter(theme, value, row);
+			std::string valueStr = formatter(value, row);
+			ImGui::PushStyleColor(ImGuiCol_Text, color);
+			ImGui::Text("%s", valueStr.c_str());
+			ImGui::PopStyleColor();
+			if (ImGui::IsItemHovered()) {
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					Util::DrawMultiLineTooltip(tooltipLines, tooltipColors);
+				}
+			}
+		};
 	};
 
-	// Always start the main table sorted alphabetically by label on first display
-	static bool firstTableDisplay = true;
-	if (firstTableDisplay) {
-		std::sort(mainRows.begin(), mainRows.end(), [](const DrawCallRow& a, const DrawCallRow& b) {
-			return a.label < b.label;
-		});
-		firstTableDisplay = false;
+	auto makeTestMetricColumn = [&](auto valueGetter, auto colorGetter, auto formatter, const std::vector<std::string>& tooltipLines, const std::vector<ImVec4>& tooltipColors) {
+		return [theme, valueGetter, colorGetter, formatter, tooltipLines, tooltipColors](const DrawCallRow& row, int) {
+			auto opt = valueGetter(row);
+			if (!opt.has_value()) {
+				ImGui::TextDisabled("-");
+				return;
+			}
+			float value = *opt;
+			ImVec4 color = colorGetter(theme, value, row);
+			std::string valueStr = formatter(value, row);
+			ImGui::PushStyleColor(ImGuiCol_Text, color);
+			ImGui::Text("%s", valueStr.c_str());
+			ImGui::PopStyleColor();
+			if (ImGui::IsItemHovered()) {
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					Util::DrawMultiLineTooltip(tooltipLines, tooltipColors);
+				}
+			}
+		};
+	};
+
+	this->CaptureTestData();
+
+	bool anyTestData = !s_testData.empty();
+	if (anyTestData) {
+		if (ImGui::Button("Clear Test Data")) {
+			clearTestDataRequested = true;
+		}
 	}
 
-	// Handle sorting: only sort mainRows, never summary rows
-	if (ImGui::BeginTable("DrawCallOverlayTable##", columnCount, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable)) {
-		// --- HEADER SETUP WITH TOOLTIP ---
-		for (int i = 0; i < headers.size(); ++i) {
-			ImGui::TableSetupColumn(headers[i].c_str());
-			if (anyTestData && (headers[i] == "Test Frame Time" || headers[i] == "Test Cost/Call")) {
-				if (ImGui::IsItemHovered()) {
-					ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
-				}
-			}
-		}
-		ImGui::TableHeadersRow();
+	// --- COLUMN CONFIG ---
+	struct ColumnConfig
+	{
+		std::string header;
+		std::function<void(const DrawCallRow&, int colIdx)> cellRender;
+		std::function<bool(const DrawCallRow&, const DrawCallRow&, bool)> sortFunc;
+		std::function<void()> headerTooltip;
+	};
 
-		if (const ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs()) {
-			if (sortSpecs->SpecsCount > 0) {
-				sortColumn = sortSpecs->Specs->ColumnIndex;
-				sortAscending = sortSpecs->Specs->SortDirection == ImGuiSortDirection_Ascending;
-				switch (sortColumn) {
-				case Col_Label:
-					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
-						return sortAscending ? (a.label < b.label) : (a.label > b.label);
-					});
-					break;
-				case Col_DrawCalls:
-					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
-						return sortAscending ? (a.drawCalls < b.drawCalls) : (a.drawCalls > b.drawCalls);
-					});
-					break;
-				case Col_FrameTime:
-					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
-						return sortAscending ? (a.percent < b.percent) : (a.percent > b.percent);
-					});
-					break;
-				case Col_CostPerCall:
-					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
-						return sortAscending ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall);
-					});
-					break;
-				case Col_TestFrameTime:
-					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
-						float aVal = a.testFrameTime.value_or(FLT_MAX);
-						float bVal = b.testFrameTime.value_or(FLT_MAX);
-						return sortAscending ? (aVal < bVal) : (aVal > bVal);
-					});
-					break;
-				case Col_TestCostPerCall:
-					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
-						float aVal = a.testCostPerCall.value_or(FLT_MAX);
-						float bVal = b.testCostPerCall.value_or(FLT_MAX);
-						return sortAscending ? (aVal < bVal) : (aVal > bVal);
-					});
-					break;
-				}
-			}
-		}
-
-		// --- Main table cell rendering switch: renders each cell based on column ---
-		for (size_t rowIdx = 0; rowIdx < mainRows.size(); ++rowIdx) {
-			const auto& row = mainRows[rowIdx];
-			ImGui::TableNextRow();
-			int colIdx = 0;
-			// Label
-			ImGui::TableSetColumnIndex(colIdx++);
-			if (!row.enabled) {
-				ImGui::PushStyleColor(ImGuiCol_Text, Menu::GetSingleton()->GetTheme().StatusPalette.Disable);
-			}
-			bool wasEnabled = row.enabled;
-			if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
-				auto maybeType = magic_enum::enum_cast<RE::BSShader::Type>(row.shaderType);
-				if (maybeType.has_value()) {
-					auto classIndex = magic_enum::enum_integer(*maybeType) - 1;
-					if (classIndex >= 0 && classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1) {
-						globals::state->enabledClasses[classIndex] = !wasEnabled;
-						// Also update test data when toggled
-						UpdateShaderTestData(row.shaderType, row.frameTime, row.costPerCall);
-					}
-				}
-			}
-			if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup | ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
-				ImGui::SetTooltip("%s", row.tooltip.c_str());
-			}
-			if (!row.enabled) {
-				ImGui::PopStyleColor();
-			}
-			// Draw Calls
-			ImGui::TableSetColumnIndex(colIdx++);
-			ImGui::Text("%d", row.drawCalls);
-			// Frame Time (%)
-			ImGui::TableSetColumnIndex(colIdx++);
-			{
-				std::string frameTimeStr = Util::FormatMilliseconds(row.frameTime) + " (" + Util::FormatPercent(row.percent) + ")";
-				ImVec4 color = Util::GetThresholdColor(row.percent, 30.0f, 60.0f,
-					Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor,
-					Menu::GetSingleton()->GetTheme().StatusPalette.Warning,
-					Menu::GetSingleton()->GetTheme().StatusPalette.Error);
-				ImGui::PushStyleColor(ImGuiCol_Text, color);
-				ImGui::Text("%s", frameTimeStr.c_str());
-				ImGui::PopStyleColor();
-			}
-			// Cost/Call
-			ImGui::TableSetColumnIndex(colIdx++);
-			{
-				ImVec4 color = Util::GetThresholdColor(row.costPerCall, 0.05f, 0.2f,
-					Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor,
-					Menu::GetSingleton()->GetTheme().StatusPalette.Warning,
-					Menu::GetSingleton()->GetTheme().StatusPalette.Error);
-				ImGui::PushStyleColor(ImGuiCol_Text, color);
-				if (row.costPerCall < 0.01f && row.costPerCall > 0.0f)
-					ImGui::Text("%s", Util::FormatMicroseconds(row.costPerCall * 1000.0f).c_str());
-				else
-					ImGui::Text("%s", Util::FormatMilliseconds(row.costPerCall).c_str());
-				ImGui::PopStyleColor();
-			}
-			// Test columns if present
-			if (anyTestData) {
-				// Test Frame Time
-				ImGui::TableSetColumnIndex(colIdx++);
-				if (row.testFrameTime.has_value()) {
-					ImVec4 testColor = Util::GetThresholdColor(*row.testFrameTime, row.frameTime, row.frameTime + 0.01f,
-						Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor,
-						Menu::GetSingleton()->GetTheme().StatusPalette.Warning,
-						Menu::GetSingleton()->GetTheme().StatusPalette.Error);
-					ImGui::PushStyleColor(ImGuiCol_Text, testColor);
-					std::string testFrameTimeStr = Util::FormatMilliseconds(*row.testFrameTime) + " (" + Util::FormatPercent(s_testData[row.shaderType].percent) + ")";
-					ImGui::Text("%s", testFrameTimeStr.c_str());
-					ImGui::PopStyleColor();
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
-					}
-				} else {
-					ImGui::TextDisabled("-");
-				}
-				// Test Cost/Call
-				ImGui::TableSetColumnIndex(colIdx++);
-				if (row.testCostPerCall.has_value()) {
-					ImVec4 testColor = Util::GetThresholdColor(*row.testCostPerCall, row.costPerCall, row.costPerCall + 0.01f,
-						Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor,
-						Menu::GetSingleton()->GetTheme().StatusPalette.Warning,
-						Menu::GetSingleton()->GetTheme().StatusPalette.Error);
-					ImGui::PushStyleColor(ImGuiCol_Text, testColor);
-					if (*row.testCostPerCall < 0.01f && *row.testCostPerCall > 0.0f)
-						ImGui::Text("%s", Util::FormatMicroseconds(*row.testCostPerCall * 1000.0f).c_str());
-					else
-						ImGui::Text("%s", Util::FormatMilliseconds(*row.testCostPerCall).c_str());
-					ImGui::PopStyleColor();
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
-					}
-				} else {
-					ImGui::TextDisabled("-");
-				}
-			}
-		}
-		// Separator row (optional, for visual separation)
-		ImGui::TableNextRow(ImGuiTableRowFlags_None, 4.0f);
-		for (int col = 0; col < columnCount; ++col) {
-			ImGui::TableSetColumnIndex(col);
-			if (col == 0)
-				ImGui::Separator();
-		}
-		// Summary rows (Other, Total)
-		for (const DrawCallRow& row : { otherRow, totalRow }) {
-			ImGui::TableNextRow();
-			int colIdx = 0;
-			ImGui::TableSetColumnIndex(colIdx++);
-			if (row.label == std::string("Total:")) {
-				if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
-					bool anyDisabled = false;
-					for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
-						if (!globals::state->enabledClasses[i]) {
-							anyDisabled = true;
-							break;
+	// --- BUILD HEADERS AND CONFIG ---
+	std::vector<ColumnConfig> columns = {
+		{ "Shader Type",
+			[theme](const DrawCallRow& row, int) {
+				if (!row.enabled)
+					ImGui::PushStyleColor(ImGuiCol_Text, theme.StatusPalette.Disable);
+				bool wasEnabled = row.enabled;
+				if (ImGui::Selectable(row.label.c_str(), false)) {
+					auto maybeType = magic_enum::enum_cast<RE::BSShader::Type>(row.shaderType);
+					if (maybeType.has_value()) {
+						auto classIndex = magic_enum::enum_integer(*maybeType) - 1;
+						if (classIndex >= 0 && classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1) {
+							bool isDisabling = wasEnabled;
+							float prevFrameTime = row.frameTime;
+							float prevCostPerCall = row.costPerCall;
+							// Capture live data for Total and Other before toggling
+							float smoothedFrameTime = static_cast<float>(PerformanceOverlay::GetSingleton()->perfOverlayState.smoothFrameTimeMs);
+							float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
+							float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
+							float measuredSum = 0.0f;
+							for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
+								if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
+									continue;
+								int typeIndex = magic_enum::enum_integer(type);
+								measuredSum += static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
+							}
+							float otherFrameTime = smoothedFrameTime - measuredSum;
+							float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
+							globals::state->enabledClasses[classIndex] = !wasEnabled;
+							if (isDisabling) {
+								// Save the last live value before disabling
+								UpdateShaderTestData(row.shaderType, prevFrameTime, prevCostPerCall);
+								// Save Total and Other test data as well
+								PerformanceOverlay::s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+								PerformanceOverlay::s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
+								PerformanceOverlay::s_testDataSource = PerformanceOverlay::TestDataSource::ManualShaderToggle;
+								PerformanceOverlay::s_testDataLastUpdated = std::chrono::steady_clock::now();
+							}
 						}
 					}
-					for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
-						globals::state->enabledClasses[i] = anyDisabled;
-					}
 				}
-			} else {
-				ImGui::TextUnformatted(row.label.c_str());
-			}
-			if (!row.tooltip.empty() && ImGui::IsItemHovered()) {
-				if (auto _tt = Util::HoverTooltipWrapper()) {
-					ImGui::TextUnformatted(row.tooltip.c_str());
-				}
-			}
-			ImGui::TableSetColumnIndex(colIdx++);
-			if (row.label == "Other:" && row.drawCalls <= 0) {
-				ImGui::TextUnformatted("N/A");
-			} else {
-				ImGui::Text("%d", row.drawCalls);
-			}
-			ImGui::TableSetColumnIndex(colIdx++);
-			if (row.label == "Other:" && row.frameTime <= 0.0f) {
-				ImGui::TextUnformatted("N/A");
-			} else {
-				ImGui::Text("%.2f ms (%.1f%%)", row.frameTime, row.percent);
-				if (row.label == "Total:" && ImGui::IsItemHovered()) {
-					float _fps = row.frameTime > 0.0f ? 1000.0f / row.frameTime : 0.0f;
+				if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup | ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
 					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::Text("FPS: %.2f", _fps);
+						ImGui::TextUnformatted(row.tooltip.c_str());
 					}
 				}
-			}
-			ImGui::TableSetColumnIndex(colIdx++);
-			if (row.label == "Other:" && row.costPerCall <= 0.0f) {
-				ImGui::TextUnformatted("N/A");
-			} else if (row.costPerCall < 0.01f && row.costPerCall > 0.0f) {
-				ImGui::Text("%.2f us", row.costPerCall * 1000.0f);
-			} else {
-				ImGui::Text("%.3f ms", row.costPerCall);
-			}
-			if (anyTestData) {
-				ImGui::TableSetColumnIndex(colIdx++);
-				auto testIt = s_testData.find(row.shaderType);
-				if (testIt != s_testData.end()) {
-					ImVec4 testColor = ImGui::GetStyleColorVec4(ImGuiCol_Text);
-					if (testIt->second.frameTime < row.frameTime)
-						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
-					else if (testIt->second.frameTime > row.frameTime)
-						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
-					ImGui::PushStyleColor(ImGuiCol_Text, testColor);
-					ImGui::Text("%.2f ms (%.1f%%)", testIt->second.frameTime, testIt->second.percent);
+				if (!row.enabled)
 					ImGui::PopStyleColor();
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.label < b.label) : (a.label > b.label); },
+			nullptr },
+		{ "Draw Calls",
+			[](const DrawCallRow& row, int) {
+				ImGui::Text("%d", row.drawCalls);
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::TextUnformatted("Draw Calls: Number of draw calls for this shader type in the current frame.");
+					}
+				}
+			},
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.drawCalls < b.drawCalls) : (a.drawCalls > b.drawCalls); },
+			[]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::TextUnformatted("Draw Calls: Number of draw calls for this shader type in the current frame.");
+					}
+				}
+			} }
+
+	};
+	columns.push_back(ColumnConfig{
+		"Frame Time (%)",
+		makeLiveMetricColumn(
+			[](const DrawCallRow& row) { return row.frameTime; },
+			[](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, 2.0f, 5.0f, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); },
+			[](float /*value*/, const DrawCallRow& row) {
+				return Util::FormatMilliseconds(row.frameTime) + " (" + Util::FormatPercent(row.percent) + ")";
+			},
+			{ "Frame Time: Time spent on this shader type (ms and % of total frame time).", "", "Reference thresholds (ms):", "  < 2 ms", "  >= 2 ms and < 5 ms", "  >= 5 ms" },
+			{ theme.Palette.Text, theme.Palette.Text, theme.Palette.Text, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error }),
+		[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.percent < b.percent) : (a.percent > b.percent); },
+		[theme]() {
+			if (ImGui::IsItemHovered()) {
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					std::vector<std::string> lines = { "Frame Time: Time spent on this shader type (ms and % of total frame time).", "", "Performance Color Legend (ms):", "  <= 2 ms", "  > 2 ms and <= 5 ms", "  > 5 ms" };
+					std::vector<ImVec4> colors = { theme.Palette.Text, theme.Palette.Text, theme.Palette.Text, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error };
+					Util::DrawMultiLineTooltip(lines, colors);
+				}
+			}
+		} });
+
+	columns.push_back(ColumnConfig{
+		"Cost/Call",
+		makeLiveMetricColumn(
+			[](const DrawCallRow& row) { return row.costPerCall; },
+			[](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, 0.05f, 0.2f, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); },
+			[](float value, const DrawCallRow&) { return (value < 0.01f && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); },
+			{ "Cost/Call: Average time per draw call for this shader type.", "", "Reference thresholds (ms/call):", "  <= 0.05 ms/call", "  > 0.05 ms and <= 0.2 ms/call", "  > 0.2 ms/call" },
+			{ theme.Palette.Text, theme.Palette.Text, theme.Palette.Text, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error }),
+		[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall); },
+		[theme]() {
+			if (ImGui::IsItemHovered()) {
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					std::vector<std::string> lines = { "Cost/Call: Average time per draw call for this shader type.", "", "Performance Color Legend (ms/call):", "  <= 0.05 ms/call", "  > 0.05 ms and <= 0.2 ms/call", "  > 0.2 ms/call" };
+					std::vector<ImVec4> colors = { theme.Palette.Text, theme.Palette.Text, theme.Palette.Text, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error };
+					Util::DrawMultiLineTooltip(lines, colors);
+				}
+			}
+		} });
+
+	// Add test columns if present
+	if (anyTestData) {
+		columns.push_back(ColumnConfig{
+			"Test Frame Time (%)",
+			makeTestMetricColumn(
+				[](const DrawCallRow& row) { return row.testFrameTime; },
+				[](const auto& theme, float value, const DrawCallRow& row) {
+					if (value < row.frameTime)
+						return theme.StatusPalette.SuccessColor;
+					if (value > row.frameTime)
+						return theme.StatusPalette.Error;
+					return theme.Palette.Text;
+				},
+				[](float value, const DrawCallRow& row) { return Util::FormatMilliseconds(value) + " (" + Util::FormatPercent(PerformanceOverlay::s_testData[row.shaderType].percent) + ")"; },
+				{ PerformanceOverlay::GetTestDataTooltip(), "", "Color legend (compared to live data):" },
+				{ theme.Palette.Text, theme.Palette.Text, theme.Palette.Text }),
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+				float aVal = a.testFrameTime.value_or(FLT_MAX);
+				float bVal = b.testFrameTime.value_or(FLT_MAX);
+				return asc ? (aVal < bVal) : (aVal > bVal);
+			},
+			[theme]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::TextUnformatted(PerformanceOverlay::GetTestDataTooltip().c_str());
+					}
+				}
+			} });
+
+		columns.push_back(ColumnConfig{
+			"Test Cost/Call",
+			makeTestMetricColumn(
+				[](const DrawCallRow& row) { return row.testCostPerCall; },
+				[](const auto& theme, float value, const DrawCallRow& row) {
+					if (value < row.costPerCall)
+						return theme.StatusPalette.SuccessColor;
+					if (value > row.costPerCall)
+						return theme.StatusPalette.Error;
+					return theme.Palette.Text;
+				},
+				[](float value, const DrawCallRow&) { return (value < 0.01f && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); },
+				{ PerformanceOverlay::GetTestDataTooltip(), "", "Color legend (compared to live data):" },
+				{ theme.Palette.Text, theme.Palette.Text, theme.Palette.Text }),
+			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+				float aVal = a.testCostPerCall.value_or(FLT_MAX);
+				float bVal = b.testCostPerCall.value_or(FLT_MAX);
+				return asc ? (aVal < bVal) : (aVal > bVal);
+			},
+			[theme]() {
+				if (ImGui::IsItemHovered()) {
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::TextUnformatted(PerformanceOverlay::GetTestDataTooltip().c_str());
+					}
+				}
+			} });
+	}
+
+	// --- BUILD ROWS ---
+	auto [mainRows, summaryRows] = this->BuildDrawCallRows();
+
+	// --- TABLE RENDER: MAIN ROWS + FOOTER ROWS ---
+	std::vector<std::function<bool(const DrawCallRow&, const DrawCallRow&, bool)>> sorters;
+	for (const auto& col : columns) sorters.push_back(col.sortFunc);
+	Util::ShowSortedStringTable<DrawCallRow>(
+		"DrawCallOverlayTable",
+		[&columns]() { std::vector<std::string> h; for (const auto& c : columns) h.push_back(c.header); return h; }(),
+		mainRows,
+		0,
+		true,
+		sorters,
+		[&columns](int rowIdx, int colIdx, const DrawCallRow& row) {
+			(void)rowIdx;
+			// Special handling for summary rows
+			if ((row.label == "Total:" || row.label == "Other:") && colIdx == 0) {
+				if (row.label == "Total:") {
+					if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
+						bool anyDisabled = false;
+						for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
+							if (!globals::state->enabledClasses[i]) {
+								anyDisabled = true;
+								break;
+							}
+						}
+						for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
+							globals::state->enabledClasses[i] = anyDisabled;
+						}
+						UpdateAllShaderTestData();
+					}
 					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
-						// Show FPS for test frame time
-						float _fps = testIt->second.frameTime > 0.0f ? 1000.0f / testIt->second.frameTime : 0.0f;
 						if (auto _tt = Util::HoverTooltipWrapper()) {
+							ImGui::TextUnformatted(row.tooltip.c_str());
+							float _fps = row.frameTime > 0.0f ? 1000.0f / row.frameTime : 0.0f;
 							ImGui::Text("FPS: %.2f", _fps);
 						}
 					}
-				} else {
-					ImGui::TextUnformatted("N/A");
-				}
-				ImGui::TableSetColumnIndex(colIdx++);
-				if (testIt != s_testData.end()) {
-					ImVec4 testColor = ImGui::GetStyleColorVec4(ImGuiCol_Text);
-					if (testIt->second.costPerCall < row.costPerCall)
-						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
-					else if (testIt->second.costPerCall > row.costPerCall)
-						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
-					ImGui::PushStyleColor(ImGuiCol_Text, testColor);
-					if (testIt->second.costPerCall < 0.01f && testIt->second.costPerCall > 0.0f)
-						ImGui::Text("%.2f us", testIt->second.costPerCall * 1000.0f);
-					else
-						ImGui::Text("%.3f ms", testIt->second.costPerCall);
-					ImGui::PopStyleColor();
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
+				} else if (row.label == "Other:") {
+					ImGui::TextUnformatted(row.label.c_str());
+					if (!row.tooltip.empty() && ImGui::IsItemHovered()) {
+						if (auto _tt = Util::HoverTooltipWrapper()) {
+							ImGui::TextUnformatted(row.tooltip.c_str());
+						}
 					}
-				} else {
-					ImGui::TextUnformatted("N/A");
 				}
+			} else if (row.label == "Total:" || row.label == "Other:") {
+				// No tooltip for summary rows in non-label columns
+				columns[colIdx].cellRender(row, colIdx);
+			} else {
+				// Normal row: ensure tooltips never modify cell content
+				columns[colIdx].cellRender(row, colIdx);
 			}
-		}
-		ImGui::EndTable();
-	}
+		},
+		summaryRows);
 
-	if (clearTestDataRequested) {
-		s_testData.clear();
+	if (clearTestDataRequested) {  // clear after all drawing complete.
+		ClearTestData();
 		clearTestDataRequested = false;
-		s_testDataSource = TestDataSource::None;
 	}
 }
 
@@ -1008,68 +1051,6 @@ void PerformanceOverlay::DrawVRAM()
 	}
 }
 
-ImVec4 PerformanceOverlay::GetPerformanceColor(float value, float lowThreshold, float highThreshold)
-{
-	auto menu = Menu::GetSingleton();
-	const auto& theme = menu->GetTheme();
-
-	if (value <= lowThreshold) {
-		return theme.StatusPalette.SuccessColor;
-	} else if (value <= highThreshold) {
-		return theme.StatusPalette.Warning;
-	} else {
-		return theme.StatusPalette.Error;
-	}
-}
-
-ImVec4 PerformanceOverlay::GetPerformanceStatusColor(int status)
-{
-	auto menu = Menu::GetSingleton();
-	const auto& theme = menu->GetTheme();
-
-	switch (status) {
-	case 0:  // Good
-		return theme.StatusPalette.SuccessColor;
-	case 1:  // Warning
-		return theme.StatusPalette.Warning;
-	case 2:  // Error
-		return theme.StatusPalette.Error;
-	case 3:  // Info
-		return theme.StatusPalette.InfoColor;
-	default:
-		return theme.StatusPalette.InfoColor;
-	}
-}
-
-bool PerformanceOverlay::RenderColorCodedMetric(const char* label, float value, float lowThreshold, float highThreshold, const char* format)
-{
-	ImVec4 color = GetPerformanceColor(value, lowThreshold, highThreshold);
-	ImGui::PushStyleColor(ImGuiCol_Text, color);
-	ImGui::Text(label);
-	ImGui::SameLine();
-	ImGui::Text(format, value);
-	ImGui::PopStyleColor();
-	return ImGui::IsItemHovered();
-}
-
-/**
- * @brief Updates all runtime state related to the performance overlay graph.
- *
- * This function synchronizes the frame time history buffer, tracks min/max frame times,
- * and computes the normalized Y-axis range for the frame time graph using statistical analysis.
- *
- * Steps performed:
- *   1. Resizes the frameTimeHistory buffer if the user has changed the setting.
- *   2. Inserts the latest frame time into the circular history buffer.
- *   3. Updates instantaneous min/max frame time values, with full rescans if necessary.
- *   4. Calculates the average (mean) and standard deviation of frame times in the buffer.
- *   5. Sets the graph Y-axis range to be centered on the average, with a spread of ±2 standard deviations,
- *      clamped to user-friendly minimum and maximum values.
- *   6. Smooths the min/max Y-axis values for visual stability using exponential smoothing.
- *
- *
- * No parameters; uses settings from the singleton.
- */
 void PerformanceOverlay::PerfOverlayState::UpdateGraphValues()
 {
 	// Get settings from the singleton

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -725,39 +725,63 @@ void PerformanceOverlay::DrawDrawCalls()
 	auto* menu = Menu::GetSingleton();
 	const auto& theme = menu->GetTheme();
 
-	// helper for creating columns
-	auto makeLiveMetricColumn = [&](auto valueGetter, auto colorGetter, auto formatter, const std::vector<std::string>& tooltipLines, const std::vector<ImVec4>& tooltipColors) {
-		return [theme, valueGetter, colorGetter, formatter, tooltipLines, tooltipColors](const DrawCallRow& row, int) {
-			float value = valueGetter(row);
-			ImVec4 color = colorGetter(theme, value, row);
-			std::string valueStr = formatter(value, row);
-			ImGui::PushStyleColor(ImGuiCol_Text, color);
-			ImGui::Text("%s", valueStr.c_str());
-			ImGui::PopStyleColor();
-			if (ImGui::IsItemHovered()) {
-				if (auto _tt = Util::HoverTooltipWrapper()) {
-					Util::DrawMultiLineTooltip(tooltipLines, tooltipColors);
-				}
-			}
-		};
-	};
+	// --- COLUMN CONFIG ---
+	using ColoredTextLines = Util::ColoredTextLines;
 
-	auto makeTestMetricColumn = [&](auto valueGetter, auto colorGetter, auto formatter, const std::vector<std::string>& tooltipLines, const std::vector<ImVec4>& tooltipColors) {
-		return [theme, valueGetter, colorGetter, formatter, tooltipLines, tooltipColors](const DrawCallRow& row, int) {
-			auto opt = valueGetter(row);
-			if (!opt.has_value()) {
-				ImGui::TextDisabled("-");
-				return;
+	// --- BUILD LEGENDS ---
+	const ColoredTextLines frameTimeLegend = {
+		{ "Frame Time: Time spent on this shader type (ms and % of total frame time).", theme.Palette.Text },
+		{ "", theme.Palette.Text },
+		{ "Performance Color Legend (ms):", theme.Palette.Text },
+		{ "  <= 2 ms", theme.StatusPalette.SuccessColor },
+		{ "  > 2 ms and <= 5 ms", theme.StatusPalette.Warning },
+		{ "  > 5 ms", theme.StatusPalette.Error }
+	};
+	const ColoredTextLines costPerCallLegend = {
+		{ "Cost/Call: Average time per draw call for this shader type.", theme.Palette.Text },
+		{ "", theme.Palette.Text },
+		{ "Color Legend (ms/call):", theme.Palette.Text },
+		{ "  <= 0.05 ms/call", theme.StatusPalette.SuccessColor },
+		{ "  > 0.05 ms and <= 0.2 ms/call", theme.StatusPalette.Warning },
+		{ "  > 0.2 ms/call", theme.StatusPalette.Error }
+	};
+	const ColoredTextLines testFrameTimeLegend = {
+		{ PerformanceOverlay::GetTestDataTooltip(), theme.Palette.Text },
+		{ "", theme.Palette.Text },
+		{ "Color Legend (compared to live data):", theme.Palette.Text },
+		{ "  Better (lower than live)", theme.StatusPalette.SuccessColor },
+		{ "  Worse (higher than live)", theme.StatusPalette.Error },
+		{ "  Same as live", theme.Palette.Text }
+	};
+	const ColoredTextLines testCostPerCallLegend = testFrameTimeLegend;
+
+	// --- COLUMN HELPERS ---
+	auto makeMetricColumn = [&](auto valueGetter, auto colorGetter, auto formatter, const ColoredTextLines& legend, const ColoredTextLines* cellLegend = nullptr) {
+		return [theme, valueGetter, colorGetter, formatter, legend, cellLegend](const DrawCallRow& row, int) {
+			using ValueType = decltype(valueGetter(row));
+			if constexpr (std::is_same_v<ValueType, std::optional<float>>) {
+				if (!valueGetter(row).has_value()) {
+					ImGui::TextDisabled("-");
+					return;
+				}
+				float value = *valueGetter(row);
+				ImVec4 color = colorGetter(theme, value, row);
+				std::string valueStr = formatter(value, row);
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				ImGui::Text("%s", valueStr.c_str());
+				ImGui::PopStyleColor();
+			} else {
+				float value = valueGetter(row);
+				ImVec4 color = colorGetter(theme, value, row);
+				std::string valueStr = formatter(value, row);
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				ImGui::Text("%s", valueStr.c_str());
+				ImGui::PopStyleColor();
 			}
-			float value = *opt;
-			ImVec4 color = colorGetter(theme, value, row);
-			std::string valueStr = formatter(value, row);
-			ImGui::PushStyleColor(ImGuiCol_Text, color);
-			ImGui::Text("%s", valueStr.c_str());
-			ImGui::PopStyleColor();
 			if (ImGui::IsItemHovered()) {
 				if (auto _tt = Util::HoverTooltipWrapper()) {
-					Util::DrawMultiLineTooltip(tooltipLines, tooltipColors);
+					const ColoredTextLines& useLegend = cellLegend ? *cellLegend : legend;
+					Util::DrawColoredMultiLineTooltip(useLegend);
 				}
 			}
 		};
@@ -853,40 +877,34 @@ void PerformanceOverlay::DrawDrawCalls()
 	};
 	columns.push_back(ColumnConfig{
 		"Frame Time (%)",
-		makeLiveMetricColumn(
+		makeMetricColumn(
 			[](const DrawCallRow& row) { return row.frameTime; },
 			[](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, 2.0f, 5.0f, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); },
 			[](float /*value*/, const DrawCallRow& row) {
 				return Util::FormatMilliseconds(row.frameTime) + " (" + Util::FormatPercent(row.percent) + ")";
 			},
-			{ "Frame Time: Time spent on this shader type (ms and % of total frame time).", "", "Reference thresholds (ms):", "  < 2 ms", "  >= 2 ms and < 5 ms", "  >= 5 ms" },
-			{ theme.Palette.Text, theme.Palette.Text, theme.Palette.Text, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error }),
+			frameTimeLegend),
 		[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.percent < b.percent) : (a.percent > b.percent); },
-		[theme]() {
+		[frameTimeLegend]() {
 			if (ImGui::IsItemHovered()) {
 				if (auto _tt = Util::HoverTooltipWrapper()) {
-					std::vector<std::string> lines = { "Frame Time: Time spent on this shader type (ms and % of total frame time).", "", "Performance Color Legend (ms):", "  <= 2 ms", "  > 2 ms and <= 5 ms", "  > 5 ms" };
-					std::vector<ImVec4> colors = { theme.Palette.Text, theme.Palette.Text, theme.Palette.Text, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error };
-					Util::DrawMultiLineTooltip(lines, colors);
+					Util::DrawColoredMultiLineTooltip(frameTimeLegend);
 				}
 			}
 		} });
 
 	columns.push_back(ColumnConfig{
 		"Cost/Call",
-		makeLiveMetricColumn(
+		makeMetricColumn(
 			[](const DrawCallRow& row) { return row.costPerCall; },
 			[](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, 0.05f, 0.2f, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); },
 			[](float value, const DrawCallRow&) { return (value < 0.01f && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); },
-			{ "Cost/Call: Average time per draw call for this shader type.", "", "Reference thresholds (ms/call):", "  <= 0.05 ms/call", "  > 0.05 ms and <= 0.2 ms/call", "  > 0.2 ms/call" },
-			{ theme.Palette.Text, theme.Palette.Text, theme.Palette.Text, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error }),
+			costPerCallLegend),
 		[](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall); },
-		[theme]() {
+		[costPerCallLegend]() {
 			if (ImGui::IsItemHovered()) {
 				if (auto _tt = Util::HoverTooltipWrapper()) {
-					std::vector<std::string> lines = { "Cost/Call: Average time per draw call for this shader type.", "", "Performance Color Legend (ms/call):", "  <= 0.05 ms/call", "  > 0.05 ms and <= 0.2 ms/call", "  > 0.2 ms/call" };
-					std::vector<ImVec4> colors = { theme.Palette.Text, theme.Palette.Text, theme.Palette.Text, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error };
-					Util::DrawMultiLineTooltip(lines, colors);
+					Util::DrawColoredMultiLineTooltip(costPerCallLegend);
 				}
 			}
 		} });
@@ -895,7 +913,7 @@ void PerformanceOverlay::DrawDrawCalls()
 	if (anyTestData) {
 		columns.push_back(ColumnConfig{
 			"Test Frame Time (%)",
-			makeTestMetricColumn(
+			makeMetricColumn(
 				[](const DrawCallRow& row) { return row.testFrameTime; },
 				[](const auto& theme, float value, const DrawCallRow& row) {
 					if (value < row.frameTime)
@@ -905,24 +923,25 @@ void PerformanceOverlay::DrawDrawCalls()
 					return theme.Palette.Text;
 				},
 				[](float value, const DrawCallRow& row) { return Util::FormatMilliseconds(value) + " (" + Util::FormatPercent(PerformanceOverlay::s_testData[row.shaderType].percent) + ")"; },
-				{ PerformanceOverlay::GetTestDataTooltip(), "", "Color legend (compared to live data):" },
-				{ theme.Palette.Text, theme.Palette.Text, theme.Palette.Text }),
+				testFrameTimeLegend),
 			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
 				float aVal = a.testFrameTime.value_or(FLT_MAX);
 				float bVal = b.testFrameTime.value_or(FLT_MAX);
 				return asc ? (aVal < bVal) : (aVal > bVal);
 			},
-			[theme]() {
+			[testFrameTimeLegend]() {
 				if (ImGui::IsItemHovered()) {
 					if (auto _tt = Util::HoverTooltipWrapper()) {
 						ImGui::TextUnformatted(PerformanceOverlay::GetTestDataTooltip().c_str());
+						ImGui::Separator();
+						Util::DrawColoredMultiLineTooltip(testFrameTimeLegend);
 					}
 				}
 			} });
 
 		columns.push_back(ColumnConfig{
 			"Test Cost/Call",
-			makeTestMetricColumn(
+			makeMetricColumn(
 				[](const DrawCallRow& row) { return row.testCostPerCall; },
 				[](const auto& theme, float value, const DrawCallRow& row) {
 					if (value < row.costPerCall)
@@ -932,17 +951,18 @@ void PerformanceOverlay::DrawDrawCalls()
 					return theme.Palette.Text;
 				},
 				[](float value, const DrawCallRow&) { return (value < 0.01f && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); },
-				{ PerformanceOverlay::GetTestDataTooltip(), "", "Color legend (compared to live data):" },
-				{ theme.Palette.Text, theme.Palette.Text, theme.Palette.Text }),
+				testCostPerCallLegend),
 			[](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
 				float aVal = a.testCostPerCall.value_or(FLT_MAX);
 				float bVal = b.testCostPerCall.value_or(FLT_MAX);
 				return asc ? (aVal < bVal) : (aVal > bVal);
 			},
-			[theme]() {
+			[testCostPerCallLegend]() {
 				if (ImGui::IsItemHovered()) {
 					if (auto _tt = Util::HoverTooltipWrapper()) {
 						ImGui::TextUnformatted(PerformanceOverlay::GetTestDataTooltip().c_str());
+						ImGui::Separator();
+						Util::DrawColoredMultiLineTooltip(testCostPerCallLegend);
 					}
 				}
 			} });
@@ -977,7 +997,29 @@ void PerformanceOverlay::DrawDrawCalls()
 						for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
 							globals::state->enabledClasses[i] = anyDisabled;
 						}
-						UpdateAllShaderTestData();
+						// Update test data and timestamp for manual toggling (not just A/B test mode)
+						bool abTest = Menu::GetSingleton() && Menu::GetSingleton()->abTestingEnabled && Menu::GetSingleton()->usingTestConfig;
+						if (abTest) {
+							UpdateAllShaderTestData();
+						} else {
+							// Manual toggle: update test data and timestamp
+							float smoothedFrameTime = static_cast<float>(PerformanceOverlay::GetSingleton()->perfOverlayState.smoothFrameTimeMs);
+							float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
+							float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
+							float measuredSum = 0.0f;
+							for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
+								if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
+									continue;
+								int typeIndex = magic_enum::enum_integer(type);
+								measuredSum += static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
+							}
+							float otherFrameTime = smoothedFrameTime - measuredSum;
+							float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
+							PerformanceOverlay::s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+							PerformanceOverlay::s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
+							PerformanceOverlay::s_testDataSource = PerformanceOverlay::TestDataSource::ManualShaderToggle;
+							PerformanceOverlay::s_testDataLastUpdated = std::chrono::steady_clock::now();
+						}
 					}
 					if (ImGui::IsItemHovered()) {
 						if (auto _tt = Util::HoverTooltipWrapper()) {

--- a/src/Features/PerformanceOverlay.h
+++ b/src/Features/PerformanceOverlay.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "../Utils/PerfUtils.h"
+#include "Menu.h"
 #include "OverlayFeature.h"
+#include "PerformanceOverlay/ABTesting/ABTestAggregator.h"
+#include "Utils/PerfUtils.h"
 #include <chrono>
 #include <nlohmann/json.hpp>
 #include <optional>
@@ -10,7 +12,6 @@
 
 // Forward declarations
 struct DrawCallRow;
-class ABTestAggregator;
 
 // Special shader type enum for summary rows
 enum class SpecialShaderType
@@ -40,6 +41,42 @@ struct ShaderRow
 	std::string tooltip;
 };
 
+// Legend and configuration structures
+struct ColumnLegend
+{
+	std::string header;
+	Util::ColoredTextLines tooltip;
+};
+
+struct ABTestLegends
+{
+	ColumnLegend shaderType;
+	ColumnLegend aAvg;
+	ColumnLegend bAvg;
+	ColumnLegend delta;
+	ColumnLegend aMedian;
+	ColumnLegend bMedian;
+	ColumnLegend medianDelta;
+};
+
+struct DrawCallLegends
+{
+	ColumnLegend shaderType;
+	ColumnLegend drawCalls;
+	ColumnLegend frameTime;
+	ColumnLegend costPerCall;
+	ColumnLegend testFrameTime;
+	ColumnLegend testCostPerCall;
+};
+
+struct ColumnConfig
+{
+	std::string header;
+	std::function<void(const DrawCallRow&, int colIdx)> cellRender;
+	std::function<bool(const DrawCallRow&, const DrawCallRow&, bool)> sortFunc;
+	std::function<void()> headerTooltip;
+};
+
 struct PerformanceOverlay : OverlayFeature
 {
 	static PerformanceOverlay* GetSingleton()
@@ -48,54 +85,64 @@ struct PerformanceOverlay : OverlayFeature
 		return &singleton;
 	}
 
-	// Virtual overrides in Feature.h order
+	// ============================================================================
+	// VIRTUAL OVERRIDES (Feature.h interface)
+	// ============================================================================
 	std::string GetName() override { return "Performance Overlay"; }
 	std::string GetShortName() override { return "PerformanceOverlay"; }
-
 	virtual bool SupportsVR() override { return true; }
 	virtual bool IsCore() const override { return true; }
 	virtual bool IsInMenu() const override { return true; }
-
+	bool IsOverlayVisible() const override { return settings.ShowInOverlay; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override;
 	virtual void DrawSettings() override;
-
 	virtual void DataLoaded() override;
+	void DrawOverlay() override;
 
-	// Core performance display functions
+	// ============================================================================
+	// CORE PERFORMANCE DISPLAY FUNCTIONS
+	// ============================================================================
 	void DrawFPS();
 	void DrawVRAM();
 
-	// Private helper for table rendering
-	void DrawDrawCallsTable(const std::vector<DrawCallRow>& mainRows, const std::vector<DrawCallRow>& summaryRows);
-
-	// Private helper for A/B testing section
+	// ============================================================================
+	// A/B TESTING FUNCTIONS
+	// ============================================================================
 	void DrawABTestSection(const std::vector<DrawCallRow>& allRows, bool showCollapsibleSections);
 	void DrawABTestResultsTable();
-
-	// Test data management
-	void UpdateShaderTestData(int shaderType, float frameTime, float costPerCall);
-	std::string GetTestDataTooltip();
-
-public:
-	void UpdateAllShaderTestData();
-
-	// A/B Test aggregator access
+	void DrawABTestStatisticalValidity(const Menu::ThemeSettings& theme, const ABTestAggregator& aggregator) const;
+	void ConvertABTestResultsToRows(const std::vector<AggregatedDrawCallStats>& results, std::vector<DrawCallRow>& mainRows, std::vector<DrawCallRow>& summaryRows) const;
+	ABTestLegends BuildABTestLegends(const Menu::ThemeSettings& theme) const;
+	std::vector<ColumnConfig> BuildABTestResultsTableColumns(const Menu::ThemeSettings& theme, const ABTestLegends& legends) const;
 	static ABTestAggregator& GetABTestAggregator();
 
-	// Test data management helpers
+	// ============================================================================
+	// TABLE BUILDING AND RENDERING FUNCTIONS
+	// ============================================================================
+	void DrawDrawCallsTable(const std::vector<DrawCallRow>& mainRows, const std::vector<DrawCallRow>& summaryRows);
+	DrawCallLegends BuildDrawCallLegends(const Menu::ThemeSettings& theme, bool anyTestData, PerformanceOverlay* overlay) const;
+	std::vector<ColumnConfig> BuildDrawCallTableColumns(const Menu::ThemeSettings& theme, const DrawCallLegends& legends, bool anyTestData, PerformanceOverlay* overlay);
+	std::pair<std::vector<DrawCallRow>, std::vector<DrawCallRow>> BuildDrawCallRows() const;
+	std::function<void(int, int, const DrawCallRow&)> CreateTableRowHandler(const std::vector<ColumnConfig>& columns, PerformanceOverlay* overlay);
+
+	// ============================================================================
+	// EVENT HANDLING FUNCTIONS
+	// ============================================================================
+	void HandleShaderToggle(const DrawCallRow& row, bool wasEnabled);
+	void HandleTotalRowToggle();
+
+	// ============================================================================
+	// TEST DATA MANAGEMENT FUNCTIONS
+	// ============================================================================
+	void UpdateShaderTestData(int shaderType, float frameTime, float costPerCall);
+	void UpdateAllShaderTestData();
 	void UpdateShaderTestDataEntry(int shaderType, float frameTime, float costPerCall, float percent = 0.0f);
 	void UpdateSummaryTestData(float smoothedFrameTime, float otherFrameTime, float otherPercent, float totalCostPerCall);
+	std::string GetTestDataTooltip();
 
-	/**
-	 * @brief Builds the main and summary rows for the performance overlay table.
-	 *
-	 * @return A pair of vectors: (mainRows, summaryRows).
-	 *         - mainRows: One row per shader type, with live and (if present) test data.
-	 *         - summaryRows: 'Other' and 'Total' rows, with live and (if present) test data.
-	 */
-	std::pair<std::vector<DrawCallRow>, std::vector<DrawCallRow>> BuildDrawCallRows() const;
-
-	// Performance overlay state management
+	// ============================================================================
+	// PERFORMANCE OVERLAY STATE MANAGEMENT
+	// ============================================================================
 	class PerfOverlayState
 	{
 	private:
@@ -261,11 +308,9 @@ public:
 
 	PerfOverlayState perfOverlayState;
 
-	// Implement OverlayFeature interface
-	void DrawOverlay() override;
-	bool IsOverlayVisible() const override { return settings.ShowInOverlay; }
-
-	// Settings structure
+	// ============================================================================
+	// SETTINGS STRUCTURE
+	// ============================================================================
 	struct PerfOverlaySettings
 	{
 		bool ShowInOverlay = true;  // was: Enabled
@@ -296,34 +341,9 @@ public:
 	PerfOverlaySettings settings;
 
 private:
-	/**
-	 * @brief Captures test data for the performance overlay table.
-	 *
-	 * This function is responsible for updating the static test data used for A/B comparison and manual shader toggling.
-	 *
-	 * - In A/B Test Mode (Variant B): If ABTestingManager is enabled and using test config, this function continuously captures
-	 *   test data for all shader types, as well as the 'Other' and 'Total' summary rows, every frame.
-	 * - In Manual Shader Toggle mode: If any shader is disabled, this function captures test data for the disabled
-	 *   shaders and summary rows at the moment of disabling, and keeps it until cleared.
-	 * - Test data is NOT cleared when shaders are re-enabled; it is only cleared by the 'Clear Test Data' button
-	 *   or if all shaders are disabled (rare edge case).
-	 *
-	 * Side effects:
-	 * - Updates s_testData, s_testDataSource, and s_testDataLastUpdated.
-	 */
-	void CaptureTestData();
-
-	/**
-	 * @brief Clears all captured test data and resets the test data source.
-	 *
-	 * This should be called when the user clicks the 'Clear Test Data' button,
-	 * or in rare cases where all shaders are disabled.
-	 *
-	 * Side effects:
-	 * - Empties s_testData and resets s_testDataSource.
-	 */
-	void ClearTestData();
-
+	// ============================================================================
+	// PRIVATE DATA STRUCTURES
+	// ============================================================================
 	struct TestData
 	{
 		float frameTime;
@@ -343,6 +363,8 @@ private:
 	bool settingsDiffLoaded = false;
 
 	// Test data management
+	void CaptureTestData();
+	void ClearTestData();
 	TestDataSource testDataSource = TestDataSource::None;
 	std::chrono::steady_clock::time_point testDataLastUpdated;
 	std::unordered_map<int, TestData> testData;

--- a/src/Features/PerformanceOverlay.h
+++ b/src/Features/PerformanceOverlay.h
@@ -3,13 +3,26 @@
 #include "../Utils/PerfUtils.h"
 #include "OverlayFeature.h"
 #include <chrono>
+#include <nlohmann/json.hpp>
 #include <optional>
 #include <unordered_map>
+#include <variant>
+
+// Forward declarations
+struct DrawCallRow;
+class ABTestAggregator;
+
+// Special shader type enum for summary rows
+enum class SpecialShaderType
+{
+	Total = -1,
+	Other = -2
+};
 
 struct DrawCallRow
 {
 	std::string label;
-	int shaderType;
+	int shaderType;  // Use int for consistency with the rest of the codebase
 	int drawCalls;
 	float frameTime;
 	float percent;
@@ -62,8 +75,14 @@ struct PerformanceOverlay : OverlayFeature
 
 	// Core performance display functions
 	void DrawFPS();
-	void DrawDrawCalls();
 	void DrawVRAM();
+
+	// Private helper for table rendering
+	void DrawDrawCallsTable(const std::vector<DrawCallRow>& mainRows, const std::vector<DrawCallRow>& summaryRows);
+
+	// Private helper for A/B testing section
+	void DrawABTestSection(const std::vector<DrawCallRow>& allRows, bool showCollapsibleSections);
+	void DrawABTestResultsTable();
 
 	// Test data management
 	static void UpdateShaderTestData(int shaderType, float frameTime, float costPerCall);
@@ -71,6 +90,22 @@ struct PerformanceOverlay : OverlayFeature
 
 public:
 	static void UpdateAllShaderTestData();
+
+	// A/B Test aggregator access
+	static ABTestAggregator& GetABTestAggregator();
+
+	// Test data management helpers
+	static void UpdateShaderTestDataEntry(int shaderType, float frameTime, float costPerCall, float percent = 0.0f);
+	static void UpdateSummaryTestData(float smoothedFrameTime, float otherFrameTime, float otherPercent, float totalCostPerCall);
+
+	/**
+	 * @brief Builds the main and summary rows for the performance overlay table.
+	 *
+	 * @return A pair of vectors: (mainRows, summaryRows).
+	 *         - mainRows: One row per shader type, with live and (if present) test data.
+	 *         - summaryRows: 'Other' and 'Total' rows, with live and (if present) test data.
+	 */
+	std::pair<std::vector<DrawCallRow>, std::vector<DrawCallRow>> BuildDrawCallRows() const;
 
 	// Performance overlay state management
 	class PerfOverlayState
@@ -102,6 +137,24 @@ public:
 		float textScale = 1.0f;
 		static constexpr float kSmoothingFactor = 0.15f;  // Smoothing factor: 0.1f = slow, 0.3f = fast.
 		std::chrono::steady_clock::time_point lastUpdateTime;
+
+		// Performance threshold constants
+		static constexpr float kFrameTimeGoodThreshold = 2.0f;       // ms - Good performance threshold
+		static constexpr float kFrameTimeWarningThreshold = 5.0f;    // ms - Warning performance threshold
+		static constexpr float kCostPerCallGoodThreshold = 0.05f;    // ms/call - Good cost per call threshold
+		static constexpr float kCostPerCallWarningThreshold = 0.2f;  // ms/call - Warning cost per call threshold
+		static constexpr float kMicrosecondThreshold = 0.01f;        // ms - Threshold for showing microseconds
+		static constexpr float kPercentDisplayThreshold = 0.01f;     // Minimum percent difference to display
+		static constexpr float kGraphSpreadMultiplier = 2.0f;        // Standard deviation multiplier for graph range
+		static constexpr float kGraphMinSpread = 2.0f;               // ms - Minimum graph spread
+		static constexpr float kGraphMaxSpread = 20.0f;              // ms - Maximum graph spread
+		static constexpr float kFrameGenerationMultiplier = 2.0f;    // Frame generation doubles frame rate
+		static constexpr float kMaxUpdateInterval = 2.0f;            // seconds - Maximum update interval
+		static constexpr float kDefaultWindowPadding = 10.0f;        // pixels - Default window padding
+		static constexpr float kLabelPadding = 100.0f;               // pixels - Padding for labels
+		static constexpr float kDrawCallsTableWidth = 600.0f;        // pixels - Draw calls table width
+		static constexpr float kVRAMSectionWidth = 300.0f;           // pixels - VRAM section width
+		static constexpr float kWindowBorderPadding = 20.0f;         // pixels - Window border padding
 
 		float SetTextScale();
 		/**
@@ -172,7 +225,7 @@ private:
 	 *
 	 * This function is responsible for updating the static test data used for A/B comparison and manual shader toggling.
 	 *
-	 * - In A/B Test Mode (Variant B): If abTestingEnabled && usingTestConfig, this function continuously captures
+	 * - In A/B Test Mode (Variant B): If ABTestingManager is enabled and using test config, this function continuously captures
 	 *   test data for all shader types, as well as the 'Other' and 'Total' summary rows, every frame.
 	 * - In Manual Shader Toggle mode: If any shader is disabled, this function captures test data for the disabled
 	 *   shaders and summary rows at the moment of disabling, and keeps it until cleared.
@@ -194,15 +247,6 @@ private:
 	 * - Empties s_testData and resets s_testDataSource.
 	 */
 	void ClearTestData();
-
-	/**
-	 * @brief Builds the main and summary rows for the performance overlay table.
-	 *
-	 * @return A pair of vectors: (mainRows, summaryRows).
-	 *         - mainRows: One row per shader type, with live and (if present) test data.
-	 *         - summaryRows: 'Other' and 'Total' rows, with live and (if present) test data.
-	 */
-	std::pair<std::vector<DrawCallRow>, std::vector<DrawCallRow>> BuildDrawCallRows() const;
 
 	struct TestData
 	{

--- a/src/Features/PerformanceOverlay.h
+++ b/src/Features/PerformanceOverlay.h
@@ -20,6 +20,9 @@ enum class SpecialShaderType
 	Other = -2
 };
 
+// Constants for special draw call values
+static constexpr int kDrawCallsNotApplicable = -1;  // Special value to indicate draw calls are not applicable
+
 struct DrawCallRow
 {
 	std::string label;
@@ -279,7 +282,7 @@ struct PerformanceOverlay : OverlayFeature
 		void ResizePostFGFrameTimeHistory(size_t size, float defaultValue = 0.0f) { postFGFrameTimeHistory.resize(size, defaultValue); }
 
 		// Methods that modify state
-		float SetTextScale();
+		float CalculateTextScale();
 		/**
 		* @brief Updates all runtime state related to the performance overlay graph.
 		*

--- a/src/Features/PerformanceOverlay.h
+++ b/src/Features/PerformanceOverlay.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../Utils/PerfUtils.h"
 #include "OverlayFeature.h"
 #include <chrono>
 #include <optional>
@@ -103,6 +104,24 @@ public:
 		std::chrono::steady_clock::time_point lastUpdateTime;
 
 		float SetTextScale();
+		/**
+		* @brief Updates all runtime state related to the performance overlay graph.
+		*
+		* This function synchronizes the frame time history buffer, tracks min/max frame times,
+		* and computes the normalized Y-axis range for the frame time graph using statistical analysis.
+		*
+		* Steps performed:
+		*   1. Resizes the frameTimeHistory buffer if the user has changed the setting.
+		*   2. Inserts the latest frame time into the circular history buffer.
+		*   3. Updates instantaneous min/max frame time values, with full rescans if necessary.
+		*   4. Calculates the average (mean) and standard deviation of frame times in the buffer.
+		*   5. Sets the graph Y-axis range to be centered on the average, with a spread of ±2 standard deviations,
+		*      clamped to user-friendly minimum and maximum values.
+		*   6. Smooths the min/max Y-axis values for visual stability using exponential smoothing.
+		*
+		*
+		* No parameters; uses settings from the singleton.
+		*/
 		void UpdateGraphValues();
 		void UpdateFrameTimeHistorySizes();
 		void UpdateMinFrameTime();
@@ -148,6 +167,43 @@ public:
 	PerfOverlaySettings settings;
 
 private:
+	/**
+	 * @brief Captures test data for the performance overlay table.
+	 *
+	 * This function is responsible for updating the static test data used for A/B comparison and manual shader toggling.
+	 *
+	 * - In A/B Test Mode (Variant B): If abTestingEnabled && usingTestConfig, this function continuously captures
+	 *   test data for all shader types, as well as the 'Other' and 'Total' summary rows, every frame.
+	 * - In Manual Shader Toggle mode: If any shader is disabled, this function captures test data for the disabled
+	 *   shaders and summary rows at the moment of disabling, and keeps it until cleared.
+	 * - Test data is NOT cleared when shaders are re-enabled; it is only cleared by the 'Clear Test Data' button
+	 *   or if all shaders are disabled (rare edge case).
+	 *
+	 * Side effects:
+	 * - Updates s_testData, s_testDataSource, and s_testDataLastUpdated.
+	 */
+	void CaptureTestData();
+
+	/**
+	 * @brief Clears all captured test data and resets the test data source.
+	 *
+	 * This should be called when the user clicks the 'Clear Test Data' button,
+	 * or in rare cases where all shaders are disabled.
+	 *
+	 * Side effects:
+	 * - Empties s_testData and resets s_testDataSource.
+	 */
+	void ClearTestData();
+
+	/**
+	 * @brief Builds the main and summary rows for the performance overlay table.
+	 *
+	 * @return A pair of vectors: (mainRows, summaryRows).
+	 *         - mainRows: One row per shader type, with live and (if present) test data.
+	 *         - summaryRows: 'Other' and 'Total' rows, with live and (if present) test data.
+	 */
+	std::pair<std::vector<DrawCallRow>, std::vector<DrawCallRow>> BuildDrawCallRows() const;
+
 	struct TestData
 	{
 		float frameTime;
@@ -165,8 +221,4 @@ private:
 	static TestDataSource s_testDataSource;
 	static std::chrono::steady_clock::time_point s_testDataLastUpdated;
 	static std::unordered_map<int, TestData> s_testData;
-
-	static ImVec4 GetPerformanceColor(float value, float lowThreshold, float highThreshold);
-	static ImVec4 GetPerformanceStatusColor(int status);  // Use int for now if PerformanceStatus is not defined
-	static bool RenderColorCodedMetric(const char* label, float value, float lowThreshold, float highThreshold, const char* format);
 };

--- a/src/Features/PerformanceOverlay.h
+++ b/src/Features/PerformanceOverlay.h
@@ -40,18 +40,6 @@ struct ShaderRow
 	std::string tooltip;
 };
 
-enum DrawCallTableColumn
-{
-	Col_Label,
-	Col_DrawCalls,
-	Col_FrameTime,
-	Col_Percent,
-	Col_CostPerCall,
-	Col_TestFrameTime,
-	Col_TestCostPerCall,
-	Col_Count
-};
-
 struct PerformanceOverlay : OverlayFeature
 {
 	static PerformanceOverlay* GetSingleton()
@@ -85,18 +73,18 @@ struct PerformanceOverlay : OverlayFeature
 	void DrawABTestResultsTable();
 
 	// Test data management
-	static void UpdateShaderTestData(int shaderType, float frameTime, float costPerCall);
-	static std::string GetTestDataTooltip();
+	void UpdateShaderTestData(int shaderType, float frameTime, float costPerCall);
+	std::string GetTestDataTooltip();
 
 public:
-	static void UpdateAllShaderTestData();
+	void UpdateAllShaderTestData();
 
 	// A/B Test aggregator access
 	static ABTestAggregator& GetABTestAggregator();
 
 	// Test data management helpers
-	static void UpdateShaderTestDataEntry(int shaderType, float frameTime, float costPerCall, float percent = 0.0f);
-	static void UpdateSummaryTestData(float smoothedFrameTime, float otherFrameTime, float otherPercent, float totalCostPerCall);
+	void UpdateShaderTestDataEntry(int shaderType, float frameTime, float costPerCall, float percent = 0.0f);
+	void UpdateSummaryTestData(float smoothedFrameTime, float otherFrameTime, float otherPercent, float totalCostPerCall);
 
 	/**
 	 * @brief Builds the main and summary rows for the performance overlay table.
@@ -110,35 +98,53 @@ public:
 	// Performance overlay state management
 	class PerfOverlayState
 	{
-	public:
+	private:
+		// Frame time history buffers
 		std::vector<float> frameTimeHistory;
 		std::vector<float> postFGFrameTimeHistory;
+
+		// State flags
 		bool initialized = false;
 		bool hasGraphs = false;
+		bool isFrameGenerationActive = false;
+
+		// History indices
 		int frameTimeHistoryIndex = 0;
 		int postFGFrameTimeHistoryIndex = 0;
-		bool isFrameGenerationActive = false;
+
+		// Performance counters
 		int64_t frequency;
 		int64_t lastFrameCounter;
 		int64_t currentFrameCounter;
+
+		// Current frame metrics
 		float frameTimeMs = 0.0f;
 		float fps = 0.0f;
 		float postFGFrameTimeMs = 0.0f;
 		float postFGFps = 0.0f;
+
+		// Smoothed metrics
 		float smoothFps = 0.0f;
 		float smoothFrameTimeMs = 0.0f;
 		float postFGSmoothFps = 0.0f;
 		float postFGSmoothFrameTimeMs = 0.0f;
+
+		// Update timing
 		float updateTimer = 0.0f;
+		std::chrono::steady_clock::time_point lastUpdateTime;
+
+		// Min/max tracking
 		float minFrameTime = 1000.0f;
 		float maxFrameTime = 0.0f;
 		float smoothedMinFrameTime = 0.0f;
 		float smoothedMaxFrameTime = 50.0f;
-		float textScale = 1.0f;
-		static constexpr float kSmoothingFactor = 0.15f;  // Smoothing factor: 0.1f = slow, 0.3f = fast.
-		std::chrono::steady_clock::time_point lastUpdateTime;
 
+		// Display settings
+		float textScale = 1.0f;
+
+	public:
 		// Performance threshold constants
+		static constexpr float kSmoothingFactor = 0.15f;             // Smoothing factor: 0.1f = slow, 0.3f = fast.
 		static constexpr float kFrameTimeGoodThreshold = 2.0f;       // ms - Good performance threshold
 		static constexpr float kFrameTimeWarningThreshold = 5.0f;    // ms - Warning performance threshold
 		static constexpr float kCostPerCallGoodThreshold = 0.05f;    // ms/call - Good cost per call threshold
@@ -155,7 +161,77 @@ public:
 		static constexpr float kDrawCallsTableWidth = 600.0f;        // pixels - Draw calls table width
 		static constexpr float kVRAMSectionWidth = 300.0f;           // pixels - VRAM section width
 		static constexpr float kWindowBorderPadding = 20.0f;         // pixels - Window border padding
+		static constexpr float kDefaultFrameTimeMs = 16.67f;         // ms - Default frame time (60 FPS)
 
+		// Getters for read-only access
+		bool IsInitialized() const { return initialized; }
+		bool HasGraphs() const { return hasGraphs; }
+		bool IsFrameGenerationActive() const { return isFrameGenerationActive; }
+
+		float GetFrameTimeMs() const { return frameTimeMs; }
+		float GetFps() const { return fps; }
+		float GetPostFGFrameTimeMs() const { return postFGFrameTimeMs; }
+		float GetPostFGFps() const { return postFGFps; }
+		float GetSmoothFps() const { return smoothFps; }
+		float GetSmoothFrameTimeMs() const { return smoothFrameTimeMs; }
+		float GetPostFGSmoothFps() const { return postFGSmoothFps; }
+		float GetPostFGSmoothFrameTimeMs() const { return postFGSmoothFrameTimeMs; }
+		float GetUpdateTimer() const { return updateTimer; }
+		float GetMinFrameTime() const { return minFrameTime; }
+		float GetMaxFrameTime() const { return maxFrameTime; }
+		float GetSmoothedMinFrameTime() const { return smoothedMinFrameTime; }
+		float GetSmoothedMaxFrameTime() const { return smoothedMaxFrameTime; }
+		float GetTextScale() const { return textScale; }
+
+		int64_t GetFrequency() const { return frequency; }
+		int64_t GetLastFrameCounter() const { return lastFrameCounter; }
+		int64_t GetCurrentFrameCounter() const { return currentFrameCounter; }
+		int GetFrameTimeHistoryIndex() const { return frameTimeHistoryIndex; }
+		int GetPostFGFrameTimeHistoryIndex() const { return postFGFrameTimeHistoryIndex; }
+
+		// Non-const getters for use with system functions that require pointers
+		int64_t& GetFrequencyRef() { return frequency; }
+		int64_t& GetLastFrameCounterRef() { return lastFrameCounter; }
+		int64_t& GetCurrentFrameCounterRef() { return currentFrameCounter; }
+
+		const std::vector<float>& GetFrameTimeHistory() const { return frameTimeHistory; }
+		const std::vector<float>& GetPostFGFrameTimeHistory() const { return postFGFrameTimeHistory; }
+		const std::chrono::steady_clock::time_point& GetLastUpdateTime() const { return lastUpdateTime; }
+
+		// Non-const getters for history vectors that need modification
+		std::vector<float>& GetFrameTimeHistoryRef() { return frameTimeHistory; }
+		std::vector<float>& GetPostFGFrameTimeHistoryRef() { return postFGFrameTimeHistory; }
+
+		// Setters for controlled state modification
+		void SetInitialized(bool value) { initialized = value; }
+		void SetHasGraphs(bool value) { hasGraphs = value; }
+		void SetFrameGenerationActive(bool value) { isFrameGenerationActive = value; }
+		void SetFrameTimeMs(float value) { frameTimeMs = value; }
+		void SetFps(float value) { fps = value; }
+		void SetPostFGFrameTimeMs(float value) { postFGFrameTimeMs = value; }
+		void SetPostFGFps(float value) { postFGFps = value; }
+		void SetSmoothFps(float value) { smoothFps = value; }
+		void SetSmoothFrameTimeMs(float value) { smoothFrameTimeMs = value; }
+		void SetPostFGSmoothFps(float value) { postFGSmoothFps = value; }
+		void SetPostFGSmoothFrameTimeMs(float value) { postFGSmoothFrameTimeMs = value; }
+		void SetUpdateTimer(float value) { updateTimer = value; }
+		void SetMinFrameTime(float value) { minFrameTime = value; }
+		void SetMaxFrameTime(float value) { maxFrameTime = value; }
+		void SetSmoothedMinFrameTime(float value) { smoothedMinFrameTime = value; }
+		void SetSmoothedMaxFrameTime(float value) { smoothedMaxFrameTime = value; }
+		void SetTextScale(float value) { textScale = value; }
+		void SetFrequency(int64_t value) { frequency = value; }
+		void SetLastFrameCounter(int64_t value) { lastFrameCounter = value; }
+		void SetCurrentFrameCounter(int64_t value) { currentFrameCounter = value; }
+		void SetFrameTimeHistoryIndex(int value) { frameTimeHistoryIndex = value; }
+		void SetPostFGFrameTimeHistoryIndex(int value) { postFGFrameTimeHistoryIndex = value; }
+		void SetLastUpdateTime(const std::chrono::steady_clock::time_point& value) { lastUpdateTime = value; }
+
+		// Buffer management methods
+		void ResizeFrameTimeHistory(size_t size, float defaultValue = 0.0f) { frameTimeHistory.resize(size, defaultValue); }
+		void ResizePostFGFrameTimeHistory(size_t size, float defaultValue = 0.0f) { postFGFrameTimeHistory.resize(size, defaultValue); }
+
+		// Methods that modify state
 		float SetTextScale();
 		/**
 		* @brief Updates all runtime state related to the performance overlay graph.
@@ -262,7 +338,12 @@ private:
 		ManualShaderToggle
 	};
 
-	static TestDataSource s_testDataSource;
-	static std::chrono::steady_clock::time_point s_testDataLastUpdated;
-	static std::unordered_map<int, TestData> s_testData;
+	// A/B testing settings diff data
+	std::vector<SettingsDiffEntry> settingsDiff;
+	bool settingsDiffLoaded = false;
+
+	// Test data management
+	TestDataSource testDataSource = TestDataSource::None;
+	std::chrono::steady_clock::time_point testDataLastUpdated;
+	std::unordered_map<int, TestData> testData;
 };

--- a/src/Features/PerformanceOverlay.h
+++ b/src/Features/PerformanceOverlay.h
@@ -1,0 +1,172 @@
+#pragma once
+
+#include "OverlayFeature.h"
+#include <chrono>
+#include <optional>
+#include <unordered_map>
+
+struct DrawCallRow
+{
+	std::string label;
+	int shaderType;
+	int drawCalls;
+	float frameTime;
+	float percent;
+	float costPerCall;
+	std::string tooltip;
+	bool enabled;
+	std::optional<float> testFrameTime;
+	std::optional<float> testCostPerCall;
+};
+
+struct ShaderRow
+{
+	std::string label;
+	int type;
+	std::string tooltip;
+};
+
+enum DrawCallTableColumn
+{
+	Col_Label,
+	Col_DrawCalls,
+	Col_FrameTime,
+	Col_Percent,
+	Col_CostPerCall,
+	Col_TestFrameTime,
+	Col_TestCostPerCall,
+	Col_Count
+};
+
+struct PerformanceOverlay : OverlayFeature
+{
+	static PerformanceOverlay* GetSingleton()
+	{
+		static PerformanceOverlay singleton;
+		return &singleton;
+	}
+
+	// Virtual overrides in Feature.h order
+	std::string GetName() override { return "Performance Overlay"; }
+	std::string GetShortName() override { return "PerformanceOverlay"; }
+
+	virtual bool SupportsVR() override { return true; }
+	virtual bool IsCore() const override { return true; }
+	virtual bool IsInMenu() const override { return true; }
+
+	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override;
+	virtual void DrawSettings() override;
+
+	virtual void DataLoaded() override;
+
+	// Core performance display functions
+	void DrawFPS();
+	void DrawDrawCalls();
+	void DrawVRAM();
+
+	// Test data management
+	static void UpdateShaderTestData(int shaderType, float frameTime, float costPerCall);
+	static std::string GetTestDataTooltip();
+
+public:
+	static void UpdateAllShaderTestData();
+
+	// Performance overlay state management
+	class PerfOverlayState
+	{
+	public:
+		std::vector<float> frameTimeHistory;
+		std::vector<float> postFGFrameTimeHistory;
+		bool initialized = false;
+		bool hasGraphs = false;
+		int frameTimeHistoryIndex = 0;
+		int postFGFrameTimeHistoryIndex = 0;
+		bool isFrameGenerationActive = false;
+		int64_t frequency;
+		int64_t lastFrameCounter;
+		int64_t currentFrameCounter;
+		float frameTimeMs = 0.0f;
+		float fps = 0.0f;
+		float postFGFrameTimeMs = 0.0f;
+		float postFGFps = 0.0f;
+		float smoothFps = 0.0f;
+		float smoothFrameTimeMs = 0.0f;
+		float postFGSmoothFps = 0.0f;
+		float postFGSmoothFrameTimeMs = 0.0f;
+		float updateTimer = 0.0f;
+		float minFrameTime = 1000.0f;
+		float maxFrameTime = 0.0f;
+		float smoothedMinFrameTime = 0.0f;
+		float smoothedMaxFrameTime = 50.0f;
+		float textScale = 1.0f;
+		static constexpr float kSmoothingFactor = 0.15f;  // Smoothing factor: 0.1f = slow, 0.3f = fast.
+		std::chrono::steady_clock::time_point lastUpdateTime;
+
+		float SetTextScale();
+		void UpdateGraphValues();
+		void UpdateFrameTimeHistorySizes();
+		void UpdateMinFrameTime();
+		void UpdateMaxFrameTime();
+		void UpdateFGFrameTime();
+		void DrawPostFGFrameTimeGraph();
+	};
+
+	PerfOverlayState perfOverlayState;
+
+	// Implement OverlayFeature interface
+	void DrawOverlay() override;
+	bool IsOverlayVisible() const override { return settings.ShowInOverlay; }
+
+	// Settings structure
+	struct PerfOverlaySettings
+	{
+		bool ShowInOverlay = true;  // was: Enabled
+		bool ShowDrawCalls = true;
+		bool ShowVRAM = true;
+		bool ShowFPS = true;
+		bool ShowPreFGFrameTimeGraph = true;
+		bool ShowPostFGFrameTimeGraph = true;
+		float UpdateInterval = 0.5f;
+		int FrameHistorySize = 120;                       // Default 120 frames = 2s @ 60fps. Clamped using static values to prevent config file values going outside of slider bounds.
+		static constexpr int kMinFrameHistorySize = 60;   // 60 frames = 1s @ 60fps. Reasonable minimum.
+		static constexpr int kMaxFrameHistorySize = 480;  // 480 frames = 10s @ 60fps or 2s @ 240fps. Reasonable maximum.
+		enum class TextSize
+		{
+			Small,
+			Medium,
+			Large
+		};
+		TextSize Size = TextSize::Medium;
+
+		float BackgroundOpacity = 0.5f;
+		bool ShowBorder = true;
+		ImVec2 Position = ImVec2(10.f, 10.f);
+		bool PositionSet = false;
+	};
+
+public:
+	PerfOverlaySettings settings;
+
+private:
+	struct TestData
+	{
+		float frameTime;
+		float costPerCall;
+		float percent;
+	};
+
+	enum class TestDataSource
+	{
+		None,
+		ABTest_VariantB,
+		ManualShaderToggle
+	};
+
+	static TestDataSource s_testDataSource;
+	static std::chrono::steady_clock::time_point s_testDataLastUpdated;
+	static std::unordered_map<int, TestData> s_testData;
+
+	static ImVec4 GetPerformanceColor(float value, float lowThreshold, float highThreshold);
+	static ImVec4 GetPerformanceStatusColor(int status);  // Use int for now if PerformanceStatus is not defined
+	static bool RenderColorCodedMetric(const char* label, float value, float lowThreshold, float highThreshold, const char* format);
+};

--- a/src/Features/PerformanceOverlay/ABTesting/ABTestAggregator.cpp
+++ b/src/Features/PerformanceOverlay/ABTesting/ABTestAggregator.cpp
@@ -1,0 +1,223 @@
+#include "ABTestAggregator.h"
+#include "Features/PerformanceOverlay.h"
+#include <algorithm>
+#include <map>
+#include <numeric>
+
+void ABTestAggregator::OnABSwitch(ABVariant variant)
+{
+	auto now = std::chrono::steady_clock::now();
+
+	// End the current interval if it exists
+	if (currentInterval) {
+		currentInterval->endTime = now;
+		intervals.push_back(std::move(*currentInterval));
+	}
+
+	// Start a new interval
+	currentInterval = new ABInterval{ variant, {}, now, now };
+
+	// Record test start time on first switch
+	if (intervals.empty()) {
+		testStartTime = now;
+	}
+}
+
+void ABTestAggregator::OnFrame(const std::vector<DrawCallRow>& rows)
+{
+	if (!currentInterval)
+		return;
+
+	// Find the Total row to check for outliers and shader compilation
+	float totalFrameTime = 0.0f;
+	for (const auto& row : rows) {
+		if (row.shaderType == -1) {  // Total row
+			totalFrameTime = row.frameTime;
+			break;
+		}
+	}
+
+	// Outlier detection: exclude frames that are more than 3x the median or > 100ms
+	// This catches shader compilation spikes, JSON loading, and other anomalies
+	static std::vector<float> recentFrameTimes;
+	recentFrameTimes.push_back(totalFrameTime);
+	if (recentFrameTimes.size() > kFrameHistoryBaseline) {  // Keep last 30 frames for baseline
+		recentFrameTimes.erase(recentFrameTimes.begin());
+	}
+
+	bool isOutlier = false;
+	if (recentFrameTimes.size() >= kMinimumFramesForAnalysis) {  // Need at least 10 frames for statistical analysis
+		// Calculate median of recent frames
+		std::vector<float> sortedTimes = recentFrameTimes;
+		std::sort(sortedTimes.begin(), sortedTimes.end());
+		float median = sortedTimes[sortedTimes.size() / 2];
+
+		// Check if current frame is an outlier
+		if (totalFrameTime > median * kOutlierMultiplier || totalFrameTime > kMaxOutlierFrameTime) {
+			isOutlier = true;
+			currentInterval->excludedFrames++;
+		}
+	}
+
+	// Only add frame if it's not an outlier
+	if (!isOutlier) {
+		currentInterval->frameRows.push_back(rows);
+	}
+}
+
+void ABTestAggregator::OnTestEnd()
+{
+	auto now = std::chrono::steady_clock::now();
+	testEndTime = now;
+
+	if (currentInterval) {
+		currentInterval->endTime = now;
+		intervals.push_back(std::move(*currentInterval));
+		currentInterval = nullptr;
+	}
+}
+
+void ABTestAggregator::Clear()
+{
+	intervals.clear();
+	if (currentInterval) {
+		delete currentInterval;
+		currentInterval = nullptr;
+	}
+	hasSettingsA = false;
+	hasSettingsB = false;
+	settingsA.clear();
+	settingsB.clear();
+}
+
+static float mean(const std::vector<float>& v)
+{
+	if (v.empty())
+		return 0.0f;
+	return std::accumulate(v.begin(), v.end(), 0.0f) / v.size();
+}
+
+static float median(std::vector<float> v)
+{
+	if (v.empty())
+		return 0.0f;
+	std::nth_element(v.begin(), v.begin() + v.size() / 2, v.end());
+	return v[v.size() / 2];
+}
+
+std::vector<AggregatedDrawCallStats> ABTestAggregator::GetAggregatedResults() const
+{
+	// Map: shaderType -> label
+	std::map<int, std::string> labelMap;
+	// Map: shaderType -> all frameTimes/costPerCall for A and B
+	std::map<int, std::vector<float>> aFrameTimes, bFrameTimes;
+	std::map<int, std::vector<float>> aCostPerCall, bCostPerCall;
+
+	for (const auto& interval : intervals) {
+		for (const auto& frameRows : interval.frameRows) {
+			for (const auto& row : frameRows) {
+				labelMap[row.shaderType] = row.label;
+				if (interval.variant == ABVariant::A) {
+					aFrameTimes[row.shaderType].push_back(row.frameTime);
+					aCostPerCall[row.shaderType].push_back(row.costPerCall);
+				} else {
+					bFrameTimes[row.shaderType].push_back(row.frameTime);
+					bCostPerCall[row.shaderType].push_back(row.costPerCall);
+				}
+			}
+		}
+	}
+
+	std::vector<AggregatedDrawCallStats> result;
+	for (const auto& [shaderType, label] : labelMap) {
+		AggregatedDrawCallStats stats;
+		stats.label = label;
+		stats.shaderType = shaderType;
+		stats.meanA = mean(aFrameTimes[shaderType]);
+		stats.meanB = mean(bFrameTimes[shaderType]);
+		stats.medianA = median(aFrameTimes[shaderType]);
+		stats.medianB = median(bFrameTimes[shaderType]);
+		stats.delta = stats.meanB - stats.meanA;
+		stats.frameCountA = static_cast<int>(aFrameTimes[shaderType].size());
+		stats.frameCountB = static_cast<int>(bFrameTimes[shaderType].size());
+		stats.totalTimeA = std::accumulate(aFrameTimes[shaderType].begin(), aFrameTimes[shaderType].end(), 0.0f);
+		stats.totalTimeB = std::accumulate(bFrameTimes[shaderType].begin(), bFrameTimes[shaderType].end(), 0.0f);
+		result.push_back(stats);
+	}
+
+	// Sort: put Total (-1) and Other (-2) at the end
+	std::sort(result.begin(), result.end(), [](const AggregatedDrawCallStats& a, const AggregatedDrawCallStats& b) {
+		// Special handling for summary rows - always put them at the end
+		if (a.shaderType == -1 || a.shaderType == -2) {
+			if (b.shaderType == -1 || b.shaderType == -2) {
+				// Both are summary rows, sort by shader type (Other before Total)
+				return a.shaderType < b.shaderType;
+			}
+			return false;  // a is summary, b is not, so a goes after b
+		}
+		if (b.shaderType == -1 || b.shaderType == -2) {
+			return true;  // b is summary, a is not, so b goes after a
+		}
+		// Both are regular shaders, sort normally
+		return a.shaderType < b.shaderType;
+	});
+
+	// Ensure Total and Other are always included even if they have no data
+	bool hasTotal = false, hasOther = false;
+	for (const auto& stat : result) {
+		if (stat.shaderType == -1)
+			hasTotal = true;
+		if (stat.shaderType == -2)
+			hasOther = true;
+	}
+
+	if (!hasTotal) {
+		AggregatedDrawCallStats totalStat;
+		totalStat.label = "Total:";
+		totalStat.shaderType = -1;
+		result.push_back(totalStat);
+	}
+
+	if (!hasOther) {
+		AggregatedDrawCallStats otherStat;
+		otherStat.label = "Other:";
+		otherStat.shaderType = -2;
+		result.push_back(otherStat);
+	}
+	return result;
+}
+
+void ABTestAggregator::SetSettingsA(const nlohmann::json& settings)
+{
+	if (!hasSettingsA) {
+		settingsA = settings;
+		hasSettingsA = true;
+	}
+}
+
+void ABTestAggregator::SetSettingsB(const nlohmann::json& settings)
+{
+	if (!hasSettingsB) {
+		settingsB = settings;
+		hasSettingsB = true;
+	}
+}
+
+float ABTestAggregator::GetTotalTestDuration() const
+{
+	if (intervals.empty())
+		return 0.0f;
+
+	auto start = intervals.front().startTime;
+	auto end = intervals.back().endTime;
+	return std::chrono::duration<float>(end - start).count();
+}
+
+int ABTestAggregator::GetTotalFrameCount() const
+{
+	int total = 0;
+	for (const auto& interval : intervals) {
+		total += static_cast<int>(interval.frameRows.size());
+	}
+	return total;
+}

--- a/src/Features/PerformanceOverlay/ABTesting/ABTestAggregator.cpp
+++ b/src/Features/PerformanceOverlay/ABTesting/ABTestAggregator.cpp
@@ -15,7 +15,7 @@ void ABTestAggregator::OnABSwitch(ABVariant variant)
 	}
 
 	// Start a new interval
-	currentInterval = new ABInterval{ variant, {}, now, now };
+	currentInterval = std::make_unique<ABInterval>(variant, std::vector<std::vector<DrawCallRow>>{}, now, now);
 
 	// Record test start time on first switch
 	if (intervals.empty()) {
@@ -39,7 +39,6 @@ void ABTestAggregator::OnFrame(const std::vector<DrawCallRow>& rows)
 
 	// Outlier detection: exclude frames that are more than 3x the median or > 100ms
 	// This catches shader compilation spikes, JSON loading, and other anomalies
-	static std::vector<float> recentFrameTimes;
 	recentFrameTimes.push_back(totalFrameTime);
 	if (recentFrameTimes.size() > kFrameHistoryBaseline) {  // Keep last 30 frames for baseline
 		recentFrameTimes.erase(recentFrameTimes.begin());
@@ -73,17 +72,15 @@ void ABTestAggregator::OnTestEnd()
 	if (currentInterval) {
 		currentInterval->endTime = now;
 		intervals.push_back(std::move(*currentInterval));
-		currentInterval = nullptr;
+		currentInterval.reset();
 	}
 }
 
 void ABTestAggregator::Clear()
 {
 	intervals.clear();
-	if (currentInterval) {
-		delete currentInterval;
-		currentInterval = nullptr;
-	}
+	currentInterval.reset();
+	recentFrameTimes.clear();
 	hasSettingsA = false;
 	hasSettingsB = false;
 	settingsA.clear();

--- a/src/Features/PerformanceOverlay/ABTesting/ABTestAggregator.h
+++ b/src/Features/PerformanceOverlay/ABTesting/ABTestAggregator.h
@@ -1,0 +1,90 @@
+#pragma once
+#include <chrono>
+#include <nlohmann/json.hpp>
+#include <vector>
+
+// A/B Testing constants
+constexpr size_t kFrameHistoryBaseline = 30;
+constexpr size_t kMinimumFramesForAnalysis = 10;
+constexpr float kOutlierMultiplier = 3.0f;
+constexpr float kMaxOutlierFrameTime = 100.0f;
+
+// Statistical validation constants
+constexpr int kMinimumSamplesForValidity = 100;      // Industry standard minimum
+constexpr float kMinimumTestDuration = 10.0f;        // At least 10 seconds
+constexpr float kMinimumValidFramesPercent = 80.0f;  // At least 80% valid frames
+constexpr int kMinimumSamplesForMarginal = 30;       // Minimum for marginal validity
+constexpr float kMinimumDurationForMarginal = 5.0f;  // Minimum duration for marginal validity
+
+// Only define ABVariant here
+enum class ABVariant
+{
+	A,
+	B
+};
+
+// Forward declarations
+struct DrawCallRow;
+
+struct AggregatedDrawCallStats
+{
+	std::string label;
+	int shaderType;
+	float meanA = 0.0f, meanB = 0.0f, delta = 0.0f;
+	float medianA = 0.0f, medianB = 0.0f;
+	int frameCountA = 0, frameCountB = 0;
+	float totalTimeA = 0.0f, totalTimeB = 0.0f;
+	// Add more stats as needed
+};
+
+struct ABInterval
+{
+	ABVariant variant;
+	std::vector<std::vector<DrawCallRow>> frameRows;
+	std::chrono::steady_clock::time_point startTime;
+	std::chrono::steady_clock::time_point endTime;
+	int excludedFrames = 0;  // Frames excluded due to outliers or shader compilation
+};
+
+class ABTestAggregator
+{
+public:
+	void OnABSwitch(ABVariant variant);
+	void OnFrame(const std::vector<DrawCallRow>& rows);
+	void OnTestEnd();
+	std::vector<AggregatedDrawCallStats> GetAggregatedResults() const;
+	bool HasResults() const { return !intervals.empty(); }
+	void Clear();
+
+	// --- Settings diff functionality ---
+	// Call these on first switch to each variant
+	void SetSettingsA(const nlohmann::json& settings);
+	void SetSettingsB(const nlohmann::json& settings);
+
+	// Test statistics
+	float GetTotalTestDuration() const;
+	int GetTotalFrameCount() const;
+	std::chrono::steady_clock::time_point GetTestStartTime() const { return testStartTime; }
+	std::chrono::steady_clock::time_point GetTestEndTime() const { return testEndTime; }
+	const std::vector<ABInterval>& GetIntervals() const { return intervals; }
+
+	// Settings access
+	const nlohmann::json& GetSettingsA() const { return settingsA; }
+	const nlohmann::json& GetSettingsB() const { return settingsB; }
+	bool HasSettingsA() const { return hasSettingsA; }
+	bool HasSettingsB() const { return hasSettingsB; }
+
+private:
+	std::vector<ABInterval> intervals;
+	ABInterval* currentInterval = nullptr;
+
+	// Settings snapshots
+	nlohmann::json settingsA;
+	nlohmann::json settingsB;
+	bool hasSettingsA = false;
+	bool hasSettingsB = false;
+
+	// Test timing
+	std::chrono::steady_clock::time_point testStartTime;
+	std::chrono::steady_clock::time_point testEndTime;
+};

--- a/src/Features/PerformanceOverlay/ABTesting/ABTestAggregator.h
+++ b/src/Features/PerformanceOverlay/ABTesting/ABTestAggregator.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <chrono>
+#include <memory>
 #include <nlohmann/json.hpp>
 #include <vector>
 
@@ -76,7 +77,7 @@ public:
 
 private:
 	std::vector<ABInterval> intervals;
-	ABInterval* currentInterval = nullptr;
+	std::unique_ptr<ABInterval> currentInterval;
 
 	// Settings snapshots
 	nlohmann::json settingsA;
@@ -87,4 +88,7 @@ private:
 	// Test timing
 	std::chrono::steady_clock::time_point testStartTime;
 	std::chrono::steady_clock::time_point testEndTime;
+
+	// Frame history for outlier detection
+	std::vector<float> recentFrameTimes;
 };

--- a/src/Features/PerformanceOverlay/ABTesting/ABTesting.cpp
+++ b/src/Features/PerformanceOverlay/ABTesting/ABTesting.cpp
@@ -1,0 +1,129 @@
+#include "ABTesting.h"
+#include "Features/PerformanceOverlay.h"
+#include "Menu.h"
+#include "State.h"
+#include "Utils/UI.h"
+#include <fmt/format.h>
+#include <imgui.h>
+
+ABTestingManager* ABTestingManager::GetSingleton()
+{
+	static ABTestingManager singleton;
+	return &singleton;
+}
+
+void ABTestingManager::SetTestInterval(uint32_t interval)
+{
+	testInterval = interval;
+}
+
+void ABTestingManager::Enable()
+{
+	if (!abTestingEnabled) {
+		auto* state = globals::state;
+		auto* performanceOverlay = PerformanceOverlay::GetSingleton();
+
+		logger::info("Saving current settings for Variant B (TEST) and starting test with interval {}.", testInterval);
+		state->Save(State::ConfigMode::TEST);
+		abTestingEnabled = true;
+
+		// Preserve overlay enabled state
+		bool overlayWasEnabled = performanceOverlay->settings.ShowInOverlay;
+		performanceOverlay->settings.ShowInOverlay = overlayWasEnabled;
+	}
+}
+
+void ABTestingManager::Disable()
+{
+	if (abTestingEnabled) {
+		auto* state = globals::state;
+		auto* performanceOverlay = PerformanceOverlay::GetSingleton();
+
+		logger::info("Disabling A/B testing. Will restore to Variant B (TEST) config.");
+		state->Load(State::ConfigMode::TEST);  // restore last settings before entering test mode
+		abTestingEnabled = false;
+
+		// Preserve overlay enabled state
+		bool overlayWasEnabled = performanceOverlay->settings.ShowInOverlay;
+		performanceOverlay->settings.ShowInOverlay = overlayWasEnabled;
+	}
+}
+
+void ABTestingManager::Update()
+{
+	if (!abTestingEnabled)
+		return;
+
+	auto* state = globals::state;
+	auto* performanceOverlay = PerformanceOverlay::GetSingleton();
+
+	// Preserve overlay enabled state when switching configs
+	float seconds = std::chrono::duration<float>(
+		std::chrono::high_resolution_clock::now() - lastTestSwitch)
+	                    .count();
+	auto remaining = static_cast<float>(testInterval) - seconds;
+
+	if (remaining < 0.0f) {
+		bool overlayWasEnabled = performanceOverlay->settings.ShowInOverlay;
+		usingTestConfig = !usingTestConfig;
+		logger::info("Swapping to {} (A/B Test): {}",
+			usingTestConfig ? "Variant B (TEST)" : "Variant A (USER)",
+			usingTestConfig ? "TEST config" : "USER config");
+		state->Load(usingTestConfig ? State::ConfigMode::TEST : State::ConfigMode::USER);
+		performanceOverlay->settings.ShowInOverlay = overlayWasEnabled;  // Restore overlay state
+		lastTestSwitch = std::chrono::high_resolution_clock::now();
+
+		// Notify the A/B test aggregator of the variant switch
+		aggregator.OnABSwitch(usingTestConfig ? ABVariant::B : ABVariant::A);
+	}
+}
+
+void ABTestingManager::DrawSettingsUI()
+{
+	auto* performanceOverlay = PerformanceOverlay::GetSingleton();
+
+	if (ImGui::SliderInt("A/B Test Interval", reinterpret_cast<int*>(&testInterval), 0, 10)) {
+		bool overlayWasEnabled = performanceOverlay->settings.ShowInOverlay;
+		if (testInterval == 0) {
+			Disable();
+		} else if (!abTestingEnabled) {
+			Enable();
+		} else {
+			logger::info("Setting new A/B test interval {}.", testInterval);
+		}
+		performanceOverlay->settings.ShowInOverlay = overlayWasEnabled;
+	}
+
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text(
+			"Sets number of seconds before toggling between Variant A (USER) and Variant B (TEST) config for A/B testing. "
+			"0 disables. Non-zero will enable A/B testing mode. "
+			"Enabling will save current settings as TEST config (Variant B). "
+			"This has no impact if no settings are changed. "
+			"Variant A = USER config, Variant B = TEST config.");
+	}
+}
+
+void ABTestingManager::DrawOverlayUI()
+{
+	if (!abTestingEnabled)
+		return;
+
+	float seconds = std::chrono::duration<float>(
+		std::chrono::high_resolution_clock::now() - lastTestSwitch)
+	                    .count();
+	auto remaining = static_cast<float>(testInterval) - seconds;
+
+	ImGui::SetNextWindowBgAlpha(1.0f);
+	ImGui::SetNextWindowPos(ImVec2(10, 10));
+	if (!ImGui::Begin("Testing", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings)) {
+		ImGui::End();
+		return;
+	}
+
+	remaining = std::max(0.0f, remaining);
+	ImGui::Text(fmt::format("{} : {:.1f} seconds left",
+		usingTestConfig ? "Variant B (TEST)" : "Variant A (USER)", remaining)
+			.c_str());
+	ImGui::End();
+}

--- a/src/Features/PerformanceOverlay/ABTesting/ABTesting.h
+++ b/src/Features/PerformanceOverlay/ABTesting/ABTesting.h
@@ -1,0 +1,37 @@
+#pragma once
+#include "ABTestAggregator.h"
+#include <chrono>
+#include <nlohmann/json.hpp>
+#include <vector>
+
+// A/B Testing Manager - handles the overall A/B testing system
+class ABTestingManager
+{
+public:
+	static ABTestingManager* GetSingleton();
+
+	// Configuration
+	void SetTestInterval(uint32_t interval);
+	uint32_t GetTestInterval() const { return testInterval; }
+	bool IsEnabled() const { return abTestingEnabled; }
+	bool IsUsingTestConfig() const { return usingTestConfig; }
+
+	// State management
+	void Enable();
+	void Disable();
+	void Update();  // Called each frame to handle timing and switching
+
+	// UI
+	void DrawSettingsUI();  // The A/B test interval slider
+	void DrawOverlayUI();   // The "Variant X: Y seconds left" overlay
+
+	// Access to aggregator
+	ABTestAggregator& GetAggregator() { return aggregator; }
+
+private:
+	uint32_t testInterval = 0;
+	bool abTestingEnabled = false;
+	bool usingTestConfig = false;
+	std::chrono::high_resolution_clock::time_point lastTestSwitch;
+	ABTestAggregator aggregator;
+};

--- a/src/Features/WeatherPicker.cpp
+++ b/src/Features/WeatherPicker.cpp
@@ -2,6 +2,14 @@
 #include "Feature.h"
 #include "Menu.h"
 #include "Utils/Game.h"
+#include <nlohmann/json.hpp>
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+	WeatherPicker::WeatherDetailsWindowSettings,
+	Enabled,
+	ShowInOverlay,
+	Position,
+	PositionSet)
 
 void WeatherPicker::DataLoaded()
 {
@@ -26,20 +34,19 @@ std::pair<std::string, std::vector<std::string>> WeatherPicker::GetFeatureSummar
 void WeatherPicker::DrawSettings()
 {
 	if (ImGui::TreeNodeEx("Weather Details", ImGuiTreeNodeFlags_DefaultOpen)) {
-		auto menu = Menu::GetSingleton();
-		const auto& themeSettings = menu->GetTheme();
-		const auto& menuSettings = menu->GetSettings();
+		const auto& themeSettings = Menu::GetSingleton()->GetTheme();
+		const auto& menuSettings = Menu::GetSingleton()->GetSettings();
 
 		// Show as Overlay checkbox
-		bool windowEnabled = menuSettings.WeatherDetailsWindow.Enabled;
-		if (ImGui::Checkbox("Show as Overlay", &windowEnabled)) {
-			menu->GetSettings().WeatherDetailsWindow.Enabled = windowEnabled;
+		bool showInOverlay = WeatherPicker::GetSingleton()->WeatherDetailsWindow.ShowInOverlay;
+		if (ImGui::Checkbox("Show in Overlay", &showInOverlay)) {
+			WeatherPicker::GetSingleton()->WeatherDetailsWindow.ShowInOverlay = showInOverlay;
 		}
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Opens weather details in a separate window that stays open\neven when the main menu is closed. ");
 			ImGui::Text("Toggle with ");
 			ImGui::SameLine();
-			ImGui::TextColored(themeSettings.StatusPalette.CurrentHotkey, "%s", Menu::KeyIdToString(menuSettings.PerfOverlay.OverlayToggleKey));
+			ImGui::TextColored(themeSettings.StatusPalette.CurrentHotkey, "%s", Menu::KeyIdToString(menuSettings.OverlayToggleKey));
 		}
 		ImGui::Spacing();
 
@@ -58,24 +65,21 @@ void WeatherPicker::RenderWeatherDetailsWindow(bool* open)
 	if (!*open)
 		return;
 
-	auto menu = Menu::GetSingleton();
-	auto& settings = menu->GetSettings();
-
 	// Set initial position if not already set
-	if (!settings.WeatherDetailsWindow.PositionSet) {
+	if (!WeatherDetailsWindow.PositionSet) {
 		ImGui::SetNextWindowPos(ImVec2(50.0f, 50.0f));
-		settings.WeatherDetailsWindow.Position = ImVec2(50.0f, 50.0f);
-		settings.WeatherDetailsWindow.PositionSet = true;
+		WeatherDetailsWindow.Position = ImVec2(50.0f, 50.0f);
+		WeatherDetailsWindow.PositionSet = true;
 	} else {
-		ImGui::SetNextWindowPos(settings.WeatherDetailsWindow.Position, ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowPos(WeatherDetailsWindow.Position, ImGuiCond_FirstUseEver);
 	}
 
 	ImGui::SetNextWindowSize(ImVec2(600, 800), ImGuiCond_FirstUseEver);
 	if (ImGui::Begin("Weather Details##Popup", open, ImGuiWindowFlags_None)) {
 		// Remember window position for next frame
 		ImVec2 currentPos = ImGui::GetWindowPos();
-		if (currentPos.x != settings.WeatherDetailsWindow.Position.x || currentPos.y != settings.WeatherDetailsWindow.Position.y) {
-			settings.WeatherDetailsWindow.Position = currentPos;
+		if (currentPos.x != WeatherDetailsWindow.Position.x || currentPos.y != WeatherDetailsWindow.Position.y) {
+			WeatherDetailsWindow.Position = currentPos;
 		}
 
 		// Enable interactive elements when a menu is open
@@ -194,8 +198,7 @@ void WeatherPicker::DisplayLightningInfo(RE::TESWeather* weather, bool showInter
 {
 	if (!weather || weather->data.thunderLightningFrequency <= 0)
 		return;
-	auto menu = Menu::GetSingleton();
-	const auto& theme = menu->GetTheme();
+	const auto& theme = Menu::GetSingleton()->GetTheme();
 	uint8_t lightningR = weather->data.lightningColor.red;
 	uint8_t lightningG = weather->data.lightningColor.green;
 	uint8_t lightningB = weather->data.lightningColor.blue;
@@ -288,8 +291,7 @@ void WeatherPicker::DisplayWindInfo(RE::TESWeather* weather)
 	auto sky = globals::game::sky;
 	if (!weather || (weather->data.windSpeed <= 0 && (!sky || sky->windSpeed <= 0.0f)))
 		return;
-	auto menu = Menu::GetSingleton();
-	const auto& theme = menu->GetTheme();
+	const auto& theme = Menu::GetSingleton()->GetTheme();
 	float windSpeedDisplay = weather->data.windSpeed / 255.0f;
 	ImGui::BulletText("Weather Wind Speed: %.2f (raw %d)", windSpeedDisplay, weather->data.windSpeed);
 	if (auto _tt = Util::HoverTooltipWrapper()) {
@@ -853,4 +855,22 @@ std::string WeatherPicker::GetDisplayName(const RE::TESWeather* weather)
 		return std::string(editorID);
 	}
 	return std::to_string(weather->GetFormID());
+}
+
+void WeatherPicker::DrawOverlay()
+{
+	bool overlayVisible = Menu::GetSingleton()->overlayVisible;
+	// If ShowInOverlay is true and overlay is visible, auto-enable the window if not already enabled
+	if (WeatherDetailsWindow.ShowInOverlay && overlayVisible) {
+		if (!WeatherDetailsWindow.Enabled) {
+			WeatherDetailsWindow.Enabled = true;
+		}
+		bool* p_open = &WeatherDetailsWindow.Enabled;
+		RenderWeatherDetailsWindow(p_open);
+	}
+}
+
+bool WeatherPicker::IsOverlayVisible() const
+{
+	return WeatherDetailsWindow.ShowInOverlay;
 }

--- a/src/Features/WeatherPicker.h
+++ b/src/Features/WeatherPicker.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "Feature.h"
+#include "Menu.h"
+#include "OverlayFeature.h"
 
-struct WeatherPicker : Feature
+struct WeatherPicker : OverlayFeature
 {
 	static WeatherPicker* GetSingleton()
 	{
@@ -35,6 +36,14 @@ struct WeatherPicker : Feature
 	// --- Refactor helpers for RenderCoreWeatherDetails ---
 	static void RenderWeatherControls(RE::Sky* sky);
 	static void RenderWeatherInformationDisplay(RE::Sky* sky, bool showInteractiveElements = true);
+
+	struct WeatherDetailsWindowSettings
+	{
+		bool Enabled = false;
+		bool ShowInOverlay = false;
+		ImVec2 Position = ImVec2(50.f, 50.f);
+		bool PositionSet = false;
+	} WeatherDetailsWindow;
 
 public:
 	/**
@@ -108,4 +117,8 @@ private:
 	static void UpdateFilteredWeathers();
 	static int FindWeatherIndex(RE::TESWeather* targetWeather);
 	static std::vector<std::string> GetWeatherFlagNames(RE::TESWeather* weather);
+
+	// Implement OverlayFeature interface
+	void DrawOverlay() override;
+	bool IsOverlayVisible() const override;
 };

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -23,6 +23,7 @@
 #include "Features/InverseSquareLighting.h"
 #include "Features/LODBlending.h"
 #include "Features/LightLimitFix.h"
+#include "Features/PerformanceOverlay.h"
 #include "Features/ScreenSpaceGI.h"
 #include "Features/ScreenSpaceShadows.h"
 #include "Features/SkySync.h"
@@ -77,6 +78,7 @@ namespace globals
 		VR* vr = nullptr;
 		WaterEffects* waterEffects = nullptr;
 		WeatherPicker* weatherPicker = nullptr;
+		PerformanceOverlay* performanceOverlay = nullptr;
 		WetnessEffects* wetnessEffects = nullptr;
 		ExtendedTranslucency* extendedTranslucency = nullptr;
 
@@ -162,6 +164,7 @@ namespace globals
 		features::vr = VR::GetSingleton();
 		features::waterEffects = WaterEffects::GetSingleton();
 		features::weatherPicker = WeatherPicker::GetSingleton();
+		features::performanceOverlay = PerformanceOverlay::GetSingleton();
 		features::wetnessEffects = WetnessEffects::GetSingleton();
 		features::extendedTranslucency = ExtendedTranslucency::GetSingleton();
 

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -24,6 +24,7 @@ struct VolumetricLighting;
 struct VR;
 struct WaterEffects;
 struct WeatherPicker;
+struct PerformanceOverlay;
 struct WetnessEffects;
 struct ExtendedTranslucency;
 
@@ -78,6 +79,7 @@ namespace globals
 		extern VR* vr;
 		extern WaterEffects* waterEffects;
 		extern WeatherPicker* weatherPicker;
+		extern PerformanceOverlay* performanceOverlay;
 		extern WetnessEffects* wetnessEffects;
 		extern ExtendedTranslucency* extendedTranslucency;
 

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -2066,13 +2066,14 @@ void Menu::PerfOverlayState::DrawFPS(Settings::PerfOverlaySettings& settings)
 		ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));  // Green line
 
 		// Draw the graph
+		float graphWidth = ImGui::GetWindowWidth() * 0.9f;
 		ImGui::PlotLines("##frametime",
 			frameTimeHistory.data(),
 			settings.FrameHistorySize,
 			frameTimeHistoryIndex,
 			overlay_text,
 			smoothedMinFrameTime, smoothedMaxFrameTime,
-			ImVec2(-FLT_MIN, 50.0f * textScale));
+			ImVec2(graphWidth, 50.0f * textScale));
 
 		ImGui::PopStyleColor();
 
@@ -2129,13 +2130,14 @@ void Menu::PerfOverlayState::DrawPostFGFrameTimeGraph(Settings::PerfOverlaySetti
 	ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
 
 	// Draw the graph
+	float graphWidth = ImGui::GetWindowWidth() * 0.9f;
 	ImGui::PlotLines("##postfgframetime",
 		postFGFrameTimeHistory.data(),
 		settings.FrameHistorySize,
 		postFGFrameTimeHistoryIndex,
 		overlay_text,
 		smoothedMinFrameTime, smoothedMaxFrameTime,
-		ImVec2(ImGui::GetWindowWidth() * 0.9f, 50.0f * textScale));
+		ImVec2(graphWidth, 50.0f * textScale));
 
 	ImGui::PopStyleColor();
 

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1705,7 +1705,7 @@ void Menu::DrawOverlay()
 
 	// Always update test data during TEST phase, regardless of overlay visibility
 	if (abTestingManager->IsEnabled()) {
-		PerformanceOverlay::UpdateAllShaderTestData();
+		PerformanceOverlay::GetSingleton()->UpdateAllShaderTestData();
 
 		// Add A/B test aggregator data collection here
 		if (auto* overlay = PerformanceOverlay::GetSingleton()) {

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -24,6 +24,8 @@
 
 #include "Features/LightLimitFix/ParticleLights.h"
 #include "Features/PerformanceOverlay.h"
+#include "Features/PerformanceOverlay/ABTesting/ABTestAggregator.h"
+#include "Features/PerformanceOverlay/ABTesting/ABTesting.h"
 #include "Features/WeatherPicker.h"
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
@@ -1415,29 +1417,9 @@ void Menu::DrawAdvancedSettings()
 				"The more threads the faster compilation will finish but may make the system unresponsive. ");
 		}
 
-		if (ImGui::SliderInt("A/B Test Interval", reinterpret_cast<int*>(&testInterval), 0, 10)) {
-			bool overlayWasEnabled = PerformanceOverlay::GetSingleton()->settings.ShowInOverlay;
-			if (testInterval == 0) {
-				abTestingEnabled = false;
-				logger::info("Disabling A/B testing. Will restore to Variant B (TEST) config.");
-				globals::state->Load(State::ConfigMode::TEST);  // restore last settings before entering test mode
-			} else if (!abTestingEnabled) {
-				logger::info("Saving current settings for Variant B (TEST) and starting test with interval {}.", testInterval);
-				globals::state->Save(State::ConfigMode::TEST);
-				abTestingEnabled = true;
-			} else {
-				logger::info("Setting new A/B test interval {}.", testInterval);
-			}
-			PerformanceOverlay::GetSingleton()->settings.ShowInOverlay = overlayWasEnabled;
-		}
-		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text(
-				"Sets number of seconds before toggling between Variant A (USER) and Variant B (TEST) config for A/B testing. "
-				"0 disables. Non-zero will enable A/B testing mode. "
-				"Enabling will save current settings as TEST config (Variant B). "
-				"This has no impact if no settings are changed. "
-				"Variant A = USER config, Variant B = TEST config.");
-		}
+		// A/B Testing settings
+		auto* abTestingManager = ABTestingManager::GetSingleton();
+		abTestingManager->DrawSettingsUI();
 		bool useFileWatcher = shaderCache->UseFileWatcher();
 		ImGui::TableNextColumn();
 		if (ImGui::Checkbox("Enable File Watcher", &useFileWatcher)) {
@@ -1484,17 +1466,16 @@ void Menu::DrawAdvancedSettings()
 	if (ImGui::CollapsingHeader("Replace Original Shaders", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick)) {
 		auto state = globals::state;
 		if (ImGui::BeginTable("##ReplaceToggles", 3, ImGuiTableFlags_SizingStretchSame)) {
-			for (int classIndex = 0; classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++classIndex) {
+			globals::state->ForEachShaderTypeWithIndex([&](auto type, int classIndex) {
 				ImGui::TableNextColumn();
 
-				auto type = magic_enum::enum_value<RE::BSShader::Type>(classIndex + 1);
 				if (!(SIE::ShaderCache::IsSupportedShader(type) || state->IsDeveloperMode())) {
 					ImGui::BeginDisabled();
 					ImGui::Checkbox(std::format("{}", magic_enum::enum_name(type)).c_str(), &state->enabledClasses[classIndex]);
 					ImGui::EndDisabled();
 				} else
 					ImGui::Checkbox(std::format("{}", magic_enum::enum_name(type)).c_str(), &state->enabledClasses[classIndex]);
-			}
+			});
 			if (state->IsDeveloperMode()) {
 				ImGui::Checkbox("Vertex", &state->enableVShaders);
 				if (auto _tt = Util::HoverTooltipWrapper()) {
@@ -1638,7 +1619,8 @@ void Menu::DrawOverlay()
 	auto shaderCache = globals::shaderCache;
 	auto failed = shaderCache->GetFailedTasks();
 	auto hide = shaderCache->IsHideErrors();
-	if (!(shaderCache->IsCompiling() || IsEnabled || abTestingEnabled || (failed && !hide) || PerformanceOverlay::GetSingleton()->settings.ShowInOverlay)) {
+	auto* abTestingManager = ABTestingManager::GetSingleton();
+	if (!(shaderCache->IsCompiling() || IsEnabled || abTestingManager->IsEnabled() || (failed && !hide) || PerformanceOverlay::GetSingleton()->settings.ShowInOverlay)) {
 		auto& io = ImGui::GetIO();
 		io.ClearInputKeys();
 		io.ClearEventsQueue();
@@ -1718,30 +1700,26 @@ void Menu::DrawOverlay()
 		}
 	}
 
-	if (abTestingEnabled) {  // In test mode
-		// Preserve overlay enabled state when switching configs
-		float seconds = (float)duration_cast<std::chrono::milliseconds>(high_resolution_clock::now() - lastTestSwitch).count() / 1000.0f;
-		auto remaining = (float)testInterval - seconds;
-		if (remaining < 0.0f) {
-			bool overlayWasEnabled = PerformanceOverlay::GetSingleton()->settings.ShowInOverlay;
-			Menu::GetSingleton()->usingTestConfig = !Menu::GetSingleton()->usingTestConfig;
-			logger::info("Swapping to {} (A/B Test): {}", Menu::GetSingleton()->usingTestConfig ? "Variant B (TEST)" : "Variant A (USER)", Menu::GetSingleton()->usingTestConfig ? "TEST config" : "USER config");
-			globals::state->Load(Menu::GetSingleton()->usingTestConfig ? State::ConfigMode::TEST : State::ConfigMode::USER);
-			PerformanceOverlay::GetSingleton()->settings.ShowInOverlay = overlayWasEnabled;  // Restore overlay state
-			lastTestSwitch = high_resolution_clock::now();
-		}
-		// Always update test data during TEST phase, regardless of overlay visibility
+	// A/B Testing management
+	abTestingManager->Update();
+
+	// Always update test data during TEST phase, regardless of overlay visibility
+	if (abTestingManager->IsEnabled()) {
 		PerformanceOverlay::UpdateAllShaderTestData();
-		ImGui::SetNextWindowBgAlpha(1.0f);
-		ImGui::SetNextWindowPos(ImVec2(10, 10));
-		if (!ImGui::Begin("Testing", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings)) {
-			ImGui::End();
-			return;
+
+		// Add A/B test aggregator data collection here
+		if (auto* overlay = PerformanceOverlay::GetSingleton()) {
+			auto [mainRows, summaryRows] = overlay->BuildDrawCallRows();
+			std::vector<DrawCallRow> allRows = mainRows;
+			allRows.insert(allRows.end(), summaryRows.begin(), summaryRows.end());
+
+			// Update the A/B test aggregator with current frame data
+			abTestingManager->GetAggregator().OnFrame(allRows);
 		}
-		remaining = std::max(0.0f, remaining);
-		ImGui::Text(fmt::format("{} : {:.1f} seconds left", Menu::GetSingleton()->usingTestConfig ? "Variant B (TEST)" : "Variant A (USER)", remaining).c_str());
-		ImGui::End();
 	}
+
+	// Draw A/B testing overlay
+	abTestingManager->DrawOverlayUI();
 
 	ImGuiStyle& style = ImGui::GetStyle();
 	style = oldStyle;

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -140,6 +140,9 @@ struct DrawCallRow
 	float costPerCall;
 	std::string tooltip;
 	bool enabled;
+	// Test data columns
+	std::optional<float> testFrameTime;
+	std::optional<float> testCostPerCall;
 };
 
 typedef RE::BSShader::Type ShaderTypeEnum;
@@ -157,8 +160,51 @@ enum DrawCallTableColumn
 	Col_DrawCalls,
 	Col_FrameTime,
 	Col_CostPerCall,
-	Col_Count  // always last, gives you the number of columns
+	Col_TestFrameTime,    // Optional: Test Frame Time (ms)
+	Col_TestCostPerCall,  // Optional: Test Cost/Call (ms)
+	Col_Count             // always last, gives you the number of columns (not including test columns)
 };
+
+// Runtime-only test data storage
+struct TestData
+{
+	float frameTime;
+	float costPerCall;
+	float percent;
+};
+static std::unordered_map<int, TestData> s_testData;
+static bool abTestingEnabled = false;
+static void UpdateShaderTestData(int shaderType, float frameTime, float costPerCall)
+{
+	s_testData[shaderType] = { frameTime, costPerCall };
+}
+
+// Add this function near the top of Menu.cpp (after abTestingEnabled, usingTestConfig, etc.)
+static void UpdateAllShaderTestData()
+{
+	if (!(abTestingEnabled && Menu::GetSingleton()->usingTestConfig))
+		return;
+	// Use the smoothed frame time for all calculations
+	float smoothedFrameTime = static_cast<float>(Menu::GetSingleton()->perfOverlayState.smoothFrameTimeMs);
+	float measuredSum = 0.0f;
+	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
+	for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
+		if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
+			continue;
+		int typeIndex = magic_enum::enum_integer(type);
+		float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
+		float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
+		float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
+		float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
+		s_testData[typeIndex] = { frameTime, costPerCall, percent };
+		measuredSum += frameTime;
+	}
+	float otherFrameTime = smoothedFrameTime - measuredSum;
+	float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
+	s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
+	float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
+	s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+}
 
 void Menu::SetupImGuiStyle() const
 {
@@ -1453,25 +1499,28 @@ void Menu::DrawAdvancedSettings()
 				"The more threads the faster compilation will finish but may make the system unresponsive. ");
 		}
 
-		if (ImGui::SliderInt("Test Interval", reinterpret_cast<int*>(&testInterval), 0, 10)) {
+		if (ImGui::SliderInt("A/B Test Interval", reinterpret_cast<int*>(&testInterval), 0, 10)) {
+			bool overlayWasEnabled = settings.PerfOverlay.Enabled;
 			if (testInterval == 0) {
-				inTestMode = false;
-				logger::info("Disabling test mode.");
+				abTestingEnabled = false;
+				logger::info("Disabling A/B testing. Will restore to Variant B (TEST) config.");
 				globals::state->Load(State::ConfigMode::TEST);  // restore last settings before entering test mode
-			} else if (!inTestMode) {
-				logger::info("Saving current settings for test mode and starting test with interval {}.", testInterval);
+			} else if (!abTestingEnabled) {
+				logger::info("Saving current settings for Variant B (TEST) and starting test with interval {}.", testInterval);
 				globals::state->Save(State::ConfigMode::TEST);
-				inTestMode = true;
+				abTestingEnabled = true;
 			} else {
-				logger::info("Setting new interval {}.", testInterval);
+				logger::info("Setting new A/B test interval {}.", testInterval);
 			}
+			settings.PerfOverlay.Enabled = overlayWasEnabled;
 		}
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
-				"Sets number of seconds before toggling between default USER and TEST config. "
-				"0 disables. Non-zero will enable testing mode. "
-				"Enabling will save current settings as TEST config. "
-				"This has no impact if no settings are changed. ");
+				"Sets number of seconds before toggling between Variant A (USER) and Variant B (TEST) config for A/B testing. "
+				"0 disables. Non-zero will enable A/B testing mode. "
+				"Enabling will save current settings as TEST config (Variant B). "
+				"This has no impact if no settings are changed. "
+				"Variant A = USER config, Variant B = TEST config.");
 		}
 		bool useFileWatcher = shaderCache->UseFileWatcher();
 		ImGui::TableNextColumn();
@@ -1674,7 +1723,7 @@ void Menu::DrawOverlay()
 	auto shaderCache = globals::shaderCache;
 	auto failed = shaderCache->GetFailedTasks();
 	auto hide = shaderCache->IsHideErrors();
-	if (!(shaderCache->IsCompiling() || IsEnabled || inTestMode || (failed && !hide) || settings.PerfOverlay.Enabled)) {
+	if (!(shaderCache->IsCompiling() || IsEnabled || abTestingEnabled || (failed && !hide) || settings.PerfOverlay.Enabled)) {
 		auto& io = ImGui::GetIO();
 		io.ClearInputKeys();
 		io.ClearEventsQueue();
@@ -1751,22 +1800,27 @@ void Menu::DrawOverlay()
 	// Draw weather details window independently of main menu
 	DrawWeatherDetailsWindow();
 
-	if (inTestMode) {  // In test mode
+	if (abTestingEnabled) {  // In test mode
+		// Preserve overlay enabled state when switching configs
 		float seconds = (float)duration_cast<std::chrono::milliseconds>(high_resolution_clock::now() - lastTestSwitch).count() / 1000.0f;
 		auto remaining = (float)testInterval - seconds;
 		if (remaining < 0.0f) {
-			usingTestConfig = !usingTestConfig;
-			logger::info("Swapping mode to {}", usingTestConfig ? "test" : "user");
-			globals::state->Load(usingTestConfig ? State::ConfigMode::TEST : State::ConfigMode::USER);
+			bool overlayWasEnabled = settings.PerfOverlay.Enabled;
+			Menu::GetSingleton()->usingTestConfig = !Menu::GetSingleton()->usingTestConfig;
+			logger::info("Swapping to {} (A/B Test): {}", Menu::GetSingleton()->usingTestConfig ? "Variant B (TEST)" : "Variant A (USER)", Menu::GetSingleton()->usingTestConfig ? "TEST config" : "USER config");
+			globals::state->Load(Menu::GetSingleton()->usingTestConfig ? State::ConfigMode::TEST : State::ConfigMode::USER);
+			settings.PerfOverlay.Enabled = overlayWasEnabled;  // Restore overlay state
 			lastTestSwitch = high_resolution_clock::now();
 		}
+		// Always update test data during TEST phase, regardless of overlay visibility
+		UpdateAllShaderTestData();
 		ImGui::SetNextWindowBgAlpha(1.0f);
 		ImGui::SetNextWindowPos(ImVec2(10, 10));
 		if (!ImGui::Begin("Testing", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings)) {
 			ImGui::End();
 			return;
 		}
-		ImGui::Text(fmt::format("{} Mode : {:.1f} seconds left", usingTestConfig ? "Test" : "User", remaining).c_str());
+		ImGui::Text(fmt::format("{} : {:.1f} seconds left", Menu::GetSingleton()->usingTestConfig ? "Variant B (TEST)" : "Variant A (USER)", remaining).c_str());
 		ImGui::End();
 	}
 
@@ -2195,8 +2249,23 @@ void Menu::PerfOverlayState::DrawPostFGFrameTimeGraph(Settings::PerfOverlaySetti
  */
 void Menu::PerfOverlayState::DrawDrawCalls()
 {
+	static bool clearTestDataRequested = false;
+	if (!s_testData.empty()) {
+		if (ImGui::Button("Clear Test Data")) {
+			clearTestDataRequested = true;
+		}
+		ImGui::SameLine();
+		ImGui::TextDisabled("Test columns are shown only when test data is present.");
+	}
+
+	// Build headers and column count dynamically
 	std::vector<std::string> headers = { "Shader Type", "Draw Calls", "Frame Time (%)", "Cost/Call" };
-	std::vector<DrawCallRow> rows;
+	bool anyTestData = !s_testData.empty();
+	if (anyTestData) {
+		headers.push_back("Test Frame Time (%)");
+		headers.push_back("Test Cost/Call");
+	}
+	int columnCount = static_cast<int>(headers.size());
 
 	// Tooltip map for shader types
 	static const std::unordered_map<RE::BSShader::Type, std::string> kShaderTypeTooltips = {
@@ -2232,27 +2301,60 @@ void Menu::PerfOverlayState::DrawDrawCalls()
 
 	// Use the smoothed frame time for all calculations
 	float smoothedFrameTime = static_cast<float>(Menu::GetSingleton()->perfOverlayState.smoothFrameTimeMs);
+
+	// --- TEST DATA RECORDING IN TEST MODE ---
+	float measuredSum = 0.0f;
+	float otherFrameTime = 0.0f;
+	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
+	if (abTestingEnabled && Menu::GetSingleton()->usingTestConfig) {
+		for (const auto& row : shaderTypes) {
+			auto typeIndex = magic_enum::enum_integer(row.type);
+			float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
+			float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
+			float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
+			float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
+			s_testData[typeIndex] = { frameTime, costPerCall, percent };
+			measuredSum += frameTime;
+		}
+		otherFrameTime = smoothedFrameTime - measuredSum;
+		float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
+		s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
+		float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
+		s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+	}
+
 	// Build main rows: all shader types
 	std::vector<DrawCallRow> mainRows;
-	float measuredSum = 0.0f;
+	measuredSum = 0.0f;
 	for (const auto& row : shaderTypes) {
-		auto typeIndex = magic_enum::enum_integer(row.type);  // safer than static_cast<int>
+		auto typeIndex = magic_enum::enum_integer(row.type);
 		float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
 		float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
-		float percent = 0.0f;  // We'll fill this in after we know the total
+		float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
 		float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
 		// Clamp small negative values to zero
 		if (std::abs(frameTime) < 1e-4f)
 			frameTime = 0.0f;
 		if (std::abs(costPerCall) < 1e-6f)
 			costPerCall = 0.0f;
-		bool enabled = globals::state->enabledClasses[typeIndex - 1];  // -1 for enabledClasses
-		mainRows.push_back({ row.label, typeIndex, static_cast<int>(drawCalls), frameTime, percent, costPerCall, row.tooltip, enabled });
+		bool enabled = globals::state->enabledClasses[typeIndex - 1];
+		std::optional<float> testFrameTime, testCostPerCall;
+		if ((abTestingEnabled && Menu::GetSingleton()->usingTestConfig) || !enabled) {
+			s_testData[typeIndex] = { frameTime, costPerCall, percent };
+		}
+		auto it = s_testData.find(typeIndex);
+		if (it != s_testData.end()) {
+			testFrameTime = it->second.frameTime;
+			testCostPerCall = it->second.costPerCall;
+			anyTestData = true;
+		}
+		DrawCallRow rowObj{ row.label, typeIndex, static_cast<int>(drawCalls), frameTime, percent, costPerCall, row.tooltip, enabled, testFrameTime, testCostPerCall };
+		mainRows.push_back(rowObj);
 		measuredSum += frameTime;
 	}
 
 	// Add summary rows (not part of main sorting)
-	float otherFrameTime = smoothedFrameTime - measuredSum;
+	otherFrameTime = smoothedFrameTime - measuredSum;
 	if (std::abs(otherFrameTime) < 1e-4f)
 		otherFrameTime = 0.0f;
 
@@ -2263,17 +2365,11 @@ void Menu::PerfOverlayState::DrawDrawCalls()
 		std::string("Frame time not attributed to any measured shader type. This includes UI, post-processing, engine work, and any GPU activity not directly measured by the overlay.")
 	};
 
-	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
 	DrawCallRow totalRow = {
 		"Total:", -1, static_cast<int>(totalSmoothedDrawCalls), smoothedFrameTime, 100.0f,
 		(totalSmoothedDrawCalls > 0.0f ? static_cast<float>(smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f),
 		std::string("Sum of all measured shader types.\nClick to enable or disable all shaders.")
 	};
-	// Now update percent and costPerCall for all measured rows
-	for (auto& row : mainRows) {
-		row.percent = (smoothedFrameTime > 0.0f) ? (row.frameTime / smoothedFrameTime) * 100.0f : 0.0f;
-		row.costPerCall = (row.drawCalls > 0) ? (row.frameTime / row.drawCalls) : 0.0f;
-	}
 
 	// Always start the main table sorted alphabetically by label on first display
 	static bool firstTableDisplay = true;
@@ -2285,35 +2381,59 @@ void Menu::PerfOverlayState::DrawDrawCalls()
 	}
 
 	// Handle sorting: only sort mainRows, never summary rows
-	if (ImGui::BeginTable("DrawCallOverlayTable##", Col_Count, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable)) {
-		for (const auto& header : headers)
-			ImGui::TableSetupColumn(header.c_str());
+	if (ImGui::BeginTable("DrawCallOverlayTable##", columnCount, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable)) {
+		// --- HEADER SETUP WITH TOOLTIP ---
+		for (int i = 0; i < headers.size(); ++i) {
+			ImGui::TableSetupColumn(headers[i].c_str());
+			if (anyTestData && (headers[i] == "Test Frame Time" || headers[i] == "Test Cost/Call")) {
+				if (ImGui::IsItemHovered()) {
+					if (abTestingEnabled) {
+						ImGui::SetTooltip("A/B Test: This data was recorded during the last TEST phase (Variant B). It is frozen until the next TEST phase.\nVariant A = USER config, Variant B = TEST config.");
+					} else {
+						ImGui::SetTooltip("Test data is recorded when a shader is disabled. Green = better, Red = worse vs. regular column.\nA/B Test: Variant A = USER config, Variant B = TEST config.");
+					}
+				}
+			}
+		}
 		ImGui::TableHeadersRow();
 
 		if (const ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs()) {
 			if (sortSpecs->SpecsCount > 0) {
 				sortColumn = sortSpecs->Specs->ColumnIndex;
 				sortAscending = sortSpecs->Specs->SortDirection == ImGuiSortDirection_Ascending;
-				// Sort using real data
 				switch (sortColumn) {
-				case Col_Label:  // label (shader type name)
+				case Col_Label:
 					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
 						return sortAscending ? (a.label < b.label) : (a.label > b.label);
 					});
 					break;
-				case Col_DrawCalls:  // drawCalls (number of draw calls)
+				case Col_DrawCalls:
 					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
 						return sortAscending ? (a.drawCalls < b.drawCalls) : (a.drawCalls > b.drawCalls);
 					});
 					break;
-				case Col_FrameTime:  // percent (frame time %)
+				case Col_FrameTime:
 					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
 						return sortAscending ? (a.percent < b.percent) : (a.percent > b.percent);
 					});
 					break;
-				case Col_CostPerCall:  // costPerCall (ms per draw call)
+				case Col_CostPerCall:
 					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
 						return sortAscending ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall);
+					});
+					break;
+				case Col_TestFrameTime:
+					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
+						float aVal = a.testFrameTime.value_or(FLT_MAX);
+						float bVal = b.testFrameTime.value_or(FLT_MAX);
+						return sortAscending ? (aVal < bVal) : (aVal > bVal);
+					});
+					break;
+				case Col_TestCostPerCall:
+					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
+						float aVal = a.testCostPerCall.value_or(FLT_MAX);
+						float bVal = b.testCostPerCall.value_or(FLT_MAX);
+						return sortAscending ? (aVal < bVal) : (aVal > bVal);
 					});
 					break;
 				}
@@ -2324,184 +2444,225 @@ void Menu::PerfOverlayState::DrawDrawCalls()
 		for (size_t rowIdx = 0; rowIdx < mainRows.size(); ++rowIdx) {
 			const auto& row = mainRows[rowIdx];
 			ImGui::TableNextRow();
-			for (int col = 0; col < Col_Count; ++col) {
-				ImGui::TableSetColumnIndex(col);
-				ImVec4 color = ImGui::GetStyleColorVec4(ImGuiCol_Text);
-				bool useColor = false;
-				switch (col) {
-				case Col_FrameTime:  // percent coloring
-					if (row.percent < 30.0f)
-						color = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
-					else if (row.percent < 60.0f)
-						color = Menu::GetSingleton()->GetTheme().StatusPalette.Warning;
-					else
-						color = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
-					useColor = true;
-					break;
-				case Col_CostPerCall:  // costPerCall coloring (ms per draw call)
-					if (row.costPerCall < 0.05f)
-						color = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
-					else if (row.costPerCall < 0.2f)
-						color = Menu::GetSingleton()->GetTheme().StatusPalette.Warning;
-					else
-						color = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
-					useColor = true;
-					break;
-				}
-				// --- Cell rendering switch: draws the actual cell content ---
-				bool wasEnabled = false;
-				switch (col) {
-				case Col_Label:  // Label (shader type name)
-					if (!row.enabled) {
-						ImGui::PushStyleColor(ImGuiCol_Text, Menu::GetSingleton()->GetTheme().StatusPalette.Disable);
+			int colIdx = 0;
+			// Label
+			ImGui::TableSetColumnIndex(colIdx++);
+			if (!row.enabled) {
+				ImGui::PushStyleColor(ImGuiCol_Text, Menu::GetSingleton()->GetTheme().StatusPalette.Disable);
+			}
+			bool wasEnabled = row.enabled;
+			if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
+				auto maybeType = magic_enum::enum_cast<RE::BSShader::Type>(row.shaderType);
+				if (maybeType.has_value()) {
+					auto classIndex = magic_enum::enum_integer(*maybeType) - 1;
+					if (classIndex >= 0 && classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1) {
+						globals::state->enabledClasses[classIndex] = !wasEnabled;
+						// Also update test data when toggled
+						UpdateShaderTestData(row.shaderType, row.frameTime, row.costPerCall);
 					}
-					wasEnabled = row.enabled;
-					if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
-						// Use magic_enum::enum_cast for safety
-						auto maybeType = magic_enum::enum_cast<RE::BSShader::Type>(row.shaderType);
-						if (maybeType.has_value()) {
-							auto classIndex = magic_enum::enum_integer(*maybeType) - 1;
-							if (classIndex >= 0 && classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1) {
-								globals::state->enabledClasses[classIndex] = !wasEnabled;
-							}
+				}
+			}
+			if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup | ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
+				ImGui::SetTooltip("%s", row.tooltip.c_str());
+			}
+			if (!row.enabled) {
+				ImGui::PopStyleColor();
+			}
+			// Draw Calls
+			ImGui::TableSetColumnIndex(colIdx++);
+			ImGui::Text("%d", row.drawCalls);
+			// Frame Time (%)
+			ImGui::TableSetColumnIndex(colIdx++);
+			ImVec4 color = ImGui::GetStyleColorVec4(ImGuiCol_Text);
+			if (row.percent < 30.0f)
+				color = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
+			else if (row.percent < 60.0f)
+				color = Menu::GetSingleton()->GetTheme().StatusPalette.Warning;
+			else
+				color = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
+			ImGui::PushStyleColor(ImGuiCol_Text, color);
+			ImGui::Text("%.2f ms (%.1f%%)", row.frameTime, row.percent);
+			ImGui::PopStyleColor();
+			// Cost/Call
+			ImGui::TableSetColumnIndex(colIdx++);
+			if (row.costPerCall < 0.05f)
+				color = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
+			else if (row.costPerCall < 0.2f)
+				color = Menu::GetSingleton()->GetTheme().StatusPalette.Warning;
+			else
+				color = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
+			ImGui::PushStyleColor(ImGuiCol_Text, color);
+			if (row.costPerCall < 0.01f && row.costPerCall > 0.0f)
+				ImGui::Text("%.2f us", row.costPerCall * 1000.0f);
+			else
+				ImGui::Text("%.3f ms", row.costPerCall);
+			ImGui::PopStyleColor();
+			// Test columns if present
+			if (anyTestData) {
+				// Test Frame Time
+				ImGui::TableSetColumnIndex(colIdx++);
+				if (row.testFrameTime.has_value()) {
+					ImVec4 testColor = ImGui::GetStyleColorVec4(ImGuiCol_Text);
+					if (*row.testFrameTime < row.frameTime)
+						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
+					else if (*row.testFrameTime > row.frameTime)
+						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
+					ImGui::PushStyleColor(ImGuiCol_Text, testColor);
+					ImGui::Text("%.2f ms (%.1f%%)", *row.testFrameTime, s_testData[row.shaderType].percent);
+					ImGui::PopStyleColor();
+					if (ImGui::IsItemHovered()) {
+						if (abTestingEnabled) {
+							ImGui::SetTooltip("A/B Test: This data was recorded during the last TEST phase (Variant B). It is frozen until the next TEST phase.\nVariant A = USER config, Variant B = TEST config.");
+						} else {
+							ImGui::SetTooltip("Test data is recorded when a shader is disabled. Green = better, Red = worse vs. regular column.\nA/B Test: Variant A = USER config, Variant B = TEST config.");
 						}
 					}
-					// Show tooltip if hovered
-					if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup | ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
-						ImGui::SetTooltip("%s", row.tooltip.c_str());
-					}
-					if (!row.enabled) {
-						ImGui::PopStyleColor();
-					}
-					break;
-				case Col_DrawCalls:  // Draw Calls (number of draw calls)
-					if (useColor)
-						ImGui::TextColored(color, "%d", row.drawCalls);
+				} else {
+					ImGui::TextDisabled("-");
+				}
+				// Test Cost/Call
+				ImGui::TableSetColumnIndex(colIdx++);
+				if (row.testCostPerCall.has_value()) {
+					ImVec4 testColor = ImGui::GetStyleColorVec4(ImGuiCol_Text);
+					if (*row.testCostPerCall < row.costPerCall)
+						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
+					else if (*row.testCostPerCall > row.costPerCall)
+						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
+					ImGui::PushStyleColor(ImGuiCol_Text, testColor);
+					if (*row.testCostPerCall < 0.01f && *row.testCostPerCall > 0.0f)
+						ImGui::Text("%.2f us", *row.testCostPerCall * 1000.0f);
 					else
-						ImGui::Text("%d", row.drawCalls);
-					break;
-				case Col_FrameTime:  // Frame Time (ms and %)
-					if (useColor)
-						ImGui::TextColored(color, "%.2f ms (%.1f%%)", row.frameTime, row.percent);
-					else
-						ImGui::Text("%.2f ms (%.1f%%)", row.frameTime, row.percent);
-					break;
-				case Col_CostPerCall:  // Cost/Call (ms or us per draw call)
-					if (row.costPerCall < 0.01f && row.costPerCall > 0.0f) {
-						if (useColor)
-							ImGui::TextColored(color, "%.2f us", row.costPerCall * 1000.0f);
-						else
-							ImGui::Text("%.2f us", row.costPerCall * 1000.0f);
-					} else {
-						if (useColor)
-							ImGui::TextColored(color, "%.3f ms", row.costPerCall);
-						else
-							ImGui::Text("%.3f ms", row.costPerCall);
+						ImGui::Text("%.3f ms", *row.testCostPerCall);
+					ImGui::PopStyleColor();
+					if (ImGui::IsItemHovered()) {
+						if (abTestingEnabled) {
+							ImGui::SetTooltip("A/B Test: This data was recorded during the last TEST phase (Variant B). It is frozen until the next TEST phase.\nVariant A = USER config, Variant B = TEST config.");
+						} else {
+							ImGui::SetTooltip("Test data is recorded when a shader is disabled. Green = better, Red = worse vs. regular column.\nA/B Test: Variant A = USER config, Variant B = TEST config.");
+						}
 					}
-					break;
+				} else {
+					ImGui::TextDisabled("-");
 				}
 			}
 		}
-
 		// Separator row (optional, for visual separation)
 		ImGui::TableNextRow(ImGuiTableRowFlags_None, 4.0f);
-		for (int col = 0; col < Col_Count; ++col) {
+		for (int col = 0; col < columnCount; ++col) {
 			ImGui::TableSetColumnIndex(col);
-			if (col == Col_Label)
+			if (col == 0)
 				ImGui::Separator();
 		}
-
-		// --- Summary row rendering switch: handles Other and Total rows ---
+		// Summary rows (Other, Total)
 		for (const DrawCallRow& row : { otherRow, totalRow }) {
 			ImGui::TableNextRow();
-			for (int col = 0; col < Col_Count; ++col) {
-				ImGui::TableSetColumnIndex(col);
-				ImVec4 color = ImGui::GetStyleColorVec4(ImGuiCol_Text);
-				bool useColor = false;
-				// Set color and useColor for percent and costPerCall columns before the switch
-				if (col == Col_FrameTime) {  // percent coloring (frame time %)
-					if (row.percent < 30.0f)
-						color = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
-					else if (row.percent < 60.0f)
-						color = Menu::GetSingleton()->GetTheme().StatusPalette.Warning;
-					else
-						color = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
-					useColor = true;
-				} else if (col == Col_CostPerCall) {  // costPerCall coloring (ms per draw call)
-					if (row.costPerCall < 0.05f)
-						color = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
-					else if (row.costPerCall < 0.2f)
-						color = Menu::GetSingleton()->GetTheme().StatusPalette.Warning;
-					else
-						color = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
-					useColor = true;
+			int colIdx = 0;
+			ImGui::TableSetColumnIndex(colIdx++);
+			if (row.label == std::string("Total:")) {
+				if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
+					bool anyDisabled = false;
+					for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
+						if (!globals::state->enabledClasses[i]) {
+							anyDisabled = true;
+							break;
+						}
+					}
+					for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
+						globals::state->enabledClasses[i] = anyDisabled;
+					}
 				}
-				// --- Cell rendering for summary rows ---
-				switch (col) {
-				case Col_Label:  // Label (Other/Total)
-					// Make Total row clickable to toggle all shaders
-					if (row.label == std::string("Total:")) {
-						if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
-							// If any are disabled, enable all; else disable all
-							bool anyDisabled = false;
-							for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
-								if (!globals::state->enabledClasses[i]) {
-									anyDisabled = true;
-									break;
-								}
-							}
-							for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
-								globals::state->enabledClasses[i] = anyDisabled;
-							}
-						}
-					} else {
-						ImGui::TextUnformatted(row.label.c_str());
+			} else {
+				ImGui::TextUnformatted(row.label.c_str());
+			}
+			if (!row.tooltip.empty() && ImGui::IsItemHovered()) {
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					ImGui::TextUnformatted(row.tooltip.c_str());
+				}
+			}
+			ImGui::TableSetColumnIndex(colIdx++);
+			if (row.label == "Other:" && row.drawCalls <= 0) {
+				ImGui::TextUnformatted("N/A");
+			} else {
+				ImGui::Text("%d", row.drawCalls);
+			}
+			ImGui::TableSetColumnIndex(colIdx++);
+			if (row.label == "Other:" && row.frameTime <= 0.0f) {
+				ImGui::TextUnformatted("N/A");
+			} else {
+				ImGui::Text("%.2f ms (%.1f%%)", row.frameTime, row.percent);
+				if (row.label == "Total:" && ImGui::IsItemHovered()) {
+					float _fps = row.frameTime > 0.0f ? 1000.0f / row.frameTime : 0.0f;
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::Text("FPS: %.2f", _fps);
 					}
-					if (!row.tooltip.empty() && ImGui::IsItemHovered()) {
+				}
+			}
+			ImGui::TableSetColumnIndex(colIdx++);
+			if (row.label == "Other:" && row.costPerCall <= 0.0f) {
+				ImGui::TextUnformatted("N/A");
+			} else if (row.costPerCall < 0.01f && row.costPerCall > 0.0f) {
+				ImGui::Text("%.2f us", row.costPerCall * 1000.0f);
+			} else {
+				ImGui::Text("%.3f ms", row.costPerCall);
+			}
+			if (anyTestData) {
+				ImGui::TableSetColumnIndex(colIdx++);
+				auto testIt = s_testData.find(row.shaderType);
+				if (testIt != s_testData.end()) {
+					ImVec4 testColor = ImGui::GetStyleColorVec4(ImGuiCol_Text);
+					if (testIt->second.frameTime < row.frameTime)
+						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
+					else if (testIt->second.frameTime > row.frameTime)
+						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
+					ImGui::PushStyleColor(ImGuiCol_Text, testColor);
+					ImGui::Text("%.2f ms (%.1f%%)", testIt->second.frameTime, testIt->second.percent);
+					ImGui::PopStyleColor();
+					if (ImGui::IsItemHovered()) {
+						if (abTestingEnabled) {
+							ImGui::SetTooltip("A/B Test: This data was recorded during the last TEST phase (Variant B). It is frozen until the next TEST phase.\nVariant A = USER config, Variant B = TEST config.");
+						} else {
+							ImGui::SetTooltip("Test data is recorded when a shader is disabled. Green = better, Red = worse vs. regular column.\nA/B Test: Variant A = USER config, Variant B = TEST config.");
+						}
+						// Show FPS for test frame time
+						float _fps = testIt->second.frameTime > 0.0f ? 1000.0f / testIt->second.frameTime : 0.0f;
 						if (auto _tt = Util::HoverTooltipWrapper()) {
-							ImGui::TextUnformatted(row.tooltip.c_str());
+							ImGui::Text("FPS: %.2f", _fps);
 						}
 					}
-					break;
-				case Col_DrawCalls:  // Draw Calls (Other/Total)
-					if (row.label == "Other:" && row.drawCalls <= 0) {
-						ImGui::TextUnformatted("N/A");
-					} else {
-						if (useColor)
-							ImGui::TextColored(color, "%d", row.drawCalls);
-						else
-							ImGui::Text("%d", row.drawCalls);
+				} else {
+					ImGui::TextUnformatted("N/A");
+				}
+				ImGui::TableSetColumnIndex(colIdx++);
+				if (testIt != s_testData.end()) {
+					ImVec4 testColor = ImGui::GetStyleColorVec4(ImGuiCol_Text);
+					if (testIt->second.costPerCall < row.costPerCall)
+						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
+					else if (testIt->second.costPerCall > row.costPerCall)
+						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
+					ImGui::PushStyleColor(ImGuiCol_Text, testColor);
+					if (testIt->second.costPerCall < 0.01f && testIt->second.costPerCall > 0.0f)
+						ImGui::Text("%.2f us", testIt->second.costPerCall * 1000.0f);
+					else
+						ImGui::Text("%.3f ms", testIt->second.costPerCall);
+					ImGui::PopStyleColor();
+					if (ImGui::IsItemHovered()) {
+						if (abTestingEnabled) {
+							ImGui::SetTooltip("A/B Test: This data was recorded during the last TEST phase (Variant B). It is frozen until the next TEST phase.\nVariant A = USER config, Variant B = TEST config.");
+						} else {
+							ImGui::SetTooltip("Test data is recorded when a shader is disabled. Green = better, Red = worse vs. regular column.\nA/B Test: Variant A = USER config, Variant B = TEST config.");
+						}
 					}
-					break;
-				case Col_FrameTime:  // Frame Time (Other/Total)
-					if (row.label == "Other:" && row.frameTime <= 0.0f) {
-						ImGui::TextUnformatted("N/A");
-					} else {
-						if (useColor)
-							ImGui::TextColored(color, "%.2f ms (%.1f%%)", row.frameTime, row.percent);
-						else
-							ImGui::Text("%.2f ms (%.1f%%)", row.frameTime, row.percent);
-					}
-					break;
-				case Col_CostPerCall:  // Cost/Call (Other/Total)
-					if (row.label == "Other:" && row.costPerCall <= 0.0f) {
-						ImGui::TextUnformatted("N/A");
-					} else if (row.costPerCall < 0.01f && row.costPerCall > 0.0f) {
-						if (useColor)
-							ImGui::TextColored(color, "%.2f us", row.costPerCall * 1000.0f);
-						else
-							ImGui::Text("%.2f us", row.costPerCall * 1000.0f);
-					} else {
-						if (useColor)
-							ImGui::TextColored(color, "%.3f ms", row.costPerCall);
-						else
-							ImGui::Text("%.3f ms", row.costPerCall);
-					}
-					break;
+				} else {
+					ImGui::TextUnformatted("N/A");
 				}
 			}
 		}
 		ImGui::EndTable();
+	}
+
+	if (clearTestDataRequested) {
+		s_testData.clear();
+		clearTestDataRequested = false;
 	}
 }
 

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -23,6 +23,7 @@
 #include "Utils/UI.h"
 
 #include "Features/LightLimitFix/ParticleLights.h"
+#include "Features/PerformanceOverlay.h"
 #include "Features/WeatherPicker.h"
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
@@ -46,29 +47,6 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ColorDefault,
 	ColorHovered,
 	MinimizedFactor)
-
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
-	Menu::Settings::PerfOverlaySettings,
-	Enabled,
-	ShowDrawCalls,
-	ShowVRAM,
-	ShowFPS,
-	ShowPreFGFrameTimeGraph,
-	ShowPostFGFrameTimeGraph,
-	UpdateInterval,
-	FrameHistorySize,
-	Size,
-	BackgroundOpacity,
-	ShowBorder,
-	Position,
-	PositionSet,
-	OverlayToggleKey)
-
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
-	Menu::Settings::WeatherDetailsWindowSettings,
-	Enabled,
-	Position,
-	PositionSet)
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ImGuiStyle,
@@ -124,137 +102,10 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ToggleKey,
 	SkipCompilationKey,
 	EffectToggleKey,
-	Theme,
-	PerfOverlay)
+	OverlayToggleKey,
+	Theme)
 
 constexpr std::uint16_t KEY_PRESSED_MASK = 0x8000;
-
-// Struct for draw call overlay table row data
-struct DrawCallRow
-{
-	std::string label;
-	int shaderType;
-	int drawCalls;
-	float frameTime;
-	float percent;
-	float costPerCall;
-	std::string tooltip;
-	bool enabled;
-	// Test data columns
-	std::optional<float> testFrameTime;
-	std::optional<float> testCostPerCall;
-};
-
-typedef RE::BSShader::Type ShaderTypeEnum;
-struct ShaderRow
-{
-	std::string label;
-	ShaderTypeEnum type;
-	std::string tooltip;
-};
-
-// Define an enum for table columns for clarity and maintainability
-enum DrawCallTableColumn
-{
-	Col_Label = 0,
-	Col_DrawCalls,
-	Col_FrameTime,
-	Col_CostPerCall,
-	Col_TestFrameTime,    // Optional: Test Frame Time (ms)
-	Col_TestCostPerCall,  // Optional: Test Cost/Call (ms)
-	Col_Count             // always last, gives you the number of columns (not including test columns)
-};
-
-// Runtime-only test data storage
-struct TestData
-{
-	float frameTime;
-	float costPerCall;
-	float percent;
-};
-
-// Test data source tracking
-enum class TestDataSource
-{
-	None,
-	ABTest_VariantB,
-	ManualShaderToggle
-};
-static TestDataSource s_testDataSource = TestDataSource::None;
-static std::chrono::steady_clock::time_point s_testDataLastUpdated;
-static std::string TimeAgoString(std::chrono::steady_clock::time_point a_last)
-{
-	using namespace std::chrono;
-	auto now = steady_clock::now();
-	auto diff = duration_cast<seconds>(now - a_last).count();
-	if (diff < 60)
-		return std::to_string(diff) + "s";
-	return std::to_string(diff / 60) + "m";
-}
-
-static std::unordered_map<int, TestData> s_testData;
-static bool abTestingEnabled = false;
-static void UpdateShaderTestData(int shaderType, float frameTime, float costPerCall)
-{
-	s_testData[shaderType] = { frameTime, costPerCall };
-	// Compute and save 'Other' and 'Total' test data
-	float smoothedFrameTime = static_cast<float>(Menu::GetSingleton()->perfOverlayState.smoothFrameTimeMs);
-	float measuredSum = 0.0f;
-	for (const auto& [type, data] : s_testData) {
-		if (type >= 0)
-			measuredSum += data.frameTime;
-	}
-	float otherFrameTime = smoothedFrameTime - measuredSum;
-	float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
-	s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
-	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
-	float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
-	s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
-
-	s_testDataSource = TestDataSource::ManualShaderToggle;
-	s_testDataLastUpdated = std::chrono::steady_clock::now();
-}
-
-// Add this function near the top of Menu.cpp (after abTestingEnabled, usingTestConfig, etc.)
-static void UpdateAllShaderTestData()
-{
-	if (!(abTestingEnabled && Menu::GetSingleton()->usingTestConfig))
-		return;
-	// Use the smoothed frame time for all calculations
-	float smoothedFrameTime = static_cast<float>(Menu::GetSingleton()->perfOverlayState.smoothFrameTimeMs);
-	float measuredSum = 0.0f;
-	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
-	for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
-		if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
-			continue;
-		int typeIndex = magic_enum::enum_integer(type);
-		float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
-		float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
-		float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
-		float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
-		s_testData[typeIndex] = { frameTime, costPerCall, percent };
-		measuredSum += frameTime;
-	}
-	float otherFrameTime = smoothedFrameTime - measuredSum;
-	float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
-	s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
-	float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
-	s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
-	s_testDataSource = TestDataSource::ABTest_VariantB;
-	s_testDataLastUpdated = std::chrono::steady_clock::now();
-}
-
-static std::string GetTestDataTooltip()
-{
-	switch (s_testDataSource) {
-	case TestDataSource::ABTest_VariantB:
-		return std::string("Test data from Test (Variant B).\nLast updated: ") + TimeAgoString(s_testDataLastUpdated) + " ago.";
-	case TestDataSource::ManualShaderToggle:
-		return std::string("Test data from manual shader toggle.\nLast updated: ") + TimeAgoString(s_testDataLastUpdated) + " ago.";
-	default:
-		return "No test data available.";
-	}
-}
 
 void Menu::SetupImGuiStyle() const
 {
@@ -1358,6 +1209,21 @@ void Menu::DrawGeneralSettings()
 					settingSkipCompilationKey = true;
 				}
 			}
+			if (settingOverlayToggleKey) {
+				ImGui::Text("Press any key to set as a toggle key for displaying the overlay...");
+			} else {
+				ImGui::AlignTextToFramePadding();
+				ImGui::Text("Overlay Toggle Key:");
+				ImGui::SameLine();
+				ImGui::AlignTextToFramePadding();
+				ImGui::TextColored(themeSettings.StatusPalette.CurrentHotkey, "%s", KeyIdToString(settings.OverlayToggleKey));
+
+				ImGui::AlignTextToFramePadding();
+				ImGui::SameLine();
+				if (ImGui::Button("Change##OverlayToggle")) {
+					settingOverlayToggleKey = true;
+				}
+			}
 			ImGui::EndTabItem();
 		}
 		if (ImGui::BeginTabItem("Interface")) {
@@ -1550,7 +1416,7 @@ void Menu::DrawAdvancedSettings()
 		}
 
 		if (ImGui::SliderInt("A/B Test Interval", reinterpret_cast<int*>(&testInterval), 0, 10)) {
-			bool overlayWasEnabled = settings.PerfOverlay.Enabled;
+			bool overlayWasEnabled = PerformanceOverlay::GetSingleton()->settings.ShowInOverlay;
 			if (testInterval == 0) {
 				abTestingEnabled = false;
 				logger::info("Disabling A/B testing. Will restore to Variant B (TEST) config.");
@@ -1562,7 +1428,7 @@ void Menu::DrawAdvancedSettings()
 			} else {
 				logger::info("Setting new A/B test interval {}.", testInterval);
 			}
-			settings.PerfOverlay.Enabled = overlayWasEnabled;
+			PerformanceOverlay::GetSingleton()->settings.ShowInOverlay = overlayWasEnabled;
 		}
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
@@ -1725,8 +1591,7 @@ void Menu::DrawDisplaySettings()
 		auto& themeSettings = settings.Theme;
 
 		const std::vector<std::pair<std::string, std::function<void()>>> features = {
-			{ "Upscaling", []() { globals::upscaling->DrawSettings(); } },
-			{ "Performance Overlay", [this]() { DrawPerformanceOverlaySettings(); } }
+			{ "Upscaling", []() { globals::upscaling->DrawSettings(); } }
 		};
 
 		for (const auto& [featureName, drawFunc] : features) {
@@ -1773,7 +1638,7 @@ void Menu::DrawOverlay()
 	auto shaderCache = globals::shaderCache;
 	auto failed = shaderCache->GetFailedTasks();
 	auto hide = shaderCache->IsHideErrors();
-	if (!(shaderCache->IsCompiling() || IsEnabled || abTestingEnabled || (failed && !hide) || settings.PerfOverlay.Enabled)) {
+	if (!(shaderCache->IsCompiling() || IsEnabled || abTestingEnabled || (failed && !hide) || PerformanceOverlay::GetSingleton()->settings.ShowInOverlay)) {
 		auto& io = ImGui::GetIO();
 		io.ClearInputKeys();
 		io.ClearEventsQueue();
@@ -1844,26 +1709,29 @@ void Menu::DrawOverlay()
 	} else {
 		ImGui::GetIO().MouseDrawCursor = false;
 	}
-	if (settings.PerfOverlay.Enabled)
-		DrawPerfOverlay();
-
-	// Draw weather details window independently of main menu
-	DrawWeatherDetailsWindow();
+	// load overlays
+	for (Feature* feat : Feature::GetFeatureList()) {
+		if (feat && feat->loaded) {
+			if (auto* overlay = dynamic_cast<OverlayFeature*>(feat)) {
+				overlay->DrawOverlay();
+			}
+		}
+	}
 
 	if (abTestingEnabled) {  // In test mode
 		// Preserve overlay enabled state when switching configs
 		float seconds = (float)duration_cast<std::chrono::milliseconds>(high_resolution_clock::now() - lastTestSwitch).count() / 1000.0f;
 		auto remaining = (float)testInterval - seconds;
 		if (remaining < 0.0f) {
-			bool overlayWasEnabled = settings.PerfOverlay.Enabled;
+			bool overlayWasEnabled = PerformanceOverlay::GetSingleton()->settings.ShowInOverlay;
 			Menu::GetSingleton()->usingTestConfig = !Menu::GetSingleton()->usingTestConfig;
 			logger::info("Swapping to {} (A/B Test): {}", Menu::GetSingleton()->usingTestConfig ? "Variant B (TEST)" : "Variant A (USER)", Menu::GetSingleton()->usingTestConfig ? "TEST config" : "USER config");
 			globals::state->Load(Menu::GetSingleton()->usingTestConfig ? State::ConfigMode::TEST : State::ConfigMode::USER);
-			settings.PerfOverlay.Enabled = overlayWasEnabled;  // Restore overlay state
+			PerformanceOverlay::GetSingleton()->settings.ShowInOverlay = overlayWasEnabled;  // Restore overlay state
 			lastTestSwitch = high_resolution_clock::now();
 		}
 		// Always update test data during TEST phase, regardless of overlay visibility
-		UpdateAllShaderTestData();
+		PerformanceOverlay::UpdateAllShaderTestData();
 		ImGui::SetNextWindowBgAlpha(1.0f);
 		ImGui::SetNextWindowPos(ImVec2(10, 10));
 		if (!ImGui::Begin("Testing", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings)) {
@@ -1881,1043 +1749,12 @@ void Menu::DrawOverlay()
 	ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
 }
 
-void Menu::DrawPerfOverlay()
-{
-	if (!settings.PerfOverlay.Enabled) {
-		return;
-	}
-
-	// Set window flags - no decoration and only movable when ShowBorder is true
-	ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize;
-
-	// Only allow mouse interaction when the main menu is open
-	if (!IsEnabled) {
-		windowFlags |= ImGuiWindowFlags_NoInputs;
-	}
-
-	if (!settings.PerfOverlay.ShowBorder) {
-		windowFlags |= ImGuiWindowFlags_NoBackground;
-	} else {
-		windowFlags &= ~ImGuiWindowFlags_NoDecoration;
-		windowFlags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize;
-	}
-
-	// Set background opacity
-	ImGui::PushStyleColor(ImGuiCol_WindowBg,
-		ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_WindowBg).x,
-			ImGui::GetStyleColorVec4(ImGuiCol_WindowBg).y,
-			ImGui::GetStyleColorVec4(ImGuiCol_WindowBg).z,
-			settings.PerfOverlay.BackgroundOpacity));
-
-	// Set text size based on user preference
-	perfOverlayState.textScale = perfOverlayState.SetTextScale(settings.PerfOverlay);
-
-	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, settings.PerfOverlay.ShowBorder ? 1.0f : 0.0f);
-
-	// Set initial position if not already set
-	if (!settings.PerfOverlay.PositionSet) {
-		ImGui::SetNextWindowPos(ImVec2(10.0f, 10.0f));
-		settings.PerfOverlay.Position = ImVec2(10.0f, 10.0f);
-		settings.PerfOverlay.PositionSet = true;
-	} else {
-		ImGui::SetNextWindowPos(settings.PerfOverlay.Position, ImGuiCond_FirstUseEver);
-	}
-
-	// Set window size based on whether graphs are shown, was rapidly changing size based on text
-	perfOverlayState.hasGraphs = settings.PerfOverlay.ShowPreFGFrameTimeGraph ||
-	                             (settings.PerfOverlay.ShowPostFGFrameTimeGraph && perfOverlayState.isFrameGenerationActive);
-	if (!perfOverlayState.hasGraphs) {
-		float fixedWidth = 325.0f * perfOverlayState.textScale;
-		ImGui::SetNextWindowSize(ImVec2(fixedWidth, 0), ImGuiCond_Always);
-	}
-
-	// Create the window
-	ImGui::Begin("Performance Overlay", NULL, windowFlags);
-
-	// Remember window position for next frame
-	if (ImGui::IsWindowAppearing()) {
-		ImGui::SetWindowPos(settings.PerfOverlay.Position);
-	}
-
-	// Track if window has been moved
-	ImVec2 currentPos = ImGui::GetWindowPos();
-	if (currentPos.x != settings.PerfOverlay.Position.x || currentPos.y != settings.PerfOverlay.Position.y) {
-		settings.PerfOverlay.Position = currentPos;
-	}
-
-	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4.0f, 1.0f));  // Tighter spacing
-	ImGui::SetWindowFontScale(perfOverlayState.textScale);
-
-	// Initialize Performance Counter if necessary
-	if (!perfOverlayState.initialized) {
-		REX::W32::QueryPerformanceFrequency(&perfOverlayState.frequency);
-		REX::W32::QueryPerformanceCounter(&perfOverlayState.lastFrameCounter);
-		perfOverlayState.initialized = true;
-	} else {
-		REX::W32::QueryPerformanceCounter(&perfOverlayState.currentFrameCounter);
-		int64_t elapsedCounter = perfOverlayState.currentFrameCounter - perfOverlayState.lastFrameCounter;
-		perfOverlayState.lastFrameCounter = perfOverlayState.currentFrameCounter;
-
-		// Calculate frametime and fps
-		perfOverlayState.frameTimeMs = Util::performanceOverlay.CalcFrameTime(elapsedCounter, perfOverlayState.frequency);
-		perfOverlayState.fps = Util::performanceOverlay.CalcFPS(perfOverlayState.frameTimeMs);
-
-		// Calculate smooth values for display using the user-defined update interval
-		auto now = std::chrono::steady_clock::now();
-		float deltaTime = std::chrono::duration<float>(now - perfOverlayState.lastUpdateTime).count();
-		perfOverlayState.lastUpdateTime = now;
-
-		// Update graph values
-		perfOverlayState.UpdateGraphValues(settings.PerfOverlay);
-
-		// Update smooth values with user-specified interval
-		perfOverlayState.updateTimer += deltaTime;
-		if (perfOverlayState.updateTimer >= settings.PerfOverlay.UpdateInterval) {
-			perfOverlayState.smoothFps = perfOverlayState.fps;
-			perfOverlayState.smoothFrameTimeMs = perfOverlayState.frameTimeMs;
-			perfOverlayState.updateTimer = 0.0f;
-		}
-
-		// Check if Frame Generation is active
-		perfOverlayState.isFrameGenerationActive = globals::upscaling && globals::upscaling->IsFrameGenerationActive();
-
-		if (perfOverlayState.isFrameGenerationActive) {
-			perfOverlayState.UpdateFGFrameTime(settings.PerfOverlay);
-		}
-
-		// Show FPS counter if enabled
-		if (settings.PerfOverlay.ShowFPS) {
-			perfOverlayState.DrawFPS(settings.PerfOverlay);
-		}
-	}
-
-	// Show Draw Calls if enabled
-	if (settings.PerfOverlay.ShowDrawCalls) {
-		ImGui::Separator();
-		perfOverlayState.DrawDrawCalls();
-		ImGui::Separator();
-	}
-
-	// VRAM & GPU Usage
-	if (settings.PerfOverlay.ShowVRAM && dxgiAdapter3) {
-		perfOverlayState.DrawVRAM(dxgiAdapter3);
-	}
-
-	ImGui::PopStyleVar();             // ItemSpacing
-	ImGui::SetWindowFontScale(1.0f);  // Reset font scale
-
-	ImGui::End();
-	ImGui::PopStyleVar();    // WindowBorderSize
-	ImGui::PopStyleColor();  // WindowBg
-}
-
-float Menu::PerfOverlayState::SetTextScale(Settings::PerfOverlaySettings& settings)
-{
-	switch (settings.Size) {
-	case Settings::PerfOverlaySettings::TextSize::Small:
-		return 0.8f;
-	case Settings::PerfOverlaySettings::TextSize::Medium:
-		return 1.0f;
-	case Settings::PerfOverlaySettings::TextSize::Large:
-		return 1.2f;
-	}
-	return 1.0f;
-}
-
-/**
- * @brief Updates all runtime state related to the performance overlay graph.
- *
- * This function synchronizes the frame time history buffer, tracks min/max frame times,
- * and computes the normalized Y-axis range for the frame time graph using statistical analysis.
- *
- * Steps performed:
- *   1. Resizes the frameTimeHistory buffer if the user has changed the setting.
- *   2. Inserts the latest frame time into the circular history buffer.
- *   3. Updates instantaneous min/max frame time values, with full rescans if necessary.
- *   4. Calculates the average (mean) and standard deviation of frame times in the buffer.
- *   5. Sets the graph Y-axis range to be centered on the average, with a spread of ±2 standard deviations,
- *      clamped to user-friendly minimum and maximum values.
- *   6. Smooths the min/max Y-axis values for visual stability using exponential smoothing.
- *
- *
- * @param settings Reference to the current performance overlay settings (controls buffer size, etc.).
- */
-void Menu::PerfOverlayState::UpdateGraphValues(Settings::PerfOverlaySettings& settings)
-{
-	// Sync frame history buffer size with user settings
-	UpdateFrameTimeHistorySizes(settings);
-
-	// Insert latest frame time into circular buffer
-	float oldFrameTime = frameTimeHistory[frameTimeHistoryIndex];
-	frameTimeHistory[frameTimeHistoryIndex] = frameTimeMs;
-	frameTimeHistoryIndex = (frameTimeHistoryIndex + 1) % settings.FrameHistorySize;
-
-	// Maintain instantaneous min/max tracking
-	if (frameTimeMs > maxFrameTime) {
-		maxFrameTime = frameTimeMs;
-	} else if (frameTimeMs < minFrameTime) {
-		minFrameTime = frameTimeMs;
-	} else if (oldFrameTime == minFrameTime) {
-		UpdateMinFrameTime();
-	} else if (oldFrameTime == maxFrameTime) {
-		UpdateMaxFrameTime();
-	}
-
-	float avgFrameTime, stdDev, graphMin, graphMax;
-	// Calculate mean and standard deviation for normalized graph range
-	if (frameTimeHistory.empty()) {
-		// Default to 60 FPS
-		avgFrameTime = 16.67f;
-		stdDev = 0.0f;
-		graphMin = 0.0f;
-		graphMax = 33.0f;
-	} else {
-		// Calculate average frame time
-		avgFrameTime = std::accumulate(frameTimeHistory.begin(), frameTimeHistory.end(), 0.0f) / frameTimeHistory.size();
-
-		// Calculate standard deviation
-		float variance = 0.0f;
-		for (float ft : frameTimeHistory) {
-			float diff = ft - avgFrameTime;
-			variance += diff * diff;
-		}
-		variance /= frameTimeHistory.size();
-		stdDev = std::sqrt(variance);
-
-		// Calculate graph range
-		float spread = std::clamp(stdDev * 2.0f, 2.0f, 20.0f);
-		graphMin = std::max(0.0f, avgFrameTime - spread);
-		graphMax = avgFrameTime + spread;
-	}
-
-	// Exponential smoothing for stable graph scaling
-	smoothedMinFrameTime += kSmoothingFactor * (graphMin - smoothedMinFrameTime);
-	smoothedMaxFrameTime += kSmoothingFactor * (graphMax - smoothedMaxFrameTime);
-}
-
-/**
- * @brief Updates the minimum frame time value by scanning the frame time history buffer.
- *
- * Finds the smallest frame time currently in the frameTimeHistory buffer and updates minFrameTime accordingly.
- * Assumes frameTimeHistory is non-empty.
- */
-void Menu::PerfOverlayState::UpdateMinFrameTime()
-{
-	minFrameTime = *std::min_element(frameTimeHistory.begin(), frameTimeHistory.end());
-}
-
-/**
- * @brief Updates the maximum frame time value by scanning the frame time history buffer.
- *
- * Finds the largest frame time currently in the frameTimeHistory buffer and updates maxFrameTime accordingly.
- * Assumes frameTimeHistory is non-empty.
- */
-void Menu::PerfOverlayState::UpdateMaxFrameTime()
-{
-	maxFrameTime = *std::max_element(frameTimeHistory.begin(), frameTimeHistory.end());
-}
-
-/**
- * @brief Updates post-frame generation (FG) frame time and FPS history values.
- *
- * Retrieves the latest frame time from the Frame Generation system if available, updates smoothed values,
- * and maintains a circular buffer of post-FG frame times. Falls back to an approximation if FG timing is unavailable.
- *
- * @param settings Reference to the current performance overlay settings (controls buffer size, etc.).
- */
-void Menu::PerfOverlayState::UpdateFGFrameTime(Settings::PerfOverlaySettings& settings)
-{
-	// Get frametime directly from the Frame Generation system
-	float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
-	if (fgDeltaTime > 0.0f) {
-		postFGFrameTimeMs = fgDeltaTime * 1000.0f;
-		postFGFps = 1000.0f / postFGFrameTimeMs;
-
-		// Update post-FG smooth values when timer elapses
-		if (updateTimer <= 0.0f) {
-			postFGSmoothFps = postFGFps;
-			postFGSmoothFrameTimeMs = postFGFrameTimeMs;
-		}
-
-		// Update post-FG frametime history
-		postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
-		postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % settings.FrameHistorySize;
-	} else {
-		// Fallback if FG time is not available
-		postFGFrameTimeMs = frameTimeMs / 2.0f;  // Approximate
-		postFGFps = fps * 2.0f;                  // Approximate
-
-		// Update smooth values when timer elapses
-		if (updateTimer <= 0.0f) {
-			postFGSmoothFps = postFGFps;
-			postFGSmoothFrameTimeMs = postFGFrameTimeMs;
-		}
-
-		// Update post-FG frametime history with approximation
-		postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
-		postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % settings.FrameHistorySize;
-	}
-}
-
-/**
- * @brief Renders the FPS and frametime statistics using ImGui, including graphs and reference lines.
- *
- * Displays pre- and post-frame generation FPS and frametime values, as well as line graphs if enabled in settings.
- * Handles both standard and frame generation rendering modes, and draws reference lines for common FPS targets.
- *
- * @param settings Reference to the current performance overlay settings (controls what is displayed).
- */
-void Menu::PerfOverlayState::DrawFPS(Settings::PerfOverlaySettings& settings)
-{
-	if (ImGui::BeginTable("FrametimeTargets", 2, ImGuiTableFlags_SizingStretchProp)) {
-		ImGui::TableSetupColumn("##prop", ImGuiTableColumnFlags_WidthFixed, ImGui::GetTextLineHeight() * 5);
-		ImGui::TableSetupColumn("##value");
-
-		ImGui::TableNextColumn();
-		ImGui::Text(isFrameGenerationActive ? "Raw FPS:" : "FPS:");
-		ImGui::TableNextColumn();
-		ImGui::Text("%.1f (%.2f ms)", smoothFps, smoothFrameTimeMs);
-
-		if (isFrameGenerationActive) {
-			ImGui::TableNextColumn();
-			ImGui::Text("Post-FG FPS:");
-			ImGui::TableNextColumn();
-			ImGui::Text("%.1f (%.2f ms)", postFGSmoothFps, postFGSmoothFrameTimeMs);
-		}
-
-		ImGui::EndTable();
-	}
-
-	// Show Pre-FG frametime graph if enabled
-	if (settings.ShowPreFGFrameTimeGraph) {
-		// Prepare overlay text
-		char overlay_text[128];
-		snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
-			"%s%.2f ms (%.1f FPS)",
-			isFrameGenerationActive ? "Pre-FG: " : "",
-			smoothFrameTimeMs, smoothFps);
-
-		// Set graph colors
-		ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));  // Green line
-
-		// Draw the graph
-		float graphWidth = ImGui::GetWindowWidth() * 0.9f;
-		ImGui::PlotLines("##frametime",
-			frameTimeHistory.data(),
-			settings.FrameHistorySize,
-			frameTimeHistoryIndex,
-			overlay_text,
-			smoothedMinFrameTime, smoothedMaxFrameTime,
-			ImVec2(graphWidth, 50.0f * textScale));
-
-		ImGui::PopStyleColor();
-
-		// Draw frametime target reference lines
-		if (ImGui::BeginTable("FrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
-			ImGui::TableNextColumn();
-			ImGui::Text("30 FPS: 33.3 ms");
-
-			ImGui::TableNextColumn();
-			ImGui::Text("60 FPS: 16.7 ms");
-
-			ImGui::TableNextColumn();
-			ImGui::Text("120 FPS: 8.3 ms");
-
-			ImGui::EndTable();
-		}
-	}
-
-	// Show Post-FG frametime graph if enabled
-	if (settings.ShowPostFGFrameTimeGraph && isFrameGenerationActive) {
-		// Check if FSR frame generation is active (FSR doesn't provide timing data)
-		bool isFSRFrameGen = globals::fidelityFX && globals::fidelityFX->isFrameGenActive;
-
-		if (isFSRFrameGen) {
-			// Show note that post-FG timing isn't available with FSR
-			ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f), "Post-FG timing not available with FSR3 Framegen");
-			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text("AMD FSR Frame Generation doesn't provide internal timing data.\nPost-FG performance metrics are only available with NVIDIA DLSS Frame Generation.");
-			}
-		} else {
-			// Show post-FG graph for DLSS
-			DrawPostFGFrameTimeGraph(settings);
-		}
-	}
-}
-
-/**
- * @brief Renders the post-frame generation frametime graph using ImGui.
- *
- * Plots the post-FG frametime history and displays reference lines for common FPS targets.
- * Only called if frame generation is active and the relevant settings are enabled.
- *
- * @param settings Reference to the current performance overlay settings (controls graph appearance and size).
- */
-void Menu::PerfOverlayState::DrawPostFGFrameTimeGraph(Settings::PerfOverlaySettings& settings)
-{
-	// Prepare overlay text
-	char overlay_text[128];
-	snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
-		"Post-FG: %.2f ms (%.1f FPS)",
-		postFGSmoothFrameTimeMs, postFGSmoothFps);
-
-	// Set graph colors - blue for post-FG
-	ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
-
-	// Draw the graph
-	float graphWidth = ImGui::GetWindowWidth() * 0.9f;
-	ImGui::PlotLines("##postfgframetime",
-		postFGFrameTimeHistory.data(),
-		settings.FrameHistorySize,
-		postFGFrameTimeHistoryIndex,
-		overlay_text,
-		smoothedMinFrameTime, smoothedMaxFrameTime,
-		ImVec2(graphWidth, 50.0f * textScale));
-
-	ImGui::PopStyleColor();
-
-	// Draw frametime target reference lines
-	if (ImGui::BeginTable("PostFGFrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
-		ImGui::TableNextColumn();
-		ImGui::Text("30 FPS: 33.3 ms");
-
-		ImGui::TableNextColumn();
-		ImGui::Text("60 FPS: 16.7 ms");
-
-		ImGui::TableNextColumn();
-		ImGui::Text("120 FPS: 8.3 ms");
-
-		ImGui::EndTable();
-	}
-}
-
 /**
  * @brief Renders the current draw call counts for various shader types using ImGui.
  *
  * Displays a breakdown of draw calls by type (e.g., Grass, Sky, Water, etc.) and the total count.
  * Values are sourced from the global state.
  */
-void Menu::PerfOverlayState::DrawDrawCalls()
-{
-	static bool clearTestDataRequested = false;
-	bool abTestActive = (abTestingEnabled && Menu::GetSingleton()->usingTestConfig);
-	bool anyShaderDisabled = false;
-	for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
-		if (!globals::state->enabledClasses[i]) {
-			anyShaderDisabled = true;
-			break;
-		}
-	}
-	if (!s_testData.empty()) {
-		if (ImGui::Button("Clear Test Data")) {
-			clearTestDataRequested = true;
-		}
-		ImGui::SameLine();
-		ImGui::TextDisabled("Test columns are shown only when test data is present.");
-	}
-
-	// Build headers and column count dynamically
-	std::vector<std::string> headers = { "Shader Type", "Draw Calls", "Frame Time (%)", "Cost/Call" };
-	bool anyTestData = !s_testData.empty();
-	if (anyTestData) {
-		headers.push_back("Test Frame Time (%)");
-		headers.push_back("Test Cost/Call");
-	}
-	int columnCount = static_cast<int>(headers.size());
-
-	// Tooltip map for shader types
-	static const std::unordered_map<RE::BSShader::Type, std::string> kShaderTypeTooltips = {
-		{ RE::BSShader::Type::Grass, "Draw calls using the Grass shader. Typically many, but each is usually cheap." },
-		{ RE::BSShader::Type::Sky, "Draw calls for the sky dome, clouds, and related effects." },
-		{ RE::BSShader::Type::Water, "Draw calls for water surfaces and effects." },
-		{ RE::BSShader::Type::Lighting, "Draw calls for dynamic and static lighting passes." },
-		{ RE::BSShader::Type::Effect, "Draw calls for special effects, particles, and post-processing." },
-		{ RE::BSShader::Type::Utility, "Draw calls for utility passes, such as shadow masks or G-buffer fills." },
-		{ RE::BSShader::Type::DistantTree, "Draw calls for distant tree rendering (LOD vegetation)." },
-		{ RE::BSShader::Type::Particle, "Draw calls for particle systems (smoke, sparks, etc.)." },
-		{ RE::BSShader::Type::BloodSplatter, "Draw calls for blood splatter effects." },
-		{ RE::BSShader::Type::ImageSpace, "Draw calls for image space post-processing effects." }
-	};
-	std::vector<ShaderRow> shaderTypes;
-	for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
-		if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
-			continue;
-		std::string label = std::string(magic_enum::enum_name(type)) + ":";
-		auto it = kShaderTypeTooltips.find(type);
-		std::string tooltip = (it != kShaderTypeTooltips.end()) ? it->second : "Draw calls for this shader type.";
-		tooltip += "\nClick to ";
-		tooltip += (globals::state->enabledClasses[magic_enum::enum_integer(type) - 1]) ? "disable" : "enable";
-		tooltip += " this shader.";
-		shaderTypes.push_back({ label, type, tooltip });
-	}
-
-	// Sorting state (declare all at the top)
-	static int sortColumn = 0;
-	static bool sortAscending = false;
-	static bool isSorted = false;
-	static std::vector<DrawCallRow> originalRows;
-
-	// Use the smoothed frame time for all calculations
-	float smoothedFrameTime = static_cast<float>(Menu::GetSingleton()->perfOverlayState.smoothFrameTimeMs);
-	float measuredSum = 0.0f;
-	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
-
-	// --- TEST DATA SNAPSHOT LOGIC ---
-	if (abTestActive) {
-		measuredSum = 0.0f;
-		for (const auto& row : shaderTypes) {
-			auto typeIndex = magic_enum::enum_integer(row.type);
-			float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
-			float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
-			float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
-			float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
-			s_testData[typeIndex] = { frameTime, costPerCall, percent };
-			measuredSum += frameTime;
-		}
-		float otherFrameTime = smoothedFrameTime - measuredSum;
-		float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
-		s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
-		float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
-		s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
-	} else if (anyShaderDisabled) {
-		measuredSum = 0.0f;
-		for (const auto& row : shaderTypes) {
-			auto typeIndex = magic_enum::enum_integer(row.type);
-			bool enabled = globals::state->enabledClasses[typeIndex - 1];
-			if (!enabled) {
-				float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
-				float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
-				float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
-				float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
-				s_testData[typeIndex] = { frameTime, costPerCall, percent };
-			}
-			measuredSum += static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
-		}
-		float otherFrameTime = smoothedFrameTime - measuredSum;
-		float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
-		s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
-		float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
-		s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
-	}
-
-	// Build main rows: all shader types
-	std::vector<DrawCallRow> mainRows;
-	measuredSum = 0.0f;
-	for (const auto& row : shaderTypes) {
-		auto typeIndex = magic_enum::enum_integer(row.type);
-		float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
-		float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
-		float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
-		float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
-		// Clamp small negative values to zero
-		if (std::abs(frameTime) < 1e-4f)
-			frameTime = 0.0f;
-		if (std::abs(costPerCall) < 1e-6f)
-			costPerCall = 0.0f;
-		bool enabled = globals::state->enabledClasses[typeIndex - 1];
-		std::optional<float> testFrameTime, testCostPerCall;
-		auto it = s_testData.find(typeIndex);
-		if (it != s_testData.end()) {
-			testFrameTime = it->second.frameTime;
-			testCostPerCall = it->second.costPerCall;
-			anyTestData = true;
-		}
-		DrawCallRow rowObj{ row.label, typeIndex, static_cast<int>(drawCalls), frameTime, percent, costPerCall, row.tooltip, enabled, testFrameTime, testCostPerCall };
-		mainRows.push_back(rowObj);
-		measuredSum += frameTime;
-	}
-
-	// Add summary rows (not part of main sorting)
-	float otherFrameTime = smoothedFrameTime - measuredSum;
-	if (std::abs(otherFrameTime) < 1e-4f)
-		otherFrameTime = 0.0f;
-
-	DrawCallRow otherRow = {
-		"Other:", -2, 0, otherFrameTime,
-		(smoothedFrameTime > 0.0f ? static_cast<float>((otherFrameTime / smoothedFrameTime) * 100.0f) : 0.0f),
-		0.0f,
-		std::string("Frame time not attributed to any measured shader type. This includes UI, post-processing, engine work, and any GPU activity not directly measured by the overlay.")
-	};
-
-	DrawCallRow totalRow = {
-		"Total:", -1, static_cast<int>(totalSmoothedDrawCalls), smoothedFrameTime, 100.0f,
-		(totalSmoothedDrawCalls > 0.0f ? static_cast<float>(smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f),
-		std::string("Sum of all measured shader types.\nClick to enable or disable all shaders.")
-	};
-
-	// Always start the main table sorted alphabetically by label on first display
-	static bool firstTableDisplay = true;
-	if (firstTableDisplay) {
-		std::sort(mainRows.begin(), mainRows.end(), [](const DrawCallRow& a, const DrawCallRow& b) {
-			return a.label < b.label;
-		});
-		firstTableDisplay = false;
-	}
-
-	// Handle sorting: only sort mainRows, never summary rows
-	if (ImGui::BeginTable("DrawCallOverlayTable##", columnCount, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable)) {
-		// --- HEADER SETUP WITH TOOLTIP ---
-		for (int i = 0; i < headers.size(); ++i) {
-			ImGui::TableSetupColumn(headers[i].c_str());
-			if (anyTestData && (headers[i] == "Test Frame Time" || headers[i] == "Test Cost/Call")) {
-				if (ImGui::IsItemHovered()) {
-					ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
-				}
-			}
-		}
-		ImGui::TableHeadersRow();
-
-		if (const ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs()) {
-			if (sortSpecs->SpecsCount > 0) {
-				sortColumn = sortSpecs->Specs->ColumnIndex;
-				sortAscending = sortSpecs->Specs->SortDirection == ImGuiSortDirection_Ascending;
-				switch (sortColumn) {
-				case Col_Label:
-					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
-						return sortAscending ? (a.label < b.label) : (a.label > b.label);
-					});
-					break;
-				case Col_DrawCalls:
-					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
-						return sortAscending ? (a.drawCalls < b.drawCalls) : (a.drawCalls > b.drawCalls);
-					});
-					break;
-				case Col_FrameTime:
-					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
-						return sortAscending ? (a.percent < b.percent) : (a.percent > b.percent);
-					});
-					break;
-				case Col_CostPerCall:
-					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
-						return sortAscending ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall);
-					});
-					break;
-				case Col_TestFrameTime:
-					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
-						float aVal = a.testFrameTime.value_or(FLT_MAX);
-						float bVal = b.testFrameTime.value_or(FLT_MAX);
-						return sortAscending ? (aVal < bVal) : (aVal > bVal);
-					});
-					break;
-				case Col_TestCostPerCall:
-					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
-						float aVal = a.testCostPerCall.value_or(FLT_MAX);
-						float bVal = b.testCostPerCall.value_or(FLT_MAX);
-						return sortAscending ? (aVal < bVal) : (aVal > bVal);
-					});
-					break;
-				}
-			}
-		}
-
-		// --- Main table cell rendering switch: renders each cell based on column ---
-		for (size_t rowIdx = 0; rowIdx < mainRows.size(); ++rowIdx) {
-			const auto& row = mainRows[rowIdx];
-			ImGui::TableNextRow();
-			int colIdx = 0;
-			// Label
-			ImGui::TableSetColumnIndex(colIdx++);
-			if (!row.enabled) {
-				ImGui::PushStyleColor(ImGuiCol_Text, Menu::GetSingleton()->GetTheme().StatusPalette.Disable);
-			}
-			bool wasEnabled = row.enabled;
-			if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
-				auto maybeType = magic_enum::enum_cast<RE::BSShader::Type>(row.shaderType);
-				if (maybeType.has_value()) {
-					auto classIndex = magic_enum::enum_integer(*maybeType) - 1;
-					if (classIndex >= 0 && classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1) {
-						globals::state->enabledClasses[classIndex] = !wasEnabled;
-						// Also update test data when toggled
-						UpdateShaderTestData(row.shaderType, row.frameTime, row.costPerCall);
-					}
-				}
-			}
-			if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup | ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
-				ImGui::SetTooltip("%s", row.tooltip.c_str());
-			}
-			if (!row.enabled) {
-				ImGui::PopStyleColor();
-			}
-			// Draw Calls
-			ImGui::TableSetColumnIndex(colIdx++);
-			ImGui::Text("%d", row.drawCalls);
-			// Frame Time (%)
-			ImGui::TableSetColumnIndex(colIdx++);
-			ImVec4 color = ImGui::GetStyleColorVec4(ImGuiCol_Text);
-			if (row.percent < 30.0f)
-				color = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
-			else if (row.percent < 60.0f)
-				color = Menu::GetSingleton()->GetTheme().StatusPalette.Warning;
-			else
-				color = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
-			ImGui::PushStyleColor(ImGuiCol_Text, color);
-			ImGui::Text("%.2f ms (%.1f%%)", row.frameTime, row.percent);
-			ImGui::PopStyleColor();
-			// Cost/Call
-			ImGui::TableSetColumnIndex(colIdx++);
-			if (row.costPerCall < 0.05f)
-				color = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
-			else if (row.costPerCall < 0.2f)
-				color = Menu::GetSingleton()->GetTheme().StatusPalette.Warning;
-			else
-				color = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
-			ImGui::PushStyleColor(ImGuiCol_Text, color);
-			if (row.costPerCall < 0.01f && row.costPerCall > 0.0f)
-				ImGui::Text("%.2f us", row.costPerCall * 1000.0f);
-			else
-				ImGui::Text("%.3f ms", row.costPerCall);
-			ImGui::PopStyleColor();
-			// Test columns if present
-			if (anyTestData) {
-				// Test Frame Time
-				ImGui::TableSetColumnIndex(colIdx++);
-				if (row.testFrameTime.has_value()) {
-					ImVec4 testColor = ImGui::GetStyleColorVec4(ImGuiCol_Text);
-					if (*row.testFrameTime < row.frameTime)
-						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
-					else if (*row.testFrameTime > row.frameTime)
-						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
-					ImGui::PushStyleColor(ImGuiCol_Text, testColor);
-					ImGui::Text("%.2f ms (%.1f%%)", *row.testFrameTime, s_testData[row.shaderType].percent);
-					ImGui::PopStyleColor();
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
-					}
-				} else {
-					ImGui::TextDisabled("-");
-				}
-				// Test Cost/Call
-				ImGui::TableSetColumnIndex(colIdx++);
-				if (row.testCostPerCall.has_value()) {
-					ImVec4 testColor = ImGui::GetStyleColorVec4(ImGuiCol_Text);
-					if (*row.testCostPerCall < row.costPerCall)
-						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
-					else if (*row.testCostPerCall > row.costPerCall)
-						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
-					ImGui::PushStyleColor(ImGuiCol_Text, testColor);
-					if (*row.testCostPerCall < 0.01f && *row.testCostPerCall > 0.0f)
-						ImGui::Text("%.2f us", *row.testCostPerCall * 1000.0f);
-					else
-						ImGui::Text("%.3f ms", *row.testCostPerCall);
-					ImGui::PopStyleColor();
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
-					}
-				} else {
-					ImGui::TextDisabled("-");
-				}
-			}
-		}
-		// Separator row (optional, for visual separation)
-		ImGui::TableNextRow(ImGuiTableRowFlags_None, 4.0f);
-		for (int col = 0; col < columnCount; ++col) {
-			ImGui::TableSetColumnIndex(col);
-			if (col == 0)
-				ImGui::Separator();
-		}
-		// Summary rows (Other, Total)
-		for (const DrawCallRow& row : { otherRow, totalRow }) {
-			ImGui::TableNextRow();
-			int colIdx = 0;
-			ImGui::TableSetColumnIndex(colIdx++);
-			if (row.label == std::string("Total:")) {
-				if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
-					bool anyDisabled = false;
-					for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
-						if (!globals::state->enabledClasses[i]) {
-							anyDisabled = true;
-							break;
-						}
-					}
-					for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
-						globals::state->enabledClasses[i] = anyDisabled;
-					}
-				}
-			} else {
-				ImGui::TextUnformatted(row.label.c_str());
-			}
-			if (!row.tooltip.empty() && ImGui::IsItemHovered()) {
-				if (auto _tt = Util::HoverTooltipWrapper()) {
-					ImGui::TextUnformatted(row.tooltip.c_str());
-				}
-			}
-			ImGui::TableSetColumnIndex(colIdx++);
-			if (row.label == "Other:" && row.drawCalls <= 0) {
-				ImGui::TextUnformatted("N/A");
-			} else {
-				ImGui::Text("%d", row.drawCalls);
-			}
-			ImGui::TableSetColumnIndex(colIdx++);
-			if (row.label == "Other:" && row.frameTime <= 0.0f) {
-				ImGui::TextUnformatted("N/A");
-			} else {
-				ImGui::Text("%.2f ms (%.1f%%)", row.frameTime, row.percent);
-				if (row.label == "Total:" && ImGui::IsItemHovered()) {
-					float _fps = row.frameTime > 0.0f ? 1000.0f / row.frameTime : 0.0f;
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::Text("FPS: %.2f", _fps);
-					}
-				}
-			}
-			ImGui::TableSetColumnIndex(colIdx++);
-			if (row.label == "Other:" && row.costPerCall <= 0.0f) {
-				ImGui::TextUnformatted("N/A");
-			} else if (row.costPerCall < 0.01f && row.costPerCall > 0.0f) {
-				ImGui::Text("%.2f us", row.costPerCall * 1000.0f);
-			} else {
-				ImGui::Text("%.3f ms", row.costPerCall);
-			}
-			if (anyTestData) {
-				ImGui::TableSetColumnIndex(colIdx++);
-				auto testIt = s_testData.find(row.shaderType);
-				if (testIt != s_testData.end()) {
-					ImVec4 testColor = ImGui::GetStyleColorVec4(ImGuiCol_Text);
-					if (testIt->second.frameTime < row.frameTime)
-						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
-					else if (testIt->second.frameTime > row.frameTime)
-						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
-					ImGui::PushStyleColor(ImGuiCol_Text, testColor);
-					ImGui::Text("%.2f ms (%.1f%%)", testIt->second.frameTime, testIt->second.percent);
-					ImGui::PopStyleColor();
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
-						// Show FPS for test frame time
-						float _fps = testIt->second.frameTime > 0.0f ? 1000.0f / testIt->second.frameTime : 0.0f;
-						if (auto _tt = Util::HoverTooltipWrapper()) {
-							ImGui::Text("FPS: %.2f", _fps);
-						}
-					}
-				} else {
-					ImGui::TextUnformatted("N/A");
-				}
-				ImGui::TableSetColumnIndex(colIdx++);
-				if (testIt != s_testData.end()) {
-					ImVec4 testColor = ImGui::GetStyleColorVec4(ImGuiCol_Text);
-					if (testIt->second.costPerCall < row.costPerCall)
-						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
-					else if (testIt->second.costPerCall > row.costPerCall)
-						testColor = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
-					ImGui::PushStyleColor(ImGuiCol_Text, testColor);
-					if (testIt->second.costPerCall < 0.01f && testIt->second.costPerCall > 0.0f)
-						ImGui::Text("%.2f us", testIt->second.costPerCall * 1000.0f);
-					else
-						ImGui::Text("%.3f ms", testIt->second.costPerCall);
-					ImGui::PopStyleColor();
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
-					}
-				} else {
-					ImGui::TextUnformatted("N/A");
-				}
-			}
-		}
-		ImGui::EndTable();
-	}
-
-	if (clearTestDataRequested) {
-		s_testData.clear();
-		clearTestDataRequested = false;
-		s_testDataSource = TestDataSource::None;
-	}
-}
-
-/**
- * @brief Renders the current GPU VRAM usage using ImGui.
- *
- * Queries the DXGI adapter for video memory info and displays current usage, total budget, and a progress bar.
- * Falls back to a message if VRAM info is unavailable.
- *
- * @param dxgiAdapter3 A COM pointer to the IDXGIAdapter3 interface for querying video memory info.
- */
-void Menu::PerfOverlayState::DrawVRAM(winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3)
-{
-	DXGI_QUERY_VIDEO_MEMORY_INFO videoMemoryInfo{};
-	HRESULT hr = dxgiAdapter3->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &videoMemoryInfo);
-
-	// Only proceed if the call succeeded and Budget is not zero
-	if (SUCCEEDED(hr) && videoMemoryInfo.Budget > 0) {
-		float currentGpuUsage = videoMemoryInfo.CurrentUsage / (1024.f * 1024.f * 1024.f);
-		float totalGpuMemory = videoMemoryInfo.Budget / (1024.f * 1024.f * 1024.f);
-		float percent = currentGpuUsage / totalGpuMemory;
-
-		// Center the VRAM text
-		ImGui::Text("VRAM Usage:");
-
-		// Use a centered text format for the numeric values
-		std::string vramText = std::format("{:.2f}GB/{:.2f}GB ({:.1f}%)", currentGpuUsage, totalGpuMemory, 100 * percent);
-		float textWidth = ImGui::CalcTextSize(vramText.c_str()).x;
-		float windowWidth = ImGui::GetWindowWidth();
-
-		// Center the text if it fits within the window
-		if (textWidth < windowWidth) {
-			ImGui::SetCursorPosX((windowWidth - textWidth) * 0.5f);
-			ImGui::Text("%s", vramText.c_str());
-		} else {
-			ImGui::Text("%s", vramText.c_str());
-		}
-
-		// Only move the progress bar, not the text
-		ImGui::ProgressBar(percent, ImVec2(ImGui::GetWindowWidth() * 0.9f, 0.0f), "");
-	} else {
-		// Display a fallback message if we couldn't get the VRAM info
-		ImGui::Text("VRAM Usage: Not available");
-	}
-}
-
-/**
- * @brief Ensures frame time history buffers are sized according to the current settings.
- *
- * Resizes the frameTimeHistory and postFGFrameTimeHistory buffers to match the user-configured history size,
- * clamping the size within allowed bounds. Resets indices if they are out of bounds after resizing.
- *
- * @param settings Reference to the current performance overlay settings (controls buffer size and limits).
- */
-void Menu::PerfOverlayState::UpdateFrameTimeHistorySizes(Settings::PerfOverlaySettings& settings)
-{
-	settings.FrameHistorySize = std::clamp(
-		settings.FrameHistorySize,
-		settings.kMinFrameHistorySize,
-		settings.kMaxFrameHistorySize);
-
-	if (frameTimeHistory.size() != static_cast<size_t>(settings.FrameHistorySize)) {
-		frameTimeHistory.resize(settings.FrameHistorySize, 0.0f);
-		if (frameTimeHistoryIndex >= settings.FrameHistorySize) {  // Reset index if it's out of new bounds
-			frameTimeHistoryIndex = 0;
-		}
-	}
-	if (postFGFrameTimeHistory.size() != static_cast<size_t>(settings.FrameHistorySize)) {
-		postFGFrameTimeHistory.resize(settings.FrameHistorySize, 0.0f);
-		if (postFGFrameTimeHistoryIndex >= settings.FrameHistorySize) {
-			postFGFrameTimeHistoryIndex = 0;
-		}
-	}
-}
-
-void Menu::DrawPerformanceOverlaySettings()
-{
-	auto& themeSettings = settings.Theme;
-
-	ImGui::Checkbox("Enable Performance Overlay", &settings.PerfOverlay.Enabled);
-
-	if (settings.PerfOverlay.Enabled) {
-		ImGui::Indent();
-
-		// Display options
-		if (ImGui::CollapsingHeader("Display Options", ImGuiTreeNodeFlags_DefaultOpen)) {
-			ImGui::Indent();
-
-			// FPS options
-			ImGui::Checkbox("Show FPS Counter", &settings.PerfOverlay.ShowFPS);
-
-			bool isFrameGenerationActive = globals::upscaling && globals::upscaling->IsFrameGenerationActive();
-			if (settings.PerfOverlay.ShowFPS) {
-				ImGui::Indent();
-
-				if (isFrameGenerationActive) {
-					// Pre-Frame Generation FPS
-					ImGui::Checkbox("Show Pre-FG Frametime Graph", &settings.PerfOverlay.ShowPreFGFrameTimeGraph);
-					// Check if FSR frame generation is active
-					bool isFSRFrameGen = globals::fidelityFX && globals::fidelityFX->isFrameGenActive;
-					if (isFSRFrameGen) {
-						// Disable post-FG option for FSR and show note
-						ImGui::BeginDisabled();
-						ImGui::Checkbox("Show Post-FG Frametime Graph", &settings.PerfOverlay.ShowPostFGFrameTimeGraph);
-						ImGui::EndDisabled();
-						if (auto _tt = Util::HoverTooltipWrapper()) {
-							ImGui::Text("Post-FG timing not available with AMD FSR Frame Generation.\nThis option is only available with NVIDIA DLSS Frame Generation.");
-						}
-					} else {
-						// Enable post-FG option for DLSS
-						ImGui::Checkbox("Show Post-FG Frametime Graph", &settings.PerfOverlay.ShowPostFGFrameTimeGraph);
-					}
-				} else {
-					// Regular FPS options when frame generation is not active
-					ImGui::Checkbox("Show Frametime Graph", &settings.PerfOverlay.ShowPreFGFrameTimeGraph);
-				}
-
-				ImGui::Unindent();
-			}
-
-			ImGui::Checkbox("Show Draw Calls", &settings.PerfOverlay.ShowDrawCalls);
-			ImGui::Checkbox("Show VRAM Usage", &settings.PerfOverlay.ShowVRAM);
-
-			ImGui::Unindent();
-		}
-		// Hotkey settings
-		if (ImGui::CollapsingHeader("Hotkeys", ImGuiTreeNodeFlags_DefaultOpen)) {
-			ImGui::Indent();
-
-			// Add hotkey configuration for toggling overlay
-			if (settingOverlayToggleKey) {
-				ImGui::Text("Press any key to set as Performance Overlay toggle key...");
-			} else {
-				ImGui::AlignTextToFramePadding();
-				ImGui::Text("Toggle Key:");
-				ImGui::SameLine();
-				ImGui::AlignTextToFramePadding();
-				ImGui::TextColored(themeSettings.StatusPalette.CurrentHotkey, "%s", KeyIdToString(settings.PerfOverlay.OverlayToggleKey));
-				ImGui::AlignTextToFramePadding();
-				ImGui::SameLine();
-				if (ImGui::Button("Change##overlayToggle")) {
-					settingOverlayToggleKey = true;
-				}
-			}
-
-			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text("Set a key to show/hide the performance overlay");
-			}
-			ImGui::Unindent();
-		}
-
-		// Appearance settings
-		if (ImGui::CollapsingHeader("Appearance", ImGuiTreeNodeFlags_DefaultOpen)) {
-			ImGui::Indent();
-
-			// Text size options
-			const char* sizes[] = { "Small", "Medium", "Large" };
-			int currentSize = static_cast<int>(settings.PerfOverlay.Size);
-			if (ImGui::Combo("Text Size", &currentSize, sizes, IM_ARRAYSIZE(sizes))) {
-				settings.PerfOverlay.Size = static_cast<Settings::PerfOverlaySettings::TextSize>(currentSize);
-			}
-
-			// Background opacity slider
-			ImGui::SliderFloat("Background Opacity", &settings.PerfOverlay.BackgroundOpacity, 0.0f, 1.0f, "%.2f");
-
-			// Border toggle
-			ImGui::Checkbox("Show Border", &settings.PerfOverlay.ShowBorder);
-
-			// FPS update interval slider - Make this slider affect all FPS and frametime displays
-			ImGui::SliderFloat("Update Interval", &settings.PerfOverlay.UpdateInterval, 0.001f, 2.0f, "%.2f seconds");
-			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text("How frequently all performance metrics should update (FPS and frametime)");
-			}
-
-			// Frame history size slider
-			ImGui::SliderInt("Frame History Size", &settings.PerfOverlay.FrameHistorySize, Settings::PerfOverlaySettings::kMinFrameHistorySize, Settings::PerfOverlaySettings::kMaxFrameHistorySize);
-			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text(
-					"Number of frames to keep in history for graphing.\n"
-					"E.g. 60 frames = 1 second @ 60fps.");
-			}
-
-			// Position options - moved inside appearance section
-			ImGui::Separator();
-			ImGui::Text("Position:");
-
-			// Reset position button
-			if (ImGui::Button("Reset Position")) {
-				settings.PerfOverlay.PositionSet = false;
-			}
-			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text("Reset the position of the performance overlay to default");
-			}
-
-			ImGui::Unindent();
-		}
-
-		ImGui::Unindent();
-	}
-}
 
 const ImGuiKey Menu::VirtualKeyToImGuiKey(WPARAM vkKey)
 {
@@ -3237,7 +2074,7 @@ void Menu::ProcessInputEventQueue()
 					{ &settings.ToggleKey, &settingToggleKey, [this](uint32_t key) { settings.ToggleKey = key; settingToggleKey = false; } },
 					{ &settings.SkipCompilationKey, &settingSkipCompilationKey, [this](uint32_t key) { settings.SkipCompilationKey = key; settingSkipCompilationKey = false; } },
 					{ &settings.EffectToggleKey, &settingsEffectsToggle, [this](uint32_t key) { settings.EffectToggleKey = key; settingsEffectsToggle = false; } },
-					{ &settings.PerfOverlay.OverlayToggleKey, &settingOverlayToggleKey, [this](uint32_t key) { settings.PerfOverlay.OverlayToggleKey = key; settingOverlayToggleKey = false; } },
+					{ &settings.OverlayToggleKey, &settingOverlayToggleKey, [this](uint32_t key) { settings.OverlayToggleKey = key; settingOverlayToggleKey = false; } },
 				};
 				bool handled = false;
 				for (auto& h : hotkeyActions) {
@@ -3259,7 +2096,9 @@ void Menu::ProcessInputEventQueue()
 						{ settings.EffectToggleKey, [shaderCache]() { shaderCache->SetEnabled(!shaderCache->IsEnabled()); } },
 						{ priorShaderKey, [shaderCache, devMode]() { if (devMode) shaderCache->IterateShaderBlock(); } },
 						{ nextShaderKey, [shaderCache, devMode]() { if (devMode) shaderCache->IterateShaderBlock(false); } },
-						{ settings.PerfOverlay.OverlayToggleKey, [this]() { settings.PerfOverlay.Enabled = !settings.PerfOverlay.Enabled; } },
+						{ settings.OverlayToggleKey, []() {
+							 Menu::GetSingleton()->overlayVisible = !Menu::GetSingleton()->overlayVisible;
+						 } },
 					};
 					for (auto& ka : keyActions) {
 						if (key == ka.settingKey) {
@@ -3367,14 +2206,14 @@ void Menu::SelectFeatureMenu(const std::string& featureName)
 
 void Menu::DrawWeatherDetailsWindow()
 {
-	if (!settings.WeatherDetailsWindow.Enabled) {
+	if (!WeatherPicker::GetSingleton()->WeatherDetailsWindow.Enabled) {
 		return;
 	}
 
 	// Use Weather core feature for all window management and rendering
 	auto weather = globals::features::weatherPicker;
 	if (weather) {
-		bool* p_open = &settings.WeatherDetailsWindow.Enabled;
+		bool* p_open = &WeatherPicker::GetSingleton()->WeatherDetailsWindow.Enabled;
 		weather->RenderWeatherDetailsWindow(p_open);
 	}
 }

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -172,11 +172,47 @@ struct TestData
 	float costPerCall;
 	float percent;
 };
+
+// Test data source tracking
+enum class TestDataSource
+{
+	None,
+	ABTest_VariantB,
+	ManualShaderToggle
+};
+static TestDataSource s_testDataSource = TestDataSource::None;
+static std::chrono::steady_clock::time_point s_testDataLastUpdated;
+static std::string TimeAgoString(std::chrono::steady_clock::time_point a_last)
+{
+	using namespace std::chrono;
+	auto now = steady_clock::now();
+	auto diff = duration_cast<seconds>(now - a_last).count();
+	if (diff < 60)
+		return std::to_string(diff) + "s";
+	return std::to_string(diff / 60) + "m";
+}
+
 static std::unordered_map<int, TestData> s_testData;
 static bool abTestingEnabled = false;
 static void UpdateShaderTestData(int shaderType, float frameTime, float costPerCall)
 {
 	s_testData[shaderType] = { frameTime, costPerCall };
+	// Compute and save 'Other' and 'Total' test data
+	float smoothedFrameTime = static_cast<float>(Menu::GetSingleton()->perfOverlayState.smoothFrameTimeMs);
+	float measuredSum = 0.0f;
+	for (const auto& [type, data] : s_testData) {
+		if (type >= 0)
+			measuredSum += data.frameTime;
+	}
+	float otherFrameTime = smoothedFrameTime - measuredSum;
+	float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
+	s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
+	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
+	float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
+	s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+
+	s_testDataSource = TestDataSource::ManualShaderToggle;
+	s_testDataLastUpdated = std::chrono::steady_clock::now();
 }
 
 // Add this function near the top of Menu.cpp (after abTestingEnabled, usingTestConfig, etc.)
@@ -204,6 +240,20 @@ static void UpdateAllShaderTestData()
 	s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
 	float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
 	s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+	s_testDataSource = TestDataSource::ABTest_VariantB;
+	s_testDataLastUpdated = std::chrono::steady_clock::now();
+}
+
+static std::string GetTestDataTooltip()
+{
+	switch (s_testDataSource) {
+	case TestDataSource::ABTest_VariantB:
+		return std::string("Test data from Test (Variant B).\nLast updated: ") + TimeAgoString(s_testDataLastUpdated) + " ago.";
+	case TestDataSource::ManualShaderToggle:
+		return std::string("Test data from manual shader toggle.\nLast updated: ") + TimeAgoString(s_testDataLastUpdated) + " ago.";
+	default:
+		return "No test data available.";
+	}
 }
 
 void Menu::SetupImGuiStyle() const
@@ -2250,6 +2300,14 @@ void Menu::PerfOverlayState::DrawPostFGFrameTimeGraph(Settings::PerfOverlaySetti
 void Menu::PerfOverlayState::DrawDrawCalls()
 {
 	static bool clearTestDataRequested = false;
+	bool abTestActive = (abTestingEnabled && Menu::GetSingleton()->usingTestConfig);
+	bool anyShaderDisabled = false;
+	for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
+		if (!globals::state->enabledClasses[i]) {
+			anyShaderDisabled = true;
+			break;
+		}
+	}
 	if (!s_testData.empty()) {
 		if (ImGui::Button("Clear Test Data")) {
 			clearTestDataRequested = true;
@@ -2301,12 +2359,12 @@ void Menu::PerfOverlayState::DrawDrawCalls()
 
 	// Use the smoothed frame time for all calculations
 	float smoothedFrameTime = static_cast<float>(Menu::GetSingleton()->perfOverlayState.smoothFrameTimeMs);
-
-	// --- TEST DATA RECORDING IN TEST MODE ---
 	float measuredSum = 0.0f;
-	float otherFrameTime = 0.0f;
 	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
-	if (abTestingEnabled && Menu::GetSingleton()->usingTestConfig) {
+
+	// --- TEST DATA SNAPSHOT LOGIC ---
+	if (abTestActive) {
+		measuredSum = 0.0f;
 		for (const auto& row : shaderTypes) {
 			auto typeIndex = magic_enum::enum_integer(row.type);
 			float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
@@ -2316,7 +2374,26 @@ void Menu::PerfOverlayState::DrawDrawCalls()
 			s_testData[typeIndex] = { frameTime, costPerCall, percent };
 			measuredSum += frameTime;
 		}
-		otherFrameTime = smoothedFrameTime - measuredSum;
+		float otherFrameTime = smoothedFrameTime - measuredSum;
+		float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
+		s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
+		float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
+		s_testData[-1] = { smoothedFrameTime, totalCostPerCall, 100.0f };
+	} else if (anyShaderDisabled) {
+		measuredSum = 0.0f;
+		for (const auto& row : shaderTypes) {
+			auto typeIndex = magic_enum::enum_integer(row.type);
+			bool enabled = globals::state->enabledClasses[typeIndex - 1];
+			if (!enabled) {
+				float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
+				float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
+				float percent = (smoothedFrameTime > 0.0f) ? (frameTime / smoothedFrameTime) * 100.0f : 0.0f;
+				float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
+				s_testData[typeIndex] = { frameTime, costPerCall, percent };
+			}
+			measuredSum += static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
+		}
+		float otherFrameTime = smoothedFrameTime - measuredSum;
 		float otherPercent = (smoothedFrameTime > 0.0f) ? (otherFrameTime / smoothedFrameTime) * 100.0f : 0.0f;
 		s_testData[-2] = { otherFrameTime, 0.0f, otherPercent };
 		float totalCostPerCall = (totalSmoothedDrawCalls > 0.0f) ? (smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f;
@@ -2339,9 +2416,6 @@ void Menu::PerfOverlayState::DrawDrawCalls()
 			costPerCall = 0.0f;
 		bool enabled = globals::state->enabledClasses[typeIndex - 1];
 		std::optional<float> testFrameTime, testCostPerCall;
-		if ((abTestingEnabled && Menu::GetSingleton()->usingTestConfig) || !enabled) {
-			s_testData[typeIndex] = { frameTime, costPerCall, percent };
-		}
 		auto it = s_testData.find(typeIndex);
 		if (it != s_testData.end()) {
 			testFrameTime = it->second.frameTime;
@@ -2354,7 +2428,7 @@ void Menu::PerfOverlayState::DrawDrawCalls()
 	}
 
 	// Add summary rows (not part of main sorting)
-	otherFrameTime = smoothedFrameTime - measuredSum;
+	float otherFrameTime = smoothedFrameTime - measuredSum;
 	if (std::abs(otherFrameTime) < 1e-4f)
 		otherFrameTime = 0.0f;
 
@@ -2387,11 +2461,7 @@ void Menu::PerfOverlayState::DrawDrawCalls()
 			ImGui::TableSetupColumn(headers[i].c_str());
 			if (anyTestData && (headers[i] == "Test Frame Time" || headers[i] == "Test Cost/Call")) {
 				if (ImGui::IsItemHovered()) {
-					if (abTestingEnabled) {
-						ImGui::SetTooltip("A/B Test: This data was recorded during the last TEST phase (Variant B). It is frozen until the next TEST phase.\nVariant A = USER config, Variant B = TEST config.");
-					} else {
-						ImGui::SetTooltip("Test data is recorded when a shader is disabled. Green = better, Red = worse vs. regular column.\nA/B Test: Variant A = USER config, Variant B = TEST config.");
-					}
+					ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
 				}
 			}
 		}
@@ -2511,11 +2581,7 @@ void Menu::PerfOverlayState::DrawDrawCalls()
 					ImGui::Text("%.2f ms (%.1f%%)", *row.testFrameTime, s_testData[row.shaderType].percent);
 					ImGui::PopStyleColor();
 					if (ImGui::IsItemHovered()) {
-						if (abTestingEnabled) {
-							ImGui::SetTooltip("A/B Test: This data was recorded during the last TEST phase (Variant B). It is frozen until the next TEST phase.\nVariant A = USER config, Variant B = TEST config.");
-						} else {
-							ImGui::SetTooltip("Test data is recorded when a shader is disabled. Green = better, Red = worse vs. regular column.\nA/B Test: Variant A = USER config, Variant B = TEST config.");
-						}
+						ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
 					}
 				} else {
 					ImGui::TextDisabled("-");
@@ -2535,11 +2601,7 @@ void Menu::PerfOverlayState::DrawDrawCalls()
 						ImGui::Text("%.3f ms", *row.testCostPerCall);
 					ImGui::PopStyleColor();
 					if (ImGui::IsItemHovered()) {
-						if (abTestingEnabled) {
-							ImGui::SetTooltip("A/B Test: This data was recorded during the last TEST phase (Variant B). It is frozen until the next TEST phase.\nVariant A = USER config, Variant B = TEST config.");
-						} else {
-							ImGui::SetTooltip("Test data is recorded when a shader is disabled. Green = better, Red = worse vs. regular column.\nA/B Test: Variant A = USER config, Variant B = TEST config.");
-						}
+						ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
 					}
 				} else {
 					ImGui::TextDisabled("-");
@@ -2618,11 +2680,7 @@ void Menu::PerfOverlayState::DrawDrawCalls()
 					ImGui::Text("%.2f ms (%.1f%%)", testIt->second.frameTime, testIt->second.percent);
 					ImGui::PopStyleColor();
 					if (ImGui::IsItemHovered()) {
-						if (abTestingEnabled) {
-							ImGui::SetTooltip("A/B Test: This data was recorded during the last TEST phase (Variant B). It is frozen until the next TEST phase.\nVariant A = USER config, Variant B = TEST config.");
-						} else {
-							ImGui::SetTooltip("Test data is recorded when a shader is disabled. Green = better, Red = worse vs. regular column.\nA/B Test: Variant A = USER config, Variant B = TEST config.");
-						}
+						ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
 						// Show FPS for test frame time
 						float _fps = testIt->second.frameTime > 0.0f ? 1000.0f / testIt->second.frameTime : 0.0f;
 						if (auto _tt = Util::HoverTooltipWrapper()) {
@@ -2646,11 +2704,7 @@ void Menu::PerfOverlayState::DrawDrawCalls()
 						ImGui::Text("%.3f ms", testIt->second.costPerCall);
 					ImGui::PopStyleColor();
 					if (ImGui::IsItemHovered()) {
-						if (abTestingEnabled) {
-							ImGui::SetTooltip("A/B Test: This data was recorded during the last TEST phase (Variant B). It is frozen until the next TEST phase.\nVariant A = USER config, Variant B = TEST config.");
-						} else {
-							ImGui::SetTooltip("Test data is recorded when a shader is disabled. Green = better, Red = worse vs. regular column.\nA/B Test: Variant A = USER config, Variant B = TEST config.");
-						}
+						ImGui::SetTooltip("%s", GetTestDataTooltip().c_str());
 					}
 				} else {
 					ImGui::TextUnformatted("N/A");
@@ -2663,6 +2717,7 @@ void Menu::PerfOverlayState::DrawDrawCalls()
 	if (clearTestDataRequested) {
 		s_testData.clear();
 		clearTestDataRequested = false;
+		s_testDataSource = TestDataSource::None;
 	}
 }
 

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1488,10 +1488,10 @@ void Menu::DrawAdvancedSettings()
 	if (ImGui::CollapsingHeader("Replace Original Shaders", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick)) {
 		auto state = globals::state;
 		if (ImGui::BeginTable("##ReplaceToggles", 3, ImGuiTableFlags_SizingStretchSame)) {
-			for (int classIndex = 0; classIndex < RE::BSShader::Type::Total - 1; ++classIndex) {
+			for (int classIndex = 0; classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++classIndex) {
 				ImGui::TableNextColumn();
 
-				auto type = (RE::BSShader::Type)(classIndex + 1);
+				auto type = magic_enum::enum_value<RE::BSShader::Type>(classIndex + 1);
 				if (!(SIE::ShaderCache::IsSupportedShader(type) || state->IsDeveloperMode())) {
 					ImGui::BeginDisabled();
 					ImGui::Checkbox(std::format("{}", magic_enum::enum_name(type)).c_str(), &state->enabledClasses[classIndex]);

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -2093,7 +2093,19 @@ void Menu::PerfOverlayState::DrawFPS(Settings::PerfOverlaySettings& settings)
 
 	// Show Post-FG frametime graph if enabled
 	if (settings.ShowPostFGFrameTimeGraph && isFrameGenerationActive) {
-		DrawPostFGFrameTimeGraph(settings);
+		// Check if FSR frame generation is active (FSR doesn't provide timing data)
+		bool isFSRFrameGen = globals::fidelityFX && globals::fidelityFX->isFrameGenActive;
+
+		if (isFSRFrameGen) {
+			// Show note that post-FG timing isn't available with FSR
+			ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f), "Post-FG timing not available with FSR3 Framegen");
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text("AMD FSR Frame Generation doesn't provide internal timing data.\nPost-FG performance metrics are only available with NVIDIA DLSS Frame Generation.");
+			}
+		} else {
+			// Show post-FG graph for DLSS
+			DrawPostFGFrameTimeGraph(settings);
+		}
 	}
 }
 
@@ -2292,7 +2304,20 @@ void Menu::DrawPerformanceOverlaySettings()
 				if (isFrameGenerationActive) {
 					// Pre-Frame Generation FPS
 					ImGui::Checkbox("Show Pre-FG Frametime Graph", &settings.PerfOverlay.ShowPreFGFrameTimeGraph);
-					ImGui::Checkbox("Show Post-FG Frametime Graph", &settings.PerfOverlay.ShowPostFGFrameTimeGraph);
+					// Check if FSR frame generation is active
+					bool isFSRFrameGen = globals::fidelityFX && globals::fidelityFX->isFrameGenActive;
+					if (isFSRFrameGen) {
+						// Disable post-FG option for FSR and show note
+						ImGui::BeginDisabled();
+						ImGui::Checkbox("Show Post-FG Frametime Graph", &settings.PerfOverlay.ShowPostFGFrameTimeGraph);
+						ImGui::EndDisabled();
+						if (auto _tt = Util::HoverTooltipWrapper()) {
+							ImGui::Text("Post-FG timing not available with AMD FSR Frame Generation.\nThis option is only available with NVIDIA DLSS Frame Generation.");
+						}
+					} else {
+						// Enable post-FG option for DLSS
+						ImGui::Checkbox("Show Post-FG Frametime Graph", &settings.PerfOverlay.ShowPostFGFrameTimeGraph);
+					}
 				} else {
 					// Regular FPS options when frame generation is not active
 					ImGui::Checkbox("Show Frametime Graph", &settings.PerfOverlay.ShowPreFGFrameTimeGraph);

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -129,6 +129,37 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 
 constexpr std::uint16_t KEY_PRESSED_MASK = 0x8000;
 
+// Struct for draw call overlay table row data
+struct DrawCallRow
+{
+	std::string label;
+	int shaderType;
+	int drawCalls;
+	float frameTime;
+	float percent;
+	float costPerCall;
+	std::string tooltip;
+	bool enabled;
+};
+
+typedef RE::BSShader::Type ShaderTypeEnum;
+struct ShaderRow
+{
+	std::string label;
+	ShaderTypeEnum type;
+	std::string tooltip;
+};
+
+// Define an enum for table columns for clarity and maintainability
+enum DrawCallTableColumn
+{
+	Col_Label = 0,
+	Col_DrawCalls,
+	Col_FrameTime,
+	Col_CostPerCall,
+	Col_Count  // always last, gives you the number of columns
+};
+
 void Menu::SetupImGuiStyle() const
 {
 	auto& style = ImGui::GetStyle();
@@ -145,17 +176,17 @@ void Menu::SetupImGuiStyle() const
 	style.HoverDelayNormal = themeSettings.TooltipHoverDelay;
 
 	if (themeSettings.UseSimplePalette) {
-		float hovoredAlpha{ 0.1f };
+		float hoveredAlpha{ 0.1f };
 
 		ImVec4 resizeGripHovered = themeSettings.Palette.Border;
-		resizeGripHovered.w = hovoredAlpha;
+		resizeGripHovered.w = hoveredAlpha;
 
 		ImVec4 textDisabled = themeSettings.Palette.Text;
 		textDisabled.w = 0.3f;
 
 		ImVec4 header{ 1.0f, 1.0f, 1.0f, 0.15f };
 		ImVec4 headerHovered = header;
-		headerHovered.w = hovoredAlpha;
+		headerHovered.w = hoveredAlpha;
 
 		ImVec4 tabHovered{ 0.2f, 0.2f, 0.2f, 1.0f };
 
@@ -2164,49 +2195,312 @@ void Menu::PerfOverlayState::DrawPostFGFrameTimeGraph(Settings::PerfOverlaySetti
  */
 void Menu::PerfOverlayState::DrawDrawCalls()
 {
-	if (ImGui::BeginTable("Draw Call Table", 2, ImGuiTableFlags_SizingStretchProp, { -FLT_MIN, 0 })) {
-		ImGui::TableSetupColumn("Shader Type", ImGuiTableColumnFlags_WidthFixed, ImGui::GetTextLineHeight() * 5);
-		ImGui::TableSetupColumn("Draw Calls");
+	std::vector<std::string> headers = { "Shader Type", "Draw Calls", "Frame Time (%)", "Cost/Call" };
+	std::vector<DrawCallRow> rows;
 
+	// Tooltip map for shader types
+	static const std::unordered_map<RE::BSShader::Type, std::string> kShaderTypeTooltips = {
+		{ RE::BSShader::Type::Grass, "Draw calls using the Grass shader. Typically many, but each is usually cheap." },
+		{ RE::BSShader::Type::Sky, "Draw calls for the sky dome, clouds, and related effects." },
+		{ RE::BSShader::Type::Water, "Draw calls for water surfaces and effects." },
+		{ RE::BSShader::Type::Lighting, "Draw calls for dynamic and static lighting passes." },
+		{ RE::BSShader::Type::Effect, "Draw calls for special effects, particles, and post-processing." },
+		{ RE::BSShader::Type::Utility, "Draw calls for utility passes, such as shadow masks or G-buffer fills." },
+		{ RE::BSShader::Type::DistantTree, "Draw calls for distant tree rendering (LOD vegetation)." },
+		{ RE::BSShader::Type::Particle, "Draw calls for particle systems (smoke, sparks, etc.)." },
+		{ RE::BSShader::Type::BloodSplatter, "Draw calls for blood splatter effects." },
+		{ RE::BSShader::Type::ImageSpace, "Draw calls for image space post-processing effects." }
+	};
+	std::vector<ShaderRow> shaderTypes;
+	for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
+		if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
+			continue;
+		std::string label = std::string(magic_enum::enum_name(type)) + ":";
+		auto it = kShaderTypeTooltips.find(type);
+		std::string tooltip = (it != kShaderTypeTooltips.end()) ? it->second : "Draw calls for this shader type.";
+		tooltip += "\nClick to ";
+		tooltip += (globals::state->enabledClasses[magic_enum::enum_integer(type) - 1]) ? "disable" : "enable";
+		tooltip += " this shader.";
+		shaderTypes.push_back({ label, type, tooltip });
+	}
+
+	// Sorting state (declare all at the top)
+	static int sortColumn = 0;
+	static bool sortAscending = false;
+	static bool isSorted = false;
+	static std::vector<DrawCallRow> originalRows;
+
+	// Use the smoothed frame time for all calculations
+	float smoothedFrameTime = static_cast<float>(Menu::GetSingleton()->perfOverlayState.smoothFrameTimeMs);
+	// Build main rows: all shader types
+	std::vector<DrawCallRow> mainRows;
+	float measuredSum = 0.0f;
+	for (const auto& row : shaderTypes) {
+		auto typeIndex = magic_enum::enum_integer(row.type);  // safer than static_cast<int>
+		float drawCalls = static_cast<float>(globals::state->smoothDrawCalls[typeIndex]);
+		float frameTime = static_cast<float>(globals::state->smoothFrameTimePerType[typeIndex]);
+		float percent = 0.0f;  // We'll fill this in after we know the total
+		float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
+		// Clamp small negative values to zero
+		if (std::abs(frameTime) < 1e-4f)
+			frameTime = 0.0f;
+		if (std::abs(costPerCall) < 1e-6f)
+			costPerCall = 0.0f;
+		bool enabled = globals::state->enabledClasses[typeIndex - 1];  // -1 for enabledClasses
+		mainRows.push_back({ row.label, typeIndex, static_cast<int>(drawCalls), frameTime, percent, costPerCall, row.tooltip, enabled });
+		measuredSum += frameTime;
+	}
+
+	// Add summary rows (not part of main sorting)
+	float otherFrameTime = smoothedFrameTime - measuredSum;
+	if (std::abs(otherFrameTime) < 1e-4f)
+		otherFrameTime = 0.0f;
+
+	DrawCallRow otherRow = {
+		"Other:", -2, 0, otherFrameTime,
+		(smoothedFrameTime > 0.0f ? static_cast<float>((otherFrameTime / smoothedFrameTime) * 100.0f) : 0.0f),
+		0.0f,
+		std::string("Frame time not attributed to any measured shader type. This includes UI, post-processing, engine work, and any GPU activity not directly measured by the overlay.")
+	};
+
+	float totalSmoothedDrawCalls = static_cast<float>(globals::state->smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
+	DrawCallRow totalRow = {
+		"Total:", -1, static_cast<int>(totalSmoothedDrawCalls), smoothedFrameTime, 100.0f,
+		(totalSmoothedDrawCalls > 0.0f ? static_cast<float>(smoothedFrameTime / totalSmoothedDrawCalls) : 0.0f),
+		std::string("Sum of all measured shader types.\nClick to enable or disable all shaders.")
+	};
+	// Now update percent and costPerCall for all measured rows
+	for (auto& row : mainRows) {
+		row.percent = (smoothedFrameTime > 0.0f) ? (row.frameTime / smoothedFrameTime) * 100.0f : 0.0f;
+		row.costPerCall = (row.drawCalls > 0) ? (row.frameTime / row.drawCalls) : 0.0f;
+	}
+
+	// Always start the main table sorted alphabetically by label on first display
+	static bool firstTableDisplay = true;
+	if (firstTableDisplay) {
+		std::sort(mainRows.begin(), mainRows.end(), [](const DrawCallRow& a, const DrawCallRow& b) {
+			return a.label < b.label;
+		});
+		firstTableDisplay = false;
+	}
+
+	// Handle sorting: only sort mainRows, never summary rows
+	if (ImGui::BeginTable("DrawCallOverlayTable##", Col_Count, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable)) {
+		for (const auto& header : headers)
+			ImGui::TableSetupColumn(header.c_str());
 		ImGui::TableHeadersRow();
 
-		ImGui::TableNextColumn();
-		ImGui::Text("Grass:");
-		ImGui::TableNextColumn();
-		ImGui::Text("%d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Grass]));
-		ImGui::TableNextColumn();
-		ImGui::Text("Sky:");
-		ImGui::TableNextColumn();
-		ImGui::Text("%d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Sky]));
-		ImGui::TableNextColumn();
-		ImGui::Text("Water:");
-		ImGui::TableNextColumn();
-		ImGui::Text("%d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Water]));
-		ImGui::TableNextColumn();
-		ImGui::Text("Lighting:");
-		ImGui::TableNextColumn();
-		ImGui::Text("%d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Lighting]));
-		ImGui::TableNextColumn();
-		ImGui::Text("Effect:");
-		ImGui::TableNextColumn();
-		ImGui::Text("%d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Effect]));
-		ImGui::TableNextColumn();
-		ImGui::Text("Utility:");
-		ImGui::TableNextColumn();
-		ImGui::Text("%d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Utility]));
-		ImGui::TableNextColumn();
-		ImGui::Text("Distant Tree:");
-		ImGui::TableNextColumn();
-		ImGui::Text("%d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::DistantTree]));
-		ImGui::TableNextColumn();
-		ImGui::Text("Particle:");
-		ImGui::TableNextColumn();
-		ImGui::Text("%d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Particle]));
-		ImGui::TableNextColumn();
-		ImGui::Text("Total:");
-		ImGui::TableNextColumn();
-		ImGui::Text("%d", int(globals::state->smoothDrawCalls[RE::BSShader::Type::Total]));
+		if (const ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs()) {
+			if (sortSpecs->SpecsCount > 0) {
+				sortColumn = sortSpecs->Specs->ColumnIndex;
+				sortAscending = sortSpecs->Specs->SortDirection == ImGuiSortDirection_Ascending;
+				// Sort using real data
+				switch (sortColumn) {
+				case Col_Label:  // label (shader type name)
+					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
+						return sortAscending ? (a.label < b.label) : (a.label > b.label);
+					});
+					break;
+				case Col_DrawCalls:  // drawCalls (number of draw calls)
+					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
+						return sortAscending ? (a.drawCalls < b.drawCalls) : (a.drawCalls > b.drawCalls);
+					});
+					break;
+				case Col_FrameTime:  // percent (frame time %)
+					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
+						return sortAscending ? (a.percent < b.percent) : (a.percent > b.percent);
+					});
+					break;
+				case Col_CostPerCall:  // costPerCall (ms per draw call)
+					std::sort(mainRows.begin(), mainRows.end(), [=](const DrawCallRow& a, const DrawCallRow& b) {
+						return sortAscending ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall);
+					});
+					break;
+				}
+			}
+		}
 
+		// --- Main table cell rendering switch: renders each cell based on column ---
+		for (size_t rowIdx = 0; rowIdx < mainRows.size(); ++rowIdx) {
+			const auto& row = mainRows[rowIdx];
+			ImGui::TableNextRow();
+			for (int col = 0; col < Col_Count; ++col) {
+				ImGui::TableSetColumnIndex(col);
+				ImVec4 color = ImGui::GetStyleColorVec4(ImGuiCol_Text);
+				bool useColor = false;
+				switch (col) {
+				case Col_FrameTime:  // percent coloring
+					if (row.percent < 30.0f)
+						color = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
+					else if (row.percent < 60.0f)
+						color = Menu::GetSingleton()->GetTheme().StatusPalette.Warning;
+					else
+						color = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
+					useColor = true;
+					break;
+				case Col_CostPerCall:  // costPerCall coloring (ms per draw call)
+					if (row.costPerCall < 0.05f)
+						color = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
+					else if (row.costPerCall < 0.2f)
+						color = Menu::GetSingleton()->GetTheme().StatusPalette.Warning;
+					else
+						color = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
+					useColor = true;
+					break;
+				}
+				// --- Cell rendering switch: draws the actual cell content ---
+				bool wasEnabled = false;
+				switch (col) {
+				case Col_Label:  // Label (shader type name)
+					if (!row.enabled) {
+						ImGui::PushStyleColor(ImGuiCol_Text, Menu::GetSingleton()->GetTheme().StatusPalette.Disable);
+					}
+					wasEnabled = row.enabled;
+					if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
+						// Use magic_enum::enum_cast for safety
+						auto maybeType = magic_enum::enum_cast<RE::BSShader::Type>(row.shaderType);
+						if (maybeType.has_value()) {
+							auto classIndex = magic_enum::enum_integer(*maybeType) - 1;
+							if (classIndex >= 0 && classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1) {
+								globals::state->enabledClasses[classIndex] = !wasEnabled;
+							}
+						}
+					}
+					// Show tooltip if hovered
+					if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup | ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
+						ImGui::SetTooltip("%s", row.tooltip.c_str());
+					}
+					if (!row.enabled) {
+						ImGui::PopStyleColor();
+					}
+					break;
+				case Col_DrawCalls:  // Draw Calls (number of draw calls)
+					if (useColor)
+						ImGui::TextColored(color, "%d", row.drawCalls);
+					else
+						ImGui::Text("%d", row.drawCalls);
+					break;
+				case Col_FrameTime:  // Frame Time (ms and %)
+					if (useColor)
+						ImGui::TextColored(color, "%.2f ms (%.1f%%)", row.frameTime, row.percent);
+					else
+						ImGui::Text("%.2f ms (%.1f%%)", row.frameTime, row.percent);
+					break;
+				case Col_CostPerCall:  // Cost/Call (ms or us per draw call)
+					if (row.costPerCall < 0.01f && row.costPerCall > 0.0f) {
+						if (useColor)
+							ImGui::TextColored(color, "%.2f us", row.costPerCall * 1000.0f);
+						else
+							ImGui::Text("%.2f us", row.costPerCall * 1000.0f);
+					} else {
+						if (useColor)
+							ImGui::TextColored(color, "%.3f ms", row.costPerCall);
+						else
+							ImGui::Text("%.3f ms", row.costPerCall);
+					}
+					break;
+				}
+			}
+		}
+
+		// Separator row (optional, for visual separation)
+		ImGui::TableNextRow(ImGuiTableRowFlags_None, 4.0f);
+		for (int col = 0; col < Col_Count; ++col) {
+			ImGui::TableSetColumnIndex(col);
+			if (col == Col_Label)
+				ImGui::Separator();
+		}
+
+		// --- Summary row rendering switch: handles Other and Total rows ---
+		for (const DrawCallRow& row : { otherRow, totalRow }) {
+			ImGui::TableNextRow();
+			for (int col = 0; col < Col_Count; ++col) {
+				ImGui::TableSetColumnIndex(col);
+				ImVec4 color = ImGui::GetStyleColorVec4(ImGuiCol_Text);
+				bool useColor = false;
+				// Set color and useColor for percent and costPerCall columns before the switch
+				if (col == Col_FrameTime) {  // percent coloring (frame time %)
+					if (row.percent < 30.0f)
+						color = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
+					else if (row.percent < 60.0f)
+						color = Menu::GetSingleton()->GetTheme().StatusPalette.Warning;
+					else
+						color = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
+					useColor = true;
+				} else if (col == Col_CostPerCall) {  // costPerCall coloring (ms per draw call)
+					if (row.costPerCall < 0.05f)
+						color = Menu::GetSingleton()->GetTheme().StatusPalette.SuccessColor;
+					else if (row.costPerCall < 0.2f)
+						color = Menu::GetSingleton()->GetTheme().StatusPalette.Warning;
+					else
+						color = Menu::GetSingleton()->GetTheme().StatusPalette.Error;
+					useColor = true;
+				}
+				// --- Cell rendering for summary rows ---
+				switch (col) {
+				case Col_Label:  // Label (Other/Total)
+					// Make Total row clickable to toggle all shaders
+					if (row.label == std::string("Total:")) {
+						if (ImGui::Selectable(row.label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
+							// If any are disabled, enable all; else disable all
+							bool anyDisabled = false;
+							for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
+								if (!globals::state->enabledClasses[i]) {
+									anyDisabled = true;
+									break;
+								}
+							}
+							for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++i) {
+								globals::state->enabledClasses[i] = anyDisabled;
+							}
+						}
+					} else {
+						ImGui::TextUnformatted(row.label.c_str());
+					}
+					if (!row.tooltip.empty() && ImGui::IsItemHovered()) {
+						if (auto _tt = Util::HoverTooltipWrapper()) {
+							ImGui::TextUnformatted(row.tooltip.c_str());
+						}
+					}
+					break;
+				case Col_DrawCalls:  // Draw Calls (Other/Total)
+					if (row.label == "Other:" && row.drawCalls <= 0) {
+						ImGui::TextUnformatted("N/A");
+					} else {
+						if (useColor)
+							ImGui::TextColored(color, "%d", row.drawCalls);
+						else
+							ImGui::Text("%d", row.drawCalls);
+					}
+					break;
+				case Col_FrameTime:  // Frame Time (Other/Total)
+					if (row.label == "Other:" && row.frameTime <= 0.0f) {
+						ImGui::TextUnformatted("N/A");
+					} else {
+						if (useColor)
+							ImGui::TextColored(color, "%.2f ms (%.1f%%)", row.frameTime, row.percent);
+						else
+							ImGui::Text("%.2f ms (%.1f%%)", row.frameTime, row.percent);
+					}
+					break;
+				case Col_CostPerCall:  // Cost/Call (Other/Total)
+					if (row.label == "Other:" && row.costPerCall <= 0.0f) {
+						ImGui::TextUnformatted("N/A");
+					} else if (row.costPerCall < 0.01f && row.costPerCall > 0.0f) {
+						if (useColor)
+							ImGui::TextColored(color, "%.2f us", row.costPerCall * 1000.0f);
+						else
+							ImGui::Text("%.2f us", row.costPerCall * 1000.0f);
+					} else {
+						if (useColor)
+							ImGui::TextColored(color, "%.3f ms", row.costPerCall);
+						else
+							ImGui::Text("%.3f ms", row.costPerCall);
+					}
+					break;
+				}
+			}
+		}
 		ImGui::EndTable();
 	}
 }

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1738,6 +1738,7 @@ void Menu::DrawOverlay()
 			ImGui::End();
 			return;
 		}
+		remaining = std::max(0.0f, remaining);
 		ImGui::Text(fmt::format("{} : {:.1f} seconds left", Menu::GetSingleton()->usingTestConfig ? "Variant B (TEST)" : "Variant A (USER)", remaining).c_str());
 		ImGui::End();
 	}

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -24,7 +24,6 @@ public:
 	void Init();
 	void DrawSettings();
 	void DrawOverlay();
-	void DrawPerfOverlay();
 	void DrawWeatherDetailsWindow();
 
 	void ProcessInputEvents(RE::InputEvent* const* a_events);
@@ -166,90 +165,19 @@ public:
 		uint32_t ToggleKey = VK_END;
 		uint32_t SkipCompilationKey = VK_ESCAPE;
 		uint32_t EffectToggleKey = VK_MULTIPLY;  // toggle all effects
+		uint32_t OverlayToggleKey = VK_F10;      // Global overlay toggle key for all overlays
 		ThemeSettings Theme;
-
-		struct PerfOverlaySettings
-		{
-			bool Enabled = false;
-			bool ShowDrawCalls = true;
-			bool ShowVRAM = true;
-			bool ShowFPS = true;
-			bool ShowPreFGFrameTimeGraph = true;
-			bool ShowPostFGFrameTimeGraph = true;
-			float UpdateInterval = 0.5f;
-			int FrameHistorySize = 120;                       // Default 120 frames = 2s @ 60fps. Clamped using static values to prevent config file values going outside of slider bounds.
-			static constexpr int kMinFrameHistorySize = 60;   // 60 frames = 1s @ 60fps. Reasonable minimum.
-			static constexpr int kMaxFrameHistorySize = 480;  // 480 frames = 10s @ 60fps or 2s @ 240fps. Reasonable maximum.
-			enum class TextSize
-			{
-				Small,
-				Medium,
-				Large
-			};
-			TextSize Size = TextSize::Medium;
-
-			float BackgroundOpacity = 0.5f;
-			bool ShowBorder = true;
-			ImVec2 Position = ImVec2(10.f, 10.f);
-			bool PositionSet = false;
-			uint32_t OverlayToggleKey = VK_F10;
-		} PerfOverlay;
-
-		struct WeatherDetailsWindowSettings
-		{
-			bool Enabled = false;
-			ImVec2 Position = ImVec2(50.f, 50.f);
-			bool PositionSet = false;
-		} WeatherDetailsWindow;
 	};
-	const ThemeSettings& GetTheme() const { return settings.Theme; }  // Provide read-only access to the Theme.
-	Settings& GetSettings() { return settings; }                      // Provide access to settings for other components
+	const ThemeSettings& GetTheme() const { return settings.Theme; }                // Provide read-only access to the Theme.
+	Settings& GetSettings() { return settings; }                                    // Provide access to settings for other components
+	winrt::com_ptr<IDXGIAdapter3> GetDXGIAdapter3() const { return dxgiAdapter3; }  // Provide access to dxgiAdapter3
 
 	void SelectFeatureMenu(const std::string& featureName);
 	static std::unordered_map<std::string, int> categoryCounts;  // Number of features in each feature category
 
-	class PerfOverlayState
-	{
-	public:
-		std::vector<float> frameTimeHistory;
-		std::vector<float> postFGFrameTimeHistory;
-		bool initialized = false;
-		bool hasGraphs = false;
-		int frameTimeHistoryIndex = 0;
-		int postFGFrameTimeHistoryIndex = 0;
-		bool isFrameGenerationActive = false;
-		int64_t frequency;
-		int64_t lastFrameCounter;
-		int64_t currentFrameCounter;
-		float frameTimeMs = 0.0f;
-		float fps = 0.0f;
-		float postFGFrameTimeMs = 0.0f;
-		float postFGFps = 0.0f;
-		float smoothFps = 0.0f;
-		float smoothFrameTimeMs = 0.0f;
-		float postFGSmoothFps = 0.0f;
-		float postFGSmoothFrameTimeMs = 0.0f;
-		float updateTimer = 0.0f;
-		float minFrameTime = 1000.0f;
-		float maxFrameTime = 0.0f;
-		float smoothedMinFrameTime = 0.0f;
-		float smoothedMaxFrameTime = 50.0f;
-		float textScale = 1.0f;
-		static constexpr float kSmoothingFactor = 0.15f;  // Smoothing factor: 0.1f = slow, 0.3f = fast.
-		std::chrono::steady_clock::time_point lastUpdateTime;
-		float SetTextScale(Settings::PerfOverlaySettings& settings);
-		void UpdateGraphValues(Settings::PerfOverlaySettings& settings);
-		void UpdateFrameTimeHistorySizes(Settings::PerfOverlaySettings& settings);
-		void UpdateMinFrameTime();
-		void UpdateMaxFrameTime();
-		void UpdateFGFrameTime(Settings::PerfOverlaySettings& settings);
-		void DrawPostFGFrameTimeGraph(Settings::PerfOverlaySettings& settings);
-		void DrawDrawCalls();
-		void DrawFPS(Settings::PerfOverlaySettings& settings);
-		void DrawVRAM(winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3);
-	};
 	bool usingTestConfig = false;
-	PerfOverlayState perfOverlayState;
+	bool abTestingEnabled = false;
+	bool overlayVisible = false;
 
 	// Static utility functions
 	static const char* KeyIdToString(uint32_t key);
@@ -281,7 +209,6 @@ private:
 	void DrawDisplaySettings();
 	void DrawDisableAtBootSettings();
 	void DrawFooter();
-	void DrawPerformanceOverlaySettings();
 	void BuildCategoryCounts();
 
 	class CharEvent : public RE::InputEvent

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -208,26 +208,6 @@ public:
 	void SelectFeatureMenu(const std::string& featureName);
 	static std::unordered_map<std::string, int> categoryCounts;  // Number of features in each feature category
 
-	// Static utility functions
-	static const char* KeyIdToString(uint32_t key);
-
-private:
-	Settings settings;
-
-	// Menu navigation
-	std::string pendingFeatureSelection;  // Feature to select on next frame
-
-	uint32_t priorShaderKey = VK_PRIOR;  // used for blocking shaders in debugging
-	uint32_t nextShaderKey = VK_NEXT;    // used for blocking shaders in debugging
-
-	bool settingToggleKey = false;
-	bool settingSkipCompilationKey = false;
-	bool settingsEffectsToggle = false;
-	bool settingOverlayToggleKey = false;
-	uint32_t testInterval = 0;     // Seconds to wait before toggling user/test settings
-	bool inTestMode = false;       // Whether we're in test mode
-	bool usingTestConfig = false;  // Whether we're using the test config
-
 	class PerfOverlayState
 	{
 	public:
@@ -267,7 +247,28 @@ private:
 		void DrawDrawCalls();
 		void DrawFPS(Settings::PerfOverlaySettings& settings);
 		void DrawVRAM(winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3);
-	} perfOverlayState;
+	};
+	bool usingTestConfig = false;
+	PerfOverlayState perfOverlayState;
+
+	// Static utility functions
+	static const char* KeyIdToString(uint32_t key);
+
+private:
+	Settings settings;
+
+	// Menu navigation
+	std::string pendingFeatureSelection;  // Feature to select on next frame
+
+	uint32_t priorShaderKey = VK_PRIOR;  // used for blocking shaders in debugging
+	uint32_t nextShaderKey = VK_NEXT;    // used for blocking shaders in debugging
+
+	bool settingToggleKey = false;
+	bool settingSkipCompilationKey = false;
+	bool settingsEffectsToggle = false;
+	bool settingOverlayToggleKey = false;
+	uint32_t testInterval = 0;  // Seconds to wait before toggling user/test settings
+	bool inTestMode = false;    // Whether we're in test mode
 
 	std::chrono::steady_clock::time_point lastTestSwitch = std::chrono::steady_clock::now();  // Time of last test switch
 

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -175,8 +175,6 @@ public:
 	void SelectFeatureMenu(const std::string& featureName);
 	static std::unordered_map<std::string, int> categoryCounts;  // Number of features in each feature category
 
-	bool usingTestConfig = false;
-	bool abTestingEnabled = false;
 	bool overlayVisible = false;
 
 	// Static utility functions
@@ -195,10 +193,6 @@ private:
 	bool settingSkipCompilationKey = false;
 	bool settingsEffectsToggle = false;
 	bool settingOverlayToggleKey = false;
-	uint32_t testInterval = 0;  // Seconds to wait before toggling user/test settings
-	bool inTestMode = false;    // Whether we're in test mode
-
-	std::chrono::steady_clock::time_point lastTestSwitch = std::chrono::steady_clock::now();  // Time of last test switch
 
 	Menu() = default;
 	void SetupImGuiStyle() const;

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -78,15 +78,37 @@ void State::Draw()
 		currentExtraFeatureDescriptor = 0;
 
 		if (frameChecker.IsNewFrame()) {
-			for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) + 1; ++i)
-				smoothDrawCalls[i] = smoothDrawCalls[i] * 0.95 + drawCalls[i] * 0.05;
+			for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) + 1; ++i) {
+				smoothDrawCalls[i] = smoothDrawCalls[i] * static_cast<float>(0.95) + drawCalls[i] * static_cast<float>(0.05);
+				smoothFrameTimePerType[i] = smoothFrameTimePerType[i] * static_cast<float>(0.95) + frameTimePerType[i] * static_cast<float>(0.05);
+			}
 			for (auto& c : drawCalls)
 				c = 0;
+			for (auto& ft : frameTimePerType)
+				ft = 0.0f;
+
+			// Start timing for this frame
+			frameStartTime = std::chrono::high_resolution_clock::now();
+			frameTimingActive = true;
+
 			ID3D11Buffer* buffers[3] = { permutationCB->CB(), sharedDataCB->CB(), featureDataCB->CB() };
 			context->PSSetConstantBuffers(4, 3, buffers);
 			context->CSSetConstantBuffers(5, 2, buffers + 1);
 		}
-		drawCalls[RE::BSShader::Type::Total]++;
+
+		// Track time for current shader type if timing is active
+		if (frameTimingActive && currentShader) {
+			auto currentTime = std::chrono::high_resolution_clock::now();
+			auto elapsed = std::chrono::duration<float, std::milli>(currentTime - frameStartTime).count();
+
+			// Add elapsed time to the current shader type
+			frameTimePerType[magic_enum::enum_integer(currentShader->shaderType.get())] += elapsed;
+			frameTimePerType[magic_enum::enum_integer(RE::BSShader::Type::Total)] += elapsed;
+
+			// Update start time for next measurement
+			frameStartTime = currentTime;
+		}
+
 		if (currentShader)
 			drawCalls[magic_enum::enum_integer(currentShader->shaderType.get())]++;
 
@@ -510,6 +532,13 @@ void State::SetupResources()
 		c = 0;
 	for (auto& c : smoothDrawCalls)
 		c = 0;
+	for (auto& ft : frameTimePerType)
+		ft = 0.0f;
+	for (auto& sft : smoothFrameTimePerType)
+		sft = 0.0f;
+
+	frameTimingActive = false;
+
 	auto renderer = globals::game::renderer;
 
 	permutationCB = new ConstantBuffer(ConstantBufferDesc<PermutationCB>());

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -18,6 +18,7 @@
 
 void State::Draw()
 {
+	auto lock = Lock();
 	auto shaderCache = globals::shaderCache;
 	auto deferred = globals::deferred;
 	auto terrainBlending = globals::features::terrainBlending;

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -78,7 +78,7 @@ void State::Draw()
 		currentExtraFeatureDescriptor = 0;
 
 		if (frameChecker.IsNewFrame()) {
-			for (int i = 0; i < RE::BSShader::Type::Total + 1; ++i)
+			for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) + 1; ++i)
 				smoothDrawCalls[i] = smoothDrawCalls[i] * 0.95 + drawCalls[i] * 0.05;
 			for (auto& c : drawCalls)
 				c = 0;
@@ -88,17 +88,17 @@ void State::Draw()
 		}
 		drawCalls[RE::BSShader::Type::Total]++;
 		if (currentShader)
-			drawCalls[currentShader->shaderType.get()]++;
+			drawCalls[magic_enum::enum_integer(currentShader->shaderType.get())]++;
 
 		if (currentShader && updateShader) {
-			auto type = currentShader->shaderType.get();
-			if (type == RE::BSShader::Type::Utility) {
-				if (currentPixelDescriptor & static_cast<uint32_t>(SIE::ShaderCache::UtilityShaderFlags::RenderShadowmask)) {
+			auto type = magic_enum::enum_integer(currentShader->shaderType.get());
+			if (type == magic_enum::enum_integer(RE::BSShader::Type::Utility)) {
+				if (currentPixelDescriptor & magic_enum::enum_integer(SIE::ShaderCache::UtilityShaderFlags::RenderShadowmask)) {
 					deferred->CopyShadowData();
 				}
 			}
 
-			if (type > 0 && type < RE::BSShader::Type::Total) {
+			if (type > 0 && type < magic_enum::enum_integer(RE::BSShader::Type::Total)) {
 				if (enabledClasses[type - 1]) {
 					// Only check against non-shader bits
 					currentPixelDescriptor &= ~modifiedPixelDescriptor;
@@ -201,7 +201,7 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 
 		if (!tryLoadConfig(configPath)) {
 			logger::info("No default config ({}), generating new one", configPath);
-			std::fill(enabledClasses, enabledClasses + RE::BSShader::Type::Total - 1, true);
+			std::fill(enabledClasses, enabledClasses + magic_enum::enum_integer(RE::BSShader::Type::Total) - 1, true);
 			Save(configMode);
 			// Attempt to load the newly created config
 			configPath = GetConfigPath(configMode);
@@ -228,7 +228,7 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 			if (advanced["Dump Shaders"].is_boolean())
 				shaderCache->SetDump(advanced["Dump Shaders"]);
 			if (advanced["Log Level"].is_number_integer())
-				logLevel = static_cast<spdlog::level::level_enum>((int)advanced["Log Level"]);
+				logLevel = magic_enum::enum_cast<spdlog::level::level_enum>(advanced["Log Level"].get<int>()).value_or(spdlog::level::info);
 			if (advanced["Shader Defines"].is_string())
 				SetDefines(advanced["Shader Defines"]);
 			if (advanced["Compiler Threads"].is_number_integer())
@@ -258,8 +258,8 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 		if (settings["Replace Original Shaders"].is_object()) {
 			logger::info("Loading 'Replace Original Shaders' settings");
 			json& originalShaders = settings["Replace Original Shaders"];
-			for (int classIndex = 0; classIndex < RE::BSShader::Type::Total - 1; ++classIndex) {
-				auto name = magic_enum::enum_name((RE::BSShader::Type)(classIndex + 1));
+			for (int classIndex = 0; classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++classIndex) {
+				auto name = magic_enum::enum_name(*magic_enum::enum_cast<RE::BSShader::Type>(classIndex + 1));
 				if (originalShaders[name].is_boolean()) {
 					enabledClasses[classIndex] = originalShaders[name];
 				} else {
@@ -386,8 +386,8 @@ void State::Save(ConfigMode a_configMode)
 	upscaling->SaveSettings(upscalingJson);
 
 	json originalShaders;
-	for (int classIndex = 0; classIndex < RE::BSShader::Type::Total - 1; ++classIndex) {
-		originalShaders[magic_enum::enum_name((RE::BSShader::Type)(classIndex + 1))] = enabledClasses[classIndex];
+	for (int classIndex = 0; classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++classIndex) {
+		originalShaders[magic_enum::enum_name(*magic_enum::enum_cast<RE::BSShader::Type>(classIndex + 1))] = enabledClasses[classIndex];
 	}
 	settings["Replace Original Shaders"] = originalShaders;
 
@@ -439,7 +439,7 @@ void State::SetLogLevel(spdlog::level::level_enum a_level)
 	logLevel = a_level;
 	spdlog::set_level(logLevel);
 	spdlog::flush_on(logLevel);
-	logger::info("Log Level set to {} ({})", magic_enum::enum_name(logLevel), static_cast<int>(logLevel));
+	logger::info("Log Level set to {} ({})", magic_enum::enum_name(logLevel), magic_enum::enum_integer(logLevel));
 }
 
 spdlog::level::level_enum State::GetLogLevel()
@@ -481,7 +481,7 @@ std::vector<std::pair<std::string, std::string>>* State::GetDefines()
 
 bool State::ShaderEnabled(const RE::BSShader::Type a_type)
 {
-	auto index = static_cast<uint32_t>(a_type) + 1;
+	auto index = magic_enum::enum_integer(a_type) + 1;
 	if (index < sizeof(enabledClasses)) {
 		return enabledClasses[index];
 	}

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -112,8 +112,10 @@ void State::Draw()
 			frameStartTime = currentTime;
 		}
 
-		if (currentShader)
+		if (currentShader) {
 			drawCalls[magic_enum::enum_integer(currentShader->shaderType.get())]++;
+			drawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]++;
+		}
 
 		if (currentShader && updateShader) {
 			auto type = magic_enum::enum_integer(currentShader->shaderType.get());

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -79,10 +79,12 @@ void State::Draw()
 		currentExtraFeatureDescriptor = 0;
 
 		if (frameChecker.IsNewFrame()) {
+			// Smooth draw calls and frame times for all shader types
 			for (int i = 0; i < magic_enum::enum_integer(RE::BSShader::Type::Total) + 1; ++i) {
 				smoothDrawCalls[i] = smoothDrawCalls[i] * static_cast<float>(0.95) + drawCalls[i] * static_cast<float>(0.05);
 				smoothFrameTimePerType[i] = smoothFrameTimePerType[i] * static_cast<float>(0.95) + frameTimePerType[i] * static_cast<float>(0.05);
 			}
+			// Reset counters for next frame
 			for (auto& c : drawCalls)
 				c = 0;
 			for (auto& ft : frameTimePerType)
@@ -281,14 +283,14 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 		if (settings["Replace Original Shaders"].is_object()) {
 			logger::info("Loading 'Replace Original Shaders' settings");
 			json& originalShaders = settings["Replace Original Shaders"];
-			for (int classIndex = 0; classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++classIndex) {
-				auto name = magic_enum::enum_name(*magic_enum::enum_cast<RE::BSShader::Type>(classIndex + 1));
+			ForEachShaderTypeWithIndex([&](auto type, int classIndex) {
+				auto name = magic_enum::enum_name(type);
 				if (originalShaders[name].is_boolean()) {
 					enabledClasses[classIndex] = originalShaders[name];
 				} else {
 					logger::warn("Invalid entry for shader class '{}', using default", name);
 				}
-			}
+			});
 		}
 		// Ensure 'Disable at Boot' section exists in the JSON
 		if (!settings.contains("Disable at Boot") || !settings["Disable at Boot"].is_object()) {
@@ -409,9 +411,9 @@ void State::Save(ConfigMode a_configMode)
 	upscaling->SaveSettings(upscalingJson);
 
 	json originalShaders;
-	for (int classIndex = 0; classIndex < magic_enum::enum_integer(RE::BSShader::Type::Total) - 1; ++classIndex) {
-		originalShaders[magic_enum::enum_name(*magic_enum::enum_cast<RE::BSShader::Type>(classIndex + 1))] = enabledClasses[classIndex];
-	}
+	ForEachShaderTypeWithIndex([&](auto type, int classIndex) {
+		originalShaders[magic_enum::enum_name(type)] = enabledClasses[classIndex];
+	});
 	settings["Replace Original Shaders"] = originalShaders;
 
 	json disabledFeaturesJson;
@@ -850,4 +852,11 @@ void State::RenderReShade()
 void State::PresentReShade()
 {
 	reshade::update_and_present_effect_runtime(reShadeRuntime);
+}
+
+// --- Utility Method Implementations ---
+
+float State::GetTotalSmoothedDrawCalls() const
+{
+	return static_cast<float>(smoothDrawCalls[magic_enum::enum_integer(RE::BSShader::Type::Total)]);
 }

--- a/src/State.h
+++ b/src/State.h
@@ -13,11 +13,22 @@ using json = nlohmann::json;
 
 #include "reshade/reshade_api.hpp"
 #include <Hooks.h>
+#include <mutex>
 #include <reshade/reshade.hpp>
 
 class State
 {
 public:
+	State()
+	{
+		std::lock_guard<std::mutex> lock(statsMutex);
+		for (auto& v : smoothDrawCalls) v = 0.0;
+		for (auto& v : drawCalls) v = 0;
+		for (auto& v : frameTimePerType) v = 0.0f;
+		for (auto& v : smoothFrameTimePerType) v = 0.0f;
+	}
+	std::lock_guard<std::mutex> Lock() { return std::lock_guard<std::mutex>(statsMutex); }
+
 	static State* GetSingleton()
 	{
 		static State singleton;
@@ -235,4 +246,5 @@ public:
 private:
 	std::shared_ptr<REX::W32::ID3DUserDefinedAnnotation> pPerf;
 	bool initialized = false;
+	std::mutex statsMutex;
 };

--- a/src/State.h
+++ b/src/State.h
@@ -4,7 +4,9 @@
 #include <Tracy/TracyD3D11.hpp>
 
 #include <Buffer.h>
+#include <chrono>
 #include <nlohmann/json.hpp>
+
 using json = nlohmann::json;
 
 #include <FeatureBuffer.h>
@@ -47,6 +49,14 @@ public:
 	float timer = 0;
 	double smoothDrawCalls[RE::BSShader::Type::Total + 1];
 	int drawCalls[RE::BSShader::Type::Total + 1];
+
+	// Frame time tracking per shader type (in milliseconds)
+	float frameTimePerType[RE::BSShader::Type::Total];
+	float smoothFrameTimePerType[RE::BSShader::Type::Total];
+
+	// Timing state for per-type frame time tracking
+	std::chrono::high_resolution_clock::time_point frameStartTime;
+	bool frameTimingActive = false;
 
 	enum ConfigMode
 	{

--- a/src/State.h
+++ b/src/State.h
@@ -62,8 +62,8 @@ public:
 	int drawCalls[RE::BSShader::Type::Total + 1];
 
 	// Frame time tracking per shader type (in milliseconds)
-	float frameTimePerType[RE::BSShader::Type::Total];
-	float smoothFrameTimePerType[RE::BSShader::Type::Total];
+	float frameTimePerType[RE::BSShader::Type::Total + 1];
+	float smoothFrameTimePerType[RE::BSShader::Type::Total + 1];
 
 	// Timing state for per-type frame time tracking
 	std::chrono::high_resolution_clock::time_point frameStartTime;
@@ -228,6 +228,59 @@ public:
 	void PresentReShade();
 
 	bool useFrameAnnotations = false;
+
+	// --- Utility Methods ---
+	/**
+	 * @brief Gets the total smoothed draw calls from the global state
+	 * @return Total number of draw calls as float
+	 */
+	float GetTotalSmoothedDrawCalls() const;
+
+	/**
+	 * @brief Base helper that iterates through valid shader types (excluding None and Total)
+	 * @param callback Function to call for each valid shader type with parameters: (type, typeIndex, classIndex)
+	 */
+	template <typename Callback>
+	static void ForEachValidShaderType(Callback callback)
+	{
+		for (auto type : magic_enum::enum_values<RE::BSShader::Type>()) {
+			if (type == RE::BSShader::Type::None || type == RE::BSShader::Type::Total)
+				continue;
+			int typeIndex = magic_enum::enum_integer(type);
+			int classIndex = typeIndex - 1;
+			callback(type, typeIndex, classIndex);
+		}
+	}
+
+	/**
+	 * @brief Iterates through valid shader types with performance metrics
+	 * @param callback Function to call for each shader type with parameters: (type, typeIndex, drawCalls, frameTime, percent, costPerCall)
+	 */
+	template <typename Callback>
+	static void ForEachShaderTypeWithMetrics(Callback callback)
+	{
+		ForEachValidShaderType([&](auto type, int typeIndex, [[maybe_unused]] int classIndex) {
+			float drawCalls = static_cast<float>(GetSingleton()->smoothDrawCalls[typeIndex]);
+			float frameTime = static_cast<float>(GetSingleton()->smoothFrameTimePerType[typeIndex]);
+			float percent = (frameTime > 0.0f && GetSingleton()->smoothFrameTimePerType[magic_enum::enum_integer(RE::BSShader::Type::Total)] > 0.0f) ?
+			                    (frameTime / GetSingleton()->smoothFrameTimePerType[magic_enum::enum_integer(RE::BSShader::Type::Total)] * 100.0f) :
+			                    0.0f;
+			float costPerCall = (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
+			callback(type, typeIndex, drawCalls, frameTime, percent, costPerCall);
+		});
+	}
+
+	/**
+	 * @brief Iterates through valid shader types with class indices for UI operations
+	 * @param callback Function to call for each shader type with parameters: (type, classIndex)
+	 */
+	template <typename Callback>
+	static void ForEachShaderTypeWithIndex(Callback callback)
+	{
+		ForEachValidShaderType([&](auto type, [[maybe_unused]] int typeIndex, int classIndex) {
+			callback(type, classIndex);
+		});
+	}
 
 	// Features that are more special then others
 	std::unordered_map<std::string, bool> specialFeatures = {

--- a/src/Utils/FileSystem.cpp
+++ b/src/Utils/FileSystem.cpp
@@ -1,4 +1,5 @@
 #include "FileSystem.h"
+#include <fstream>
 
 namespace Util
 {
@@ -77,4 +78,51 @@ namespace Util
 			return result;
 		}
 	}
+}
+
+std::vector<SettingsDiffEntry> Util::FileSystem::LoadJsonDiff(const std::filesystem::path& userPath, const std::filesystem::path& testPath)
+{
+	std::vector<SettingsDiffEntry> diffEntries;
+
+	try {
+		if (!std::filesystem::exists(userPath) || !std::filesystem::exists(testPath)) {
+			return diffEntries;
+		}
+
+		std::ifstream userFile(userPath);
+		std::ifstream testFile(testPath);
+
+		if (!userFile.is_open() || !testFile.is_open()) {
+			return diffEntries;
+		}
+
+		nlohmann::json userJson, testJson;
+		userFile >> userJson;
+		testFile >> testJson;
+
+		auto diff = nlohmann::json::diff(userJson, testJson);
+
+		for (const auto& change : diff) {
+			std::string op = change.value("op", "");
+			std::string path = change.value("path", "");
+			std::string aVal, bVal;
+
+			if (op == "replace") {
+				aVal = userJson.at(nlohmann::json::json_pointer(path)).dump();
+				bVal = testJson.at(nlohmann::json::json_pointer(path)).dump();
+			} else if (op == "add") {
+				aVal = "(none)";
+				bVal = testJson.at(nlohmann::json::json_pointer(path)).dump();
+			} else if (op == "remove") {
+				aVal = userJson.at(nlohmann::json::json_pointer(path)).dump();
+				bVal = "(none)";
+			}
+
+			diffEntries.push_back({ path, aVal, bVal });
+		}
+	} catch (const std::exception& e) {
+		logger::warn("Failed to load JSON diff: {}", e.what());
+	}
+
+	return diffEntries;
 }

--- a/src/Utils/FileSystem.h
+++ b/src/Utils/FileSystem.h
@@ -6,9 +6,17 @@
 #include <algorithm>
 #include <filesystem>
 #include <imgui.h>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <tuple>
 #include <vector>
+
+struct SettingsDiffEntry
+{
+	std::string path;
+	std::string aValue;
+	std::string bValue;
+};
 
 namespace Util
 {
@@ -98,4 +106,8 @@ namespace Util
 		return result;
 	}
 
+	namespace FileSystem
+	{
+		std::vector<SettingsDiffEntry> LoadJsonDiff(const std::filesystem::path& userPath, const std::filesystem::path& testPath);
+	}
 }

--- a/src/Utils/Format.cpp
+++ b/src/Utils/Format.cpp
@@ -1,4 +1,5 @@
 #include "Format.h"
+#include "Globals.h"
 #include <chrono>
 #include <cmath>
 #include <iomanip>
@@ -114,5 +115,33 @@ namespace Util
 		if (diff < 3600)
 			return std::to_string(diff / 60) + "m";
 		return std::to_string(diff / 3600) + "h";
+	}
+
+	std::string FormatDeltaWithPercent(float a, float b, float threshold)
+	{
+		float delta = b - a;
+		float percentDelta = 0.0f;
+		if (a < b && a > 0.0f) {
+			percentDelta = 100.0f * (b - a) / a;
+		} else if (b < a && b > 0.0f) {
+			percentDelta = 100.0f * (a - b) / b;
+		}
+		std::string percentStr = (percentDelta >= threshold) ? std::format(" ({:+.1f}%)", (b < a ? -percentDelta : percentDelta)) : "";
+		return (delta > 0.0f ? "+" : "") + FormatMilliseconds(delta) + percentStr;
+	}
+
+	float CalculatePercentage(float part, float total, float defaultValue)
+	{
+		return (total > 0.0f) ? (part / total * 100.0f) : defaultValue;
+	}
+
+	float CalculateCostPerCall(float frameTime, float drawCalls)
+	{
+		return (drawCalls > 0.0f) ? (frameTime / drawCalls) : 0.0f;
+	}
+
+	float CalculateOtherFrameTime(float totalFrameTime, float measuredSum)
+	{
+		return totalFrameTime - measuredSum;
 	}
 }  // namespace Util

--- a/src/Utils/Format.cpp
+++ b/src/Utils/Format.cpp
@@ -1,4 +1,8 @@
 #include "Format.h"
+#include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <sstream>
 
 namespace Util
 {
@@ -70,5 +74,45 @@ namespace Util
 			return (char)c;
 		});
 		return result;
+	}
+
+	std::string FormatMilliseconds(float ms)
+	{
+		if (std::abs(ms) < 1e-4f)
+			return "0 ms";
+		std::ostringstream oss;
+		if (ms < 0.1f)
+			oss << std::fixed << std::setprecision(3) << ms << " ms";
+		else
+			oss << std::fixed << std::setprecision(2) << ms << " ms";
+		return oss.str();
+	}
+
+	std::string FormatMicroseconds(float us)
+	{
+		if (std::abs(us) < 1e-4f)
+			return "0 us";
+		std::ostringstream oss;
+		oss << std::fixed << std::setprecision(2) << us << " us";
+		return oss.str();
+	}
+
+	std::string FormatPercent(float percent)
+	{
+		std::ostringstream oss;
+		oss << std::fixed << std::setprecision(1) << percent << "%";
+		return oss.str();
+	}
+
+	std::string TimeAgoString(std::chrono::steady_clock::time_point last)
+	{
+		using namespace std::chrono;
+		auto now = steady_clock::now();
+		auto diff = duration_cast<seconds>(now - last).count();
+		if (diff < 60)
+			return std::to_string(diff) + "s";
+		if (diff < 3600)
+			return std::to_string(diff / 60) + "m";
+		return std::to_string(diff / 3600) + "h";
 	}
 }  // namespace Util

--- a/src/Utils/Format.h
+++ b/src/Utils/Format.h
@@ -41,4 +41,45 @@ namespace Util
 	 * Returns a human-readable string for the time elapsed since the given time point (e.g., '5s', '2m', '1h').
 	 */
 	std::string TimeAgoString(std::chrono::steady_clock::time_point last);
+
+	/**
+	 * Formats a delta value with percentage difference for A/B test comparisons.
+	 * Returns a string like "+0.45 ms (+12.3%)" or "-0.23 ms (-8.1%)".
+	 *
+	 * @param a The first value (typically Variant A)
+	 * @param b The second value (typically Variant B)
+	 * @param threshold Minimum percentage difference to display (default 0.01 = 1%)
+	 * @return Formatted string showing delta and percentage difference
+	 */
+	std::string FormatDeltaWithPercent(float a, float b, float threshold = 0.01f);
+
+	/**
+	 * Calculates the percentage of a part relative to a total value.
+	 * Returns defaultValue if total is zero or negative.
+	 *
+	 * @param part The part value to calculate percentage for
+	 * @param total The total value to calculate percentage relative to
+	 * @param defaultValue Value to return if total is invalid (default 0.0f)
+	 * @return Percentage as a float (0.0f to 100.0f)
+	 */
+	float CalculatePercentage(float part, float total, float defaultValue = 0.0f);
+
+	/**
+	 * Calculates the cost per call (frame time per draw call).
+	 * Returns 0.0f if drawCalls is zero or negative.
+	 *
+	 * @param frameTime The frame time in milliseconds
+	 * @param drawCalls The number of draw calls
+	 * @return Cost per call in milliseconds
+	 */
+	float CalculateCostPerCall(float frameTime, float drawCalls);
+
+	/**
+	 * Calculates the "other" frame time (total frame time minus measured sum).
+	 *
+	 * @param totalFrameTime The total frame time
+	 * @param measuredSum The sum of all measured frame times
+	 * @return The remaining frame time not accounted for by measured components
+	 */
+	float CalculateOtherFrameTime(float totalFrameTime, float measuredSum);
 }  // namespace Util

--- a/src/Utils/Format.h
+++ b/src/Utils/Format.h
@@ -22,4 +22,23 @@ namespace Util
 	 */
 	std::string FixFilePath(const std::string& a_path);
 	std::string WStringToString(const std::wstring& wideString);
+
+	/**
+	 * Formats a float value as milliseconds, using 2 or 3 decimal places as appropriate.
+	 * Returns '0 ms' for exact zero values.
+	 */
+	std::string FormatMilliseconds(float ms);
+	/**
+	 * Formats a float value as microseconds, using 2 decimal places.
+	 * Returns '0 us' for exact zero values.
+	 */
+	std::string FormatMicroseconds(float us);
+	/**
+	 * Formats a float value as a percentage string with 1 decimal place.
+	 */
+	std::string FormatPercent(float percent);
+	/**
+	 * Returns a human-readable string for the time elapsed since the given time point (e.g., '5s', '2m', '1h').
+	 */
+	std::string TimeAgoString(std::chrono::steady_clock::time_point last);
 }  // namespace Util

--- a/src/Utils/PerfUtils.h
+++ b/src/Utils/PerfUtils.h
@@ -24,6 +24,8 @@ namespace Util
      */
 	inline float CalcFPS(float frameTimeMs)
 	{
+		if (frameTimeMs <= 0.0f)
+			return 0.0f;
 		return 1000.0f / frameTimeMs;
 	}
 
@@ -42,13 +44,27 @@ namespace Util
 	/**
      * @brief Calculates the median of a vector of floats.
      * @param v Vector of floats.
-     * @return Median value.
+     * @return Median value. For even-sized vectors, returns the average of the two middle elements.
      */
 	inline float Median(std::vector<float> v)
 	{
 		if (v.empty())
 			return 0.0f;
-		std::nth_element(v.begin(), v.begin() + v.size() / 2, v.end());
-		return v[v.size() / 2];
+
+		size_t n = v.size();
+		size_t mid = n / 2;
+
+		if (n % 2 == 1) {
+			// Odd-sized vector: return the middle element
+			std::nth_element(v.begin(), v.begin() + mid, v.end());
+			return v[mid];
+		} else {
+			// Even-sized vector: return average of two middle elements
+			std::nth_element(v.begin(), v.begin() + mid - 1, v.end());
+			float lower = v[mid - 1];
+			std::nth_element(v.begin() + mid, v.begin() + mid, v.end());
+			float upper = v[mid];
+			return (lower + upper) / 2.0f;
+		}
 	}
 }

--- a/src/Utils/PerfUtils.h
+++ b/src/Utils/PerfUtils.h
@@ -1,0 +1,26 @@
+#pragma once
+#include <cstdint>
+
+namespace Util
+{
+	/**
+     * @brief Converts elapsed timer ticks to milliseconds.
+     * @param timeElapsed Number of timer ticks elapsed.
+     * @param frequency Timer frequency (ticks per second).
+     * @return Elapsed time in milliseconds.
+     */
+	inline float CalcFrameTime(uint64_t timeElapsed, uint64_t frequency)
+	{
+		return 1000.0f * static_cast<float>(timeElapsed) / static_cast<float>(frequency);
+	}
+
+	/**
+     * @brief Calculates frames per second (FPS) from a frame time in milliseconds.
+     * @param frameTimeMs Frame time in milliseconds.
+     * @return Frames per second.
+     */
+	inline float CalcFPS(float frameTimeMs)
+	{
+		return 1000.0f / frameTimeMs;
+	}
+}

--- a/src/Utils/PerfUtils.h
+++ b/src/Utils/PerfUtils.h
@@ -1,5 +1,8 @@
 #pragma once
+#include <algorithm>
 #include <cstdint>
+#include <numeric>
+#include <vector>
 
 namespace Util
 {
@@ -22,5 +25,30 @@ namespace Util
 	inline float CalcFPS(float frameTimeMs)
 	{
 		return 1000.0f / frameTimeMs;
+	}
+
+	/**
+     * @brief Calculates the mean of a vector of floats.
+     * @param v Vector of floats.
+     * @return Mean value.
+     */
+	inline float Mean(const std::vector<float>& v)
+	{
+		if (v.empty())
+			return 0.0f;
+		return std::accumulate(v.begin(), v.end(), 0.0f) / v.size();
+	}
+
+	/**
+     * @brief Calculates the median of a vector of floats.
+     * @param v Vector of floats.
+     * @return Median value.
+     */
+	inline float Median(std::vector<float> v)
+	{
+		if (v.empty())
+			return 0.0f;
+		std::nth_element(v.begin(), v.begin() + v.size() / 2, v.end());
+		return v[v.size() / 2];
 	}
 }

--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -10,8 +10,11 @@
 
 #define STB_IMAGE_IMPLEMENTATION
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <functional>
+#include <iomanip>
+#include <sstream>
 #include <stb_image.h>
 #include <string>
 #include <vector>
@@ -597,13 +600,16 @@ namespace Util
 		return VersionStringLess(a, b, asc);
 	};
 
+	using TableCellRenderFunc = std::function<void(int row, int col, const std::string& value)>;
+
 	void ShowSortedStringTable(
 		const char* table_id,
 		const std::vector<std::string>& headers,
 		std::vector<std::vector<std::string>> rows,
 		size_t sortColumn,
 		bool ascending,
-		const std::vector<TableSortFunc>& customSorts)
+		const std::vector<TableSortFunc>& customSorts,
+		TableCellRenderFunc cellRender)
 	{
 		ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable;
 		if (ImGui::BeginTable(table_id, static_cast<int>(headers.size()), flags)) {
@@ -634,15 +640,115 @@ namespace Util
 			}
 			// else: no sorting if sortCol is invalid
 
-			for (const auto& row : rows) {
+			for (size_t rowIdx = 0; rowIdx < rows.size(); ++rowIdx) {
+				const auto& row = rows[rowIdx];
 				ImGui::TableNextRow();
 				for (size_t col = 0; col < headers.size(); ++col) {
 					ImGui::TableSetColumnIndex(static_cast<int>(col));
-					if (col < row.size())
-						ImGui::TextUnformatted(row[col].c_str());
+					if (col < row.size()) {
+						if (cellRender) {
+							cellRender(static_cast<int>(rowIdx), static_cast<int>(col), row[col]);
+						} else {
+							ImGui::TextUnformatted(row[col].c_str());
+						}
+					}
 				}
 			}
 			ImGui::EndTable();
 		}
+	}
+
+	template <typename T>
+	void ShowSortedStringTable(
+		const char* table_id,
+		const std::vector<std::string>& headers,
+		std::vector<T>& rows,
+		size_t sortColumn,
+		bool ascending,
+		const std::vector<std::function<bool(const T&, const T&, bool)>>& customSorts,
+		std::function<void(int, int, const T&)> cellRender)
+	{
+		ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable;
+		if (ImGui::BeginTable(table_id, static_cast<int>(headers.size()), flags)) {
+			for (const auto& header : headers)
+				ImGui::TableSetupColumn(header.c_str());
+			ImGui::TableHeadersRow();
+
+			// Interactive sorting
+			int sortCol = static_cast<int>(sortColumn);
+			bool sortAsc = ascending;
+			if (const ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs()) {
+				if (sortSpecs->SpecsCount > 0) {
+					sortCol = sortSpecs->Specs->ColumnIndex;
+					sortAsc = sortSpecs->Specs->SortDirection == ImGuiSortDirection_Ascending;
+				}
+			}
+			if (sortCol >= 0 && static_cast<size_t>(sortCol) < headers.size()) {
+				if (sortCol < static_cast<int>(customSorts.size()) && customSorts[sortCol]) {
+					auto cmp = customSorts[sortCol];
+					std::sort(rows.begin(), rows.end(), [sortCol, sortAsc, &cmp](const T& a, const T& b) {
+						return cmp(a, b, sortAsc);
+					});
+				}
+			}
+
+			for (size_t rowIdx = 0; rowIdx < rows.size(); ++rowIdx) {
+				const auto& row = rows[rowIdx];
+				ImGui::TableNextRow();
+				for (size_t col = 0; col < headers.size(); ++col) {
+					ImGui::TableSetColumnIndex(static_cast<int>(col));
+					if (cellRender) {
+						cellRender(static_cast<int>(rowIdx), static_cast<int>(col), row);
+					}
+				}
+			}
+			ImGui::EndTable();
+		}
+	}
+
+	std::string FormatMilliseconds(float ms)
+	{
+		std::ostringstream oss;
+		if (ms < 0.1f)
+			oss << std::fixed << std::setprecision(3) << ms << " ms";
+		else
+			oss << std::fixed << std::setprecision(2) << ms << " ms";
+		return oss.str();
+	}
+
+	std::string FormatMicroseconds(float us)
+	{
+		std::ostringstream oss;
+		oss << std::fixed << std::setprecision(2) << us << " us";
+		return oss.str();
+	}
+
+	std::string FormatPercent(float percent)
+	{
+		std::ostringstream oss;
+		oss << std::fixed << std::setprecision(1) << percent << "%";
+		return oss.str();
+	}
+
+	ImVec4 GetThresholdColor(float value, float good, float warn, ImVec4 goodColor, ImVec4 warnColor, ImVec4 badColor)
+	{
+		if (value < good)
+			return goodColor;
+		else if (value < warn)
+			return warnColor;
+		else
+			return badColor;
+	}
+
+	std::string TimeAgoString(std::chrono::steady_clock::time_point last)
+	{
+		using namespace std::chrono;
+		auto now = steady_clock::now();
+		auto diff = duration_cast<seconds>(now - last).count();
+		if (diff < 60)
+			return std::to_string(diff) + "s";
+		if (diff < 3600)
+			return std::to_string(diff / 60) + "m";
+		return std::to_string(diff / 3600) + "h";
 	}
 }  // namespace Util

--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -21,8 +21,6 @@
 
 namespace Util
 {
-	PerformanceOverlay performanceOverlay;
-
 	HoverTooltipWrapper::HoverTooltipWrapper()
 	{
 		hovered = ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal);
@@ -555,6 +553,17 @@ namespace Util
 		}
 	}
 
+	void DrawColorLegendTooltip(const std::vector<std::pair<const char*, ImVec4>>& items, const char* title)
+	{
+		if (title) {
+			ImGui::TextUnformatted(title);
+			ImGui::Separator();
+		}
+		for (const auto& [label, color] : items) {
+			ImGui::TextColored(color, "%s", label);
+		}
+	}
+
 	void SortTableRowsByColumn(std::vector<std::vector<std::string>>& rows, size_t column, bool ascending)
 	{
 		std::sort(rows.begin(), rows.end(), [column, ascending](const auto& a, const auto& b) {
@@ -600,136 +609,6 @@ namespace Util
 		return VersionStringLess(a, b, asc);
 	};
 
-	using TableCellRenderFunc = std::function<void(int row, int col, const std::string& value)>;
-
-	void ShowSortedStringTable(
-		const char* table_id,
-		const std::vector<std::string>& headers,
-		std::vector<std::vector<std::string>> rows,
-		size_t sortColumn,
-		bool ascending,
-		const std::vector<TableSortFunc>& customSorts,
-		TableCellRenderFunc cellRender)
-	{
-		ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable;
-		if (ImGui::BeginTable(table_id, static_cast<int>(headers.size()), flags)) {
-			for (const auto& header : headers)
-				ImGui::TableSetupColumn(header.c_str());
-			ImGui::TableHeadersRow();
-
-			// Interactive sorting
-			int sortCol = static_cast<int>(sortColumn);
-			bool sortAsc = ascending;
-			if (const ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs()) {
-				if (sortSpecs->SpecsCount > 0) {
-					sortCol = sortSpecs->Specs->ColumnIndex;
-					sortAsc = sortSpecs->Specs->SortDirection == ImGuiSortDirection_Ascending;
-				}
-			}
-			if (sortCol >= 0 && static_cast<size_t>(sortCol) < headers.size()) {
-				if (sortCol < static_cast<int>(customSorts.size()) && customSorts[sortCol]) {
-					auto cmp = customSorts[sortCol];
-					std::sort(rows.begin(), rows.end(), [sortCol, sortAsc, &cmp](const auto& a, const auto& b) {
-						return cmp(a[sortCol], b[sortCol], sortAsc);
-					});
-				} else {
-					std::sort(rows.begin(), rows.end(), [sortCol, sortAsc](const auto& a, const auto& b) {
-						return sortAsc ? (a[sortCol] < b[sortCol]) : (a[sortCol] > b[sortCol]);
-					});
-				}
-			}
-			// else: no sorting if sortCol is invalid
-
-			for (size_t rowIdx = 0; rowIdx < rows.size(); ++rowIdx) {
-				const auto& row = rows[rowIdx];
-				ImGui::TableNextRow();
-				for (size_t col = 0; col < headers.size(); ++col) {
-					ImGui::TableSetColumnIndex(static_cast<int>(col));
-					if (col < row.size()) {
-						if (cellRender) {
-							cellRender(static_cast<int>(rowIdx), static_cast<int>(col), row[col]);
-						} else {
-							ImGui::TextUnformatted(row[col].c_str());
-						}
-					}
-				}
-			}
-			ImGui::EndTable();
-		}
-	}
-
-	template <typename T>
-	void ShowSortedStringTable(
-		const char* table_id,
-		const std::vector<std::string>& headers,
-		std::vector<T>& rows,
-		size_t sortColumn,
-		bool ascending,
-		const std::vector<std::function<bool(const T&, const T&, bool)>>& customSorts,
-		std::function<void(int, int, const T&)> cellRender)
-	{
-		ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable;
-		if (ImGui::BeginTable(table_id, static_cast<int>(headers.size()), flags)) {
-			for (const auto& header : headers)
-				ImGui::TableSetupColumn(header.c_str());
-			ImGui::TableHeadersRow();
-
-			// Interactive sorting
-			int sortCol = static_cast<int>(sortColumn);
-			bool sortAsc = ascending;
-			if (const ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs()) {
-				if (sortSpecs->SpecsCount > 0) {
-					sortCol = sortSpecs->Specs->ColumnIndex;
-					sortAsc = sortSpecs->Specs->SortDirection == ImGuiSortDirection_Ascending;
-				}
-			}
-			if (sortCol >= 0 && static_cast<size_t>(sortCol) < headers.size()) {
-				if (sortCol < static_cast<int>(customSorts.size()) && customSorts[sortCol]) {
-					auto cmp = customSorts[sortCol];
-					std::sort(rows.begin(), rows.end(), [sortCol, sortAsc, &cmp](const T& a, const T& b) {
-						return cmp(a, b, sortAsc);
-					});
-				}
-			}
-
-			for (size_t rowIdx = 0; rowIdx < rows.size(); ++rowIdx) {
-				const auto& row = rows[rowIdx];
-				ImGui::TableNextRow();
-				for (size_t col = 0; col < headers.size(); ++col) {
-					ImGui::TableSetColumnIndex(static_cast<int>(col));
-					if (cellRender) {
-						cellRender(static_cast<int>(rowIdx), static_cast<int>(col), row);
-					}
-				}
-			}
-			ImGui::EndTable();
-		}
-	}
-
-	std::string FormatMilliseconds(float ms)
-	{
-		std::ostringstream oss;
-		if (ms < 0.1f)
-			oss << std::fixed << std::setprecision(3) << ms << " ms";
-		else
-			oss << std::fixed << std::setprecision(2) << ms << " ms";
-		return oss.str();
-	}
-
-	std::string FormatMicroseconds(float us)
-	{
-		std::ostringstream oss;
-		oss << std::fixed << std::setprecision(2) << us << " us";
-		return oss.str();
-	}
-
-	std::string FormatPercent(float percent)
-	{
-		std::ostringstream oss;
-		oss << std::fixed << std::setprecision(1) << percent << "%";
-		return oss.str();
-	}
-
 	ImVec4 GetThresholdColor(float value, float good, float warn, ImVec4 goodColor, ImVec4 warnColor, ImVec4 badColor)
 	{
 		if (value < good)
@@ -738,17 +617,5 @@ namespace Util
 			return warnColor;
 		else
 			return badColor;
-	}
-
-	std::string TimeAgoString(std::chrono::steady_clock::time_point last)
-	{
-		using namespace std::chrono;
-		auto now = steady_clock::now();
-		auto diff = duration_cast<seconds>(now - last).count();
-		if (diff < 60)
-			return std::to_string(diff) + "s";
-		if (diff < 3600)
-			return std::to_string(diff / 60) + "m";
-		return std::to_string(diff / 3600) + "h";
 	}
 }  // namespace Util

--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -553,14 +553,10 @@ namespace Util
 		}
 	}
 
-	void DrawColorLegendTooltip(const std::vector<std::pair<const char*, ImVec4>>& items, const char* title)
+	void DrawColoredMultiLineTooltip(const ColoredTextLines& lines)
 	{
-		if (title) {
-			ImGui::TextUnformatted(title);
-			ImGui::Separator();
-		}
-		for (const auto& [label, color] : items) {
-			ImGui::TextColored(color, "%s", label);
+		for (const auto& line : lines) {
+			ImGui::TextColored(line.color, "%s", line.text.c_str());
 		}
 	}
 

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -254,6 +254,8 @@ namespace Util
 	 */
 	void SortTableRowsByColumn(std::vector<std::vector<std::string>>& rows, size_t column, bool ascending = true);
 
+	using TableCellRenderFunc = std::function<void(int row, int col, const std::string& value)>;
+
 	/**
 	 * @brief Renders a sortable ImGui table with arbitrary columns and per-column custom sorting.
 	 *
@@ -263,6 +265,7 @@ namespace Util
 	 * @param sortColumn Default sort column index.
 	 * @param ascending Default sort direction.
 	 * @param customSorts Vector of custom comparator functions, one per column (nullptr for default string sort).
+	 * @param cellRender Optional cell renderer function for custom cell rendering.
 	 */
 	void ShowSortedStringTable(
 		const char* table_id,
@@ -270,7 +273,8 @@ namespace Util
 		std::vector<std::vector<std::string>> rows,
 		size_t sortColumn = 0,
 		bool ascending = true,
-		const std::vector<TableSortFunc>& customSorts = {});
+		const std::vector<TableSortFunc>& customSorts = {},
+		TableCellRenderFunc cellRender = nullptr);
 
 	/**
 	 * @brief Compares two version strings (e.g., "1.2.3") numerically.
@@ -285,4 +289,11 @@ namespace Util
 	 * @brief TableSortFunc for version strings, using VersionStringLess.
 	 */
 	extern const TableSortFunc VersionSortComparator;
+
+	// Performance overlay formatting and color helpers
+	std::string FormatMilliseconds(float ms);
+	std::string FormatMicroseconds(float us);
+	std::string FormatPercent(float percent);
+	ImVec4 GetThresholdColor(float value, float good, float warn, ImVec4 goodColor, ImVec4 warnColor, ImVec4 badColor);
+	std::string TimeAgoString(std::chrono::steady_clock::time_point last);
 }  // namespace Util

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -213,27 +213,29 @@ namespace Util
 		const ColorCodedValueConfig& config,
 		bool useBullet = true);
 
-	class PerformanceOverlay
-	{
-	public:
-		static float CalcFrameTime(uint64_t timeElapsed, uint64_t frequency)
-		{
-			return 1000.0f * (float)timeElapsed / (float)frequency;
-		}
-
-		static float CalcFPS(float frameTimeMs)
-		{
-			return 1000.0f / frameTimeMs;
-		}
-	};
-	extern PerformanceOverlay performanceOverlay;
-
 	/**
 	 * @brief Draws a multi-line tooltip with optional per-line coloring.
+	 *
+	 * IMPORTANT: This function should only be called from within a tooltip context
+	 * (e.g., from within a HoverTooltipWrapper or BeginTooltip/EndTooltip block).
+	 * Do not call this function directly without proper tooltip context.
+	 *
 	 * @param lines The lines of text to display in the tooltip (as std::vector<std::string>).
 	 * @param colors Optional per-line colors (if empty, default color is used for all lines).
 	 */
 	void DrawMultiLineTooltip(const std::vector<std::string>& lines, const std::vector<ImVec4>& colors = {});
+
+	/**
+	 * Draws a color legend tooltip for overlay color meanings (e.g., green = better, red = worse, white = similar).
+	 *
+	 * IMPORTANT: This function should only be called from within a tooltip context
+	 * (e.g., from within a HoverTooltipWrapper or BeginTooltip/EndTooltip block).
+	 * Do not call this function directly without proper tooltip context.
+	 *
+	 * @param items Vector of (label, color) pairs.
+	 * @param title Optional title for the legend.
+	 */
+	void DrawColorLegendTooltip(const std::vector<std::pair<const char*, ImVec4>>& items, const char* title = nullptr);
 
 	/**
 	 * @brief Comparator function type for table sorting.
@@ -257,7 +259,92 @@ namespace Util
 	using TableCellRenderFunc = std::function<void(int row, int col, const std::string& value)>;
 
 	/**
+	 * @brief Renders a sortable ImGui table with arbitrary columns and per-column custom sorting for custom row types.
+	 *
+	 * @tparam T The row type. Must be copyable and compatible with the provided cellRender and customSorts functions.
+	 * @param table_id Unique ImGui table ID.
+	 * @param headers Column headers.
+	 * @param rows Table data, each row is of type T.
+	 * @param sortColumn Default sort column index.
+	 * @param ascending Default sort direction.
+	 * @param customSorts Vector of custom comparator functions, one per column.
+	 *        Each function should compare two rows and return true if the first should come before the second.
+	 * @param cellRender Function to render a cell: (rowIdx, colIdx, const T& row).
+	 * @param footerRows Optional static footer rows (not sorted, rendered after main rows).
+	 *
+	 * Example usage:
+	 *   struct MyRow { ... };
+	 *   Util::ShowSortedStringTable<MyRow>(..., rows, ..., customSorts, cellRender, footerRows);
+	 */
+	template <typename T>
+	void ShowSortedStringTable(
+		const char* table_id,
+		const std::vector<std::string>& headers,
+		std::vector<T>& rows,
+		size_t sortColumn,
+		bool ascending,
+		const std::vector<std::function<bool(const T&, const T&, bool)>>& customSorts,
+		std::function<void(int, int, const T&)> cellRender,
+		const std::vector<T>& footerRows = {})
+	{
+		ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable;
+		if (ImGui::BeginTable(table_id, static_cast<int>(headers.size()), flags)) {
+			for (const auto& header : headers)
+				ImGui::TableSetupColumn(header.c_str());
+			ImGui::TableHeadersRow();
+
+			// Interactive sorting
+			int sortCol = static_cast<int>(sortColumn);
+			bool sortAsc = ascending;
+			if (const ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs()) {
+				if (sortSpecs->SpecsCount > 0) {
+					sortCol = sortSpecs->Specs->ColumnIndex;
+					sortAsc = sortSpecs->Specs->SortDirection == ImGuiSortDirection_Ascending;
+				}
+			}
+			if (sortCol >= 0 && static_cast<size_t>(sortCol) < headers.size()) {
+				if (sortCol < static_cast<int>(customSorts.size()) && customSorts[sortCol]) {
+					auto cmp = customSorts[sortCol];
+					std::sort(rows.begin(), rows.end(), [sortCol, sortAsc, &cmp](const T& a, const T& b) {
+						return cmp(a, b, sortAsc);
+					});
+				}
+			}
+
+			// Render main (sorted) rows
+			for (size_t rowIdx = 0; rowIdx < rows.size(); ++rowIdx) {
+				const auto& row = rows[rowIdx];
+				ImGui::TableNextRow();
+				for (size_t col = 0; col < headers.size(); ++col) {
+					ImGui::TableSetColumnIndex(static_cast<int>(col));
+					if (cellRender) {
+						cellRender(static_cast<int>(rowIdx), static_cast<int>(col), row);
+					} else if constexpr (std::is_same_v<T, std::vector<std::string>>) {
+						if (col < row.size())
+							ImGui::TextUnformatted(row[col].c_str());
+					}
+				}
+			}
+			// Render static footer rows (not sorted)
+			for (size_t rowIdx = 0; rowIdx < footerRows.size(); ++rowIdx) {
+				const auto& row = footerRows[rowIdx];
+				ImGui::TableNextRow();
+				for (size_t col = 0; col < headers.size(); ++col) {
+					ImGui::TableSetColumnIndex(static_cast<int>(col));
+					if (cellRender) {
+						cellRender(static_cast<int>(rows.size() + rowIdx), static_cast<int>(col), row);
+					}
+				}
+			}
+			ImGui::EndTable();
+		}
+	}
+
+	/**
 	 * @brief Renders a sortable ImGui table with arbitrary columns and per-column custom sorting.
+	 *
+	 * This overload is for tables where each row is a std::vector<std::string>.
+	 * For custom row types, use the template version above.
 	 *
 	 * @param table_id Unique ImGui table ID.
 	 * @param headers Column headers.
@@ -265,16 +352,51 @@ namespace Util
 	 * @param sortColumn Default sort column index.
 	 * @param ascending Default sort direction.
 	 * @param customSorts Vector of custom comparator functions, one per column (nullptr for default string sort).
-	 * @param cellRender Optional cell renderer function for custom cell rendering.
+	 *        Each function should compare two strings and return true if the first should come before the second.
+	 * @param cellRender Optional cell renderer function for custom cell rendering. Signature: (row, col, value)
 	 */
-	void ShowSortedStringTable(
+	inline void ShowSortedStringTable(
 		const char* table_id,
 		const std::vector<std::string>& headers,
 		std::vector<std::vector<std::string>> rows,
 		size_t sortColumn = 0,
 		bool ascending = true,
 		const std::vector<TableSortFunc>& customSorts = {},
-		TableCellRenderFunc cellRender = nullptr);
+		TableCellRenderFunc cellRender = nullptr)
+	{
+		// Adapt TableSortFunc to std::function<bool(const std::vector<std::string>&, const std::vector<std::string>&, bool)>
+		std::vector<std::function<bool(const std::vector<std::string>&, const std::vector<std::string>&, bool)>> adaptedSorts;
+		adaptedSorts.reserve(customSorts.size());
+		for (size_t i = 0; i < customSorts.size(); ++i) {
+			const auto& sort = customSorts[i];
+			if (sort) {
+				adaptedSorts.push_back([i, sort](const std::vector<std::string>& a, const std::vector<std::string>& b, bool asc) {
+					// Use the i-th column for comparison if available
+					const std::string& aVal = (i < a.size()) ? a[i] : std::string();
+					const std::string& bVal = (i < b.size()) ? b[i] : std::string();
+					return sort(aVal, bVal, asc);
+				});
+			} else {
+				adaptedSorts.push_back(nullptr);
+			}
+		}
+		// Adapt TableCellRenderFunc to std::function<void(int, int, const std::vector<std::string>&)>
+		std::function<void(int, int, const std::vector<std::string>&)> adaptedCellRender = nullptr;
+		if (cellRender) {
+			adaptedCellRender = [cellRender](int row, int col, const std::vector<std::string>& value) {
+				if (col < value.size())
+					cellRender(row, col, value[col]);
+			};
+		}
+		ShowSortedStringTable<std::vector<std::string>>(
+			table_id,
+			headers,
+			rows,
+			sortColumn,
+			ascending,
+			adaptedSorts,
+			adaptedCellRender);
+	}
 
 	/**
 	 * @brief Compares two version strings (e.g., "1.2.3") numerically.
@@ -291,9 +413,5 @@ namespace Util
 	extern const TableSortFunc VersionSortComparator;
 
 	// Performance overlay formatting and color helpers
-	std::string FormatMilliseconds(float ms);
-	std::string FormatMicroseconds(float us);
-	std::string FormatPercent(float percent);
 	ImVec4 GetThresholdColor(float value, float good, float warn, ImVec4 goodColor, ImVec4 warnColor, ImVec4 badColor);
-	std::string TimeAgoString(std::chrono::steady_clock::time_point last);
 }  // namespace Util

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -330,6 +330,14 @@ namespace Util
 					}
 				}
 			}
+
+			// Add separator between main rows and footer rows if there are footer rows
+			if (!footerRows.empty() && !rows.empty()) {
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::Separator();
+			}
+
 			// Render static footer rows (not sorted)
 			for (size_t rowIdx = 0; rowIdx < footerRows.size(); ++rowIdx) {
 				const auto& row = footerRows[rowIdx];

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -371,7 +371,7 @@ namespace Util
 	inline void ShowSortedStringTable(
 		const char* table_id,
 		const std::vector<std::string>& headers,
-		std::vector<std::vector<std::string>> rows,
+		const std::vector<std::vector<std::string>>& rows,
 		size_t sortColumn = 0,
 		bool ascending = true,
 		const std::vector<TableSortFunc>& customSorts = {},
@@ -401,14 +401,36 @@ namespace Util
 					cellRender(row, col, value[col]);
 			};
 		}
-		ShowSortedStringTable<std::vector<std::string>>(
-			table_id,
-			headers,
-			rows,
-			sortColumn,
-			ascending,
-			adaptedSorts,
-			adaptedCellRender);
+
+		// Check if sorting is needed by looking at ImGui table sort specs
+		bool needsSorting = false;
+		if (const ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs()) {
+			needsSorting = (sortSpecs->SpecsCount > 0);
+		}
+
+		// Only make a copy if we need to sort, otherwise use the original data
+		if (needsSorting) {
+			std::vector<std::vector<std::string>> rowsCopy = rows;
+			ShowSortedStringTable<std::vector<std::string>>(
+				table_id,
+				headers,
+				rowsCopy,
+				sortColumn,
+				ascending,
+				adaptedSorts,
+				adaptedCellRender);
+		} else {
+			// For non-sorting case, we can use the original data directly
+			// We need to const_cast because the template expects non-const, but we know it won't be modified
+			ShowSortedStringTable<std::vector<std::string>>(
+				table_id,
+				headers,
+				const_cast<std::vector<std::vector<std::string>>&>(rows),
+				sortColumn,
+				ascending,
+				adaptedSorts,
+				adaptedCellRender);
+		}
 	}
 
 	/**

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -30,6 +30,16 @@ class Menu;
 
 namespace Util
 {
+	/**
+	 * Represents a single line and its color for any colored text rendering (tooltips, legends, etc.).
+	 */
+	struct ColoredTextLine
+	{
+		std::string text;
+		ImVec4 color;
+	};
+	using ColoredTextLines = std::vector<ColoredTextLine>;
+
 	// Text rendering constants
 	constexpr float DefaultHeaderTextScale = 1.5f;  // Larger scale for header text to improve readability
 
@@ -226,16 +236,11 @@ namespace Util
 	void DrawMultiLineTooltip(const std::vector<std::string>& lines, const std::vector<ImVec4>& colors = {});
 
 	/**
-	 * Draws a color legend tooltip for overlay color meanings (e.g., green = better, red = worse, white = similar).
+	 * @brief Draws a multi-line tooltip with optional per-line coloring.
 	 *
-	 * IMPORTANT: This function should only be called from within a tooltip context
-	 * (e.g., from within a HoverTooltipWrapper or BeginTooltip/EndTooltip block).
-	 * Do not call this function directly without proper tooltip context.
-	 *
-	 * @param items Vector of (label, color) pairs.
-	 * @param title Optional title for the legend.
+	 * Expects a vector of {text, color} pairs. Should be called from within a tooltip context.
 	 */
-	void DrawColorLegendTooltip(const std::vector<std::pair<const char*, ImVec4>>& items, const char* title = nullptr);
+	void DrawColoredMultiLineTooltip(const ColoredTextLines& lines);
 
 	/**
 	 * @brief Comparator function type for table sorting.


### PR DESCRIPTION
- Add frame timing stats and per shader disabling
- Add a/b testing
- Use new feature type `overlay` and moved both weatherpicker and perfoverlay to use this

<img width="1131" height="1372" alt="image" src="https://github.com/user-attachments/assets/fbb7bfee-d680-49df-8755-9224a02f8d0b" />
<img width="1123" height="765" alt="image" src="https://github.com/user-attachments/assets/c9e9b68c-df46-4ff0-b371-fc6ebe2efb38" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive, modular performance overlay for real-time monitoring of FPS, frame times, draw calls, VRAM usage, and per-shader performance, with advanced A/B testing and comparison tools.
  * Added an A/B Testing system for automated performance comparisons between shader configurations, including statistical analysis and settings diff display.
  * Weather Picker now supports overlay display and improved configuration options.
  * Enhanced overlay system to support multiple, independently togglable overlays.

* **Improvements**
  * Added detailed per-shader frame time tracking and smoothing for more accurate performance insights.
  * Improved overlay toggle and hotkey configuration for easier access.

* **Bug Fixes**
  * Corrected hotkey display for overlay toggling.

* **Refactor**
  * Replaced legacy performance overlay with a modular, extensible overlay and testing framework.
  * Standardized shader type handling and improved thread safety in performance statistics.

* **Chores**
  * Added utility functions for formatting, statistics, and JSON diffing to support new overlay features.
  * Updated documentation and internal structure for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->