### PR TITLE
fix: ctd due to opencomposite stubs

### DIFF
--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -980,7 +980,8 @@ void VR::UpdateVROverlayPosition()
 		if (settings.VRMenuPositioningMethod == 0) {
 			// HMD Relative positioning
 			vr::TrackedDevicePose_t hmdPose;
-			ctx.system->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseStanding, 0, &hmdPose, 1);
+			if (!Util::GetDeviceToAbsoluteTrackingPoseCompatible(vr::TrackingUniverseStanding, 0, &hmdPose, 1))
+				return;
 
 			if (hmdPose.bPoseIsValid) {
 				// Calculate position in front of HMD using offsets directly
@@ -1809,7 +1810,8 @@ void VR::UpdateActiveDrag()
 
 				if (attachedControllerIndex != vr::k_unTrackedDeviceIndexInvalid) {
 					vr::TrackedDevicePose_t controllerPose;
-					system->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseStanding, 0, &controllerPose, 1);
+					if (!Util::GetDeviceToAbsoluteTrackingPoseCompatible(vr::TrackingUniverseStanding, 0, &controllerPose, 1))
+						break;
 					if (controllerPose.bPoseIsValid) {
 						Matrix attachedControllerMatrix = Util::HmdMatrix34ToMatrix(controllerPose.mDeviceToAbsoluteTracking);
 
@@ -1841,7 +1843,8 @@ void VR::UpdateActiveDrag()
 			{
 				// Get current HMD transform to convert world deltas to local space
 				vr::TrackedDevicePose_t hmdPose;
-				system->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseStanding, 0, &hmdPose, 1);
+				if (!Util::GetDeviceToAbsoluteTrackingPoseCompatible(vr::TrackingUniverseStanding, 0, &hmdPose, 1))
+					break;
 				if (hmdPose.bPoseIsValid) {
 					Matrix hmdMatrix = Util::HmdMatrix34ToMatrix(hmdPose.mDeviceToAbsoluteTracking);
 

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -2057,8 +2057,8 @@ void VR::TryStartNewDrag()
 						vr::ETrackedControllerRole deviceRole = system->GetControllerRoleForTrackedDeviceIndex(deviceIdx);
 						bool isRightController = (deviceRole == vr::ETrackedControllerRole::TrackedControllerRole_RightHand);
 						if (isRightController == isRight) {
-							// Trigger haptic pulse (100ms = 100,000 microseconds)
-							system->TriggerHapticPulse(deviceIdx, 0, static_cast<unsigned short>(100000));
+							// Use BSOpenVR's haptic pulse method instead of direct OpenVR call
+							openvr->TriggerHapticPulse(isRightController, 25.0f);  // 100ms pulse
 							break;
 						}
 					}

--- a/src/Utils/VRUtils.cpp
+++ b/src/Utils/VRUtils.cpp
@@ -86,7 +86,8 @@ namespace Util
 			return transform;
 
 		vr::TrackedDevicePose_t hmdPose;
-		system->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseStanding, 0, &hmdPose, 1);
+		if (!GetDeviceToAbsoluteTrackingPoseCompatible(vr::TrackingUniverseStanding, 0, &hmdPose, 1))
+			return transform;
 		if (!hmdPose.bPoseIsValid)
 			return transform;
 
@@ -132,6 +133,12 @@ namespace Util
 	//=============================================================================
 	// NEW ACTIVE FUNCTIONS FROM VR.CPP
 	//=============================================================================
+
+	// NOTE: OpenComposite Compatibility
+	// The functions below provide compatibility with OpenComposite, which has issues
+	// with GetDeviceToAbsoluteTrackingPose when requesting poses. We completely avoid
+	// using GetDeviceToAbsoluteTrackingPose and instead use VRCompositor interfaces
+	// obtained through BSOpenVR to avoid static linking issues on non-VR systems.
 
 	OpenVRContext::OpenVRContext()
 	{
@@ -201,7 +208,9 @@ namespace Util
 			return false;
 
 		vr::TrackedDevicePose_t poses[vr::k_unMaxTrackedDeviceCount];
-		ctx.system->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseStanding, 0, poses, vr::k_unMaxTrackedDeviceCount);
+		if (!GetDeviceToAbsoluteTrackingPoseCompatible(vr::TrackingUniverseStanding, 0, poses, vr::k_unMaxTrackedDeviceCount))
+			return false;
+
 		if (!poses[index].bPoseIsValid)
 			return false;
 
@@ -209,5 +218,72 @@ namespace Util
 			for (int j = 0; j < 4; ++j)
 				out[i][j] = poses[index].mDeviceToAbsoluteTracking.m[i][j];
 		return true;
+	}
+
+	bool GetDeviceToAbsoluteTrackingPoseCompatible(vr::ETrackingUniverseOrigin eOrigin, float fPredictedSecondsToPhotonsFromNow, vr::TrackedDevicePose_t* pTrackedDevicePoseArray, uint32_t unTrackedDevicePoseArrayCount)
+	{
+		(void)fPredictedSecondsToPhotonsFromNow;
+		(void)eOrigin;
+		OpenVRContext ctx;
+		if (!ctx.IsValid())
+			return false;
+
+		// For single device requests (common with HMD pose requests),
+		// use a full pose array to ensure OpenComposite compatibility
+		if (unTrackedDevicePoseArrayCount == 1) {
+			vr::TrackedDevicePose_t allPoses[vr::k_unMaxTrackedDeviceCount];
+
+			// Try to use compositor interface first for better OpenComposite compatibility
+			// Use BSOpenVR's method to avoid static linking issues
+			auto* compositor = RE::BSOpenVR::GetIVRCompositor();
+			if (!compositor && ctx.openvr) {
+				// Fallback to compositor from the context
+				compositor = ctx.openvr->vrContext.vrCompositor;
+			}
+
+			if (compositor) {
+				// For OpenComposite compatibility, try to use GetLastPoses which is more stable
+				auto error = compositor->GetLastPoses(allPoses, vr::k_unMaxTrackedDeviceCount, nullptr, 0);
+				if (error == vr::VRCompositorError_None) {
+					// Copy HMD pose (index 0) to output
+					pTrackedDevicePoseArray[0] = allPoses[0];
+					return true;
+				}
+				// Fallback to WaitGetPoses if GetLastPoses fails
+				error = compositor->WaitGetPoses(allPoses, vr::k_unMaxTrackedDeviceCount, nullptr, 0);
+				if (error == vr::VRCompositorError_None) {
+					// Copy HMD pose (index 0) to output
+					pTrackedDevicePoseArray[0] = allPoses[0];
+					return true;
+				}
+			}
+
+			// If compositor methods failed, return false rather than using the problematic direct call
+			return false;
+		}
+
+		// For full device array requests, try compositor first
+		// Use BSOpenVR's method to avoid static linking issues
+		auto* compositor = RE::BSOpenVR::GetIVRCompositor();
+		if (!compositor && ctx.openvr) {
+			// Fallback to compositor from the context
+			compositor = ctx.openvr->vrContext.vrCompositor;
+		}
+
+		if (compositor) {
+			// For OpenComposite compatibility, try to use GetLastPoses which is more stable
+			auto error = compositor->GetLastPoses(pTrackedDevicePoseArray, unTrackedDevicePoseArrayCount, nullptr, 0);
+			if (error == vr::VRCompositorError_None) {
+				return true;
+			}
+			// Fallback to WaitGetPoses if GetLastPoses fails
+			error = compositor->WaitGetPoses(pTrackedDevicePoseArray, unTrackedDevicePoseArrayCount, nullptr, 0);
+			if (error == vr::VRCompositorError_None) {
+				return true;
+			}
+		}
+
+		// If compositor methods failed, return false rather than using the problematic direct call
+		return false;
 	}
 }

