### PR TITLE
chore(perfoverlay): disable interactivity in menus

### DIFF
--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -379,9 +379,8 @@ void PerformanceOverlay::DrawOverlay()
 			this->perfOverlayState.UpdateFGFrameTime();
 		}
 
-		// Check if we should show collapsible sections (menu open or should swallow input)
-		bool showCollapsibleSections = Menu::GetSingleton()->ShouldSwallowInput() ||
-		                               (globals::game::ui && globals::game::ui->IsMenuOpen(RE::CursorMenu::MENU_NAME));
+		// Check if we should show collapsible sections (should swallow input only)
+		bool showCollapsibleSections = Menu::GetSingleton()->ShouldSwallowInput();
 
 		// Show FPS counter if enabled
 		if (this->settings.ShowFPS) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the logic controlling the visibility of collapsible sections in the performance overlay UI, resulting in more consistent display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->