### PR TITLE
fix(VR): disable hmd menu for incompatible openvr

### DIFF
--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -431,37 +431,113 @@ namespace
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Set to 0 to hide the overlay, or a positive value to show it for that many seconds");
 			}
-			ImGui::TextWrapped("Menu:");
-			ImGui::BulletText("Open Community Shaders Menu: Hold both configured buttons (Primary Controller) while in the main menu or tween menu");
-			ImGui::BulletText("Close: Hold the configured buttons on both controllers at the same time");
-			ImGui::TextWrapped("Overlay:");
-			ImGui::BulletText("Open Overlay: Primary Controller configured button while in the main menu or tween menu");
-			ImGui::BulletText("Close Overlay: Secondary Controller configured button while in the main menu or tween menu");
-			ImGui::Spacing();
-			ImGui::TextWrapped("Controller Input:");
-			ImGui::BulletText("Trigger (Both Controllers): Left mouse button");
-			ImGui::BulletText("Grip (Both Controllers): Right mouse button");
-			ImGui::BulletText("Touchpad Click (Both Controllers): Middle mouse button");
-			ImGui::BulletText("Stick Click (Both Controllers): Middle mouse button");
-			ImGui::BulletText("A/X (Both Controllers): Enter");
-			ImGui::BulletText("B/Y (Primary Controller): Tab");
-			ImGui::BulletText("B/Y (Secondary Controller): Shift+Tab");
-
-			// Show dynamic controller assignments based on attach mode
-			bool useAttachedControllerForCursor = (settings.attachMode == VR::Settings::OverlayAttachMode::ControllerOnly ||
-												   settings.attachMode == VR::Settings::OverlayAttachMode::Both);
-
-			if (useAttachedControllerForCursor) {
-				if (settings.VRMenuAttachController == ControllerDevice::Primary) {
-					ImGui::BulletText("Primary Controller Thumbstick: Mouse movement (attached controller)");
-					ImGui::BulletText("Secondary Controller Thumbstick: Scroll");
+			ImGui::TextWrapped("Menu (while in the main menu or tween menu):");
+			if (ImGui::BeginTable("MenuInstructionsTable", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::Text("Open Community Shaders Menu:");
+				ImGui::TableSetColumnIndex(1);
+				Util::DrawButtonCombo(settings.VRMenuOpenKeys, true);
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::Text("Close Community Shaders Menu:");
+				ImGui::TableSetColumnIndex(1);
+				Util::DrawButtonCombo(settings.VRMenuCloseKeys, true);
+				ImGui::EndTable();
+			}
+			ImGui::TextWrapped("Overlay (while in the main menu or tween menu):");
+			if (ImGui::BeginTable("OverlayInstructionsTable", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::Text("Open Overlay:");
+				ImGui::TableSetColumnIndex(1);
+				Util::DrawButtonCombo(settings.VROverlayOpenKeys, true);
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::Text("Close Overlay:");
+				ImGui::TableSetColumnIndex(1);
+				Util::DrawButtonCombo(settings.VROverlayCloseKeys, true);
+				ImGui::EndTable();
+			}
+			ImGui::TextWrapped("Menu Controller Input:");
+			if (ImGui::BeginTable("ControllerInputTable", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::TextColored(Util::GetControllerBothColor(), "Trigger (Both Controllers)");
+				ImGui::TableSetColumnIndex(1);
+				ImGui::Text("Left mouse button");
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::TextColored(Util::GetControllerBothColor(), "Grip (Both Controllers)");
+				ImGui::TableSetColumnIndex(1);
+				ImGui::Text("Right mouse button");
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::TextColored(Util::GetControllerBothColor(), "Touchpad Click (Both Controllers)");
+				ImGui::TableSetColumnIndex(1);
+				ImGui::Text("Middle mouse button");
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::TextColored(Util::GetControllerBothColor(), "Stick Click (Both Controllers)");
+				ImGui::TableSetColumnIndex(1);
+				ImGui::Text("Middle mouse button");
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::TextColored(Util::GetControllerBothColor(), "A/X (Both Controllers)");
+				ImGui::TableSetColumnIndex(1);
+				ImGui::Text("Enter");
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::TextColored(Util::GetControllerPrimaryColor(), "B/Y (Primary Controller)");
+				ImGui::TableSetColumnIndex(1);
+				ImGui::Text("Tab");
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::TextColored(Util::GetControllerSecondaryColor(), "B/Y (Secondary Controller)");
+				ImGui::TableSetColumnIndex(1);
+				ImGui::Text("Shift+Tab");
+				ImGui::EndTable();
+			}
+			// Thumbstick instructions
+			bool useAttachedControllerForCursor = (settings.attachMode == VR::Settings::OverlayAttachMode::ControllerOnly || settings.attachMode == VR::Settings::OverlayAttachMode::Both);
+			if (ImGui::BeginTable("ThumbstickInstructionsTable", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
+				if (useAttachedControllerForCursor) {
+					if (settings.VRMenuAttachController == ControllerDevice::Primary) {
+						ImGui::TableNextRow();
+						ImGui::TableSetColumnIndex(0);
+						ImGui::TextColored(Util::GetControllerPrimaryColor(), "Primary Controller Thumbstick");
+						ImGui::TableSetColumnIndex(1);
+						ImGui::Text("Mouse movement (attached controller)");
+						ImGui::TableNextRow();
+						ImGui::TableSetColumnIndex(0);
+						ImGui::TextColored(Util::GetControllerSecondaryColor(), "Secondary Controller Thumbstick");
+						ImGui::TableSetColumnIndex(1);
+						ImGui::Text("Scroll");
+					} else {
+						ImGui::TableNextRow();
+						ImGui::TableSetColumnIndex(0);
+						ImGui::TextColored(Util::GetControllerPrimaryColor(), "Primary Controller Thumbstick");
+						ImGui::TableSetColumnIndex(1);
+						ImGui::Text("Scroll");
+						ImGui::TableNextRow();
+						ImGui::TableSetColumnIndex(0);
+						ImGui::TextColored(Util::GetControllerSecondaryColor(), "Secondary Controller Thumbstick");
+						ImGui::TableSetColumnIndex(1);
+						ImGui::Text("Mouse movement (attached controller)");
+					}
 				} else {
-					ImGui::BulletText("Primary Controller Thumbstick: Scroll");
-					ImGui::BulletText("Secondary Controller Thumbstick: Mouse movement (attached controller)");
+					ImGui::TableNextRow();
+					ImGui::TableSetColumnIndex(0);
+					ImGui::TextColored(Util::GetControllerPrimaryColor(), "Primary Controller Thumbstick");
+					ImGui::TableSetColumnIndex(1);
+					ImGui::Text("Mouse movement (HMD mode)");
+					ImGui::TableNextRow();
+					ImGui::TableSetColumnIndex(0);
+					ImGui::TextColored(Util::GetControllerSecondaryColor(), "Secondary Controller Thumbstick");
+					ImGui::TableSetColumnIndex(1);
+					ImGui::Text("Scroll");
 				}
-			} else {
-				ImGui::BulletText("Primary Controller Thumbstick: Mouse movement (HMD mode)");
-				ImGui::BulletText("Secondary Controller Thumbstick: Scroll");
+				ImGui::EndTable();
 			}
 		}
 	}
@@ -1800,7 +1876,6 @@ void VR::ProcessControllerInputForImGui()
 	}
 }
 
-// Helper: Get controller world matrix from OpenVR pose
 // --- File-scope static helpers for drag logic ---
 static bool CanStartAny(vr::ETrackedControllerRole role)
 {

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -122,7 +122,7 @@ void VR::DrawOverlay()
 	static LARGE_INTEGER overlayShowStart = { 0 };
 	static LARGE_INTEGER freq = { 0 };
 
-	bool shouldShow = settings.kAutoHideSeconds > 0 && globals::game::ui && globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME);
+	bool shouldShow = settings.kAutoHideSeconds > 0 && globals::game::ui && globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) && globals::menu && !globals::menu->IsEnabled;
 
 	if (!shouldShow) {
 		overlayShowStart.QuadPart = 0;  // Reset timer when overlay is not shown

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -46,7 +46,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	VROverlayCloseKeys,
 	comboTimeout,
 	EnableDragToReposition,
-	ShowHowToUseMessage)
+	kAutoHideSeconds)
 
 //=============================================================================
 // FEATURE BASE CLASS OVERRIDES
