### PR TITLE
fix(extended translucency): fix default material model not applied

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -3200,20 +3200,19 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		if defined(ANISOTROPIC_ALPHA)
 	// Uniform alpha material settings
 	uint AlphaMaterialModel = ExtendedTranslucency::GetMaterialModelFromDescriptor(Permutation::ExtraFeatureDescriptor);
+	float AlphaMaterialReduction = 0.f;
+	float AlphaMaterialSoftness = 0.f;
+	float AlphaMaterialStrength = 0.f;
+	[branch] if (AlphaMaterialModel == ExtendedTranslucency::MaterialModel::Default) {
+		AlphaMaterialModel = SharedData::extendedTranslucencySettings.MaterialModel;
+		AlphaMaterialReduction = SharedData::extendedTranslucencySettings.Reduction;
+		AlphaMaterialSoftness = SharedData::extendedTranslucencySettings.Softness;
+		AlphaMaterialStrength = SharedData::extendedTranslucencySettings.Strength;
+	}
+
 	[branch] if (ExtendedTranslucency::IsValidMaterial(AlphaMaterialModel))
 	{
 		if (alpha >= 0.0156862754 && alpha < 1.0) {
-			float AlphaMaterialReduction = 0.f;
-			float AlphaMaterialSoftness = 0.f;
-			float AlphaMaterialStrength = 0.f;
-
-			if (AlphaMaterialModel == ExtendedTranslucency::MaterialModel::Default) {
-				AlphaMaterialModel = SharedData::extendedTranslucencySettings.MaterialModel;
-				AlphaMaterialReduction = SharedData::extendedTranslucencySettings.Reduction;
-				AlphaMaterialSoftness = SharedData::extendedTranslucencySettings.Softness;
-				AlphaMaterialStrength = SharedData::extendedTranslucencySettings.Strength;
-			}
-
 			float originalAlpha = alpha;
 			alpha = alpha * (1.0 - AlphaMaterialReduction);
 			[branch] if (AlphaMaterialModel == ExtendedTranslucency::MaterialModel::AnisotropicFabric)

--- a/src/Features/ExtendedTranslucency.cpp
+++ b/src/Features/ExtendedTranslucency.cpp
@@ -25,8 +25,9 @@ void ExtendedTranslucency::BSLightingShader_SetupGeometry(RE::BSRenderPass* pass
 	// TODO: PERFORMANCE: Caching the feature descriptor in map<RE::BSGeometry*, uint> if this get more complex
 	auto& unknownProperty = pass->geometry->GetGeometryRuntimeData().properties[RE::BSGeometry::States::kProperty];
 	auto alphaProperty = unknownProperty && unknownProperty->GetRTTI() == globals::rtti::NiAlphaPropertyRTTI.get() ? static_cast<RE::NiAlphaProperty*>(unknownProperty.get()) : nullptr;
+	auto* feature = ExtendedTranslucency::GetSingleton();
 	// Check alpha property exists and blending is enabled
-	if (alphaProperty && alphaProperty->GetAlphaBlending()) {
+	if (alphaProperty && alphaProperty->GetAlphaBlending() && (pass->geometry->GetGeometryRuntimeData().skinInstance != nullptr || (feature && !feature->SkinnedOnly))) {
 		if (auto* data = pass->geometry->GetExtraData(NiExtraDataName_AnisotropicAlphaMaterial)) {
 			if (data->GetRTTI() == globals::rtti::NiIntegerExtraDataRTTI.get()) {
 				uint32_t material = static_cast<uint32_t>(static_cast<RE::NiIntegerExtraData*>(data)->value) & ExtraFeatureDescriptorMask;
@@ -94,6 +95,12 @@ void ExtendedTranslucency::DrawSettings()
 				"  - Isotropic Fabric: Imaginary fabric weaved from threads in one direction, respect normal map.\n"
 				"  - Anisotropic Fabric: Common fabric weaved from tangent and birnormal direction, ignores normal map.\n");
 		}
+		if (ImGui::Checkbox("Skinned Mesh Only", &SkinnedOnly)) {
+			changed = true;
+		}
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Control if this effect should only apply to skinned mesh, check this option if your are seeing undesired effect on random objects.");
+		}
 
 		if (ImGui::SliderFloat("Transparency Increase", &settings.AlphaReduction, 0.f, 1.f)) {
 			changed = true;
@@ -125,11 +132,13 @@ void ExtendedTranslucency::DrawSettings()
 void ExtendedTranslucency::LoadSettings(json& o_json)
 {
 	settings = o_json;
+	SkinnedOnly = o_json.value("SkinnedOnly", true);
 }
 
 void ExtendedTranslucency::SaveSettings(json& o_json)
 {
 	o_json = settings;
+	o_json["SkinnedOnly"] = SkinnedOnly;
 }
 
 void ExtendedTranslucency::RestoreDefaultSettings()

--- a/src/Features/ExtendedTranslucency.h
+++ b/src/Features/ExtendedTranslucency.h
@@ -51,6 +51,7 @@ struct ExtendedTranslucency final : Feature
 	};
 
 	MaterialParams settings;
+	bool SkinnedOnly = true;
 
 	static const RE::BSFixedString NiExtraDataName_AnisotropicAlphaMaterial;
 };


### PR DESCRIPTION
This was accidentally broken in #1249 
The code's logic is a little convoluted >_<
1. AlphaMaterialModel = Nif setting or force-disabled for non alpha blending mesh (in extra feature descriptor)
2. If AlphaMaterialModel  == 0, use global default material settings
3. If AlphaMaterialModel  == 1, 2, 3, do the math to change the alpha


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new setting to control whether the Extended Translucency effect applies only to skinned meshes.
  * Introduced a user interface checkbox with a tooltip for toggling this setting.

* **Settings**
  * The new option is now saved to and loaded from the configuration, ensuring user preferences are retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->