### PR TITLE
perf(shadercache): use faster clock

### DIFF
--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -2606,6 +2606,9 @@ namespace SIE
 	{
 		double totalMs = static_cast<double>(totalTime.QuadPart) * 1000.0 / frequency.QuadPart;
 
+		if (totalMs == 0.0) {
+			return 0.0; // Avoid division by zero
+		}
 		auto rate = completedTasks / totalMs;
 		auto remaining = totalTasks - completedTasks - failedTasks;
 		return std::max(remaining / rate, 0.0);

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -2529,7 +2529,8 @@ namespace SIE
 			return std::nullopt;
 		}
 		if (!shaderCache->IsCompiling()) {  // we just got woken up because there's a task, start clock
-			lastCalculation = lastReset = high_resolution_clock::now();
+			QueryPerformanceCounter(&lastReset);
+			lastCalculation = lastReset;
 		}
 		auto node = availableTasks.extract(availableTasks.begin());
 		auto& task = node.value();
@@ -2564,8 +2565,9 @@ namespace SIE
 			logger::debug("Compiling Task failed: {}", key);
 			failedTasks++;
 		}
-		auto now = high_resolution_clock::now();
-		totalMs += duration_cast<milliseconds>(now - lastCalculation).count();
+		LARGE_INTEGER now;
+		QueryPerformanceCounter(&now);
+		totalTime.QuadPart += now.QuadPart - lastCalculation.QuadPart;
 		lastCalculation = now;
 		std::scoped_lock lock(compilationMutex);
 		processedTasks.insert(task);
@@ -2583,14 +2585,14 @@ namespace SIE
 		completedTasks = 0;
 		failedTasks = 0;
 		cacheHitTasks = 0;
-		lastReset = high_resolution_clock::now();
-		lastCalculation = high_resolution_clock::now();
-		totalMs = (double)duration_cast<std::chrono::milliseconds>(lastReset - lastReset).count();
+		QueryPerformanceCounter(&lastReset);
+		QueryPerformanceCounter(&lastCalculation);
+		totalTime = { 0 };
 	}
 
-	std::string CompilationSet::GetHumanTime(double a_totalms)
+	std::string CompilationSet::GetHumanTime(double a_totalMs)
 	{
-		int milliseconds = (int)a_totalms;
+		int milliseconds = (int)a_totalMs;
 		int seconds = milliseconds / 1000;
 		int minutes = seconds / 60;
 		seconds %= 60;
@@ -2602,6 +2604,8 @@ namespace SIE
 
 	double CompilationSet::GetEta()
 	{
+		double totalMs = static_cast<double>(totalTime.QuadPart) * 1000.0 / frequency.QuadPart;
+
 		auto rate = completedTasks / totalMs;
 		auto remaining = totalTasks - completedTasks - failedTasks;
 		return std::max(remaining / rate, 0.0);
@@ -2609,6 +2613,8 @@ namespace SIE
 
 	std::string CompilationSet::GetStatsString(bool a_timeOnly)
 	{
+		double totalMs = static_cast<double>(totalTime.QuadPart) * 1000.0 / frequency.QuadPart;
+
 		if (a_timeOnly)
 			return fmt::format("{}/{}",
 				GetHumanTime(totalMs),

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -2607,7 +2607,7 @@ namespace SIE
 		double totalMs = static_cast<double>(totalTime.QuadPart) * 1000.0 / frequency.QuadPart;
 
 		if (totalMs == 0.0) {
-			return 0.0; // Avoid division by zero
+			return 0.0;  // Avoid division by zero
 		}
 		auto rate = completedTasks / totalMs;
 		auto remaining = totalTasks - completedTasks - failedTasks;

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -242,11 +242,22 @@ namespace SIE
 	class CompilationSet
 	{
 	public:
+		LARGE_INTEGER lastReset;
+		LARGE_INTEGER lastCalculation;
+		LARGE_INTEGER frequency;
+		LARGE_INTEGER totalTime = { 0 };
+
+	   	CompilationSet() {
+			QueryPerformanceFrequency(&frequency);
+			QueryPerformanceCounter(&lastReset);
+			QueryPerformanceCounter(&lastCalculation);
+    	}
+
 		std::optional<ShaderCompilationTask> WaitTake(std::stop_token stoken);
 		void Add(const ShaderCompilationTask& task);
 		void Complete(const ShaderCompilationTask& task);
 		void Clear();
-		std::string GetHumanTime(double a_totalms);
+		std::string GetHumanTime(double a_totalMs);
 		double GetEta();
 		std::string GetStatsString(bool a_timeOnly = false);
 		std::atomic<uint64_t> completedTasks = 0;
@@ -260,9 +271,6 @@ namespace SIE
 		std::unordered_set<ShaderCompilationTask> tasksInProgress;
 		std::unordered_set<ShaderCompilationTask> processedTasks;  // completed or failed
 		std::condition_variable_any conditionVariable;
-		std::chrono::steady_clock::time_point lastReset = high_resolution_clock::now();
-		std::chrono::steady_clock::time_point lastCalculation = high_resolution_clock::now();
-		double totalMs = (double)duration_cast<std::chrono::milliseconds>(lastReset - lastReset).count();
 	};
 
 	struct ShaderCacheResult

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -247,11 +247,12 @@ namespace SIE
 		LARGE_INTEGER frequency;
 		LARGE_INTEGER totalTime = { 0 };
 
-	   	CompilationSet() {
+		CompilationSet()
+		{
 			QueryPerformanceFrequency(&frequency);
 			QueryPerformanceCounter(&lastReset);
 			QueryPerformanceCounter(&lastCalculation);
-    	}
+		}
 
 		std::optional<ShaderCompilationTask> WaitTake(std::stop_token stoken);
 		void Add(const ShaderCompilationTask& task);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved timing accuracy for shader compilation tracking and ETA estimation by switching to Windows high-resolution performance counters.
  * Updated internal timing mechanisms for better performance and reliability on Windows systems.

* **Style**
  * Minor parameter name adjustment for consistency in time-related methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->