### PR TITLE
ci: allow tag pushes to create draft releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -243,6 +243,22 @@ jobs:
                   }
                   "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
+            - name: Fail if CMake version does not match tag
+              if: success() && github.ref_type == 'tag'
+              shell: pwsh
+              run: |
+                  $tag = '${{ github.ref_name }}'
+                  $expected = $tag.TrimStart('v')
+                  $version = '${{ steps.get_version.outputs.version }}'
+                  if (-not $version -or $version -eq "") {
+                    Write-Error "Version extraction failed: no version found in previous step" -ErrorAction Stop
+                  }
+                  if ($version -ne $expected) {
+                    Write-Error "CMakeLists.txt version '$version' does not match tag version '$expected'. Please update CMakeLists.txt before tagging." -ErrorAction Stop
+                  } else {
+                    Write-Host "CMakeLists.txt version matches tag."
+                  }
+
             - name: Upload dist artifacts
               if: success()
               uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,7 +108,7 @@ jobs:
               github.event.inputs.build-cpp == 'true') ||
             (github.event_name == 'pull_request_target' &&
              !github.event.pull_request.draft) ||
-            (github.event_name == 'release'))
+            (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')))
         name: Build plugin and addons
         runs-on: windows-2022
         permissions:
@@ -259,7 +259,7 @@ jobs:
               !github.event.pull_request.draft) ||
              (github.event_name == 'workflow_dispatch' &&
               github.event.inputs.validate-shaders == 'true') ||
-             (github.event_name == 'release'))
+             (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')))
         name: Validate shader compilation
         runs-on: windows-2022
         permissions:
@@ -606,7 +606,7 @@ jobs:
         if: >
             github.event_name == 'workflow_dispatch' ||
             startsWith(github.ref, 'refs/tags/v') ||
-            github.event_name == 'release'
+            (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')))
         runs-on: windows-2022
         permissions:
             contents: write

--- a/tools/update-cmake-version.ps1
+++ b/tools/update-cmake-version.ps1
@@ -1,0 +1,42 @@
+param(
+    [string]$Tag
+)
+
+if (-not $Tag) {
+    Write-Error "No tag provided. Use -Tag vX.Y.Z"
+    exit 1
+}
+
+# Remove leading 'v' if present
+$version = $Tag.TrimStart('v')
+
+# Path to CMakeLists.txt (assume script run from repo root or CI)
+$cmakeFile = "CMakeLists.txt"
+
+if (-not (Test-Path $cmakeFile)) {
+    Write-Error "CMakeLists.txt not found in current directory."
+    exit 1
+}
+
+# Read all lines
+$lines = Get-Content $cmakeFile
+
+# Find the line with 'VERSION'
+$versionLineIndex = $lines | Select-String -Pattern '^\s*VERSION\s+\d+\.\d+\.\d+' | Select-Object -First 1 | ForEach-Object { $_.LineNumber - 1 }
+
+if ($null -eq $versionLineIndex) {
+    Write-Error "VERSION line not found in CMakeLists.txt."
+    exit 1
+}
+
+$currentVersion = ($lines[$versionLineIndex] -replace '^\s*VERSION\s+([0-9.]+).*', '$1')
+
+if ($currentVersion -eq $version) {
+    Write-Host "CMakeLists.txt already at version $version. No change needed."
+    exit 0
+}
+
+Write-Host "Updating CMakeLists.txt from version $currentVersion to $version."
+$lines[$versionLineIndex] = $lines[$versionLineIndex] -replace 'VERSION\s+[0-9.]+', "VERSION $version"
+$lines | Set-Content $cmakeFile
+Write-Host "CMakeLists.txt updated."

--- a/tools/update-cmake-version.ps1
+++ b/tools/update-cmake-version.ps1
@@ -22,7 +22,7 @@ if (-not (Test-Path $cmakeFile)) {
 $lines = Get-Content $cmakeFile
 
 # Find the line with 'VERSION'
-$versionLineIndex = $lines | Select-String -Pattern '^\s*VERSION\s+\d+\.\d+\.\d+' | Select-Object -First 1 | ForEach-Object { $_.LineNumber - 1 }
+$versionLineIndex = $lines | Select-String -Pattern '^\s*VERSION\s+\d+\.\d+\.\d+(\.\d+)?' | Select-Object -First 1 | ForEach-Object { $_.LineNumber - 1 }
 
 if ($null -eq $versionLineIndex) {
     Write-Error "VERSION line not found in CMakeLists.txt."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflow triggers to run builds and releases only on version tag pushes.
  * Added a version consistency check between Git tags and CMake configuration during the build process.
  * Introduced a new script to easily update the version number in CMake configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->