### PR TITLE
fix: font rebuild at every frame

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1304,9 +1304,7 @@ void Menu::DrawGeneralSettings()
 						auto& io = ImGui::GetIO();
 						io.FontGlobalScale = trueScale;
 					}
-					if (ImGui::SliderFloat("Font Size", &themeSettings.FontSize, Constants::MIN_FONT_SIZE, Constants::MAX_FONT_SIZE, "%.0f")) {
-						pendingFontChange = true;
-					}
+					ImGui::SliderFloat("Font Size", &themeSettings.FontSize, Constants::MIN_FONT_SIZE, Constants::MAX_FONT_SIZE, "%.0f");
 					ImGui::SliderFloat2("Window Padding", (float*)&style.WindowPadding, 0.0f, 20.0f, "%.0f");
 					ImGui::SliderFloat2("Frame Padding", (float*)&style.FramePadding, 0.0f, 20.0f, "%.0f");
 					ImGui::SliderFloat2("Item Spacing", (float*)&style.ItemSpacing, 0.0f, 20.0f, "%.0f");
@@ -1662,7 +1660,7 @@ void Menu::DrawFooter()
 
 void Menu::DrawOverlay()
 {
-	ProcessInputEventQueue();  //Synchronize Inputs to frame
+	ProcessInputEventQueue();  // Synchronize Inputs to frame
 
 	auto shaderCache = globals::shaderCache;
 	auto failed = shaderCache->GetFailedTasks();
@@ -1676,7 +1674,7 @@ void Menu::DrawOverlay()
 	}
 
 	// Reload font if user changed something
-	if (pendingFontChange) {
+	if (cachedFontSize - settings.Theme.FontSize > 0.01) {
 		ReloadFont();
 	}
 
@@ -2290,5 +2288,5 @@ void Menu::ReloadFont()
 
 	io.FontGlobalScale = exp2(settings.Theme.GlobalScale);
 
-	pendingFontChange = false;
+	cachedFontSize = settings.Theme.FontSize;
 }

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1676,7 +1676,7 @@ void Menu::DrawOverlay()
 	}
 
 	// Reload font if user changed something
-	if (pendingFontChange || std::abs(ImGui::GetFontSize() - settings.Theme.FontSize) > 0.01f) {
+	if (pendingFontChange) {
 		ReloadFont();
 	}
 

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1674,7 +1674,7 @@ void Menu::DrawOverlay()
 	}
 
 	// Reload font if user changed something
-	if (cachedFontSize - settings.Theme.FontSize > 0.01f) {
+	if (std::abs(cachedFontSize - settings.Theme.FontSize) > 0.01f) {
 		ReloadFont();
 	}
 

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1674,7 +1674,7 @@ void Menu::DrawOverlay()
 	}
 
 	// Reload font if user changed something
-	if (cachedFontSize - settings.Theme.FontSize > 0.01) {
+	if (cachedFontSize - settings.Theme.FontSize > 0.01f) {
 		ReloadFont();
 	}
 

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -205,8 +205,8 @@ public:
 private:
 	Settings settings;
 
-	bool pendingFontChange = false;  // Tracks whether font has been modified and may require reloading
-	void ReloadFont();               // Credit to user patchuli: https://github.com/Patchu1i/ModExplorerMenu/tree/master
+	bool pendingFontChange = true;  // Tracks whether font has been modified and may require reloading
+	void ReloadFont();              // Credit to user patchuli: https://github.com/Patchu1i/ModExplorerMenu/tree/master
 
 	// Menu navigation
 	std::string pendingFeatureSelection;  // Feature to select on next frame

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -205,8 +205,8 @@ public:
 private:
 	Settings settings;
 
-	bool pendingFontChange = true;  // Tracks whether font has been modified and may require reloading
-	void ReloadFont();              // Credit to user patchuli: https://github.com/Patchu1i/ModExplorerMenu/tree/master
+	float cachedFontSize = Constants::DEFAULT_FONT_SIZE;  // Tracks whether font has been modified and may require reloading
+	void ReloadFont();                                    // Credit to user patchuli: https://github.com/Patchu1i/ModExplorerMenu/tree/master
 
 	// Menu navigation
 	std::string pendingFeatureSelection;  // Feature to select on next frame


### PR DESCRIPTION
Addresses https://github.com/doodlum/skyrim-community-shaders/milestone/1 perf issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the logic for when fonts are reloaded in the menu overlay, making font reloads more predictable and consistent. No changes to public features or interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->