### PR TITLE
fix(ISL): stealth light level calculations

### DIFF
--- a/src/Features/InverseSquareLighting.cpp
+++ b/src/Features/InverseSquareLighting.cpp
@@ -15,6 +15,7 @@ void InverseSquareLighting::EarlyPrepass()
 void InverseSquareLighting::PostPostLoad()
 {
 	stl::detour_thunk<CreatePointLight>(REL::RelocationID(17208, 17610));
+	stl::detour_thunk<BSLight_GetLuminance>(REL::RelocationID(101303, 108292));
 
 	logger::info("[InverseSquareLighting] Installed hooks");
 }
@@ -90,4 +91,23 @@ float InverseSquareLighting::GetAttenuation(const float distance, const float ra
 	const float fadeZone = std::clamp(FadeZoneBase / radius, 0.0f, 1.0f);
 	const float fade = SmoothStep(0, radius * fadeZone, radius - distance);
 	return attenuation * fade;
+}
+
+float InverseSquareLighting::BSLight_GetLuminance::thunk(RE::BSLight* bsLight, RE::NiPoint3* targetPosition, RE::NiLight* refLight)
+{	
+	auto* niLight = bsLight->light.get();
+	const auto runtimeData = ISLCommon::RuntimeLightDataExt::Get(niLight);
+	
+	if (refLight == niLight || runtimeData->flags.any(LightLimitFix::LightFlags::Disabled))
+		return 0.0f;
+	
+	if (!bsLight->pointLight || runtimeData->flags.none(LightLimitFix::LightFlags::InverseSquare))
+		return func(bsLight, targetPosition, refLight);
+
+	const float dist = niLight->world.translate.GetDistance(*targetPosition);
+	const float attenuation = GetAttenuation(dist, runtimeData->radius.x);
+	const float luminance = (runtimeData->diffuse.red + runtimeData->diffuse.green + runtimeData->diffuse.blue) * runtimeData->fade * attenuation * (1.0f / 3.0f);
+	bsLight->luminance = luminance;
+	
+	return luminance;
 }

--- a/src/Features/InverseSquareLighting.cpp
+++ b/src/Features/InverseSquareLighting.cpp
@@ -94,13 +94,13 @@ float InverseSquareLighting::GetAttenuation(const float distance, const float ra
 }
 
 float InverseSquareLighting::BSLight_GetLuminance::thunk(RE::BSLight* bsLight, RE::NiPoint3* targetPosition, RE::NiLight* refLight)
-{	
+{
 	auto* niLight = bsLight->light.get();
 	const auto runtimeData = ISLCommon::RuntimeLightDataExt::Get(niLight);
-	
+
 	if (refLight == niLight || runtimeData->flags.any(LightLimitFix::LightFlags::Disabled))
 		return 0.0f;
-	
+
 	if (!bsLight->pointLight || runtimeData->flags.none(LightLimitFix::LightFlags::InverseSquare))
 		return func(bsLight, targetPosition, refLight);
 
@@ -108,6 +108,6 @@ float InverseSquareLighting::BSLight_GetLuminance::thunk(RE::BSLight* bsLight, R
 	const float attenuation = GetAttenuation(dist, runtimeData->radius.x);
 	const float luminance = (runtimeData->diffuse.red + runtimeData->diffuse.green + runtimeData->diffuse.blue) * runtimeData->fade * attenuation * (1.0f / 3.0f);
 	bsLight->luminance = luminance;
-	
+
 	return luminance;
 }

--- a/src/Features/InverseSquareLighting.h
+++ b/src/Features/InverseSquareLighting.h
@@ -57,6 +57,12 @@ public:
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
+	struct BSLight_GetLuminance
+	{
+		static float thunk(RE::BSLight* bsLight, RE::NiPoint3* targetPosition, RE::NiLight* refLight);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
 private:
 	LightEditor editor = LightEditor();
 

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -154,7 +154,7 @@ bool Load()
 	}
 
 	if (REL::Module::IsVR()) {
-		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.179.0", true);
+		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.181.0", true);
 	}
 
 	auto privateProfileRedirectorVersion = Util::GetDllVersion(L"Data/SKSE/Plugins/PrivateProfileRedirector.dll");


### PR DESCRIPTION
- CPU side light level calculations used for determining player visibility updated to account for inverse square falloff lights
- VR requires VR library update -> https://github.com/alandtse/skyrim_vr_address_library/pull/100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved lighting realism by updating luminance calculations for point lights using the inverse square law, enhancing visual accuracy for lights with the "InverseSquare" property.

* **Chores**
  * Updated the minimum required version of the VR address library to 0.181.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->