### PR TITLE
perf: use `unordered_dense` maps, misc optimisation

### DIFF
--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1507,7 +1507,7 @@ namespace SIE
 		{
 			using enum RE::ImageSpaceManager::ImageSpaceEffectEnum;
 
-			static const std::unordered_map<std::string_view, uint32_t> descriptors{
+			static const ankerl::unordered_dense::map<std::string_view, uint32_t> descriptors{
 				// { "BSImagespaceShaderISBlur", static_cast<uint32_t>(ISBlur) },
 				// { "BSImagespaceShaderBlur3", static_cast<uint32_t>(ISBlur3) },
 				// { "BSImagespaceShaderBlur5", static_cast<uint32_t>(ISBlur5) },

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -647,15 +647,14 @@ namespace SIE
 
 		~ShaderCache();
 
-		std::array<eastl::unordered_map<uint32_t, std::unique_ptr<RE::BSGraphics::VertexShader>>,
-			static_cast<size_t>(RE::BSShader::Type::Total)>
-			vertexShaders;
-		std::array<eastl::unordered_map<uint32_t, std::unique_ptr<RE::BSGraphics::PixelShader>>,
-			static_cast<size_t>(RE::BSShader::Type::Total)>
-			pixelShaders;
-		std::array<eastl::unordered_map<uint32_t, std::unique_ptr<RE::BSGraphics::ComputeShader>>,
-			static_cast<size_t>(RE::BSShader::Type::Total)>
-			computeShaders;
+		template <typename ShaderType>
+		using ShaderMapArray = std::array<
+			ankerl::unordered_dense::map<uint32_t, std::unique_ptr<ShaderType>>,
+			RE::BSShader::Type::Total>;
+
+		ShaderMapArray<RE::BSGraphics::VertexShader> vertexShaders;
+		ShaderMapArray<RE::BSGraphics::PixelShader> pixelShaders;
+		ShaderMapArray<RE::BSGraphics::ComputeShader> computeShaders;
 
 		bool isEnabled = true;
 		bool isDiskCache = true;
@@ -669,12 +668,12 @@ namespace SIE
 		std::mutex pixelShadersMutex;
 		std::mutex computeShadersMutex;
 		CompilationSet compilationSet;
-		std::unordered_map<std::string, ShaderCacheResult> shaderMap{};
-		std::mutex mapMutex;                                                            // guard for shaderMap
-		std::unordered_map<std::string, system_clock::time_point> modifiedShaderMap{};  // hashmap when a shader source file last modified
-		std::mutex modifiedMapMutex;                                                    // guard for modifiedShaderMap
-		std::unordered_map<std::string, std::set<hlslRecord>> hlslToShaderMap{};        // hashmap linking specific hlsl files to shader keys in shaderMap
-		std::mutex hlslMapMutex;                                                        // guard for hlslToShaderMap
+		ankerl::unordered_dense::map<std::string, ShaderCacheResult> shaderMap{};
+		std::mutex mapMutex;                                                                      // guard for shaderMap
+		ankerl::unordered_dense::map<std::string, system_clock::time_point> modifiedShaderMap{};  // hashmap when a shader source file last modified
+		std::mutex modifiedMapMutex;                                                              // guard for modifiedShaderMap
+		ankerl::unordered_dense::map<std::string, std::set<hlslRecord>> hlslToShaderMap{};        // hashmap linking specific hlsl files to shader keys in shaderMap
+		std::mutex hlslMapMutex;                                                                  // guard for hlslToShaderMap
 
 		// efsw file watcher
 		efsw::FileWatcher* fileWatcher = nullptr;

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -983,11 +983,9 @@ bool TruePBR::BSLightingShader_SetupMaterial(RE::BSLightingShader* shader, RE::B
 				shadowState->SetPSTextureAddressMode(11, RE::BSGraphics::TextureAddressMode::kClampSClampT);
 			}
 
-			std::array<float, 4> characterLightParams;
+			std::array<float, 4> characterLightParams{};  // in C++, arrays will be zero-initialized
 			if (smState->characterLightEnabled) {
 				std::copy_n(smState->characterLightParams, 4, characterLightParams.data());
-			} else {
-				std::fill_n(characterLightParams.data(), 4, 0.f);
 			}
 			shadowState->SetPSConstant(characterLightParams, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.CharacterLightParams);
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal data structures for shader management to use a more efficient map implementation.
  * Improved initialization of certain shader parameter arrays for clarity and efficiency.

No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->