### PR TITLE
fix(skysync): ctd with null sky

### DIFF
--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -394,7 +394,7 @@ void SkySync::ClimateTimings::Update(const RE::TESClimate* climate)
 
 void SkySync::Sky_OnNewClimate::thunk(RE::Sky* sky)
 {
-	if (const auto singleton = GetSingleton(); singleton->settings.Enabled && sky)
+	if (const auto singleton = GetSingleton(); sky && singleton->settings.Enabled)
 		singleton->timings.Update(sky->currentClimate);
 	func(sky);
 }

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -394,7 +394,7 @@ void SkySync::ClimateTimings::Update(const RE::TESClimate* climate)
 
 void SkySync::Sky_OnNewClimate::thunk(RE::Sky* sky)
 {
-	if (const auto singleton = GetSingleton(); singleton->settings.Enabled)
+	if (const auto singleton = GetSingleton(); singleton->settings.Enabled && sky)
 		singleton->timings.Update(sky->currentClimate);
 	func(sky);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by adding a check to prevent potential errors when the sky data is unavailable during climate updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->