### PR TITLE
feat(grass): add ragdoll collisions

### DIFF
--- a/src/Features/GrassCollision.cpp
+++ b/src/Features/GrassCollision.cpp
@@ -1,10 +1,20 @@
 #include "GrassCollision.h"
-
+#include "../Utils/ActorUtils.h"
 #include "State.h"
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	GrassCollision::Settings,
-	EnableGrassCollision)
+	EnableGrassCollision,
+	TrackRagdolls)
+
+struct ActorRow
+{
+	RE::TESObjectREFR* actor;
+	std::vector<std::string> row;
+	float sqDist;
+};
+
+static bool GetShapeBound(RE::bhkNiCollisionObject* Colliedobj, RE::NiPoint3& centerPos, float& radius);
 
 void GrassCollision::DrawSettings()
 {
@@ -13,13 +23,130 @@ void GrassCollision::DrawSettings()
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Allows player collision to modify grass position.");
 		}
-
+		ImGui::Checkbox("Track Ragdolls", &settings.TrackRagdolls);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("If enabled, dead actors (ragdolls) will be tracked and shown in the table.");
+		}
 		ImGui::TreePop();
 	}
 	if (ImGui::TreeNodeEx("Statistics", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Text(std::format("Active/Total Actors : {}/{}", activeActorCount, totalActorCount).c_str());
 		ImGui::Text(std::format("Total Collisions : {}", currentCollisionCount).c_str());
+
+		std::vector<std::string> headers = { "Name/EditorID", "FormID", "Type", "X", "Y", "Z", "SqDist" };
+		std::vector<ActorRow> sortableRows;
+		RE::NiPoint3 eyePos = Util::GetAverageEyePosition();
+		RE::NiPoint3 playerPos{};
+		if (auto player = RE::PlayerCharacter::GetSingleton()) {
+			playerPos = player->GetPosition();
+		}
+		for (const auto ref : actorList) {
+			Util::ActorDisplayInfo info;
+			if (!Util::GetActorDisplayInfo(ref, eyePos, settings.TrackRagdolls, info))
+				continue;
+			float offsetSqDist = (info.pos).GetSquaredDistance(playerPos);
+			std::vector<std::string> row = {
+				info.name,
+				info.formID,
+				info.type,
+				std::format("{:.2f}", info.pos.x),
+				std::format("{:.2f}", info.pos.y),
+				std::format("{:.2f}", info.pos.z),
+				std::format("{:.2f}", offsetSqDist)
+			};
+			sortableRows.push_back(ActorRow{ info.actor, row, offsetSqDist });
+		}
+		ImGui::BeginChild("GrassCollidersTableChild", ImVec2(0, 300), true);
+		Util::ShowSortedStringTableCustom<ActorRow>(
+			"GrassCollidersTable",
+			headers,
+			sortableRows,
+			6,  // Default sort by sqDist
+			true,
+			{
+				// Custom comparators for each column
+				[](const ActorRow& a, const ActorRow& b, bool asc) { return asc ? a.row[0] < b.row[0] : a.row[0] > b.row[0]; },                                              // Name
+				[](const ActorRow& a, const ActorRow& b, bool asc) { return asc ? a.row[1] < b.row[1] : a.row[1] > b.row[1]; },                                              // FormID
+				[](const ActorRow& a, const ActorRow& b, bool asc) { return asc ? a.row[2] < b.row[2] : a.row[2] > b.row[2]; },                                              // Type
+				[](const ActorRow& a, const ActorRow& b, bool asc) { return asc ? std::stof(a.row[3]) < std::stof(b.row[3]) : std::stof(a.row[3]) > std::stof(b.row[3]); },  // X
+				[](const ActorRow& a, const ActorRow& b, bool asc) { return asc ? std::stof(a.row[4]) < std::stof(b.row[4]) : std::stof(a.row[4]) > std::stof(b.row[4]); },  // Y
+				[](const ActorRow& a, const ActorRow& b, bool asc) { return asc ? std::stof(a.row[5]) < std::stof(b.row[5]) : std::stof(a.row[5]) > std::stof(b.row[5]); },  // Z
+				[](const ActorRow& a, const ActorRow& b, bool asc) { return asc ? a.sqDist < b.sqDist : a.sqDist > b.sqDist; }                                               // SqDist
+			},
+			[](int, int colIdx, const ActorRow& actorRow) {
+				if (colIdx == 0) {
+					if (ImGui::Selectable(actorRow.row[colIdx].c_str(), false, ImGuiSelectableFlags_SpanAllColumns)) {
+						// Teleport player to actor
+						if (auto player = RE::PlayerCharacter::GetSingleton()) {
+							auto actor = static_cast<RE::Actor*>(actorRow.actor);
+							if (actor) {
+								RE::NiPoint3 dest = actor->GetPosition();
+								player->SetPosition(dest, true);
+							}
+						}
+					}
+					if (ImGui::IsItemHovered()) {
+						ImGui::SetTooltip("Teleport to this actor's position.");
+					}
+				} else {
+					ImGui::TextUnformatted(actorRow.row[colIdx].c_str());
+				}
+			});
+		ImGui::EndChild();
 		ImGui::TreePop();
+	}
+}
+
+static bool ExtractShapeBound(const RE::hkpShape* shape, RE::NiPoint3& centerPos, float& radius)
+{
+	(void)centerPos;
+	using ShapeType = RE::hkpShapeType;
+	if (!shape)
+		return false;
+	if (shape->type == ShapeType::kCapsule) {
+		float upExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, 1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+		float downExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, -1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+		auto z_extent = (upExtent + downExtent) / 2.0f;
+		float forwardExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+		float backwardExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, -1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+		auto y_extent = (forwardExtent + backwardExtent) / 2.0f;
+		float leftExtent = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+		float rightExtent = shape->GetMaximumProjection(RE::hkVector4{ -1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+		auto x_extent = (leftExtent + rightExtent) / 2.0f;
+		radius = sqrtf(x_extent * x_extent + y_extent * y_extent + z_extent * z_extent);
+		return true;
+	} else if (shape->type == ShapeType::kSphere) {
+		float sphereRadius = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+		radius = sphereRadius;
+		return true;
+	} else if (shape->type == ShapeType::kBox) {
+		float x_extent = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+		float y_extent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+		float z_extent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, 1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+		radius = sqrtf(x_extent * x_extent + y_extent * y_extent + z_extent * z_extent) * 0.5f;
+		return true;
+	} else if (shape->type == ShapeType::kCylinder) {
+		float x_extent = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+		float y_extent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+		float z_extent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, 1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+		radius = sqrtf(std::max(x_extent, y_extent) * std::max(x_extent, y_extent) + z_extent * z_extent) * 0.5f;
+		return true;
+	} else if (shape->type == ShapeType::kConvexVertices || shape->type == ShapeType::kTriangle) {
+		float max_extent = 0.0f;
+		for (const auto& dir : { RE::hkVector4{ 1, 0, 0, 0 }, RE::hkVector4{ 0, 1, 0, 0 }, RE::hkVector4{ 0, 0, 1, 0 }, RE::hkVector4{ -1, 0, 0, 0 }, RE::hkVector4{ 0, -1, 0, 0 }, RE::hkVector4{ 0, 0, -1, 0 } }) {
+			float extent = shape->GetMaximumProjection(dir) * RE::bhkWorld::GetWorldScaleInverse();
+			max_extent = std::max(max_extent, extent);
+		}
+		radius = max_extent;
+		return true;
+	} else {
+		float max_extent = 0.0f;
+		for (const auto& dir : { RE::hkVector4{ 1, 0, 0, 0 }, RE::hkVector4{ 0, 1, 0, 0 }, RE::hkVector4{ 0, 0, 1, 0 }, RE::hkVector4{ -1, 0, 0, 0 }, RE::hkVector4{ 0, -1, 0, 0 }, RE::hkVector4{ 0, 0, -1, 0 } }) {
+			float extent = shape->GetMaximumProjection(dir) * RE::bhkWorld::GetWorldScaleInverse();
+			max_extent = std::max(max_extent, extent);
+		}
+		radius = max_extent;
+		return true;
 	}
 }
 
@@ -40,27 +167,8 @@ static bool GetShapeBound(RE::NiAVObject* a_node, RE::NiPoint3& centerPos, float
 		float massTrans[4];
 		_mm_store_ps(massTrans, massCenter.quad);
 		centerPos = RE::NiPoint3(massTrans[0], massTrans[1], massTrans[2]) * RE::bhkWorld::GetWorldScaleInverse();
-
-		const RE::hkpShape* shape = hkpRigid->collidable.GetShape();
-		if (shape && shape->type == RE::hkpShapeType::kCapsule) {
-			float upExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, 1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			float downExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, -1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			auto z_extent = (upExtent + downExtent) / 2.0f;
-
-			float forwardExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			float backwardExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, -1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			auto y_extent = (forwardExtent + backwardExtent) / 2.0f;
-
-			float leftExtent = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			float rightExtent = shape->GetMaximumProjection(RE::hkVector4{ -1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			auto x_extent = (leftExtent + rightExtent) / 2.0f;
-
-			radius = sqrtf(x_extent * x_extent + y_extent * y_extent + z_extent * z_extent);
-
-			return true;
-		}
+		return ExtractShapeBound(hkpRigid->collidable.GetShape(), centerPos, radius);
 	}
-
 	return false;
 }
 
@@ -77,33 +185,15 @@ static bool GetShapeBound(RE::bhkNiCollisionObject* Colliedobj, RE::NiPoint3& ce
 		float massTrans[4];
 		_mm_store_ps(massTrans, massCenter.quad);
 		centerPos = RE::NiPoint3(massTrans[0], massTrans[1], massTrans[2]) * RE::bhkWorld::GetWorldScaleInverse();
-
-		const RE::hkpShape* shape = hkpRigid->collidable.GetShape();
-		if (shape && shape->type == RE::hkpShapeType::kCapsule) {
-			float upExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, 1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			float downExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, -1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			auto z_extent = (upExtent + downExtent) / 2.0f;
-
-			float forwardExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			float backwardExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, -1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			auto y_extent = (forwardExtent + backwardExtent) / 2.0f;
-
-			float leftExtent = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			float rightExtent = shape->GetMaximumProjection(RE::hkVector4{ -1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			auto x_extent = (leftExtent + rightExtent) / 2.0f;
-
-			radius = sqrtf(x_extent * x_extent + y_extent * y_extent + z_extent * z_extent);
-
-			return true;
-		}
+		return ExtractShapeBound(hkpRigid->collidable.GetShape(), centerPos, radius);
 	}
-
 	return false;
 }
 
 void GrassCollision::UpdateCollisions(PerFrame& perFrameData)
 {
 	actorList.clear();
+	std::vector<Util::ActorDisplayInfo> actorDisplayInfos;
 
 	// Actor query code from po3 under MIT
 	// https://github.com/powerof3/PapyrusExtenderSSE/blob/7a73b47bc87331bec4e16f5f42f2dbc98b66c3a7/include/Papyrus/Functions/Faction.h#L24C7-L46
@@ -127,14 +217,23 @@ void GrassCollision::UpdateCollisions(PerFrame& perFrameData)
 	RE::NiPoint3 cameraPosition = Util::GetAverageEyePosition();
 
 	for (const auto actor : actorList) {
+		Util::ActorDisplayInfo info;
+		if (!Util::GetActorDisplayInfo(actor, cameraPosition, settings.TrackRagdolls, info))
+			continue;
+		actorDisplayInfos.push_back(info);
+	}
+
+	for (const auto& info : actorDisplayInfos) {
 		if (currentCollisionCount == 256)
 			break;
-		if (auto root = actor->Get3D(false)) {
-			auto position = actor->GetPosition();
-			float distance = cameraPosition.GetDistance(position);
-			if (distance > 2048.0f)  // Cull against distance
+		auto actor = static_cast<RE::Actor*>(info.actor);
+		if (actor && actor->Is3DLoaded()) {
+			auto root = actor->Get3D(false);
+			if (!root)
 				continue;
-
+			float distance = cameraPosition.GetDistance(info.pos);
+			if (distance > 2048.0f)
+				continue;
 			activeActorCount++;
 			RE::BSVisit::TraverseScenegraphCollision(root, [&](RE::bhkNiCollisionObject* a_object) -> RE::BSVisit::BSVisitControl {
 				RE::NiPoint3 centerPos;

--- a/src/Features/GrassCollision.cpp
+++ b/src/Features/GrassCollision.cpp
@@ -14,8 +14,6 @@ struct ActorRow
 	float sqDist;
 };
 
-static bool GetShapeBound(RE::bhkNiCollisionObject* Colliedobj, RE::NiPoint3& centerPos, float& radius);
-
 void GrassCollision::DrawSettings()
 {
 	if (ImGui::TreeNodeEx("Grass Collision", ImGuiTreeNodeFlags_DefaultOpen)) {
@@ -97,99 +95,6 @@ void GrassCollision::DrawSettings()
 	}
 }
 
-static bool ExtractShapeBound(const RE::hkpShape* shape, RE::NiPoint3& centerPos, float& radius)
-{
-	(void)centerPos;
-	using ShapeType = RE::hkpShapeType;
-	if (!shape)
-		return false;
-	if (shape->type == ShapeType::kCapsule) {
-		float upExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, 1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-		float downExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, -1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-		auto z_extent = (upExtent + downExtent) / 2.0f;
-		float forwardExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-		float backwardExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, -1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-		auto y_extent = (forwardExtent + backwardExtent) / 2.0f;
-		float leftExtent = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-		float rightExtent = shape->GetMaximumProjection(RE::hkVector4{ -1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-		auto x_extent = (leftExtent + rightExtent) / 2.0f;
-		radius = sqrtf(x_extent * x_extent + y_extent * y_extent + z_extent * z_extent);
-		return true;
-	} else if (shape->type == ShapeType::kSphere) {
-		float sphereRadius = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-		radius = sphereRadius;
-		return true;
-	} else if (shape->type == ShapeType::kBox) {
-		float x_extent = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-		float y_extent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-		float z_extent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, 1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-		radius = sqrtf(x_extent * x_extent + y_extent * y_extent + z_extent * z_extent) * 0.5f;
-		return true;
-	} else if (shape->type == ShapeType::kCylinder) {
-		float x_extent = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-		float y_extent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-		float z_extent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, 1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-		radius = sqrtf(std::max(x_extent, y_extent) * std::max(x_extent, y_extent) + z_extent * z_extent) * 0.5f;
-		return true;
-	} else if (shape->type == ShapeType::kConvexVertices || shape->type == ShapeType::kTriangle) {
-		float max_extent = 0.0f;
-		for (const auto& dir : { RE::hkVector4{ 1, 0, 0, 0 }, RE::hkVector4{ 0, 1, 0, 0 }, RE::hkVector4{ 0, 0, 1, 0 }, RE::hkVector4{ -1, 0, 0, 0 }, RE::hkVector4{ 0, -1, 0, 0 }, RE::hkVector4{ 0, 0, -1, 0 } }) {
-			float extent = shape->GetMaximumProjection(dir) * RE::bhkWorld::GetWorldScaleInverse();
-			max_extent = std::max(max_extent, extent);
-		}
-		radius = max_extent;
-		return true;
-	} else {
-		float max_extent = 0.0f;
-		for (const auto& dir : { RE::hkVector4{ 1, 0, 0, 0 }, RE::hkVector4{ 0, 1, 0, 0 }, RE::hkVector4{ 0, 0, 1, 0 }, RE::hkVector4{ -1, 0, 0, 0 }, RE::hkVector4{ 0, -1, 0, 0 }, RE::hkVector4{ 0, 0, -1, 0 } }) {
-			float extent = shape->GetMaximumProjection(dir) * RE::bhkWorld::GetWorldScaleInverse();
-			max_extent = std::max(max_extent, extent);
-		}
-		radius = max_extent;
-		return true;
-	}
-}
-
-static bool GetShapeBound(RE::NiAVObject* a_node, RE::NiPoint3& centerPos, float& radius)
-{
-	RE::bhkNiCollisionObject* Colliedobj = nullptr;
-	if (a_node->collisionObject)
-		Colliedobj = a_node->collisionObject->AsBhkNiCollisionObject();
-
-	if (!Colliedobj)
-		return false;
-
-	RE::bhkRigidBody* bhkRigid = Colliedobj->body.get() ? Colliedobj->body.get()->AsBhkRigidBody() : nullptr;
-	RE::hkpRigidBody* hkpRigid = bhkRigid ? skyrim_cast<RE::hkpRigidBody*>(bhkRigid->referencedObject.get()) : nullptr;
-	if (bhkRigid && hkpRigid) {
-		RE::hkVector4 massCenter;
-		bhkRigid->GetCenterOfMassWorld(massCenter);
-		float massTrans[4];
-		_mm_store_ps(massTrans, massCenter.quad);
-		centerPos = RE::NiPoint3(massTrans[0], massTrans[1], massTrans[2]) * RE::bhkWorld::GetWorldScaleInverse();
-		return ExtractShapeBound(hkpRigid->collidable.GetShape(), centerPos, radius);
-	}
-	return false;
-}
-
-static bool GetShapeBound(RE::bhkNiCollisionObject* Colliedobj, RE::NiPoint3& centerPos, float& radius)
-{
-	if (!Colliedobj)
-		return false;
-
-	RE::bhkRigidBody* bhkRigid = Colliedobj->body.get() ? Colliedobj->body.get()->AsBhkRigidBody() : nullptr;
-	RE::hkpRigidBody* hkpRigid = bhkRigid ? skyrim_cast<RE::hkpRigidBody*>(bhkRigid->referencedObject.get()) : nullptr;
-	if (bhkRigid && hkpRigid) {
-		RE::hkVector4 massCenter;
-		bhkRigid->GetCenterOfMassWorld(massCenter);
-		float massTrans[4];
-		_mm_store_ps(massTrans, massCenter.quad);
-		centerPos = RE::NiPoint3(massTrans[0], massTrans[1], massTrans[2]) * RE::bhkWorld::GetWorldScaleInverse();
-		return ExtractShapeBound(hkpRigid->collidable.GetShape(), centerPos, radius);
-	}
-	return false;
-}
-
 void GrassCollision::UpdateCollisions(PerFrame& perFrameData)
 {
 	actorList.clear();
@@ -238,7 +143,7 @@ void GrassCollision::UpdateCollisions(PerFrame& perFrameData)
 			RE::BSVisit::TraverseScenegraphCollision(root, [&](RE::bhkNiCollisionObject* a_object) -> RE::BSVisit::BSVisitControl {
 				RE::NiPoint3 centerPos;
 				float radius;
-				if (GetShapeBound(a_object, centerPos, radius)) {
+				if (Util::GetShapeBound(a_object, centerPos, radius)) {
 					if (radius < distance * 0.01f)
 						return RE::BSVisit::BSVisitControl::kContinue;
 					radius *= 2.0f;

--- a/src/Features/GrassCollision.h
+++ b/src/Features/GrassCollision.h
@@ -29,7 +29,7 @@ public:
 	struct Settings
 	{
 		bool EnableGrassCollision = 1;
-		bool TrackRagdolls = true;
+		bool TrackRagdolls = false;
 	};
 
 	struct alignas(16) CollisionData

--- a/src/Features/GrassCollision.h
+++ b/src/Features/GrassCollision.h
@@ -29,6 +29,7 @@ public:
 	struct Settings
 	{
 		bool EnableGrassCollision = 1;
+		bool TrackRagdolls = true;
 	};
 
 	struct alignas(16) CollisionData

--- a/src/Utils/ActorUtils.cpp
+++ b/src/Utils/ActorUtils.cpp
@@ -50,7 +50,9 @@ namespace Util
 		if (shape->type == ShapeType::kCapsule) {
 			float hx, hy, hz;
 			symmetricHalfExtents(hx, hy, hz);
-			radius = halfDiagonal(hx, hy, hz);
+			// For capsules, use the maximum half-extent (typically hz for vertical orientation)
+			// as the farthest point lies along the capsule's main axis, not at the diagonal
+			radius = std::max(hx, std::max(hy, hz));
 			return true;
 		} else if (shape->type == ShapeType::kSphere) {
 			// For spheres, any axis should yield the same half-extent; use symmetric X

--- a/src/Utils/ActorUtils.cpp
+++ b/src/Utils/ActorUtils.cpp
@@ -15,7 +15,8 @@ namespace Util
 			RE::hkVector4 massCenter;
 			bhkRigid->GetCenterOfMassWorld(massCenter);
 			float massTrans[4];
-			_mm_store_ps(massTrans, massCenter.quad);
+			// Use unaligned store to avoid UB from potential stack misalignment
+			_mm_storeu_ps(massTrans, massCenter.quad);
 			centerPos = RE::NiPoint3(massTrans[0], massTrans[1], massTrans[2]) * RE::bhkWorld::GetWorldScaleInverse();
 			return Util::ExtractShapeBound(hkpRigid->collidable.GetShape(), radius);
 		}
@@ -27,49 +28,59 @@ namespace Util
 		using ShapeType = RE::hkpShapeType;
 		if (!shape)
 			return false;
+
+		// Helpers to avoid repeating projection math and ensure offset-invariant half-extents
+		auto project = [shape](float x, float y, float z) {
+			return shape->GetMaximumProjection(RE::hkVector4{ x, y, z, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+		};
+		auto symmetricHalfExtents = [&project](float& hx, float& hy, float& hz) {
+			float x_pos = project(1.0f, 0.0f, 0.0f);
+			float x_neg = project(-1.0f, 0.0f, 0.0f);
+			float y_pos = project(0.0f, 1.0f, 0.0f);
+			float y_neg = project(0.0f, -1.0f, 0.0f);
+			float z_pos = project(0.0f, 0.0f, 1.0f);
+			float z_neg = project(0.0f, 0.0f, -1.0f);
+			hx = 0.5f * (x_pos + x_neg);
+			hy = 0.5f * (y_pos + y_neg);
+			hz = 0.5f * (z_pos + z_neg);
+		};
+		auto halfDiagonal = [](float hx, float hy, float hz) {
+			return sqrtf(hx * hx + hy * hy + hz * hz);
+		};
 		if (shape->type == ShapeType::kCapsule) {
-			float upExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, 1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			float downExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, -1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			auto z_extent = (upExtent + downExtent) / 2.0f;
-			float forwardExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			float backwardExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, -1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			auto y_extent = (forwardExtent + backwardExtent) / 2.0f;
-			float leftExtent = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			float rightExtent = shape->GetMaximumProjection(RE::hkVector4{ -1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			auto x_extent = (leftExtent + rightExtent) / 2.0f;
-			radius = sqrtf(x_extent * x_extent + y_extent * y_extent + z_extent * z_extent);
+			float hx, hy, hz;
+			symmetricHalfExtents(hx, hy, hz);
+			radius = halfDiagonal(hx, hy, hz);
 			return true;
 		} else if (shape->type == ShapeType::kSphere) {
-			float sphereRadius = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			radius = sphereRadius;
+			// For spheres, any axis should yield the same half-extent; use symmetric X
+			float hx, hy, hz;
+			symmetricHalfExtents(hx, hy, hz);
+			radius = hx;
 			return true;
 		} else if (shape->type == ShapeType::kBox) {
-			float x_extent = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			float y_extent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			float z_extent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, 1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			radius = sqrtf(x_extent * x_extent + y_extent * y_extent + z_extent * z_extent) * 0.5f;
+			float hx, hy, hz;
+			symmetricHalfExtents(hx, hy, hz);
+			radius = halfDiagonal(hx, hy, hz);
 			return true;
 		} else if (shape->type == ShapeType::kCylinder) {
-			float x_extent = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			float y_extent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			float z_extent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, 1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
-			radius = sqrtf(std::max(x_extent, y_extent) * std::max(x_extent, y_extent) + z_extent * z_extent) * 0.5f;
+			// Use symmetric half-extents; cylinder radius is max of X/Y half-extents
+			float hx, hy, hz;
+			symmetricHalfExtents(hx, hy, hz);
+			float hr = std::max(hx, hy);
+			radius = sqrtf(hr * hr + hz * hz);
 			return true;
 		} else if (shape->type == ShapeType::kConvexVertices || shape->type == ShapeType::kTriangle) {
-			float max_extent = 0.0f;
-			for (const auto& dir : { RE::hkVector4{ 1, 0, 0, 0 }, RE::hkVector4{ 0, 1, 0, 0 }, RE::hkVector4{ 0, 0, 1, 0 }, RE::hkVector4{ -1, 0, 0, 0 }, RE::hkVector4{ 0, -1, 0, 0 }, RE::hkVector4{ 0, 0, -1, 0 } }) {
-				float extent = shape->GetMaximumProjection(dir) * RE::bhkWorld::GetWorldScaleInverse();
-				max_extent = std::max(max_extent, extent);
-			}
-			radius = max_extent;
+			// Offset-invariant estimate: take symmetric half-extents per axis and use the max
+			float hx, hy, hz;
+			symmetricHalfExtents(hx, hy, hz);
+			radius = std::max(hx, std::max(hy, hz));
 			return true;
 		} else {
-			float max_extent = 0.0f;
-			for (const auto& dir : { RE::hkVector4{ 1, 0, 0, 0 }, RE::hkVector4{ 0, 1, 0, 0 }, RE::hkVector4{ 0, 0, 1, 0 }, RE::hkVector4{ -1, 0, 0, 0 }, RE::hkVector4{ 0, -1, 0, 0 }, RE::hkVector4{ 0, 0, -1, 0 } }) {
-				float extent = shape->GetMaximumProjection(dir) * RE::bhkWorld::GetWorldScaleInverse();
-				max_extent = std::max(max_extent, extent);
-			}
-			radius = max_extent;
+			// Fallback: mirror the convex/triangle approach for consistency
+			float hx, hy, hz;
+			symmetricHalfExtents(hx, hy, hz);
+			radius = std::max(hx, std::max(hy, hz));
 			return true;
 		}
 	}

--- a/src/Utils/ActorUtils.cpp
+++ b/src/Utils/ActorUtils.cpp
@@ -1,0 +1,77 @@
+#include "ActorUtils.h"
+#include <algorithm>
+#include <cmath>
+
+namespace Util
+{
+	bool GetShapeBound(RE::bhkNiCollisionObject* Colliedobj, RE::NiPoint3& centerPos, float& radius)
+	{
+		if (!Colliedobj)
+			return false;
+
+		RE::bhkRigidBody* bhkRigid = Colliedobj->body.get() ? Colliedobj->body.get()->AsBhkRigidBody() : nullptr;
+		RE::hkpRigidBody* hkpRigid = bhkRigid ? skyrim_cast<RE::hkpRigidBody*>(bhkRigid->referencedObject.get()) : nullptr;
+		if (bhkRigid && hkpRigid) {
+			RE::hkVector4 massCenter;
+			bhkRigid->GetCenterOfMassWorld(massCenter);
+			float massTrans[4];
+			_mm_store_ps(massTrans, massCenter.quad);
+			centerPos = RE::NiPoint3(massTrans[0], massTrans[1], massTrans[2]) * RE::bhkWorld::GetWorldScaleInverse();
+			return Util::ExtractShapeBound(hkpRigid->collidable.GetShape(), centerPos, radius);
+		}
+		return false;
+	}
+
+	bool ExtractShapeBound(const RE::hkpShape* shape, RE::NiPoint3& centerPos, float& radius)
+	{
+		(void)centerPos;
+		using ShapeType = RE::hkpShapeType;
+		if (!shape)
+			return false;
+		if (shape->type == ShapeType::kCapsule) {
+			float upExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, 1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+			float downExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, -1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+			auto z_extent = (upExtent + downExtent) / 2.0f;
+			float forwardExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+			float backwardExtent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, -1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+			auto y_extent = (forwardExtent + backwardExtent) / 2.0f;
+			float leftExtent = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+			float rightExtent = shape->GetMaximumProjection(RE::hkVector4{ -1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+			auto x_extent = (leftExtent + rightExtent) / 2.0f;
+			radius = sqrtf(x_extent * x_extent + y_extent * y_extent + z_extent * z_extent);
+			return true;
+		} else if (shape->type == ShapeType::kSphere) {
+			float sphereRadius = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+			radius = sphereRadius;
+			return true;
+		} else if (shape->type == ShapeType::kBox) {
+			float x_extent = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+			float y_extent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+			float z_extent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, 1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+			radius = sqrtf(x_extent * x_extent + y_extent * y_extent + z_extent * z_extent) * 0.5f;
+			return true;
+		} else if (shape->type == ShapeType::kCylinder) {
+			float x_extent = shape->GetMaximumProjection(RE::hkVector4{ 1.0f, 0.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+			float y_extent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 1.0f, 0.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+			float z_extent = shape->GetMaximumProjection(RE::hkVector4{ 0.0f, 0.0f, 1.0f, 0.0f }) * RE::bhkWorld::GetWorldScaleInverse();
+			radius = sqrtf(std::max(x_extent, y_extent) * std::max(x_extent, y_extent) + z_extent * z_extent) * 0.5f;
+			return true;
+		} else if (shape->type == ShapeType::kConvexVertices || shape->type == ShapeType::kTriangle) {
+			float max_extent = 0.0f;
+			for (const auto& dir : { RE::hkVector4{ 1, 0, 0, 0 }, RE::hkVector4{ 0, 1, 0, 0 }, RE::hkVector4{ 0, 0, 1, 0 }, RE::hkVector4{ -1, 0, 0, 0 }, RE::hkVector4{ 0, -1, 0, 0 }, RE::hkVector4{ 0, 0, -1, 0 } }) {
+				float extent = shape->GetMaximumProjection(dir) * RE::bhkWorld::GetWorldScaleInverse();
+				max_extent = std::max(max_extent, extent);
+			}
+			radius = max_extent;
+			return true;
+		} else {
+			float max_extent = 0.0f;
+			for (const auto& dir : { RE::hkVector4{ 1, 0, 0, 0 }, RE::hkVector4{ 0, 1, 0, 0 }, RE::hkVector4{ 0, 0, 1, 0 }, RE::hkVector4{ -1, 0, 0, 0 }, RE::hkVector4{ 0, -1, 0, 0 }, RE::hkVector4{ 0, 0, -1, 0 } }) {
+				float extent = shape->GetMaximumProjection(dir) * RE::bhkWorld::GetWorldScaleInverse();
+				max_extent = std::max(max_extent, extent);
+			}
+			radius = max_extent;
+			return true;
+		}
+	}
+}

--- a/src/Utils/ActorUtils.cpp
+++ b/src/Utils/ActorUtils.cpp
@@ -17,14 +17,13 @@ namespace Util
 			float massTrans[4];
 			_mm_store_ps(massTrans, massCenter.quad);
 			centerPos = RE::NiPoint3(massTrans[0], massTrans[1], massTrans[2]) * RE::bhkWorld::GetWorldScaleInverse();
-			return Util::ExtractShapeBound(hkpRigid->collidable.GetShape(), centerPos, radius);
+			return Util::ExtractShapeBound(hkpRigid->collidable.GetShape(), radius);
 		}
 		return false;
 	}
 
-	bool ExtractShapeBound(const RE::hkpShape* shape, RE::NiPoint3& centerPos, float& radius)
+	bool ExtractShapeBound(const RE::hkpShape* shape, float& radius)
 	{
-		(void)centerPos;
 		using ShapeType = RE::hkpShapeType;
 		if (!shape)
 			return false;

--- a/src/Utils/ActorUtils.cpp
+++ b/src/Utils/ActorUtils.cpp
@@ -4,12 +4,12 @@
 
 namespace Util
 {
-	bool GetShapeBound(RE::bhkNiCollisionObject* Colliedobj, RE::NiPoint3& centerPos, float& radius)
+	bool GetShapeBound(RE::bhkNiCollisionObject* collisionObj, RE::NiPoint3& centerPos, float& radius)
 	{
-		if (!Colliedobj)
+		if (!collisionObj)
 			return false;
 
-		RE::bhkRigidBody* bhkRigid = Colliedobj->body.get() ? Colliedobj->body.get()->AsBhkRigidBody() : nullptr;
+		RE::bhkRigidBody* bhkRigid = collisionObj->body.get() ? collisionObj->body.get()->AsBhkRigidBody() : nullptr;
 		RE::hkpRigidBody* hkpRigid = bhkRigid ? skyrim_cast<RE::hkpRigidBody*>(bhkRigid->referencedObject.get()) : nullptr;
 		if (bhkRigid && hkpRigid) {
 			RE::hkVector4 massCenter;

--- a/src/Utils/ActorUtils.h
+++ b/src/Utils/ActorUtils.h
@@ -1,0 +1,112 @@
+
+
+#pragma once
+#include "RE/Skyrim.h"
+#include <string>
+#include <vector>
+
+// Forward declarations for Skyrim types
+namespace RE
+{
+	class bhkNiCollisionObject;
+	class hkpShape;
+	class NiPoint3;
+}
+
+namespace Util
+{
+	/**
+     * @brief Extracts the shape bounds from a collision object.
+     * @param Colliedobj Pointer to the collision object.
+     * @param centerPos Output: center position of the shape.
+     * @param radius Output: radius of the shape.
+     * @return True if bounds were successfully extracted, false otherwise.
+     */
+	bool GetShapeBound(RE::bhkNiCollisionObject* Colliedobj, RE::NiPoint3& centerPos, float& radius);
+
+	/**
+     * @brief Extracts the shape bounds from a hkpShape.
+     * @param shape Pointer to the shape.
+     * @param centerPos Output: center position of the shape.
+     * @param radius Output: radius of the shape.
+     * @return True if bounds were successfully extracted, false otherwise.
+     */
+	bool ExtractShapeBound(const RE::hkpShape* shape, RE::NiPoint3& centerPos, float& radius);
+
+	/**
+     * @brief Holds display info for an actor (used in UI tables).
+     */
+	struct ActorDisplayInfo
+	{
+		RE::TESObjectREFR* actor;  ///< Reference to the actor
+		std::string name;          ///< Actor name
+		std::string formID;        ///< FormID as string
+		std::string type;          ///< Type string (e.g., "Actor", "Actor (Dead/Ragdoll)")
+		RE::NiPoint3 pos;          ///< Position
+		float sqDist;              ///< Squared distance from reference point
+	};
+
+	/**
+     * @brief Gets the ragdoll center for a dead actor.
+     * @param actor Pointer to the actor.
+     * @param outCenter Output: center position of the ragdoll.
+     * @return True if center was found, false otherwise.
+     */
+	inline bool GetRagdollCenter(RE::Actor* actor, RE::NiPoint3& outCenter)
+	{
+		if (!actor || !actor->IsDead())
+			return false;
+		if (auto root = actor->Get3D(false)) {
+			bool found = false;
+			RE::NiPoint3 ragdollCenter;
+			RE::BSVisit::TraverseScenegraphCollision(root, [&](RE::bhkNiCollisionObject* a_object) -> RE::BSVisit::BSVisitControl {
+				float radius = 0.0f;
+				RE::NiPoint3 centerPos;
+				if (Util::GetShapeBound(a_object, centerPos, radius)) {
+					ragdollCenter = centerPos;
+					found = true;
+					return RE::BSVisit::BSVisitControl::kStop;
+				}
+				return RE::BSVisit::BSVisitControl::kContinue;
+			});
+			if (found) {
+				outCenter = ragdollCenter;
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+     * @brief Fills outInfo with display info for an actor, including ragdoll center if dead.
+     * @param ref Reference to the actor.
+     * @param eyePos Position to use for distance calculation.
+     * @param trackRagdolls Whether to include ragdoll info for dead actors.
+     * @param outInfo Output: filled display info struct.
+     * @return True if info was filled, false otherwise.
+     */
+	inline bool GetActorDisplayInfo(RE::TESObjectREFR* ref, const RE::NiPoint3& eyePos, bool trackRagdolls, ActorDisplayInfo& outInfo)
+	{
+		if (!ref)
+			return false;
+		auto actor = static_cast<RE::Actor*>(ref);
+		outInfo.actor = ref;
+		outInfo.name = ref->GetName();
+		outInfo.formID = std::format("{:X}", ref->GetFormID());
+		outInfo.type = "Actor";
+		if (actor && actor->IsDead()) {
+			if (!trackRagdolls)
+				return false;
+			outInfo.type = "Actor (Dead/Ragdoll)";
+			RE::NiPoint3 pos;
+			if (!GetRagdollCenter(actor, pos)) {
+				pos = actor->GetPosition();
+			}
+			outInfo.pos = pos;
+		} else {
+			outInfo.pos = ref->GetPosition();
+		}
+		outInfo.sqDist = outInfo.pos.GetSquaredDistance(eyePos);
+		return true;
+	}
+}

--- a/src/Utils/ActorUtils.h
+++ b/src/Utils/ActorUtils.h
@@ -27,11 +27,10 @@ namespace Util
 	/**
      * @brief Extracts the shape bounds from a hkpShape.
      * @param shape Pointer to the shape.
-     * @param centerPos Output: center position of the shape.
      * @param radius Output: radius of the shape.
      * @return True if bounds were successfully extracted, false otherwise.
      */
-	bool ExtractShapeBound(const RE::hkpShape* shape, RE::NiPoint3& centerPos, float& radius);
+	bool ExtractShapeBound(const RE::hkpShape* shape, float& radius);
 
 	/**
      * @brief Holds display info for an actor (used in UI tables).

--- a/src/Utils/ActorUtils.h
+++ b/src/Utils/ActorUtils.h
@@ -17,12 +17,12 @@ namespace Util
 {
 	/**
      * @brief Extracts the shape bounds from a collision object.
-     * @param Colliedobj Pointer to the collision object.
+     * @param collisionObj Pointer to the collision object.
      * @param centerPos Output: center position of the shape.
      * @param radius Output: radius of the shape.
      * @return True if bounds were successfully extracted, false otherwise.
      */
-	bool GetShapeBound(RE::bhkNiCollisionObject* Colliedobj, RE::NiPoint3& centerPos, float& radius);
+	bool GetShapeBound(RE::bhkNiCollisionObject* collisionObj, RE::NiPoint3& centerPos, float& radius);
 
 	/**
      * @brief Extracts the shape bounds from a hkpShape.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to track ragdoll actors, which can be enabled or disabled in the settings UI.
  * Enhanced the statistics UI with a detailed, sortable table displaying actors (including ragdolls if enabled) with their name, ID, type, position, and distance from the player.
  * Users can now teleport to an actor's position by selecting its name in the table.

* **Refactor**
  * Improved performance and maintainability by streamlining shape bounding calculations and collision update logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->