### PR TITLE
fix(VL): fix crash when VL disabled

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -957,12 +957,12 @@ namespace Hooks
 						} else if (CurrentlyDispatchedComputeShader->name == std::string_view("ISVolumetricLightingRaymarchCS")) {
 							isShader = globals::features::volumetricLighting->GetOrCreateRaymarchCS(CurrentlyDispatchedComputeShader);
 						}
-					} else if (CurrentlyDispatchedComputeShader->name == std::string_view("ISVolumetricLightingBlurHCS")) {
+					} else if (vl->loaded && CurrentlyDispatchedComputeShader->name == std::string_view("ISVolumetricLightingBlurHCS")) {
 						techniqueId = 0;
 						isShader = vl->GetOrCreateBlurHCS(CurrentlyDispatchedComputeShader);
 						vl->SetDimensionsCB();
 						vl->SetGroupCountsHCS(threadGroupCountX);
-					} else if (CurrentlyDispatchedComputeShader->name == std::string_view("ISVolumetricLightingBlurVCS")) {
+					} else if (vl->loaded && CurrentlyDispatchedComputeShader->name == std::string_view("ISVolumetricLightingBlurVCS")) {
 						techniqueId = 0;
 						isShader = vl->GetOrCreateBlurVCS(CurrentlyDispatchedComputeShader);
 						vl->SetDimensionsCB();


### PR DESCRIPTION
Now checks if the CS VL feature is loaded before overriding with the new compute shaders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of volumetric lighting blur compute shaders to ensure they are only processed when the volumetric lighting feature is loaded, preventing potential errors or unexpected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->