### PR TITLE
feat: SkyScale as a multiplier instead of add

### DIFF
--- a/package/Shaders/Sky.hlsl
+++ b/package/Shaders/Sky.hlsl
@@ -192,6 +192,7 @@ Texture2D<float> TexDepthSampler : register(t17);
 PS_OUTPUT main(PS_INPUT input)
 {
 	PS_OUTPUT psout;
+	float3 yyy = PParams.yyy;
 #	if !defined(VR)
 	uint eyeIndex = 0;
 #	else
@@ -216,10 +217,10 @@ PS_OUTPUT main(PS_INPUT input)
 		TexNoiseGradSampler.Sample(SampNoiseGradSampler, noiseGradUv).x * 0.03125 + -0.0078125;
 
 #			ifdef TEX
-	psout.Color.xyz = (input.Color.xyz * baseColor.xyz + PParams.yyy) + noiseGrad;
+	psout.Color.xyz = (input.Color.xyz * baseColor.xyz * (1 + yyy)) + noiseGrad;
 	psout.Color.w = baseColor.w * input.Color.w;
 #			else
-	psout.Color.xyz = (PParams.yyy + input.Color.xyz) + noiseGrad;
+	psout.Color.xyz = (input.Color.xyz * (1 + yyy)) + noiseGrad;
 	psout.Color.w = input.Color.w;
 #			endif  // TEX
 
@@ -231,11 +232,11 @@ PS_OUTPUT main(PS_INPUT input)
 	}
 
 #		elif defined(HORIZFADE)
-	psout.Color.xyz = float3(1.5, 1.5, 1.5) * (input.Color.xyz * baseColor.xyz + PParams.yyy);
+	psout.Color.xyz = float3(1.5, 1.5, 1.5) * (input.Color.xyz * baseColor.xyz * (1 + yyy));
 	psout.Color.w = input.TexCoord2.x * (baseColor.w * input.Color.w);
 #		else
 	psout.Color.w = input.Color.w * baseColor.w;
-	psout.Color.xyz = input.Color.xyz * baseColor.xyz + PParams.yyy;
+	psout.Color.xyz = input.Color.xyz * baseColor.xyz * (1 + yyy);
 #		endif
 
 #	else


### PR DESCRIPTION
Simply replaces skyColor + skyScale with SkyColor*(1 + skyScale). Makes sky scale brighten the sky instead of turning it white. Very experimental, idk, looks good in my game.