### PR TITLE
fix: always update eye position

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -1134,7 +1134,7 @@ namespace Hooks
 
 		// Patch eye position in BSLightingShader::SetupGeometry to always update due to additional effects which may require it
 		// The variable updateEyePosition is set to false by default. By patching to be true it will always update the eye position
-		// SE and AE use a 6-byte instruction whereas VR uses a 7-byte instruction
+		// SE and AE use a 7-byte instruction whereas VR uses a 8-byte instruction
 		// We offset from the base address of the containing function to the instruction itself and then to the value the instruction sets
 		{
 			uintptr_t setupGeometryUpdateEyePosition = REL::RelocationID(100565, 107300).address() + REL::Relocate(0x50, 0x75, 0x78);

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -1134,8 +1134,8 @@ namespace Hooks
 
 		// Patch EyePosition in BSLightingShader::SetupGeometry to always update due to additional effects which may require it
 		{
-			uintptr_t setupGeometryUpdateEyePosition = REL::RelocationID(100565, 107300).address() + REL::Relocate(0x50, 0x75);
-			REL::safe_write(setupGeometryUpdateEyePosition + 6, uint8_t{ 1 });
+			uintptr_t setupGeometryUpdateEyePosition = REL::RelocationID(100565, 107300).address() + REL::Relocate(0x50, 0x75, 0x78);
+			REL::safe_write(setupGeometryUpdateEyePosition + +REL::Relocate(6, 6, 7), uint8_t{ 1 });
 		}
 	}
 

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -1131,6 +1131,12 @@ namespace Hooks
 			stl::write_thunk_call<Main_Update_Begin>(REL::RelocationID(35565, 36564).address() + REL::Relocate(0x53, 0x6E));
 			stl::write_thunk_call<Main_Update_Swap>(REL::RelocationID(35565, 36564).address() + REL::Relocate(0x5D2, 0xA97));
 		}
+
+		// Patch EyePosition in BSLightingShader::SetupGeometry to always update due to additional effects which may require it
+		{
+			uintptr_t setupGeometryUpdateEyePosition = REL::RelocationID(100565, 107300).address() + REL::Relocate(0x50, 0x75);
+			REL::safe_write(setupGeometryUpdateEyePosition + 6, uint8_t{ 1 });
+		}
 	}
 
 	/**

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -1137,6 +1137,7 @@ namespace Hooks
 		// SE and AE use a 7-byte instruction whereas VR uses a 8-byte instruction
 		// We offset from the base address of the containing function to the instruction itself and then to the value the instruction sets
 		{
+			logger::info("Patching BSLightingShader::SetupGeometry::updateEyePosition");
 			uintptr_t setupGeometryUpdateEyePosition = REL::RelocationID(100565, 107300).address() + REL::Relocate(0x50, 0x75, 0x78);
 			REL::safe_write(setupGeometryUpdateEyePosition + REL::Relocate(6, 6, 7), bool{ true });
 		}

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -1135,6 +1135,7 @@ namespace Hooks
 		// Patch eye position in BSLightingShader::SetupGeometry to always update due to additional effects which may require it
 		// The variable updateEyePosition is set to false by default. By patching to be true it will always update the eye position
 		// SE and AE use a 6-byte instruction whereas VR uses a 7-byte instruction
+		// We offset from the base address of the containing function to the instruction itself and then to the value the instruction sets
 		{
 			uintptr_t setupGeometryUpdateEyePosition = REL::RelocationID(100565, 107300).address() + REL::Relocate(0x50, 0x75, 0x78);
 			REL::safe_write(setupGeometryUpdateEyePosition + REL::Relocate(6, 6, 7), bool{ true });

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -1135,7 +1135,7 @@ namespace Hooks
 		// Patch EyePosition in BSLightingShader::SetupGeometry to always update due to additional effects which may require it
 		{
 			uintptr_t setupGeometryUpdateEyePosition = REL::RelocationID(100565, 107300).address() + REL::Relocate(0x50, 0x75, 0x78);
-			REL::safe_write(setupGeometryUpdateEyePosition + +REL::Relocate(6, 6, 7), uint8_t{ 1 });
+			REL::safe_write(setupGeometryUpdateEyePosition + REL::Relocate(6, 6, 7), uint8_t{ 1 });
 		}
 	}
 

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -1132,10 +1132,12 @@ namespace Hooks
 			stl::write_thunk_call<Main_Update_Swap>(REL::RelocationID(35565, 36564).address() + REL::Relocate(0x5D2, 0xA97));
 		}
 
-		// Patch EyePosition in BSLightingShader::SetupGeometry to always update due to additional effects which may require it
+		// Patch eye position in BSLightingShader::SetupGeometry to always update due to additional effects which may require it
+		// The variable updateEyePosition is set to false by default. By patching to be true it will always update the eye position
+		// SE and AE use a 6-byte instruction whereas VR uses a 7-byte instruction
 		{
 			uintptr_t setupGeometryUpdateEyePosition = REL::RelocationID(100565, 107300).address() + REL::Relocate(0x50, 0x75, 0x78);
-			REL::safe_write(setupGeometryUpdateEyePosition + REL::Relocate(6, 6, 7), uint8_t{ 1 });
+			REL::safe_write(setupGeometryUpdateEyePosition + REL::Relocate(6, 6, 7), bool{ true });
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/doodlum/skyrim-community-shaders/issues/1230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * EyePosition is now always updated during the lighting shader setup, enhancing visual consistency and support for additional effects when not in VR mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->