### PR TITLE
feat(menu): add Performance Mode toggle to Advanced Settings

### DIFF
--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -153,11 +153,11 @@ void PerformanceOverlay::DrawSettings()
 	auto menu = Menu::GetSingleton();
 	const auto& themeSettings = menu->GetTheme();
 	const auto& menuSettings = menu->GetSettings();
-	
+
 	ImGui::BeginDisabled(menuSettings.PerformanceMode);
-		ImGui::Checkbox("Show in Overlay", &this->settings.ShowInOverlay);
+	ImGui::Checkbox("Show in Overlay", &this->settings.ShowInOverlay);
 	ImGui::EndDisabled();
-	
+
 	if (menuSettings.PerformanceMode && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
 		ImGui::SetTooltip("Disabled in Performance Mode.");
 	} else {

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -153,12 +153,20 @@ void PerformanceOverlay::DrawSettings()
 	auto menu = Menu::GetSingleton();
 	const auto& themeSettings = menu->GetTheme();
 	const auto& menuSettings = menu->GetSettings();
-	ImGui::Checkbox("Show in Overlay", &this->settings.ShowInOverlay);
-	if (auto _tt = Util::HoverTooltipWrapper()) {
-		ImGui::Text("Opens performance overlay in a separate window that stays open\neven when the main menu is closed. ");
-		ImGui::Text("Toggle with ");
-		ImGui::SameLine();
-		ImGui::TextColored(themeSettings.StatusPalette.CurrentHotkey, "%s", Menu::KeyIdToString(menuSettings.OverlayToggleKey));
+	
+	ImGui::BeginDisabled(menuSettings.PerformanceMode);
+		ImGui::Checkbox("Show in Overlay", &this->settings.ShowInOverlay);
+	ImGui::EndDisabled();
+	
+	if (menuSettings.PerformanceMode && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+		ImGui::SetTooltip("Disabled in Performance Mode.");
+	} else {
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Opens performance overlay in a separate window that stays open\neven when the main menu is closed. ");
+			ImGui::Text("Toggle with ");
+			ImGui::SameLine();
+			ImGui::TextColored(themeSettings.StatusPalette.CurrentHotkey, "%s", Menu::KeyIdToString(menuSettings.OverlayToggleKey));
+		}
 	}
 
 	if (this->settings.ShowInOverlay) {

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1520,13 +1520,13 @@ void Menu::DrawAdvancedSettings()
 		static bool lastPerformanceMode = false;
 		static bool frameAnnotationsBackup = false;
 		static bool performanceOverlayBackup = false;
-		
+
 		if (settings.PerformanceMode != lastPerformanceMode) {
 			if (settings.PerformanceMode) {
 				// Entering Performance Mode - backup and disable
 				frameAnnotationsBackup = globals::state->frameAnnotations;
 				globals::state->frameAnnotations = false;
-				
+
 				performanceOverlayBackup = PerformanceOverlay::GetSingleton()->settings.ShowInOverlay;
 				PerformanceOverlay::GetSingleton()->settings.ShowInOverlay = false;
 			} else {
@@ -1536,7 +1536,7 @@ void Menu::DrawAdvancedSettings()
 			}
 			lastPerformanceMode = settings.PerformanceMode;
 		}
-		
+
 		// Force settings to false while in Performance Mode
 		if (settings.PerformanceMode) {
 			if (globals::state->frameAnnotations) {
@@ -1546,9 +1546,9 @@ void Menu::DrawAdvancedSettings()
 				PerformanceOverlay::GetSingleton()->settings.ShowInOverlay = false;
 			}
 		}
-		
+
 		ImGui::BeginDisabled(settings.PerformanceMode);
-			ImGui::Checkbox("Frame Annotations", &globals::state->frameAnnotations);
+		ImGui::Checkbox("Frame Annotations", &globals::state->frameAnnotations);
 		ImGui::EndDisabled();
 		if (settings.PerformanceMode && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
 			ImGui::SetTooltip("Disabled in Performance Mode.");

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -106,6 +106,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	SkipCompilationKey,
 	EffectToggleKey,
 	OverlayToggleKey,
+	PerformanceMode,
 	Theme)
 
 void Menu::SetupImGuiStyle() const
@@ -1463,6 +1464,14 @@ void Menu::DrawAdvancedSettings()
 				"The more threads the faster compilation will finish but may make the system unresponsive. ");
 		}
 
