### PR TITLE
fix: fix invalid vanilla adaptation texture

### DIFF
--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -107,6 +107,21 @@ void Deferred::SetupResources()
 		SetupRenderTarget(NORMALROUGHNESS, texDesc, srvDesc, rtvDesc, uavDesc, DXGI_FORMAT_R10G10B10A2_UNORM, D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE);
 		// Masks
 		SetupRenderTarget(MASKS, texDesc, srvDesc, rtvDesc, uavDesc, DXGI_FORMAT_R8G8B8A8_UNORM, D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE);
+
+		texDesc.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
+		texDesc.Width = 2;
+		texDesc.Height = 2;
+
+		adaptationTextures[0] = new Texture2D(texDesc);
+		adaptationTextures[1] = new Texture2D(texDesc);
+
+		srvDesc.Format = texDesc.Format;
+		adaptationTextures[0]->CreateSRV(srvDesc);
+		adaptationTextures[1]->CreateSRV(srvDesc);
+
+		rtvDesc.Format = texDesc.Format;
+		adaptationTextures[0]->CreateRTV(rtvDesc);
+		adaptationTextures[1]->CreateRTV(rtvDesc);
 	}
 
 	{
@@ -751,9 +766,56 @@ ID3D11ComputeShader* Deferred::GetComputeMainCompositeInterior()
 	return mainCompositeInteriorCS;
 }
 
-// Testing code for imagespace shaders
-void Deferred::BindLUT()
+void Deferred::HDRShaderHacks()
 {
+	if (globals::state->currentShader && globals::state->currentShader->shaderType.get() == RE::BSShader::Type::ImageSpace) {
+		const auto& isShader = static_cast<const RE::BSImagespaceShader&>(*globals::state->currentShader);
+
+		enum class ShaderAction
+		{
+			Adaptation,
+			HDR
+		};
+
+		static const ankerl::unordered_dense::map<std::string_view, ShaderAction> shaderMap{
+			{ "BSImagespaceShaderHDRDownSample4LightAdapt", ShaderAction::Adaptation },
+			{ "BSImagespaceShaderHDRDownSample16LightAdapt", ShaderAction::Adaptation },
+			{ "BSImagespaceShaderHDRTonemapBlendCinematic", ShaderAction::HDR },
+			{ "BSImagespaceShaderHDRTonemapBlendCinematicFade", ShaderAction::HDR }
+		};
+
+		auto it = shaderMap.find(isShader.name);
+		if (it != shaderMap.cend()) {
+			switch (it->second) {
+			case ShaderAction::Adaptation:
+				BindAdaptationShader();
+				break;
+			case ShaderAction::HDR:
+				BindHDRShader();
+				break;
+			}
+		}
+	}
+}
+
+void Deferred::BindAdaptationShader()
+{
+	uint frameSwap = (globals::state->frameCount % 2);
+
+	auto srv = adaptationTextures[frameSwap]->srv.get();
+	globals::d3d::context->PSSetShaderResources(1, 1, &srv);
+
+	auto rtv = adaptationTextures[!frameSwap]->rtv.get();
+	globals::d3d::context->OMSetRenderTargets(1, &rtv, nullptr);
+}
+
+void Deferred::BindHDRShader()
+{
+	uint frameSwap = (globals::state->frameCount % 2);
+
+	auto srv = adaptationTextures[!frameSwap]->srv.get();
+	globals::d3d::context->PSSetShaderResources(2, 1, &srv);
+
 	auto view = lutTexture.get();
 	if (view)
 		globals::d3d::context->PSSetShaderResources(100, 1, &view);

--- a/src/Deferred.h
+++ b/src/Deferred.h
@@ -35,6 +35,12 @@ public:
 
 	ID3D11ComputeShader* GetComputeMainCompositeInterior();
 
+	void HDRShaderHacks();
+
+	void BindAdaptationShader();
+
+	void BindHDRShader();
+
 	ID3D11BlendState* deferredBlendStates[7][2][13][2];
 	ID3D11BlendState* forwardBlendStates[7][2][13][2];
 
@@ -73,8 +79,8 @@ public:
 	Buffer* perShadow = nullptr;
 	ID3D11ShaderResourceView* shadowView = nullptr;
 
+	Texture2D* adaptationTextures[2];
 	winrt::com_ptr<ID3D11ShaderResourceView> lutTexture = nullptr;
-	void BindLUT();
 
 	struct Hooks
 	{
@@ -108,26 +114,6 @@ public:
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 
-		struct BSImagespaceShaderHDRTonemapBlendCinematic_SetupTechnique
-		{
-			static void thunk(RE::BSShader* a_shader, RE::BSShaderMaterial* a_material)
-			{
-				GetSingleton()->BindLUT();
-				func(a_shader, a_material);
-			}
-			static inline REL::Relocation<decltype(thunk)> func;
-		};
-
-		struct BSImagespaceShaderHDRTonemapBlendCinematicFade_SetupTechnique
-		{
-			static void thunk(RE::BSShader* a_shader, RE::BSShaderMaterial* a_material)
-			{
-				GetSingleton()->BindLUT();
-				func(a_shader, a_material);
-			}
-			static inline REL::Relocation<decltype(thunk)> func;
-		};
-
 		struct Main_RenderFirstPersonView
 		{
 			static void thunk(bool a1, bool a2);
@@ -154,9 +140,6 @@ public:
 				stl::write_thunk_call<Main_RenderFirstPersonView>(REL::RelocationID(35560, 36559).address() + REL::Relocate(0x944, 0x954));
 
 			stl::detour_thunk<Renderer_ResetState>(REL::RelocationID(75570, 77371));
-
-			stl::write_vfunc<0x2, BSImagespaceShaderHDRTonemapBlendCinematic_SetupTechnique>(RE::VTABLE_BSImagespaceShaderHDRTonemapBlendCinematic[0]);
-			stl::write_vfunc<0x2, BSImagespaceShaderHDRTonemapBlendCinematicFade_SetupTechnique>(RE::VTABLE_BSImagespaceShaderHDRTonemapBlendCinematicFade[0]);
 
 			logger::info("[Deferred] Installed hooks");
 		}

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -39,6 +39,8 @@ void State::Draw()
 
 		truePBR->SetShaderResouces(context);
 
+		globals::deferred->HDRShaderHacks();
+
 		if (permutationData != permutationDataPrevious) {
 			permutationCB->Update(permutationData);
 			permutationDataPrevious = permutationData;


### PR DESCRIPTION
Fixes the vanilla adaptation texture randomly not being set, by just replacing it.
This could cause black screens because trying to access the texture would have random results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for HDR adaptation textures, enabling improved HDR light adaptation effects.
  * Introduced dynamic handling of HDR image space shaders, with resources and render targets now bound based on the active shader and frame count.

* **Refactor**
  * Replaced previous LUT binding logic with enhanced HDR shader handling methods.
  * Removed outdated hooks related to cinematic HDR tonemapping shaders for a cleaner integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->