### PR TITLE
fix: ViewDirection not working for Wave mesh

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -314,11 +314,7 @@ VS_OUTPUT main(VS_INPUT input)
 	vsout.TexProj = TextureProj[eyeIndex][2].xyz;
 #	endif
 
-#	if defined(ENVMAP) || defined(MULTI_LAYER_PARALLAX) || defined(SKINNED)
 	vsout.ViewVector = EyePosition[eyeIndex].xyz - worldPosition.xyz;
-#	else
-	vsout.ViewVector = EyePosition[eyeIndex].xyz - input.Position.xyz;
-#	endif
 
 #	if defined(EYE)
 	precise float4 modelEyeCenter = float4(LeftEyeCenter.xyz + input.EyeParameter.xxx * (RightEyeCenter.xyz - LeftEyeCenter.xyz), 1);


### PR DESCRIPTION
When investigating #1230 , I notice the wavelet nif is not a skinned/envmap/parallax mesh.
And RenderDoc capture shows its current ViewVector is mostly -input. Position.
<img width="3537" height="627" alt="image" src="https://github.com/user-attachments/assets/9861dc19-e4e9-44db-9be5-a7091e227999" />
Because these wavelet quads are just z-up rectangle, with constant normal `(0,0,1)`, the angle between view and normal, `dot(view, normal)` was evaluate to constant 0, not affecting by view angle at all...
With the eye position fixed, I think we should always use the world position instead of the model space position.