### PR TITLE
fix: interior dynamic cubemap for non-deferred

### DIFF
--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -47,6 +47,7 @@ namespace DynamicCubemaps
 		if (SharedData::InInterior) {
 			float3 specularIrradiance = Color::GammaToLinear(EnvReflectionsTexture.SampleLevel(SampColorSampler, R, level).xyz);
 
+			finalIrradiance += specularIrradiance;
 			return finalIrradiance;
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interior lighting by ensuring specular irradiance is correctly included in dynamic cubemaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->