--- a/src/Utils/VRUtils.h
+++ b/src/Utils/VRUtils.h
@@ -143,6 +143,20 @@ namespace Util
 	 */
 	bool GetControllerWorldMatrix(vr::TrackedDeviceIndex_t index, float out[3][4]);
 
+	/**
+	 * @brief OpenComposite-compatible function to get device poses
+	 * @param eOrigin The tracking universe origin
+	 * @param fPredictedSecondsToPhotonsFromNow Prediction time for poses
+	 * @param pTrackedDevicePoseArray Output array for tracked device poses
+	 * @param unTrackedDevicePoseArrayCount Number of poses to retrieve
+	 * @return true if poses were retrieved successfully
+	 *
+	 * This function provides a compatibility layer for getting device poses that works
+	 * with both standard OpenVR and OpenComposite. It uses the compositor interface
+	 * when available for better OpenComposite compatibility.
+	 */
+	bool GetDeviceToAbsoluteTrackingPoseCompatible(vr::ETrackingUniverseOrigin eOrigin, float fPredictedSecondsToPhotonsFromNow, vr::TrackedDevicePose_t* pTrackedDevicePoseArray, uint32_t unTrackedDevicePoseArrayCount);
+
 	//=============================================================================
 	// MATRIX CONVERSION UTILITIES
 	//=============================================================================


### PR DESCRIPTION
OpenComposite has not implemented GetDeviceToAbsoluteTrackingPose so
causes a ctd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compatibility with OpenComposite for VR device pose retrieval, enhancing support for a wider range of VR runtimes.

* **Bug Fixes**
  * Added error handling for pose retrieval failures, resulting in more stable VR interactions.
  * Updated haptic feedback triggering to use a compatibility method, ensuring consistent controller vibration across different VR systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->