+		bool performanceMode = settings.PerformanceMode;
+		if (ImGui::Checkbox("Performance Mode", &performanceMode)) {
+			settings.PerformanceMode = performanceMode;
+		}
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Disables certain menu options to improve performance.");
+		}
+
 		// A/B Testing settings
 		auto* abTestingManager = ABTestingManager::GetSingleton();
 		abTestingManager->DrawSettingsUI();
@@ -1506,7 +1515,48 @@ void Menu::DrawAdvancedSettings()
 			ImGui::Text(std::format("Shader Compiler : {}", shaderCache->GetShaderStatsString()).c_str());
 			ImGui::TreePop();
 		}
-		ImGui::Checkbox("Frame Annotations", &globals::state->frameAnnotations);
+
+		// Handle frameAnnotations and Performance Overlay backup/restore when PerformanceMode changes
+		static bool lastPerformanceMode = false;
+		static bool frameAnnotationsBackup = false;
+		static bool performanceOverlayBackup = false;
+		
+		if (settings.PerformanceMode != lastPerformanceMode) {
+			if (settings.PerformanceMode) {
+				// Entering Performance Mode - backup and disable
+				frameAnnotationsBackup = globals::state->frameAnnotations;
+				globals::state->frameAnnotations = false;
+				
+				performanceOverlayBackup = PerformanceOverlay::GetSingleton()->settings.ShowInOverlay;
+				PerformanceOverlay::GetSingleton()->settings.ShowInOverlay = false;
+			} else {
+				// Exiting Performance Mode - restore backups
+				globals::state->frameAnnotations = frameAnnotationsBackup;
+				PerformanceOverlay::GetSingleton()->settings.ShowInOverlay = performanceOverlayBackup;
+			}
+			lastPerformanceMode = settings.PerformanceMode;
+		}
+		
+		// Force settings to false while in Performance Mode
+		if (settings.PerformanceMode) {
+			if (globals::state->frameAnnotations) {
+				globals::state->frameAnnotations = false;
+			}
+			if (PerformanceOverlay::GetSingleton()->settings.ShowInOverlay) {
+				PerformanceOverlay::GetSingleton()->settings.ShowInOverlay = false;
+			}
+		}
+		
+		ImGui::BeginDisabled(settings.PerformanceMode);
+			ImGui::Checkbox("Frame Annotations", &globals::state->frameAnnotations);
+		ImGui::EndDisabled();
+		if (settings.PerformanceMode && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+			ImGui::SetTooltip("Disabled in Performance Mode.");
+		} else {
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text("Enables frame annotations for debug purposes.");
+			}
+		}
 	}
 
 	if (ImGui::CollapsingHeader("Replace Original Shaders", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick)) {

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -188,6 +188,7 @@ public:
 		uint32_t SkipCompilationKey = VK_ESCAPE;
 		uint32_t EffectToggleKey = VK_MULTIPLY;  // toggle all effects
 		uint32_t OverlayToggleKey = VK_F10;      // Global overlay toggle key for all overlays
+		bool PerformanceMode = false; // Force-disables certain menu options to improve performance
 		ThemeSettings Theme;
 	};
 	const ThemeSettings& GetTheme() const { return settings.Theme; }                // Provide read-only access to the Theme.

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -188,7 +188,7 @@ public:
 		uint32_t SkipCompilationKey = VK_ESCAPE;
 		uint32_t EffectToggleKey = VK_MULTIPLY;  // toggle all effects
 		uint32_t OverlayToggleKey = VK_F10;      // Global overlay toggle key for all overlays
-		bool PerformanceMode = false; // Force-disables certain menu options to improve performance
+		bool PerformanceMode = false;            // Force-disables certain menu options to improve performance
 		ThemeSettings Theme;
 	};
 	const ThemeSettings& GetTheme() const { return settings.Theme; }                // Provide read-only access to the Theme.


### PR DESCRIPTION
Added the toggle as a new option which force-disables Frame Annotations and Performance Overlay.
New setting is serialized. 
Restores previous on/off state of those two settings if enabled and subsequently disabled without closing the game.