### PR TITLE
fix(perfoverlay): disable interactivity in game

### DIFF
--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -255,7 +255,7 @@ void PerformanceOverlay::DrawOverlay()
 	ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize;
 
 	// Only allow mouse interaction when the main menu is open
-	if (!this->settings.ShowInOverlay) {
+	if (!menu->IsEnabled) {
 		windowFlags |= ImGuiWindowFlags_NoInputs;
 	}
 


### PR DESCRIPTION
closes #1300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the logic controlling mouse interaction with the performance overlay to better align with the main menu's enabled state, improving user interaction consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->