@@ -95,7 +95,7 @@ void VR::DrawOverlay()
 	static LARGE_INTEGER overlayShowStart = { 0 };
 	static LARGE_INTEGER freq = { 0 };
 
-	bool shouldShow = settings.ShowHowToUseMessage && globals::game::ui && globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME);
+	bool shouldShow = settings.kAutoHideSeconds > 0 && globals::game::ui && globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME);
 
 	if (!shouldShow) {
 		overlayShowStart.QuadPart = 0;  // Reset timer when overlay is not shown
@@ -114,11 +114,11 @@ void VR::DrawOverlay()
 	}
 
 	double elapsed = double(now.QuadPart - overlayShowStart.QuadPart) / double(freq.QuadPart);
-	const double kAutoHideSeconds = 15.0;
-	if (elapsed >= kAutoHideSeconds) {
+	const double autoHideSeconds = static_cast<double>(settings.kAutoHideSeconds);
+	if (elapsed >= autoHideSeconds) {
 		return;
 	}
-	int secondsLeft = int(std::ceil(kAutoHideSeconds - elapsed));
+	int secondsLeft = int(std::ceil(autoHideSeconds - elapsed));
 
 	ImGuiIO& io = ImGui::GetIO();
 	ImVec2 overlaySize(480, 0);  // width, height auto
@@ -396,7 +396,11 @@ namespace
 		auto vr = VR::GetSingleton();
 		VR::Settings& settings = vr->settings;
 		if (ImGui::CollapsingHeader("Controller Input Instructions", ImGuiTreeNodeFlags_DefaultOpen)) {
-			ImGui::Checkbox("Show 'How to Use' Message", &settings.ShowHowToUseMessage);
+			ImGui::SliderInt("Auto-hide overlay timeout (seconds)", &settings.kAutoHideSeconds, 0, VR::Config::kMaxAutoHideSeconds,
+				settings.kAutoHideSeconds <= 0 ? "Hidden" : "%d seconds");
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text("Set to 0 to hide the overlay, or a positive value to show it for that many seconds");
+			}
 			ImGui::TextWrapped("Menu:");
 			ImGui::BulletText("Open Community Shaders Menu: Hold both configured buttons (Primary Controller) while in the main menu or tween menu");
 			ImGui::BulletText("Close: Hold the configured buttons on both controllers at the same time");
@@ -1267,7 +1271,7 @@ void VR::SubmitOverlayFrame()
 	UpdateOverlayDrag();
 	auto& enabled = globals::menu->IsEnabled;
 	auto& overlayVisible = globals::menu->overlayVisible;
-	if ((enabled || overlayVisible || settings.ShowHowToUseMessage) && menuOverlayHandle != vr::k_ulOverlayHandleInvalid && menuTexture && menuRTV) {
+	if ((enabled || overlayVisible || settings.kAutoHideSeconds > 0) && menuOverlayHandle != vr::k_ulOverlayHandleInvalid && menuTexture && menuRTV) {
 		// Copy ImGui output to overlay texture
 		ID3D11RenderTargetView* oldRTV = nullptr;
 		globals::d3d::context->OMGetRenderTargets(1, &oldRTV, nullptr);

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -17,6 +17,8 @@
 #include <magic_enum.hpp>
 #include <unordered_map>
 #include <windows.h>
+#include <winver.h>
+#pragma comment(lib, "version.lib")
 
 using AttachMode = VR::Settings::OverlayAttachMode;
 
@@ -69,6 +71,29 @@ void VR::RestoreDefaultSettings()
 	settings = {};
 }
 
+void VR::SetupResources()
+{
+	// Detect OpenVR version and compatibility early to avoid CTDs
+	DetectOpenVRInfo();
+
+	// Log OpenVR information
+	if (openVRInfo.isAvailable) {
+		logger::info("OpenVR DLL detected:");
+		logger::info("  Path: {}", openVRInfo.dllPath);
+		logger::info("  Version: {}", openVRInfo.version);
+		logger::info("  Size: {} bytes", openVRInfo.fileSize);
+		logger::info("  Modified: {}", openVRInfo.modificationTime);
+		logger::info("  Compatible: {}", openVRInfo.isCompatible ? "Yes" : "No");
+
+		if (!openVRInfo.isCompatible) {
+			logger::info("OpenVR version is incompatible.");
+			logger::info("Community Shaders VR menus will be disabled for stability");
+		}
+	} else {
+		logger::info("OpenVR DLL not available in current process");
+	}
+}
+
 void VR::PostPostLoad()
 {
 	gDepthBufferCulling = reinterpret_cast<bool*>(REL::Offset(0x1EC6B88).address());
@@ -92,6 +117,8 @@ void VR::DataLoaded()
 
 void VR::DrawOverlay()
 {
+	if (!VR::GetSingleton()->openVRInfo.isCompatible)
+		return;
 	static LARGE_INTEGER overlayShowStart = { 0 };
 	static LARGE_INTEGER freq = { 0 };
 
@@ -173,14 +200,15 @@ void VR::DrawSettings()
 		}
 
 		// Key Bindings Tab
-		if (ImGui::BeginTabItem("Bindings")) {
-			if (ImGui::BeginChild("##VRBindingsFrame", { 0, 0 }, true)) {
-				DrawKeyBindings(this);
+		if (openVRInfo.isCompatible) {
+			if (ImGui::BeginTabItem("Bindings")) {
+				if (ImGui::BeginChild("##VRBindingsFrame", { 0, 0 }, true)) {
+					DrawKeyBindings(this);
+				}
+				ImGui::EndChild();
+				ImGui::EndTabItem();
 			}
-			ImGui::EndChild();
-			ImGui::EndTabItem();
 		}
-
 		// Debug Tab (existing debug functionality)
 		if (ImGui::BeginTabItem("Debug")) {
 			if (ImGui::BeginChild("##VRDebugFrame", { 0, 0 }, true)) {
@@ -394,6 +422,8 @@ namespace
 	void DrawControllerInputInstructions()
 	{
 		auto vr = VR::GetSingleton();
+		if (!VR::GetSingleton()->openVRInfo.isCompatible)
+			return;
 		VR::Settings& settings = vr->settings;
 		if (ImGui::CollapsingHeader("Controller Input Instructions", ImGuiTreeNodeFlags_DefaultOpen)) {
 			ImGui::SliderInt("Auto-hide overlay timeout (seconds)", &settings.kAutoHideSeconds, 0, VR::Config::kMaxAutoHideSeconds,
@@ -454,6 +484,8 @@ namespace
 
 	void DrawMenuSettings()
 	{
+		if (!VR::GetSingleton()->openVRInfo.isCompatible)
+			return;
 		auto vr = VR::GetSingleton();
 		VR::Settings& settings = vr->settings;
 		if (ImGui::CollapsingHeader("Menu Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
@@ -496,6 +528,8 @@ namespace
 
 	void DrawMouseSettings()
 	{
+		if (!VR::GetSingleton()->openVRInfo.isCompatible)
+			return;
 		auto vr = VR::GetSingleton();
 		VR::Settings& settings = vr->settings;
 		if (ImGui::CollapsingHeader("Mouse Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
@@ -506,6 +540,8 @@ namespace
 
 	void DrawDragSettings()
 	{
+		if (!VR::GetSingleton()->openVRInfo.isCompatible)
+			return;
 		auto vr = VR::GetSingleton();
 		VR::Settings& settings = vr->settings;
 		if (ImGui::CollapsingHeader("Drag Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
@@ -657,6 +693,25 @@ namespace
 	{
 		VR::Settings& settings = vr->settings;
 		auto menu = globals::menu;
+
+		// OpenVR Version Information
+		if (ImGui::CollapsingHeader("OpenVR Information", ImGuiTreeNodeFlags_DefaultOpen)) {
+			auto& info = vr->openVRInfo;
+			if (info.isAvailable) {
+				ImGui::Text("OpenVR System: %s", info.isCompatible ? "Active & Compatible" : "Active but INCOMPATIBLE");
+				if (!info.isCompatible) {
+					std::string reason = std::format("{} {}", "OpenVR version is incompatible.", "VR menus disabled.");
+					ImGui::TextColored(ImVec4(1.0f, 0.5f, 0.5f, 1.0f), "Reason: %s", reason.c_str());
+				}
+				ImGui::Text("DLL Path: %s", info.dllPath.c_str());
+				ImGui::Text("DLL Version: %s", info.version.c_str());
+				ImGui::Text("DLL Size: %llu bytes", info.fileSize);
+				ImGui::Text("Modified: %s", info.modificationTime.c_str());
+			} else {
+				ImGui::Text("OpenVR system not available");
+			}
+		}
+
 		// Controller Diagnostics Section
 		if (ImGui::CollapsingHeader("Controller Diagnostics", ImGuiTreeNodeFlags_DefaultOpen)) {
 			if (ImGui::Checkbox("Test Mode: Disable controller menu input (except scroll controller and triggers)", &settings.VRMenuControllerDiagnosticsTestMode)) {
@@ -1143,6 +1198,12 @@ void VR::UpdateVROverlayControllerPosition()
 // Add overlay management methods for VR menu overlays
 void VR::EnsureOverlayInitialized()
 {
+	// Check OpenVR compatibility first
+	if (!openVRInfo.isCompatible) {
+		logger::warn("OpenVR version is incompatible.");
+		return;
+	}
+
 	RE::BSOpenVR* openvr = RE::BSOpenVR::GetSingleton();
 	logger::info("BSOpenVR: 0x{:X}", reinterpret_cast<uintptr_t>(openvr));
 	if (!openvr) {
@@ -1244,6 +1305,11 @@ void VR::RecreateOverlayTexturesIfNeeded()
 
 void VR::SubmitOverlayFrame()
 {
+	// Skip overlay operations if OpenVR is incompatible
+	if (!openVRInfo.isCompatible) {
+		return;
+	}
+
 	RE::BSOpenVR* openvr = RE::BSOpenVR::GetSingleton();
 	auto* gameOverlay = openvr ? RE::BSOpenVR::GetIVROverlayFromContext(&openvr->vrContext) : nullptr;
 	auto* cleanOverlay = RE::BSOpenVR::GetCleanIVROverlay();
@@ -2081,4 +2147,101 @@ void VR::SetFixedOverlayToCurrentHMD()
 		settings.VRMenuOffsetY,
 		settings.VRMenuOffsetZ);
 	fixedWorldOverlayPosition.m = Util::HmdMatrix34ToMatrix(transform);
+}
+
+//=============================================================================
+// OPENVR VERSION DETECTION AND COMPATIBILITY
+//=============================================================================
+
+void VR::DetectOpenVRInfo()
+{
+	// Reset info
+	openVRInfo = {};
+
+	// Find the OpenVR DLL module
+	HMODULE hModule = GetModuleHandleA("openvr_api.dll");
+	if (!hModule) {
+		openVRInfo.isAvailable = false;
+		return;
+	}
+
+	openVRInfo.isAvailable = true;
+
+	// Get the full path to the DLL
+	char dllPath[MAX_PATH];
+	if (GetModuleFileNameA(hModule, dllPath, MAX_PATH) == 0) {
+		openVRInfo.isCompatible = false;
+		return;
+	}
+
+	openVRInfo.dllPath = dllPath;
+
+	// Get file version information
+	DWORD dwSize = GetFileVersionInfoSizeA(dllPath, nullptr);
+	if (dwSize > 0) {
+		std::vector<BYTE> buffer(dwSize);
+		if (GetFileVersionInfoA(dllPath, 0, dwSize, buffer.data())) {
+			VS_FIXEDFILEINFO* pFileInfo = nullptr;
+			UINT len = 0;
+			if (VerQueryValueA(buffer.data(), "\\", (LPVOID*)&pFileInfo, &len)) {
+				DWORD major = HIWORD(pFileInfo->dwFileVersionMS);
+				DWORD minor = LOWORD(pFileInfo->dwFileVersionMS);
+				DWORD build = HIWORD(pFileInfo->dwFileVersionLS);
+				DWORD revision = LOWORD(pFileInfo->dwFileVersionLS);
+				openVRInfo.version = std::format("{}.{}.{}.{}", major, minor, build, revision);
+			}
+		}
+	}
+
+	if (openVRInfo.version.empty()) {
+		openVRInfo.version = "Unknown";
+	}
+
+	// Get file size and timestamp
+	WIN32_FIND_DATAA findData;
+	HANDLE hFind = FindFirstFileA(dllPath, &findData);
+	if (hFind != INVALID_HANDLE_VALUE) {
+		FindClose(hFind);
+		ULARGE_INTEGER fileSize;
+		fileSize.LowPart = findData.nFileSizeLow;
+		fileSize.HighPart = findData.nFileSizeHigh;
+		openVRInfo.fileSize = fileSize.QuadPart;
+
+		// Convert file time to readable format
+		SYSTEMTIME st;
+		FileTimeToSystemTime(&findData.ftLastWriteTime, &st);
+		openVRInfo.modificationTime = std::format("{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}",
+			st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
+	}
+
+	// Check compatibility
+	openVRInfo.isCompatible = IsOpenVRCompatible();
+}
+
+bool VR::IsOpenVRCompatible() const
+{
+	if (!openVRInfo.isAvailable) {
+		return false;
+	}
+
+	// Whitelist: Only allow explicitly known compatible versions
+	struct WhitelistedVersion
+	{
+		std::string version;
+		uint64_t fileSize;
+		std::string modificationTime;
+	};
+
+	static const std::vector<WhitelistedVersion> whitelist = {
+		{ "1.0.10.0", 598816, "2022-04-18 00:47:59" },
+		// Add more known compatible versions here
+	};
+
+	for (const auto& entry : whitelist) {
+		if (openVRInfo.version == entry.version) {
+			return true;
+		}
+	}
+
+	return false;  // Not compatible unless explicitly whitelisted
 }

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -1002,14 +1002,13 @@ namespace
 		}
 
 		// Debugging addresses for copy/paste
-		if (ImGui::TreeNodeEx("Addresses")) {
+		if (ImGui::CollapsingHeader("OpenVR Addresses")) {
 			auto openvr = RE::BSOpenVR::GetSingleton();
 			auto overlay = openvr ? RE::BSOpenVR::GetIVROverlayFromContext(&openvr->vrContext) : nullptr;
 			auto vrSystem = openvr ? openvr->vrSystem : nullptr;
 			ADDRESS_NODE(openvr)
 			ADDRESS_NODE(overlay)
 			ADDRESS_NODE(vrSystem)
-			ImGui::TreePop();
 		}
 	}
 }  // namespace

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -1000,6 +1000,17 @@ namespace
 				ImGui::EndTable();
 			}
 		}
+
+		// Debugging addresses for copy/paste
+		if (ImGui::TreeNodeEx("Addresses")) {
+			auto openvr = RE::BSOpenVR::GetSingleton();
+			auto overlay = openvr ? RE::BSOpenVR::GetIVROverlayFromContext(&openvr->vrContext) : nullptr;
+			auto vrSystem = openvr ? openvr->vrSystem : nullptr;
+			ADDRESS_NODE(openvr)
+			ADDRESS_NODE(overlay)
+			ADDRESS_NODE(vrSystem)
+			ImGui::TreePop();
+		}
 	}
 }  // namespace
 
@@ -1205,25 +1216,25 @@ void VR::EnsureOverlayInitialized()
 	}
 
 	RE::BSOpenVR* openvr = RE::BSOpenVR::GetSingleton();
-	logger::info("BSOpenVR: 0x{:X}", reinterpret_cast<uintptr_t>(openvr));
+	logger::debug("BSOpenVR: 0x{:X}", reinterpret_cast<uintptr_t>(openvr));
 	if (!openvr) {
 		logger::error("BSOpenVR::GetSingleton() returned nullptr");
 		return;
 	}
 	auto* vrSystem = openvr->vrSystem;
 	auto* overlay = openvr ? RE::BSOpenVR::GetIVROverlayFromContext(&openvr->vrContext) : nullptr;
-	logger::info("openVR->vrSystem: 0x{:X}", reinterpret_cast<uintptr_t>(vrSystem));
-	logger::info("openVR->vrContext: 0x{:X}", reinterpret_cast<uintptr_t>(&openvr->vrContext));
-	logger::info("openVR->vrContext.vrOverlay: 0x{:X}", reinterpret_cast<uintptr_t>(openvr->vrContext.vrOverlay));
-	logger::info("openVR->hmdDeviceType: {} ({})", static_cast<int>(openvr->hmdDeviceType), magic_enum::enum_name(openvr->hmdDeviceType));
+	logger::debug("openVR->vrSystem: 0x{:X}", reinterpret_cast<uintptr_t>(vrSystem));
+	logger::debug("openVR->vrContext: 0x{:X}", reinterpret_cast<uintptr_t>(&openvr->vrContext));
+	logger::debug("openVR->vrContext.vrOverlay: 0x{:X}", reinterpret_cast<uintptr_t>(openvr->vrContext.vrOverlay));
+	logger::debug("openVR->hmdDeviceType: {} ({})", static_cast<int>(openvr->hmdDeviceType), magic_enum::enum_name(openvr->hmdDeviceType));
 	for (int i = 0; i < RE::BSVRInterface::Hand::kTotal; ++i) {
-		logger::info("openVR->controllerNodes[{}]: 0x{:X}", i, reinterpret_cast<uintptr_t>(openvr->controllerNodes[i].get()));
+		logger::debug("openVR->controllerNodes[{}]: 0x{:X}", i, reinterpret_cast<uintptr_t>(openvr->controllerNodes[i].get()));
 		if (openvr->controllerNodes[i] && reinterpret_cast<uintptr_t>(openvr->controllerNodes[i].get()) < 0x1000) {
 			logger::warn("controllerNodes[{}] is suspiciously low (0x{:X})", i, reinterpret_cast<uintptr_t>(openvr->controllerNodes[i].get()));
 		}
 	}
-	logger::info("menuOverlayHandle: 0x{:X}", menuOverlayHandle);
-	logger::info("menuControllerOverlayHandle: 0x{:X}", menuControllerOverlayHandle);
+	logger::debug("menuOverlayHandle: 0x{:X}", menuOverlayHandle);
+	logger::debug("menuControllerOverlayHandle: 0x{:X}", menuControllerOverlayHandle);
 	if (!overlay) {
 		logger::error("IVROverlay is nullptr after GetIVROverlay");
 		return;
@@ -1233,7 +1244,7 @@ void VR::EnsureOverlayInitialized()
 	std::string name = "Community Shaders Menu";
 	vr::EVROverlayError err = overlay->CreateOverlay(key.c_str(), name.c_str(), &menuOverlayHandle);
 	if (err == vr::VROverlayError_None) {
-		logger::info("CreateOverlay succeeded for menuOverlayHandle: 0x{:X}", menuOverlayHandle);
+		logger::debug("CreateOverlay succeeded for menuOverlayHandle: 0x{:X}", menuOverlayHandle);
 		Util::SetOverlayInputFlags(overlay, menuOverlayHandle);
 		overlay->SetOverlayWidthInMeters(menuOverlayHandle, 1.0f);
 	} else {
@@ -1244,7 +1255,7 @@ void VR::EnsureOverlayInitialized()
 	std::string controllerName = "Community Shaders Menu (Controller)";
 	err = overlay->CreateOverlay(controllerKey.c_str(), controllerName.c_str(), &menuControllerOverlayHandle);
 	if (err == vr::VROverlayError_None) {
-		logger::info("CreateOverlay succeeded for menuControllerOverlayHandle: 0x{:X}", menuControllerOverlayHandle);
+		logger::debug("CreateOverlay succeeded for menuControllerOverlayHandle: 0x{:X}", menuControllerOverlayHandle);
 		Util::CreateOverlayTextureAndRTV(globals::d3d::device, kOverlayWidth, kOverlayHeight, &menuControllerTexture, &menuControllerRTV);
 		Util::SetOverlayInputFlags(overlay, menuControllerOverlayHandle);
 		overlay->SetOverlayWidthInMeters(menuControllerOverlayHandle, 1.0f);
@@ -1317,7 +1328,7 @@ void VR::SubmitOverlayFrame()
 	static bool cleanOverlayLogged = false;
 	if (!cleanOverlayLogged) {
 		if (cleanOverlay) {
-			logger::info("VR: Successfully acquired clean IVROverlay interface via CommonLib: 0x{:X}", reinterpret_cast<uintptr_t>(cleanOverlay));
+			logger::debug("VR: Successfully acquired clean IVROverlay interface via CommonLib: 0x{:X}", reinterpret_cast<uintptr_t>(cleanOverlay));
 		} else {
 			logger::error("VR: Failed to get clean IVROverlay interface via CommonLib");
 		}
@@ -1530,7 +1541,7 @@ void VR::ProcessVREvents(std::vector<Menu::KeyEvent>& vrEvents)
 	static bool firstCall = true;
 	if (firstCall || currentLeftHandedMode != lastKnownLeftHandedMode) {
 		if (!firstCall) {
-			logger::info("VR handedness changed: {} -> {}", lastKnownLeftHandedMode ? "Left" : "Right", currentLeftHandedMode ? "Left" : "Right");
+			logger::debug("VR handedness changed: {} -> {}", lastKnownLeftHandedMode ? "Left" : "Right", currentLeftHandedMode ? "Left" : "Right");
 		}
 		firstCall = false;
 		lastKnownLeftHandedMode = currentLeftHandedMode;

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -48,7 +48,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	VROverlayCloseKeys,
 	comboTimeout,
 	EnableDragToReposition,
-	kAutoHideSeconds)
+	kAutoHideSeconds,
+	VRMenuAutoResetDistance)
 
 //=============================================================================
 // FEATURE BASE CLASS OVERRIDES
@@ -426,7 +427,7 @@ namespace
 			return;
 		VR::Settings& settings = vr->settings;
 		if (ImGui::CollapsingHeader("Controller Input Instructions", ImGuiTreeNodeFlags_DefaultOpen)) {
-			ImGui::SliderInt("Auto-hide overlay timeout (seconds)", &settings.kAutoHideSeconds, 0, VR::Config::kMaxAutoHideSeconds,
+			ImGui::SliderInt("Auto-hide Welcome overlay timeout", &settings.kAutoHideSeconds, 0, VR::Config::kMaxAutoHideSeconds,
 				settings.kAutoHideSeconds <= 0 ? "Hidden" : "%d seconds");
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Set to 0 to hide the overlay, or a positive value to show it for that many seconds");
@@ -598,6 +599,19 @@ namespace
 				ImGui::SliderFloat("HMD Offset X", &settings.VRMenuOffsetX, -2.0f, 2.0f, "%.2f");
 				ImGui::SliderFloat("HMD Offset Y", &settings.VRMenuOffsetY, -2.0f, 2.0f, "%.2f");
 				ImGui::SliderFloat("HMD Offset Z", &settings.VRMenuOffsetZ, -2.0f, 2.0f, "%.2f");
+			}
+
+			// Fixed World Position: show auto reset distance and manual reset button
+			if (settings.VRMenuPositioningMethod == 1) {  // 1 = Fixed World Position
+				ImGui::Separator();
+				ImGui::Text("Fixed World Position Settings");
+				ImGui::SliderFloat("Auto Reset Distance (game units)", &settings.VRMenuAutoResetDistance, 100.0f, 5000.0f, "%.0f");
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					ImGui::Text("If you move farther than this distance from the menu, it will automatically reset to your HMD position. %s", Util::Units::FormatDistance(settings.VRMenuAutoResetDistance).c_str());
+				}
+				if (ImGui::Button("Reset Menu to HMD Position")) {
+					vr->SetFixedOverlayToCurrentHMD();
+				}
 			}
 		}
 	}
@@ -1191,11 +1205,22 @@ void VR::UpdateVROverlayPosition()
 			// Fixed World Position
 			if (justSwitchedToFixed) {
 				SetFixedOverlayToCurrentHMD();
+				// Save player position when switching to Fixed World Position
+				savedPlayerWorldPos = RE::PlayerCharacter::GetSingleton()->GetPosition();
 			}
 
-			vr::HmdMatrix34_t fixedTransform = Util::MatrixToHmdMatrix34(fixedWorldOverlayPosition.m);
+			// --- Auto reset logic using player world position ---
+			RE::NiPoint3 currentPos = RE::PlayerCharacter::GetSingleton()->GetPosition();
+			float sqDist = currentPos.GetSquaredDistance(savedPlayerWorldPos);
+			float thresholdSq = settings.VRMenuAutoResetDistance * settings.VRMenuAutoResetDistance;
+			if (sqDist > thresholdSq) {
+				SetFixedOverlayToCurrentHMD();
+				// Update saved position after reset
+				savedPlayerWorldPos = RE::PlayerCharacter::GetSingleton()->GetPosition();
+			}
 
 			// Scale the overlay based on width/height (same as relative HMD mode)
+			vr::HmdMatrix34_t fixedTransform = Util::MatrixToHmdMatrix34(fixedWorldOverlayPosition.m);
 			fixedTransform.m[0][0] *= overlayWidth;
 			fixedTransform.m[1][1] *= overlayHeight;
 

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -165,7 +165,7 @@ void VR::DrawOverlay()
 	Util::DrawButtonCombo(settings.VRMenuCloseKeys, true);
 	ImGui::Spacing();
 	ImGui::TextDisabled("(This message will auto-disable in %d seconds)", secondsLeft);
-	ImGui::TextDisabled("(You can disable this message in VR settings > Controller Instructions)");
+	ImGui::TextDisabled("(You can disable this message in VR settings > Controller Input Instructions)");
 	ImGui::End();
 }
 
@@ -189,8 +189,8 @@ void VR::DrawSettings()
 		// General Settings Tab
 		if (ImGui::BeginTabItem("General")) {
 			if (ImGui::BeginChild("##VRGeneralFrame", { 0, 0 }, true)) {
-				DrawControllerInputInstructions();
 				DrawGeneralVRSettings();
+				DrawControllerInputInstructions();
 				DrawMenuSettings();
 				DrawMouseSettings();
 				DrawDragSettings();

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -288,6 +288,7 @@ public:
 		};
 	}
 
+	virtual void SetupResources() override;
 	virtual bool SupportsVR() override { return true; }
 	virtual bool IsCore() const override { return true; }
 
@@ -307,7 +308,7 @@ public:
 	//=============================================================================
 
 	virtual void DrawOverlay() override;
-	virtual bool IsOverlayVisible() const override { return settings.kAutoHideSeconds > 0 && !globals::menu->IsEnabled; }
+	virtual bool IsOverlayVisible() const override { return openVRInfo.isCompatible && settings.kAutoHideSeconds > 0 && !globals::menu->IsEnabled; }
 
 	//=============================================================================
 	// SETTINGS STRUCTURE
@@ -579,10 +580,23 @@ public:
 	// Button controller recording state for UI settings
 	std::unordered_map<uint32_t, ControllerDevice> recordingButtonControllers;
 
-private:
+	// OpenVR version and compatibility information
+	struct OpenVRInfo
+	{
+		bool isAvailable = false;
+		bool isCompatible = true;
+		std::string dllPath;
+		std::string version;
+		uint64_t fileSize = 0;
+		std::string modificationTime;
+	} openVRInfo;
+
+public:
 	//=============================================================================
 	// PRIVATE IMPLEMENTATION
 	//=============================================================================
 
 	void CleanupOverlayTextures();
+	void DetectOpenVRInfo();
+	bool IsOpenVRCompatible() const;
 };

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -327,7 +327,7 @@ public:
 
 		// VR Menu Overlay positioning settings
 		float VRMenuScale = Config::kDefaultMenuScale;  ///< Scale factor for overlay UI (0.5-2.0)
-		int VRMenuPositioningMethod = 0;                ///< 0 = HMD relative, 1 = Fixed world position
+		int VRMenuPositioningMethod = 1;                ///< 0 = HMD relative, 1 = Fixed world position
 
 		/**
 		 * @brief Defines how overlays are attached and positioned in VR space

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -242,6 +242,8 @@ public:
 		static constexpr float kDefaultComboTimeout = 3.0f;   ///< Default timeout for button combos (seconds)
 		static constexpr float kDefaultMouseDeadzone = 0.1f;  ///< Default thumbstick deadzone for mouse input
 		static constexpr float kDefaultMouseSpeed = 10.0f;    ///< Default mouse speed multiplier
+		static constexpr int kDefaultAutoHideSeconds = 30;    ///< Default auto-hide timeout for overlay messages
+		static constexpr int kMaxAutoHideSeconds = 300;       ///< Maximum auto-hide timeout (5 minutes)
 
 		// Default HMD overlay offset values (in meters, relative to HMD)
 		static constexpr float kDefaultHMDOffsetX = 0.26f;   ///< Default horizontal offset from HMD
@@ -305,7 +307,7 @@ public:
 	//=============================================================================
 
 	virtual void DrawOverlay() override;
-	virtual bool IsOverlayVisible() const override { return settings.ShowHowToUseMessage; }
+	virtual bool IsOverlayVisible() const override { return settings.kAutoHideSeconds > 0 && !globals::menu->IsEnabled; }
 
 	//=============================================================================
 	// SETTINGS STRUCTURE
@@ -375,9 +377,9 @@ public:
 		};
 
 		// General interaction settings
-		float comboTimeout = Config::kDefaultComboTimeout;  ///< Timeout for button combo sequences (1.0-10.0 seconds)
-		bool ShowHowToUseMessage = true;                    ///< Show instructional overlay messages
-		bool EnableDragToReposition = true;                 ///< Allow drag-and-drop overlay repositioning
+		float comboTimeout = Config::kDefaultComboTimeout;       ///< Timeout for button combo sequences (1.0-10.0 seconds)
+		int kAutoHideSeconds = Config::kDefaultAutoHideSeconds;  ///< Auto-hide timeout for overlay messages (>0 shows overlay, <=0 hides it)
+		bool EnableDragToReposition = true;                      ///< Allow drag-and-drop overlay repositioning
 
 		/**
 		 * @brief Validates if the current menu scale is within acceptable range
@@ -410,6 +412,7 @@ public:
 			mouseDeadzone = std::clamp(mouseDeadzone, 0.0f, 1.0f);
 			mouseSpeed = std::clamp(mouseSpeed, 0.1f, 50.0f);
 			comboTimeout = std::clamp(comboTimeout, 1.0f, 10.0f);
+			kAutoHideSeconds = std::clamp(kAutoHideSeconds, 0, Config::kMaxAutoHideSeconds);
 		}
 	};
 

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -382,6 +382,8 @@ public:
 		int kAutoHideSeconds = Config::kDefaultAutoHideSeconds;  ///< Auto-hide timeout for overlay messages (>0 shows overlay, <=0 hides it)
 		bool EnableDragToReposition = true;                      ///< Allow drag-and-drop overlay repositioning
 
+		float VRMenuAutoResetDistance = 1000.0f;  // Default: 1000 units ≈ 14.3 meters
+
 		/**
 		 * @brief Validates if the current menu scale is within acceptable range
 		 * @return true if scale is between kMinMenuScale and kMaxMenuScale
@@ -590,6 +592,8 @@ public:
 		uint64_t fileSize = 0;
 		std::string modificationTime;
 	} openVRInfo;
+
+	RE::NiPoint3 savedPlayerWorldPos = RE::NiPoint3();  // Used for auto-reset distance check
 
 public:
 	//=============================================================================

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -12,6 +12,7 @@
 #include "Features/InteriorSunShadows.h"
 #include "Features/LightLimitFix.h"
 #include "Features/TerrainHelper.h"
+#include "Features/VR.h"
 #include "Features/VolumetricLighting.h"
 
 #include "ShaderTools/BSShaderHooks.h"
@@ -579,17 +580,16 @@ struct BSInputDeviceManager_PollInputDevices
 					if (globals::game::isVR) {
 						// Check if this is a VR device that should be blocked when menu is open
 						bool vrDevice = false;
-#ifdef ENABLE_SKYRIM_VR
 						vrDevice = (globals::game::isVR && ((device == RE::INPUT_DEVICES::INPUT_DEVICE::kVivePrimary) ||
 															   (device == RE::INPUT_DEVICES::INPUT_DEVICE::kViveSecondary) ||
 															   (device == RE::INPUT_DEVICES::INPUT_DEVICE::kOculusPrimary) ||
 															   (device == RE::INPUT_DEVICES::INPUT_DEVICE::kOculusSecondary) ||
 															   (device == RE::INPUT_DEVICES::INPUT_DEVICE::kWMRPrimary) ||
 															   (device == RE::INPUT_DEVICES::INPUT_DEVICE::kWMRSecondary)));
-#endif
 						// Block VR devices when menu is open to prevent game interaction
 						// Allow gamepad and non-VR devices to pass through
-						blockedDevice = !((device == RE::INPUT_DEVICES::INPUT_DEVICE::kGamepad) || !vrDevice);
+						// Only block VR device if openvr is compatible with the in game vr menu
+						blockedDevice = !((device == RE::INPUT_DEVICES::INPUT_DEVICE::kGamepad) || !vrDevice || (vrDevice && !globals::features::vr->IsOpenVRCompatible()));
 					} else {
 						// Block all devices except gamepad when menu is open
 						blockedDevice = (device != RE::INPUT_DEVICES::INPUT_DEVICE::kGamepad);

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -301,7 +301,7 @@ void Menu::Init()
 
 	BuildCategoryCounts();
 
-	if (REL::Module::IsVR()) {
+	if (globals::features::vr && globals::features::vr->IsOpenVRCompatible()) {
 		globals::features::vr->EnsureOverlayInitialized();
 	}
 
@@ -1620,7 +1620,7 @@ void Menu::DrawDisplaySettings()
 		for (const auto& [featureName, drawFunc] : features) {
 			bool isDisabled = globals::state->IsFeatureDisabled(featureName);
 
-			if (featureName == "Frame Generation" && REL::Module::IsVR()) {
+			if (featureName == "Frame Generation" && globals::features::vr) {
 				isDisabled = true;
 			}
 
@@ -1656,11 +1656,11 @@ void Menu::DrawFooter()
 
 void Menu::DrawOverlay()
 {
-	if (REL::Module::IsVR()) {
+	if (globals::features::vr && globals::features::vr->IsOpenVRCompatible()) {
 		globals::features::vr->RecreateOverlayTexturesIfNeeded();
 	}
 	ProcessInputEventQueue();
-	if (REL::Module::IsVR()) {
+	if (globals::features::vr && globals::features::vr->IsOpenVRCompatible()) {
 		globals::features::vr->ProcessControllerInputForImGui();
 	}
 
@@ -1779,7 +1779,7 @@ void Menu::DrawOverlay()
 	ImGui::Render();
 	ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
 
-	if (REL::Module::IsVR()) {
+	if (globals::features::vr && globals::features::vr->IsOpenVRCompatible()) {
 		globals::features::vr->SubmitOverlayFrame();
 	}
 }
@@ -2073,7 +2073,8 @@ void Menu::ProcessInputEventQueue()
 		bool isVRController = ((event.device == RE::INPUT_DEVICE::kVivePrimary || event.device == RE::INPUT_DEVICE::kViveSecondary ||
 								event.device == RE::INPUT_DEVICE::kOculusPrimary || event.device == RE::INPUT_DEVICE::kOculusSecondary ||
 								event.device == RE::INPUT_DEVICE::kWMRPrimary || event.device == RE::INPUT_DEVICE::kWMRSecondary));
-		if (REL::Module::IsVR() && isVRController) {
+
+		if (globals::features::vr && globals::features::vr->IsOpenVRCompatible() && isVRController) {
 			vrEvents.push_back(event);
 		} else {
 			nonVREvents.push_back(event);

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -64,9 +64,9 @@ namespace Util
 	/**
 	 * Usage:
 	 * {
-     *      auto _ = DisableGuard(disableThis);
-     *      ... Some settings ...
-     * }
+	 *      auto _ = DisableGuard(disableThis);
+	 *      ... Some settings ...
+	 * }
 	*/
 	class DisableGuard
 	{

--- a/src/Utils/VRUtils.cpp
+++ b/src/Utils/VRUtils.cpp
@@ -20,16 +20,16 @@ namespace Util
 			ImVec4 color;
 			switch (combo[i].GetDevice()) {
 			case ControllerDevice::Primary:
-				color = ImVec4(0.0f, 1.0f, 0.0f, 1.0f);
+				color = ImVec4(1.0f, 1.0f, 0.0f, 1.0f);  // Yellow
 				break;
 			case ControllerDevice::Secondary:
-				color = ImVec4(0.0f, 0.6f, 1.0f, 1.0f);
+				color = ImVec4(0.0f, 0.5f, 1.0f, 1.0f);  // Blue
 				break;
 			case ControllerDevice::Both:
-				color = ImVec4(0.5f, 0.0f, 0.5f, 1.0f);
+				color = ImVec4(0.0f, 1.0f, 0.0f, 1.0f);  // Green (yellow+blue)
 				break;
 			default:
-				color = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+				color = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);  // White
 				break;
 			}
 			ImGui::PushStyleColor(ImGuiCol_Text, color);
@@ -41,13 +41,13 @@ namespace Util
 				const char* label = "";
 				switch (combo[i].GetDevice()) {
 				case ControllerDevice::Primary:
-					label = "(Primary)";
+					label = "(Primary Controller)";
 					break;
 				case ControllerDevice::Secondary:
-					label = "(Secondary)";
+					label = "(Secondary Controller)";
 					break;
 				case ControllerDevice::Both:
-					label = "(Both)";
+					label = "(Both Controllers)";
 					break;
 				default:
 					break;
@@ -60,9 +60,9 @@ namespace Util
 		if (anyDrawn) {
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				Util::DrawColoredMultiLineTooltip({ { "Color coding:", ImVec4(1, 1, 1, 1) },
-					{ "Green = Primary controller", ImVec4(0.0f, 1.0f, 0.0f, 1.0f) },
-					{ "Blue = Secondary controller", ImVec4(0.0f, 0.6f, 1.0f, 1.0f) },
-					{ "Purple = Both controllers", ImVec4(0.5f, 0.0f, 0.5f, 1.0f) } });
+					{ "Yellow = Primary controller", ImVec4(1.0f, 1.0f, 0.0f, 1.0f) },
+					{ "Blue = Secondary controller", ImVec4(0.0f, 0.5f, 1.0f, 1.0f) },
+					{ "Green = Both controllers (Yellow + Blue)", ImVec4(0.0f, 1.0f, 0.0f, 1.0f) } });
 			}
 		}
 	}

--- a/src/Utils/VRUtils.cpp
+++ b/src/Utils/VRUtils.cpp
@@ -20,16 +20,16 @@ namespace Util
 			ImVec4 color;
 			switch (combo[i].GetDevice()) {
 			case ControllerDevice::Primary:
-				color = ImVec4(1.0f, 1.0f, 0.0f, 1.0f);  // Yellow
+				color = Util::GetControllerPrimaryColor();
 				break;
 			case ControllerDevice::Secondary:
-				color = ImVec4(0.0f, 0.5f, 1.0f, 1.0f);  // Blue
+				color = Util::GetControllerSecondaryColor();
 				break;
 			case ControllerDevice::Both:
-				color = ImVec4(0.0f, 1.0f, 0.0f, 1.0f);  // Green (yellow+blue)
+				color = Util::GetControllerBothColor();
 				break;
 			default:
-				color = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);  // White
+				color = Util::GetControllerDefaultColor();
 				break;
 			}
 			ImGui::PushStyleColor(ImGuiCol_Text, color);
@@ -38,31 +38,35 @@ namespace Util
 			anyDrawn = true;
 			if (showControllerLabels) {
 				ImGui::SameLine();
+				ImVec4 labelColor = Util::GetControllerDefaultColor();
 				const char* label = "";
 				switch (combo[i].GetDevice()) {
 				case ControllerDevice::Primary:
 					label = "(Primary Controller)";
+					labelColor = Util::GetControllerPrimaryColor();
 					break;
 				case ControllerDevice::Secondary:
 					label = "(Secondary Controller)";
+					labelColor = Util::GetControllerSecondaryColor();
 					break;
 				case ControllerDevice::Both:
 					label = "(Both Controllers)";
+					labelColor = Util::GetControllerBothColor();
 					break;
 				default:
 					break;
 				}
-				ImGui::TextDisabled("%s", label);
+				ImGui::TextColored(labelColor, "%s", label);
 				if (i < combo.size() - 1)
 					ImGui::SameLine();
 			}
 		}
 		if (anyDrawn) {
 			if (auto _tt = Util::HoverTooltipWrapper()) {
-				Util::DrawColoredMultiLineTooltip({ { "Color coding:", ImVec4(1, 1, 1, 1) },
-					{ "Yellow = Primary controller", ImVec4(1.0f, 1.0f, 0.0f, 1.0f) },
-					{ "Blue = Secondary controller", ImVec4(0.0f, 0.5f, 1.0f, 1.0f) },
-					{ "Green = Both controllers (Yellow + Blue)", ImVec4(0.0f, 1.0f, 0.0f, 1.0f) } });
+				Util::DrawColoredMultiLineTooltip({ { "Color coding:", Util::GetControllerDefaultColor() },
+					{ "Yellow = Primary controller", Util::GetControllerPrimaryColor() },
+					{ "Blue = Secondary controller", Util::GetControllerSecondaryColor() },
+					{ "Green = Both controllers (Yellow + Blue)", Util::GetControllerBothColor() } });
 			}
 		}
 	}

--- a/src/Utils/VRUtils.h
+++ b/src/Utils/VRUtils.h
@@ -2,7 +2,7 @@
 #include "D3D.h"
 #include <SimpleMath.h>
 #include <d3d11.h>
-#include <imgui.h>
+#include <imgui.h>  // For ImVec4
 #include <openvr.h>
 #include <vector>
 
@@ -19,6 +19,22 @@ struct ButtonCombo;
  */
 namespace Util
 {
+	// -----------------------------------------------------------------------------
+	// Centralized UI Colors for Util functions
+	// -----------------------------------------------------------------------------
+	namespace Colors
+	{
+		constexpr ImVec4 Primary = ImVec4(1.0f, 1.0f, 0.0f, 1.0f);    // Yellow
+		constexpr ImVec4 Secondary = ImVec4(0.0f, 0.5f, 1.0f, 1.0f);  // Blue
+		constexpr ImVec4 Both = ImVec4(0.0f, 1.0f, 0.0f, 1.0f);       // Green
+		constexpr ImVec4 Default = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);    // White
+	}
+
+	inline ImVec4 GetControllerPrimaryColor() { return Colors::Primary; }
+	inline ImVec4 GetControllerSecondaryColor() { return Colors::Secondary; }
+	inline ImVec4 GetControllerBothColor() { return Colors::Both; }
+	inline ImVec4 GetControllerDefaultColor() { return Colors::Default; }
+
 	/**
 	 * @brief Draws a button combination in the ImGui interface with color coding
 	 * @param combo Vector of ButtonCombo structures representing the key combination


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added robust detection and display of OpenVR version and compatibility status in the VR debug UI.
  * Introduced an auto-reset feature for fixed world position overlay based on player movement distance.
  * Overlay auto-hide timeout is now configurable, replacing the previous boolean setting.
  * Added new VR settings for overlay auto-hide duration and auto-reset distance, with manual reset control.

* **Improvements**
  * VR menus, overlays, and related UI elements are conditionally shown or hidden based on OpenVR compatibility, enhancing stability.
  * VR device input blocking now depends on OpenVR compatibility, improving input reliability.
  * VR overlay visibility and behavior dynamically respond to OpenVR version compatibility.
  * Updated VR controller button combo colors and labels for clearer identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->