### PR TITLE
refactor(perf overlay): tidy up perf overlay state update

### DIFF
--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -242,9 +242,6 @@ void PerformanceOverlay::DrawOverlay()
 		return;
 	}
 
-	// Check if Frame Generation is active
-	this->state.isFrameGenerationActive = globals::upscaling && globals::upscaling->IsFrameGenerationActive();
-
 	// Build draw call rows ONCE per frame and reuse
 	auto [mainRows, summaryRows] = this->BuildDrawCallRows();
 	std::vector<DrawCallRow> allRows = mainRows;
@@ -1872,6 +1869,18 @@ void PerformanceOverlay::UpdateSummaryTestData(float smoothedFrameTime, float ot
 
 void PerformanceOverlay::UpdateGraphValues()
 {
+	// Check if Frame Generation is active
+	state.isFrameGenerationActive = globals::upscaling && globals::upscaling->IsFrameGenerationActive();
+
+	// Sync frame history buffer size with user settings
+	settings.FrameHistorySize = std::clamp(
+		settings.FrameHistorySize,
+		settings.kMinFrameHistorySize,
+		settings.kMaxFrameHistorySize);
+	state.frameTimeHistory.Resize(settings.FrameHistorySize);
+	state.postFGFrameTimeHistory.Resize(settings.FrameHistorySize);
+
+	// Calculate counter deltas
 	REX::W32::QueryPerformanceCounter(&state.currentFrameCounter);
 	int64_t elapsedCounter = state.currentFrameCounter - state.lastFrameCounter;
 	state.lastFrameCounter = state.currentFrameCounter;
@@ -1893,14 +1902,7 @@ void PerformanceOverlay::UpdateGraphValues()
 	                  static_cast<float>(state.overlayTimingFrequency.QuadPart);
 	state.lastUpdateTime = now;
 
-	// Sync frame history buffer size with user settings
-	settings.FrameHistorySize = std::clamp(
-		settings.FrameHistorySize,
-		settings.kMinFrameHistorySize,
-		settings.kMaxFrameHistorySize);
-	state.frameTimeHistory.Resize(settings.FrameHistorySize);
-	state.postFGFrameTimeHistory.Resize(settings.FrameHistorySize);
-
+	// WHAT DOES oldFrameTime EVEN MEAN???????
 	// Insert latest frame time into circular buffer
 	float oldFrameTime = state.frameTimeHistory.GetData()[state.frameTimeHistory.GetHeadIdx()];
 	state.frameTimeHistory.Push(state.frameTimeMs);
@@ -1944,7 +1946,7 @@ void PerformanceOverlay::UpdateGraphValues()
 	state.smoothedMinFrameTime = state.smoothedMinFrameTime + Settings::kSmoothingFactor * (graphMin - state.smoothedMinFrameTime);
 	state.smoothedMaxFrameTime = state.smoothedMaxFrameTime + Settings::kSmoothingFactor * (graphMax - state.smoothedMaxFrameTime);
 
-	if (state.isFrameGenerationActive && globals::upscaling) {
+	if (state.isFrameGenerationActive) {
 		// Get frametime directly from the Frame Generation system
 		float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
 
@@ -1955,8 +1957,8 @@ void PerformanceOverlay::UpdateGraphValues()
 			state.postFGFps = 1000.0f / state.postFGFrameTimeMs;
 		} else {
 			// Fallback if FG time is not available
-			state.postFGFrameTimeMs = state.frameTimeMs / PerformanceOverlay::Settings::kFrameGenerationMultiplier;
-			state.postFGFps = state.fps * PerformanceOverlay::Settings::kFrameGenerationMultiplier;
+			state.postFGFrameTimeMs = state.frameTimeMs / Settings::kFrameGenerationMultiplier;
+			state.postFGFps = state.fps * Settings::kFrameGenerationMultiplier;
 		}
 
 		// Update post-FG smooth values when timer elapses
@@ -1972,7 +1974,7 @@ void PerformanceOverlay::UpdateGraphValues()
 	// Update smooth values with user-specified interval
 	state.updateTimer += deltaTime;
 	if (state.updateTimer >= settings.UpdateInterval) {
-		state.smoothFps = state.fps;
+		state.smoothFps = state.fps;  // Sampling white noise won't give you smoothed noise. This is useless.
 		state.smoothFrameTimeMs = state.frameTimeMs;
 		state.updateTimer = 0.0f;
 	}

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -100,7 +100,7 @@ static std::tuple<float, float, float> CalculateSummaryData(float smoothedFrameT
 }
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
-	PerformanceOverlay::PerfOverlaySettings,
+	PerformanceOverlay::Settings,
 	ShowInOverlay,
 	ShowDrawCalls,
 	ShowVRAM,
@@ -197,7 +197,7 @@ void PerformanceOverlay::DrawSettings()
 			ImGui::SliderFloat("Text Size", &this->settings.TextSize, 0.8f, 1.2f, "%.2f");
 			ImGui::SliderFloat("Background Opacity", &this->settings.BackgroundOpacity, 0.0f, 1.0f, "%.2f");
 			ImGui::Checkbox("Show Border", &this->settings.ShowBorder);
-			ImGui::SliderFloat("Update Interval", &this->settings.UpdateInterval, 0.001f, PerformanceOverlay::PerfOverlaySettings::kMaxUpdateInterval, "%.2f seconds");
+			ImGui::SliderFloat("Update Interval", &this->settings.UpdateInterval, 0.001f, PerformanceOverlay::Settings::kMaxUpdateInterval, "%.2f seconds");
 			ImGui::SliderInt("Frame History Size", &this->settings.FrameHistorySize,
 				this->settings.kMinFrameHistorySize, this->settings.kMaxFrameHistorySize);
 
@@ -216,10 +216,10 @@ void PerformanceOverlay::DrawSettings()
 void PerformanceOverlay::DataLoaded()
 {
 	// Initialize performance overlay state
-	REX::W32::QueryPerformanceFrequency(&this->perfOverlayState.frequency);
-	REX::W32::QueryPerformanceCounter(&this->perfOverlayState.lastFrameCounter);
-	this->perfOverlayState.frameTimeHistory.Resize(this->settings.FrameHistorySize);
-	this->perfOverlayState.postFGFrameTimeHistory.Resize(this->settings.FrameHistorySize);
+	REX::W32::QueryPerformanceFrequency(&this->state.frequency);
+	REX::W32::QueryPerformanceCounter(&this->state.lastFrameCounter);
+	this->state.frameTimeHistory.Resize(this->settings.FrameHistorySize);
+	this->state.postFGFrameTimeHistory.Resize(this->settings.FrameHistorySize);
 }
 
 void PerformanceOverlay::DrawOverlay()
@@ -243,7 +243,7 @@ void PerformanceOverlay::DrawOverlay()
 	}
 
 	// Check if Frame Generation is active
-	this->perfOverlayState.isFrameGenerationActive = globals::upscaling && globals::upscaling->IsFrameGenerationActive();
+	this->state.isFrameGenerationActive = globals::upscaling && globals::upscaling->IsFrameGenerationActive();
 
 	// Build draw call rows ONCE per frame and reuse
 	auto [mainRows, summaryRows] = this->BuildDrawCallRows();
@@ -276,8 +276,8 @@ void PerformanceOverlay::DrawOverlay()
 
 	// Set initial position if not already set
 	if (!this->settings.PositionSet) {
-		ImGui::SetNextWindowPos(ImVec2(PerformanceOverlay::PerfOverlaySettings::kDefaultWindowPadding, PerformanceOverlay::PerfOverlaySettings::kDefaultWindowPadding));
-		this->settings.Position = ImVec2(PerformanceOverlay::PerfOverlaySettings::kDefaultWindowPadding, PerformanceOverlay::PerfOverlaySettings::kDefaultWindowPadding);
+		ImGui::SetNextWindowPos(ImVec2(PerformanceOverlay::Settings::kDefaultWindowPadding, PerformanceOverlay::Settings::kDefaultWindowPadding));
+		this->settings.Position = ImVec2(PerformanceOverlay::Settings::kDefaultWindowPadding, PerformanceOverlay::Settings::kDefaultWindowPadding);
 		this->settings.PositionSet = true;
 	} else {
 		ImGui::SetNextWindowPos(this->settings.Position, ImGuiCond_FirstUseEver);
@@ -285,7 +285,7 @@ void PerformanceOverlay::DrawOverlay()
 
 	// Set window size based on whether graphs are shown, was rapidly changing size based on text
 	bool hasGraphs = this->settings.ShowPreFGFrameTimeGraph ||
-	                 (this->settings.ShowPostFGFrameTimeGraph && this->perfOverlayState.isFrameGenerationActive);
+	                 (this->settings.ShowPostFGFrameTimeGraph && this->state.isFrameGenerationActive);
 	if (!hasGraphs) {
 		// Calculate minimum width needed based on actual content
 		float minWidth = 0.0f;
@@ -293,24 +293,24 @@ void PerformanceOverlay::DrawOverlay()
 		// Calculate width needed for each enabled section
 		if (this->settings.ShowFPS) {
 			// Measure FPS text width
-			std::string fpsText = std::format("{:.1f} ({:.2f} ms)", this->perfOverlayState.smoothFps, this->perfOverlayState.smoothFrameTimeMs);
-			if (this->perfOverlayState.isFrameGenerationActive) {
-				fpsText = std::format("Raw FPS: {:.1f} ({:.2f} ms)", this->perfOverlayState.smoothFps, this->perfOverlayState.smoothFrameTimeMs);
+			std::string fpsText = std::format("{:.1f} ({:.2f} ms)", this->state.smoothFps, this->state.smoothFrameTimeMs);
+			if (this->state.isFrameGenerationActive) {
+				fpsText = std::format("Raw FPS: {:.1f} ({:.2f} ms)", this->state.smoothFps, this->state.smoothFrameTimeMs);
 			}
 			float fpsWidth = ImGui::CalcTextSize(fpsText.c_str()).x;
-			minWidth = std::max(minWidth, fpsWidth + PerformanceOverlay::PerfOverlaySettings::kLabelPadding);  // Add padding for labels
+			minWidth = std::max(minWidth, fpsWidth + PerformanceOverlay::Settings::kLabelPadding);  // Add padding for labels
 		}
 		if (this->settings.ShowDrawCalls) {
 			// Draw calls table needs significant width for all columns
-			minWidth = std::max(minWidth, PerformanceOverlay::PerfOverlaySettings::kDrawCallsTableWidth * this->settings.TextSize);
+			minWidth = std::max(minWidth, PerformanceOverlay::Settings::kDrawCallsTableWidth * this->settings.TextSize);
 		}
 		if (this->settings.ShowVRAM && menu->GetDXGIAdapter3()) {
 			// VRAM section needs width for the progress bar and text
-			minWidth = std::max(minWidth, PerformanceOverlay::PerfOverlaySettings::kVRAMSectionWidth * this->settings.TextSize);
+			minWidth = std::max(minWidth, PerformanceOverlay::Settings::kVRAMSectionWidth * this->settings.TextSize);
 		}
 
 		// Add some padding for window borders and spacing
-		minWidth += PerformanceOverlay::PerfOverlaySettings::kWindowBorderPadding;
+		minWidth += PerformanceOverlay::Settings::kWindowBorderPadding;
 
 		// Set minimum width, but allow auto-resize for larger content
 		ImGui::SetNextWindowSize(ImVec2(minWidth, 0), ImGuiCond_FirstUseEver);
@@ -333,37 +333,8 @@ void PerformanceOverlay::DrawOverlay()
 	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4.0f, 1.0f));  // Tighter spacing
 	ImGui::SetWindowFontScale(this->settings.TextSize);
 
-	REX::W32::QueryPerformanceCounter(&this->perfOverlayState.currentFrameCounter);
-	int64_t elapsedCounter = this->perfOverlayState.currentFrameCounter - this->perfOverlayState.lastFrameCounter;
-	this->perfOverlayState.lastFrameCounter = this->perfOverlayState.currentFrameCounter;
-
-	// Calculate frametime and fps
-	this->perfOverlayState.frameTimeMs = Util::CalcFrameTime(elapsedCounter, this->perfOverlayState.frequency);
-	this->perfOverlayState.fps = Util::CalcFPS(this->perfOverlayState.frameTimeMs);
-
-	// Calculate smooth values for display using the user-defined update interval
-	// Initialize overlay timing frequency if needed
-	if (this->perfOverlayState.overlayTimingFrequency.QuadPart == 0) {
-		QueryPerformanceFrequency(&this->perfOverlayState.overlayTimingFrequency);
-		QueryPerformanceCounter(&this->perfOverlayState.lastUpdateTime);
-	}
-
-	LARGE_INTEGER now;
-	QueryPerformanceCounter(&now);
-	float deltaTime = (now.QuadPart - this->perfOverlayState.lastUpdateTime.QuadPart) /
-	                  static_cast<float>(this->perfOverlayState.overlayTimingFrequency.QuadPart);
-	this->perfOverlayState.lastUpdateTime = now;
-
 	// Update graph values
-	this->perfOverlayState.UpdateGraphValues();
-
-	// Update smooth values with user-specified interval
-	this->perfOverlayState.updateTimer += deltaTime;
-	if (this->perfOverlayState.updateTimer >= this->settings.UpdateInterval) {
-		this->perfOverlayState.smoothFps = this->perfOverlayState.fps;
-		this->perfOverlayState.smoothFrameTimeMs = this->perfOverlayState.frameTimeMs;  // TODO: is smoothFrameTimeMs smoothed at all?
-		this->perfOverlayState.updateTimer = 0.0f;
-	}
+	this->UpdateGraphValues();
 
 	// Check if we should show collapsible sections (should swallow input only)
 	bool showCollapsibleSections = Menu::GetSingleton()->ShouldSwallowInput();
@@ -422,15 +393,15 @@ void PerformanceOverlay::DrawFPS()
 		ImGui::TableSetupColumn("##value");
 
 		ImGui::TableNextColumn();
-		ImGui::Text(this->perfOverlayState.isFrameGenerationActive ? "Raw FPS:" : "FPS:");
+		ImGui::Text(this->state.isFrameGenerationActive ? "Raw FPS:" : "FPS:");
 		ImGui::TableNextColumn();
-		ImGui::Text("%.1f (%.2f ms)", this->perfOverlayState.smoothFps, this->perfOverlayState.smoothFrameTimeMs);
+		ImGui::Text("%.1f (%.2f ms)", this->state.smoothFps, this->state.smoothFrameTimeMs);
 
-		if (this->perfOverlayState.isFrameGenerationActive) {
+		if (this->state.isFrameGenerationActive) {
 			ImGui::TableNextColumn();
 			ImGui::Text("Post-FG FPS:");
 			ImGui::TableNextColumn();
-			ImGui::Text("%.1f (%.2f ms)", this->perfOverlayState.postFGSmoothFps, this->perfOverlayState.postFGSmoothFrameTimeMs);
+			ImGui::Text("%.1f (%.2f ms)", this->state.postFGSmoothFps, this->state.postFGSmoothFrameTimeMs);
 		}
 
 		ImGui::EndTable();
@@ -442,8 +413,8 @@ void PerformanceOverlay::DrawFPS()
 		char overlay_text[128];
 		snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
 			"%s%.2f ms (%.1f FPS)",
-			this->perfOverlayState.isFrameGenerationActive ? "Pre-FG: " : "",
-			this->perfOverlayState.smoothFrameTimeMs, this->perfOverlayState.smoothFps);
+			this->state.isFrameGenerationActive ? "Pre-FG: " : "",
+			this->state.smoothFrameTimeMs, this->state.smoothFps);
 
 		// Set graph colors
 		ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));  // Green line
@@ -451,11 +422,11 @@ void PerformanceOverlay::DrawFPS()
 		// Draw the graph
 		float graphWidth = ImGui::GetWindowWidth() * 0.9f;
 		ImGui::PlotLines("##frametime",
-			this->perfOverlayState.frameTimeHistory.GetData().data(),
+			this->state.frameTimeHistory.GetData().data(),
 			this->settings.FrameHistorySize,
-			static_cast<int>(this->perfOverlayState.frameTimeHistory.GetHeadIdx()),
+			static_cast<int>(this->state.frameTimeHistory.GetHeadIdx()),
 			overlay_text,
-			this->perfOverlayState.smoothedMinFrameTime, this->perfOverlayState.smoothedMaxFrameTime,
+			this->state.smoothedMinFrameTime, this->state.smoothedMaxFrameTime,
 			ImVec2(graphWidth, 50.0f * this->settings.TextSize));
 
 		ImGui::PopStyleColor();
@@ -476,7 +447,7 @@ void PerformanceOverlay::DrawFPS()
 	}
 
 	// Show Post-FG frametime graph if enabled
-	if (this->settings.ShowPostFGFrameTimeGraph && this->perfOverlayState.isFrameGenerationActive) {
+	if (this->settings.ShowPostFGFrameTimeGraph && this->state.isFrameGenerationActive) {
 		// Check if FSR frame generation is active (FSR doesn't provide timing data)
 		bool isFSRFrameGen = globals::fidelityFX && globals::fidelityFX->isFrameGenActive;
 
@@ -922,7 +893,7 @@ std::vector<ColumnConfig> PerformanceOverlay::BuildABTestResultsTableColumns(con
 					color = theme.StatusPalette.Error;  // Worse performance (positive delta)
 				}
 				ImGui::PushStyleColor(ImGuiCol_Text, color);
-				ImGui::Text("%s", Util::FormatDeltaWithPercent(row.frameTime, *row.testFrameTime, PerformanceOverlay::PerfOverlaySettings::kPercentDisplayThreshold).c_str());
+				ImGui::Text("%s", Util::FormatDeltaWithPercent(row.frameTime, *row.testFrameTime, PerformanceOverlay::Settings::kPercentDisplayThreshold).c_str());
 				ImGui::PopStyleColor();
 				if (ImGui::IsItemHovered()) {
 					if (auto _tt = Util::HoverTooltipWrapper()) {
@@ -1442,7 +1413,7 @@ std::vector<ColumnConfig> PerformanceOverlay::BuildDrawCallTableColumns(const Me
 
 	columns.push_back(ColumnConfig{
 		legends.frameTime.header,
-		MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.frameTime; }, [](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, PerformanceOverlay::PerfOverlaySettings::kFrameTimeGoodThreshold, PerformanceOverlay::PerfOverlaySettings::kFrameTimeWarningThreshold, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); }, [](float /*value*/, const DrawCallRow& row) { return Util::FormatMilliseconds(row.frameTime) + " (" + Util::FormatPercent(row.percent) + ")"; }, legends.frameTime.tooltip), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.percent < b.percent) : (a.percent > b.percent); }, [legends]() {
+		MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.frameTime; }, [](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, PerformanceOverlay::Settings::kFrameTimeGoodThreshold, PerformanceOverlay::Settings::kFrameTimeWarningThreshold, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); }, [](float /*value*/, const DrawCallRow& row) { return Util::FormatMilliseconds(row.frameTime) + " (" + Util::FormatPercent(row.percent) + ")"; }, legends.frameTime.tooltip), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.percent < b.percent) : (a.percent > b.percent); }, [legends]() {
 			 if (ImGui::IsItemHovered()) {
 				 if (auto _tt = Util::HoverTooltipWrapper()) {
 					 Util::DrawColoredMultiLineTooltip(legends.frameTime.tooltip);
@@ -1451,7 +1422,7 @@ std::vector<ColumnConfig> PerformanceOverlay::BuildDrawCallTableColumns(const Me
 
 	columns.push_back(ColumnConfig{
 		legends.costPerCall.header,
-		MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.costPerCall; }, [](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, PerformanceOverlay::PerfOverlaySettings::kCostPerCallGoodThreshold, PerformanceOverlay::PerfOverlaySettings::kCostPerCallWarningThreshold, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); }, [](float value, const DrawCallRow&) { return (value < PerformanceOverlay::PerfOverlaySettings::kMicrosecondThreshold && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); }, legends.costPerCall.tooltip), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall); }, [legends]() {
+		MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.costPerCall; }, [](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, PerformanceOverlay::Settings::kCostPerCallGoodThreshold, PerformanceOverlay::Settings::kCostPerCallWarningThreshold, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); }, [](float value, const DrawCallRow&) { return (value < PerformanceOverlay::Settings::kMicrosecondThreshold && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); }, legends.costPerCall.tooltip), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall); }, [legends]() {
 			 if (ImGui::IsItemHovered()) {
 				 if (auto _tt = Util::HoverTooltipWrapper()) {
 					 Util::DrawColoredMultiLineTooltip(legends.costPerCall.tooltip);
@@ -1484,7 +1455,7 @@ std::vector<ColumnConfig> PerformanceOverlay::BuildDrawCallTableColumns(const Me
 						 return theme.StatusPalette.SuccessColor;
 					 if (value > row.costPerCall)
 						 return theme.StatusPalette.Error;
-					 return theme.Palette.Text; }, [](float value, const DrawCallRow&) { return (value < PerformanceOverlay::PerfOverlaySettings::kMicrosecondThreshold && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); }, legends.testCostPerCall.tooltip), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+					 return theme.Palette.Text; }, [](float value, const DrawCallRow&) { return (value < PerformanceOverlay::Settings::kMicrosecondThreshold && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); }, legends.testCostPerCall.tooltip), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
 				 float aVal = a.testCostPerCall.value_or(FLT_MAX);
 				 float bVal = b.testCostPerCall.value_or(FLT_MAX);
 				 return asc ? (aVal < bVal) : (aVal > bVal); }, [legends]() {
@@ -1501,7 +1472,7 @@ std::vector<ColumnConfig> PerformanceOverlay::BuildDrawCallTableColumns(const Me
 std::pair<std::vector<DrawCallRow>, std::vector<DrawCallRow>> PerformanceOverlay::BuildDrawCallRows() const
 {
 	std::vector<DrawCallRow> mainRows;
-	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.smoothFrameTimeMs);
+	float smoothedFrameTime = static_cast<float>(this->state.smoothFrameTimeMs);
 	float measuredSum = 0.0f;
 
 	globals::state->ForEachShaderTypeWithMetrics([&mainRows, &measuredSum, smoothedFrameTime, this](auto type, int typeIndex, float drawCalls, float frameTime, float percent, float costPerCall) {
@@ -1635,7 +1606,7 @@ void PerformanceOverlay::HandleShaderToggle(const DrawCallRow& row, bool wasEnab
 	float prevCostPerCall = row.costPerCall;
 
 	// Capture live data for Total and Other before toggling
-	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.smoothFrameTimeMs);
+	float smoothedFrameTime = static_cast<float>(this->state.smoothFrameTimeMs);
 	float measuredSum = 0.0f;
 	globals::state->ForEachShaderTypeWithMetrics([&measuredSum]([[maybe_unused]] auto type, [[maybe_unused]] int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, [[maybe_unused]] float percent, [[maybe_unused]] float costPerCall) {
 		measuredSum += frameTime;
@@ -1682,7 +1653,7 @@ void PerformanceOverlay::HandleTotalRowToggle()
 		this->UpdateAllShaderTestData();
 	} else {
 		// Manual toggle: update test data and timestamp
-		float smoothedFrameTime = static_cast<float>(this->perfOverlayState.smoothFrameTimeMs);
+		float smoothedFrameTime = static_cast<float>(this->state.smoothFrameTimeMs);
 		float measuredSum = 0.0f;
 		globals::state->ForEachShaderTypeWithMetrics([&measuredSum]([[maybe_unused]] auto type, [[maybe_unused]] int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, [[maybe_unused]] float percent, [[maybe_unused]] float costPerCall) {
 			measuredSum += frameTime;
@@ -1718,7 +1689,7 @@ void PerformanceOverlay::UpdateShaderTestData(int shaderType, float frameTime, f
 {
 	UpdateShaderTestDataEntry(shaderType, frameTime, costPerCall);
 
-	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.smoothFrameTimeMs);
+	float smoothedFrameTime = static_cast<float>(this->state.smoothFrameTimeMs);
 	float measuredSum = 0.0f;
 	for (const auto& [type, data] : testData) {
 		if (type >= 0)
@@ -1766,7 +1737,7 @@ void PerformanceOverlay::UpdateAllShaderTestData()
 		return;
 	}
 
-	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.smoothFrameTimeMs);
+	float smoothedFrameTime = static_cast<float>(this->state.smoothFrameTimeMs);
 	float measuredSum = 0.0f;
 
 	globals::state->ForEachShaderTypeWithMetrics([&measuredSum, smoothedFrameTime, this]([[maybe_unused]] auto type, int typeIndex, [[maybe_unused]] float drawCalls, float frameTime, float percent, float costPerCall) {
@@ -1784,9 +1755,9 @@ std::string PerformanceOverlay::GetTestDataTooltip() const
 {
 	switch (testDataSource) {
 	case TestDataSource::ABTest_VariantB:
-		return std::string("Test data from Test (Variant B).\nLast updated: ") + Util::TimeAgoStringQPC(testDataLastUpdated, perfOverlayState.overlayTimingFrequency) + " ago.";
+		return std::string("Test data from Test (Variant B).\nLast updated: ") + Util::TimeAgoStringQPC(testDataLastUpdated, state.overlayTimingFrequency) + " ago.";
 	case TestDataSource::ManualShaderToggle:
-		return std::string("Test data from manual shader toggle.\nLast updated: ") + Util::TimeAgoStringQPC(testDataLastUpdated, perfOverlayState.overlayTimingFrequency) + " ago.";
+		return std::string("Test data from manual shader toggle.\nLast updated: ") + Util::TimeAgoStringQPC(testDataLastUpdated, state.overlayTimingFrequency) + " ago.";
 	default:
 		return "No test data available.";
 	}
@@ -1811,7 +1782,7 @@ void PerformanceOverlay::CaptureTestData()
 			anyShaderDisabled = true;
 		}
 	});
-	float smoothedFrameTime = static_cast<float>(this->perfOverlayState.smoothFrameTimeMs);
+	float smoothedFrameTime = static_cast<float>(this->state.smoothFrameTimeMs);
 	float measuredSum = 0.0f;
 	if (abTestActive) {
 		measuredSum = 0.0f;
@@ -1860,97 +1831,114 @@ void PerformanceOverlay::UpdateSummaryTestData(float smoothedFrameTime, float ot
 // PERFORMANCE OVERLAY STATE MANAGEMENT
 // ============================================================================
 
-void PerformanceOverlay::PerfOverlayState::UpdateFGFrameTime()
+void PerformanceOverlay::UpdateGraphValues()
 {
-	// Defensive: Check for upscaling pointer
-	if (!globals::upscaling)
-		return;
+	REX::W32::QueryPerformanceCounter(&state.currentFrameCounter);
+	int64_t elapsedCounter = state.currentFrameCounter - state.lastFrameCounter;
+	state.lastFrameCounter = state.currentFrameCounter;
 
-	// Get frametime directly from the Frame Generation system
-	float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
+	// Calculate frametime and fps
+	state.frameTimeMs = Util::CalcFrameTime(elapsedCounter, state.frequency);
+	state.fps = Util::CalcFPS(state.frameTimeMs);
 
-	// Check if FSR frame generation is active (FSR doesn't provide timing data)
-	bool isFSRFrameGen = globals::fidelityFX && globals::fidelityFX->isFrameGenActive;
-	if (fgDeltaTime > 0.0f && !isFSRFrameGen) {
-		postFGFrameTimeMs = fgDeltaTime * 1000.0f;
-		postFGFps = 1000.0f / postFGFrameTimeMs;
-	} else {
-		// Fallback if FG time is not available
-		postFGFrameTimeMs = frameTimeMs / PerformanceOverlay::PerfOverlaySettings::kFrameGenerationMultiplier;
-		postFGFps = fps * PerformanceOverlay::PerfOverlaySettings::kFrameGenerationMultiplier;
+	// Calculate smooth values for display using the user-defined update interval
+	// Initialize overlay timing frequency if needed
+	if (state.overlayTimingFrequency.QuadPart == 0) {
+		QueryPerformanceFrequency(&state.overlayTimingFrequency);
+		QueryPerformanceCounter(&state.lastUpdateTime);
 	}
 
-	// Update post-FG smooth values when timer elapses
-	if (updateTimer <= 0.0f) {
-		postFGSmoothFps = postFGFps;
-		postFGSmoothFrameTimeMs = postFGFrameTimeMs;
-	}
-
-	// Update post-FG frametime history
-	postFGFrameTimeHistory.Push(postFGFrameTimeMs);
-}
-
-void PerformanceOverlay::PerfOverlayState::UpdateGraphValues()
-{
-	// Get settings from the singleton
-	auto& overlaySettings = globals::features::performanceOverlay.settings;
+	LARGE_INTEGER now;
+	QueryPerformanceCounter(&now);
+	float deltaTime = (now.QuadPart - state.lastUpdateTime.QuadPart) /
+	                  static_cast<float>(state.overlayTimingFrequency.QuadPart);
+	state.lastUpdateTime = now;
 
 	// Sync frame history buffer size with user settings
-	overlaySettings.FrameHistorySize = std::clamp(
-		overlaySettings.FrameHistorySize,
-		overlaySettings.kMinFrameHistorySize,
-		overlaySettings.kMaxFrameHistorySize);
-	frameTimeHistory.Resize(overlaySettings.FrameHistorySize);
-	postFGFrameTimeHistory.Resize(overlaySettings.FrameHistorySize);
+	settings.FrameHistorySize = std::clamp(
+		settings.FrameHistorySize,
+		settings.kMinFrameHistorySize,
+		settings.kMaxFrameHistorySize);
+	state.frameTimeHistory.Resize(settings.FrameHistorySize);
+	state.postFGFrameTimeHistory.Resize(settings.FrameHistorySize);
 
 	// Insert latest frame time into circular buffer
-	float oldFrameTime = frameTimeHistory.GetData()[frameTimeHistory.GetHeadIdx()];
-	frameTimeHistory.Push(frameTimeMs);
+	float oldFrameTime = state.frameTimeHistory.GetData()[state.frameTimeHistory.GetHeadIdx()];
+	state.frameTimeHistory.Push(state.frameTimeMs);
 
 	// Maintain instantaneous min/max tracking
-	if (frameTimeMs > maxFrameTime) {
-		maxFrameTime = frameTimeMs;
-	} else if (frameTimeMs < minFrameTime) {
-		minFrameTime = frameTimeMs;
-	} else if (oldFrameTime == minFrameTime) {
-		minFrameTime = *std::ranges::min_element(frameTimeHistory.GetData());
-	} else if (oldFrameTime == maxFrameTime) {
-		maxFrameTime = *std::ranges::max_element(frameTimeHistory.GetData());
+	if (state.frameTimeMs > state.maxFrameTime) {
+		state.maxFrameTime = state.frameTimeMs;
+	} else if (state.frameTimeMs < state.minFrameTime) {
+		state.minFrameTime = state.frameTimeMs;
+	} else if (oldFrameTime == state.minFrameTime) {
+		state.minFrameTime = *std::ranges::min_element(state.frameTimeHistory.GetData());
+	} else if (oldFrameTime == state.maxFrameTime) {
+		state.maxFrameTime = *std::ranges::max_element(state.frameTimeHistory.GetData());
 	}
 
 	float avgFrameTime, stdDev, graphMin, graphMax;
 	// Calculate mean and standard deviation for normalized graph range
-	if (frameTimeHistory.GetData().empty()) {
+	if (state.frameTimeHistory.GetData().empty()) {
 		// Default to 60 FPS
 		avgFrameTime = kDefaultFrameTimeMs;
 		stdDev = 0.0f;
 		graphMin = 0.0f;
-		graphMax = PerformanceOverlay::PerfOverlaySettings::kGraphSpreadMultiplier * kDefaultFrameTimeMs;
+		graphMax = Settings::kGraphSpreadMultiplier * kDefaultFrameTimeMs;
 	} else {
 		// Calculate average frame time
-		avgFrameTime = std::accumulate(frameTimeHistory.GetData().begin(), frameTimeHistory.GetData().end(), 0.0f) / frameTimeHistory.GetData().size();
+		avgFrameTime = std::accumulate(state.frameTimeHistory.GetData().begin(), state.frameTimeHistory.GetData().end(), 0.0f) / state.frameTimeHistory.GetData().size();
 
 		// Calculate standard deviation
 		float variance = 0.0f;
-		for (float ft : frameTimeHistory.GetData()) {
+		for (float ft : state.frameTimeHistory.GetData()) {
 			float diff = ft - avgFrameTime;
 			variance += diff * diff;
 		}
-		variance /= frameTimeHistory.GetData().size();
+		variance /= state.frameTimeHistory.GetData().size();
 		stdDev = std::sqrt(variance);
 
 		// Calculate graph range
-		float spread = std::clamp(stdDev * PerformanceOverlay::PerfOverlaySettings::kGraphSpreadMultiplier, PerformanceOverlay::PerfOverlaySettings::kGraphMinSpread, PerformanceOverlay::PerfOverlaySettings::kGraphMaxSpread);
+		float spread = std::clamp(stdDev * Settings::kGraphSpreadMultiplier, Settings::kGraphMinSpread, Settings::kGraphMaxSpread);
 		graphMin = std::max(0.0f, avgFrameTime - spread);
 		graphMax = avgFrameTime + spread;
 	}
 
 	// Exponential smoothing for stable graph scaling
-	smoothedMinFrameTime = smoothedMinFrameTime + PerformanceOverlay::PerfOverlaySettings::kSmoothingFactor * (graphMin - smoothedMinFrameTime);
-	smoothedMaxFrameTime = smoothedMaxFrameTime + PerformanceOverlay::PerfOverlaySettings::kSmoothingFactor * (graphMax - smoothedMaxFrameTime);
+	state.smoothedMinFrameTime = state.smoothedMinFrameTime + Settings::kSmoothingFactor * (graphMin - state.smoothedMinFrameTime);
+	state.smoothedMaxFrameTime = state.smoothedMaxFrameTime + Settings::kSmoothingFactor * (graphMax - state.smoothedMaxFrameTime);
 
-	if (isFrameGenerationActive) {
-		UpdateFGFrameTime();
+	if (state.isFrameGenerationActive && globals::upscaling) {
+		// Get frametime directly from the Frame Generation system
+		float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
+
+		// Check if FSR frame generation is active (FSR doesn't provide timing data)
+		bool isFSRFrameGen = globals::fidelityFX && globals::fidelityFX->isFrameGenActive;
+		if (fgDeltaTime > 0.0f && !isFSRFrameGen) {
+			state.postFGFrameTimeMs = fgDeltaTime * 1000.0f;
+			state.postFGFps = 1000.0f / state.postFGFrameTimeMs;
+		} else {
+			// Fallback if FG time is not available
+			state.postFGFrameTimeMs = state.frameTimeMs / PerformanceOverlay::Settings::kFrameGenerationMultiplier;
+			state.postFGFps = state.fps * PerformanceOverlay::Settings::kFrameGenerationMultiplier;
+		}
+
+		// Update post-FG smooth values when timer elapses
+		if (state.updateTimer <= 0.0f) {
+			state.postFGSmoothFps = state.postFGFps;
+			state.postFGSmoothFrameTimeMs = state.postFGFrameTimeMs;
+		}
+
+		// Update post-FG frametime history
+		state.postFGFrameTimeHistory.Push(state.postFGFrameTimeMs);
+	}
+
+	// Update smooth values with user-specified interval
+	state.updateTimer += deltaTime;
+	if (state.updateTimer >= settings.UpdateInterval) {
+		state.smoothFps = state.fps;
+		state.smoothFrameTimeMs = state.frameTimeMs;  // TODO: is smoothFrameTimeMs smoothed at all?
+		state.updateTimer = 0.0f;
 	}
 }
 
@@ -1960,7 +1948,7 @@ void PerformanceOverlay::DrawPostFGFrameTimeGraph()
 	char overlay_text[128];
 	snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
 		"Post-FG: %.2f ms (%.1f FPS)",
-		perfOverlayState.postFGSmoothFrameTimeMs, perfOverlayState.postFGSmoothFps);
+		state.postFGSmoothFrameTimeMs, state.postFGSmoothFps);
 
 	// Set graph colors - blue for post-FG
 	ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
@@ -1968,11 +1956,11 @@ void PerformanceOverlay::DrawPostFGFrameTimeGraph()
 	// Draw the graph
 	float graphWidth = ImGui::GetWindowWidth() * 0.9f;
 	ImGui::PlotLines("##postfgframetime",
-		perfOverlayState.postFGFrameTimeHistory.GetData().data(),
+		state.postFGFrameTimeHistory.GetData().data(),
 		settings.FrameHistorySize,
-		static_cast<int>(perfOverlayState.postFGFrameTimeHistory.GetHeadIdx()),
+		static_cast<int>(state.postFGFrameTimeHistory.GetHeadIdx()),
 		overlay_text,
-		perfOverlayState.smoothedMinFrameTime, perfOverlayState.smoothedMaxFrameTime,
+		state.smoothedMinFrameTime, state.smoothedMaxFrameTime,
 		ImVec2(graphWidth, 50.0f * settings.TextSize));
 
 	ImGui::PopStyleColor();

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -504,6 +504,45 @@ void PerformanceOverlay::DrawVRAM()
 		ImGui::Text("VRAM Usage: Not available");
 	}
 }
+
+void PerformanceOverlay::DrawPostFGFrameTimeGraph()
+{
+	// Prepare overlay text
+	char overlay_text[128];
+	snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
+		"Post-FG: %.2f ms (%.1f FPS)",
+		state.postFGSmoothFrameTimeMs, state.postFGSmoothFps);
+
+	// Set graph colors - blue for post-FG
+	ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
+
+	// Draw the graph
+	float graphWidth = ImGui::GetWindowWidth() * 0.9f;
+	ImGui::PlotLines("##postfgframetime",
+		state.postFGFrameTimeHistory.GetData().data(),
+		settings.FrameHistorySize,
+		static_cast<int>(state.postFGFrameTimeHistory.GetHeadIdx()),
+		overlay_text,
+		state.smoothedMinFrameTime, state.smoothedMaxFrameTime,
+		ImVec2(graphWidth, 50.0f * settings.TextSize));
+
+	ImGui::PopStyleColor();
+
+	// Draw frametime target reference lines
+	if (ImGui::BeginTable("PostFGFrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
+		ImGui::TableNextColumn();
+		ImGui::Text("30 FPS: 33.3 ms");
+
+		ImGui::TableNextColumn();
+		ImGui::Text("60 FPS: 16.7 ms");
+
+		ImGui::TableNextColumn();
+		ImGui::Text("120 FPS: 8.3 ms");
+
+		ImGui::EndTable();
+	}
+}
+
 // ============================================================================
 // A/B TESTING FUNCTIONS
 // ============================================================================
@@ -1877,15 +1916,12 @@ void PerformanceOverlay::UpdateGraphValues()
 		state.maxFrameTime = *std::ranges::max_element(state.frameTimeHistory.GetData());
 	}
 
-	float avgFrameTime, stdDev, graphMin, graphMax;
+	float avgFrameTime = kDefaultFrameTimeMs,
+		  stdDev = 0.0f,
+		  graphMin = 0.0f,
+		  graphMax = Settings::kGraphSpreadMultiplier * kDefaultFrameTimeMs;
 	// Calculate mean and standard deviation for normalized graph range
-	if (state.frameTimeHistory.GetData().empty()) {
-		// Default to 60 FPS
-		avgFrameTime = kDefaultFrameTimeMs;
-		stdDev = 0.0f;
-		graphMin = 0.0f;
-		graphMax = Settings::kGraphSpreadMultiplier * kDefaultFrameTimeMs;
-	} else {
+	if (!state.frameTimeHistory.GetData().empty()) {
 		// Calculate average frame time
 		avgFrameTime = std::accumulate(state.frameTimeHistory.GetData().begin(), state.frameTimeHistory.GetData().end(), 0.0f) / state.frameTimeHistory.GetData().size();
 
@@ -1937,45 +1973,7 @@ void PerformanceOverlay::UpdateGraphValues()
 	state.updateTimer += deltaTime;
 	if (state.updateTimer >= settings.UpdateInterval) {
 		state.smoothFps = state.fps;
-		state.smoothFrameTimeMs = state.frameTimeMs;  // TODO: is smoothFrameTimeMs smoothed at all?
+		state.smoothFrameTimeMs = state.frameTimeMs;
 		state.updateTimer = 0.0f;
-	}
-}
-
-void PerformanceOverlay::DrawPostFGFrameTimeGraph()
-{
-	// Prepare overlay text
-	char overlay_text[128];
-	snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
-		"Post-FG: %.2f ms (%.1f FPS)",
-		state.postFGSmoothFrameTimeMs, state.postFGSmoothFps);
-
-	// Set graph colors - blue for post-FG
-	ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
-
-	// Draw the graph
-	float graphWidth = ImGui::GetWindowWidth() * 0.9f;
-	ImGui::PlotLines("##postfgframetime",
-		state.postFGFrameTimeHistory.GetData().data(),
-		settings.FrameHistorySize,
-		static_cast<int>(state.postFGFrameTimeHistory.GetHeadIdx()),
-		overlay_text,
-		state.smoothedMinFrameTime, state.smoothedMaxFrameTime,
-		ImVec2(graphWidth, 50.0f * settings.TextSize));
-
-	ImGui::PopStyleColor();
-
-	// Draw frametime target reference lines
-	if (ImGui::BeginTable("PostFGFrametimeTargets", 3, ImGuiTableFlags_SizingStretchSame)) {
-		ImGui::TableNextColumn();
-		ImGui::Text("30 FPS: 33.3 ms");
-
-		ImGui::TableNextColumn();
-		ImGui::Text("60 FPS: 16.7 ms");
-
-		ImGui::TableNextColumn();
-		ImGui::Text("120 FPS: 8.3 ms");
-
-		ImGui::EndTable();
 	}
 }

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -197,7 +197,7 @@ void PerformanceOverlay::DrawSettings()
 			ImGui::SliderFloat("Text Size", &this->settings.TextSize, 0.8f, 1.2f, "%.2f");
 			ImGui::SliderFloat("Background Opacity", &this->settings.BackgroundOpacity, 0.0f, 1.0f, "%.2f");
 			ImGui::Checkbox("Show Border", &this->settings.ShowBorder);
-			ImGui::SliderFloat("Update Interval", &this->settings.UpdateInterval, 0.001f, PerformanceOverlay::PerfOverlayState::kMaxUpdateInterval, "%.2f seconds");
+			ImGui::SliderFloat("Update Interval", &this->settings.UpdateInterval, 0.001f, PerformanceOverlay::PerfOverlaySettings::kMaxUpdateInterval, "%.2f seconds");
 			ImGui::SliderInt("Frame History Size", &this->settings.FrameHistorySize,
 				this->settings.kMinFrameHistorySize, this->settings.kMaxFrameHistorySize);
 
@@ -216,9 +216,10 @@ void PerformanceOverlay::DrawSettings()
 void PerformanceOverlay::DataLoaded()
 {
 	// Initialize performance overlay state
-	this->perfOverlayState.initialized = false;
-	this->perfOverlayState.frameTimeHistory.resize(this->settings.FrameHistorySize, 0.0f);
-	this->perfOverlayState.postFGFrameTimeHistory.resize(this->settings.FrameHistorySize, 0.0f);
+	REX::W32::QueryPerformanceFrequency(&this->perfOverlayState.frequency);
+	REX::W32::QueryPerformanceCounter(&this->perfOverlayState.lastFrameCounter);
+	this->perfOverlayState.frameTimeHistory.Resize(this->settings.FrameHistorySize);
+	this->perfOverlayState.postFGFrameTimeHistory.Resize(this->settings.FrameHistorySize);
 }
 
 void PerformanceOverlay::DrawOverlay()
@@ -275,8 +276,8 @@ void PerformanceOverlay::DrawOverlay()
 
 	// Set initial position if not already set
 	if (!this->settings.PositionSet) {
-		ImGui::SetNextWindowPos(ImVec2(PerformanceOverlay::PerfOverlayState::kDefaultWindowPadding, PerformanceOverlay::PerfOverlayState::kDefaultWindowPadding));
-		this->settings.Position = ImVec2(PerformanceOverlay::PerfOverlayState::kDefaultWindowPadding, PerformanceOverlay::PerfOverlayState::kDefaultWindowPadding);
+		ImGui::SetNextWindowPos(ImVec2(PerformanceOverlay::PerfOverlaySettings::kDefaultWindowPadding, PerformanceOverlay::PerfOverlaySettings::kDefaultWindowPadding));
+		this->settings.Position = ImVec2(PerformanceOverlay::PerfOverlaySettings::kDefaultWindowPadding, PerformanceOverlay::PerfOverlaySettings::kDefaultWindowPadding);
 		this->settings.PositionSet = true;
 	} else {
 		ImGui::SetNextWindowPos(this->settings.Position, ImGuiCond_FirstUseEver);
@@ -297,19 +298,19 @@ void PerformanceOverlay::DrawOverlay()
 				fpsText = std::format("Raw FPS: {:.1f} ({:.2f} ms)", this->perfOverlayState.smoothFps, this->perfOverlayState.smoothFrameTimeMs);
 			}
 			float fpsWidth = ImGui::CalcTextSize(fpsText.c_str()).x;
-			minWidth = std::max(minWidth, fpsWidth + PerformanceOverlay::PerfOverlayState::kLabelPadding);  // Add padding for labels
+			minWidth = std::max(minWidth, fpsWidth + PerformanceOverlay::PerfOverlaySettings::kLabelPadding);  // Add padding for labels
 		}
 		if (this->settings.ShowDrawCalls) {
 			// Draw calls table needs significant width for all columns
-			minWidth = std::max(minWidth, PerformanceOverlay::PerfOverlayState::kDrawCallsTableWidth * this->settings.TextSize);
+			minWidth = std::max(minWidth, PerformanceOverlay::PerfOverlaySettings::kDrawCallsTableWidth * this->settings.TextSize);
 		}
 		if (this->settings.ShowVRAM && menu->GetDXGIAdapter3()) {
 			// VRAM section needs width for the progress bar and text
-			minWidth = std::max(minWidth, PerformanceOverlay::PerfOverlayState::kVRAMSectionWidth * this->settings.TextSize);
+			minWidth = std::max(minWidth, PerformanceOverlay::PerfOverlaySettings::kVRAMSectionWidth * this->settings.TextSize);
 		}
 
 		// Add some padding for window borders and spacing
-		minWidth += PerformanceOverlay::PerfOverlayState::kWindowBorderPadding;
+		minWidth += PerformanceOverlay::PerfOverlaySettings::kWindowBorderPadding;
 
 		// Set minimum width, but allow auto-resize for larger content
 		ImGui::SetNextWindowSize(ImVec2(minWidth, 0), ImGuiCond_FirstUseEver);
@@ -332,90 +333,83 @@ void PerformanceOverlay::DrawOverlay()
 	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4.0f, 1.0f));  // Tighter spacing
 	ImGui::SetWindowFontScale(this->settings.TextSize);
 
-	// Initialize Performance Counter if necessary
-	if (!this->perfOverlayState.initialized) {
-		REX::W32::QueryPerformanceFrequency(&this->perfOverlayState.frequency);
-		REX::W32::QueryPerformanceCounter(&this->perfOverlayState.lastFrameCounter);
-		this->perfOverlayState.initialized = true;
-	} else {
-		REX::W32::QueryPerformanceCounter(&this->perfOverlayState.currentFrameCounter);
-		int64_t elapsedCounter = this->perfOverlayState.currentFrameCounter - this->perfOverlayState.lastFrameCounter;
-		this->perfOverlayState.lastFrameCounter = this->perfOverlayState.currentFrameCounter;
+	REX::W32::QueryPerformanceCounter(&this->perfOverlayState.currentFrameCounter);
+	int64_t elapsedCounter = this->perfOverlayState.currentFrameCounter - this->perfOverlayState.lastFrameCounter;
+	this->perfOverlayState.lastFrameCounter = this->perfOverlayState.currentFrameCounter;
 
-		// Calculate frametime and fps
-		this->perfOverlayState.frameTimeMs = Util::CalcFrameTime(elapsedCounter, this->perfOverlayState.frequency);
-		this->perfOverlayState.fps = Util::CalcFPS(this->perfOverlayState.frameTimeMs);
+	// Calculate frametime and fps
+	this->perfOverlayState.frameTimeMs = Util::CalcFrameTime(elapsedCounter, this->perfOverlayState.frequency);
+	this->perfOverlayState.fps = Util::CalcFPS(this->perfOverlayState.frameTimeMs);
 
-		// Calculate smooth values for display using the user-defined update interval
-		// Initialize overlay timing frequency if needed
-		if (this->perfOverlayState.overlayTimingFrequency.QuadPart == 0) {
-			QueryPerformanceFrequency(&this->perfOverlayState.overlayTimingFrequency);
-			QueryPerformanceCounter(&this->perfOverlayState.lastUpdateTime);
-		}
-
-		LARGE_INTEGER now;
-		QueryPerformanceCounter(&now);
-		float deltaTime = (now.QuadPart - this->perfOverlayState.lastUpdateTime.QuadPart) /
-		                  static_cast<float>(this->perfOverlayState.overlayTimingFrequency.QuadPart);
-		this->perfOverlayState.lastUpdateTime = now;
-
-		// Update graph values
-		this->perfOverlayState.UpdateGraphValues();
-
-		// Update smooth values with user-specified interval
-		this->perfOverlayState.updateTimer += deltaTime;
-		if (this->perfOverlayState.updateTimer >= this->settings.UpdateInterval) {
-			this->perfOverlayState.smoothFps = this->perfOverlayState.fps;
-			this->perfOverlayState.smoothFrameTimeMs = this->perfOverlayState.frameTimeMs;  // TODO: is smoothFrameTimeMs smoothed at all?
-			this->perfOverlayState.updateTimer = 0.0f;
-		}
-
-		// Check if we should show collapsible sections (should swallow input only)
-		bool showCollapsibleSections = Menu::GetSingleton()->ShouldSwallowInput();
-
-		// Show FPS counter if enabled
-		if (this->settings.ShowFPS) {
-			static bool fpsExpanded = true;
-			if (showCollapsibleSections) {
-				Util::DrawSectionHeader("FPS & Frame Time", false, true, &fpsExpanded);
-			}
-			if (fpsExpanded) {
-				DrawFPS();
-			}
-		}
-
-		// Show Draw Calls if enabled
-		if (this->settings.ShowDrawCalls) {
-			static bool drawCallsExpanded = true;
-			if (showCollapsibleSections) {
-				Util::DrawSectionHeader("Draw Calls & Shader Performance", false, true, &drawCallsExpanded);
-			}
-			if (drawCallsExpanded) {
-				DrawDrawCallsTable(mainRows, summaryRows);
-			}
-		}
-
-		// VRAM & GPU Usage
-		if (this->settings.ShowVRAM && menu->GetDXGIAdapter3()) {
-			static bool vramExpanded = true;
-			if (showCollapsibleSections) {
-				Util::DrawSectionHeader("VRAM Usage", false, true, &vramExpanded);
-			}
-			if (vramExpanded) {
-				DrawVRAM();
-			}
-		}
-
-		ImGui::PopStyleVar();             // ItemSpacing
-		ImGui::SetWindowFontScale(1.0f);  // Reset font scale
-
-		// --- A/B Test Section ---
-		DrawABTestSection(allRows, showCollapsibleSections);
-
-		ImGui::End();
-		ImGui::PopStyleVar();    // WindowBorderSize
-		ImGui::PopStyleColor();  // WindowBg
+	// Calculate smooth values for display using the user-defined update interval
+	// Initialize overlay timing frequency if needed
+	if (this->perfOverlayState.overlayTimingFrequency.QuadPart == 0) {
+		QueryPerformanceFrequency(&this->perfOverlayState.overlayTimingFrequency);
+		QueryPerformanceCounter(&this->perfOverlayState.lastUpdateTime);
 	}
+
+	LARGE_INTEGER now;
+	QueryPerformanceCounter(&now);
+	float deltaTime = (now.QuadPart - this->perfOverlayState.lastUpdateTime.QuadPart) /
+	                  static_cast<float>(this->perfOverlayState.overlayTimingFrequency.QuadPart);
+	this->perfOverlayState.lastUpdateTime = now;
+
+	// Update graph values
+	this->perfOverlayState.UpdateGraphValues();
+
+	// Update smooth values with user-specified interval
+	this->perfOverlayState.updateTimer += deltaTime;
+	if (this->perfOverlayState.updateTimer >= this->settings.UpdateInterval) {
+		this->perfOverlayState.smoothFps = this->perfOverlayState.fps;
+		this->perfOverlayState.smoothFrameTimeMs = this->perfOverlayState.frameTimeMs;  // TODO: is smoothFrameTimeMs smoothed at all?
+		this->perfOverlayState.updateTimer = 0.0f;
+	}
+
+	// Check if we should show collapsible sections (should swallow input only)
+	bool showCollapsibleSections = Menu::GetSingleton()->ShouldSwallowInput();
+
+	// Show FPS counter if enabled
+	if (this->settings.ShowFPS) {
+		static bool fpsExpanded = true;
+		if (showCollapsibleSections) {
+			Util::DrawSectionHeader("FPS & Frame Time", false, true, &fpsExpanded);
+		}
+		if (fpsExpanded) {
+			DrawFPS();
+		}
+	}
+
+	// Show Draw Calls if enabled
+	if (this->settings.ShowDrawCalls) {
+		static bool drawCallsExpanded = true;
+		if (showCollapsibleSections) {
+			Util::DrawSectionHeader("Draw Calls & Shader Performance", false, true, &drawCallsExpanded);
+		}
+		if (drawCallsExpanded) {
+			DrawDrawCallsTable(mainRows, summaryRows);
+		}
+	}
+
+	// VRAM & GPU Usage
+	if (this->settings.ShowVRAM && menu->GetDXGIAdapter3()) {
+		static bool vramExpanded = true;
+		if (showCollapsibleSections) {
+			Util::DrawSectionHeader("VRAM Usage", false, true, &vramExpanded);
+		}
+		if (vramExpanded) {
+			DrawVRAM();
+		}
+	}
+
+	ImGui::PopStyleVar();             // ItemSpacing
+	ImGui::SetWindowFontScale(1.0f);  // Reset font scale
+
+	// --- A/B Test Section ---
+	DrawABTestSection(allRows, showCollapsibleSections);
+
+	ImGui::End();
+	ImGui::PopStyleVar();    // WindowBorderSize
+	ImGui::PopStyleColor();  // WindowBg
 }
 // ============================================================================
 // CORE PERFORMANCE DISPLAY FUNCTIONS
@@ -457,9 +451,9 @@ void PerformanceOverlay::DrawFPS()
 		// Draw the graph
 		float graphWidth = ImGui::GetWindowWidth() * 0.9f;
 		ImGui::PlotLines("##frametime",
-			this->perfOverlayState.frameTimeHistory.data(),
+			this->perfOverlayState.frameTimeHistory.GetData().data(),
 			this->settings.FrameHistorySize,
-			this->perfOverlayState.frameTimeHistoryIndex,
+			static_cast<int>(this->perfOverlayState.frameTimeHistory.GetHeadIdx()),
 			overlay_text,
 			this->perfOverlayState.smoothedMinFrameTime, this->perfOverlayState.smoothedMaxFrameTime,
 			ImVec2(graphWidth, 50.0f * this->settings.TextSize));
@@ -928,7 +922,7 @@ std::vector<ColumnConfig> PerformanceOverlay::BuildABTestResultsTableColumns(con
 					color = theme.StatusPalette.Error;  // Worse performance (positive delta)
 				}
 				ImGui::PushStyleColor(ImGuiCol_Text, color);
-				ImGui::Text("%s", Util::FormatDeltaWithPercent(row.frameTime, *row.testFrameTime, PerformanceOverlay::PerfOverlayState::kPercentDisplayThreshold).c_str());
+				ImGui::Text("%s", Util::FormatDeltaWithPercent(row.frameTime, *row.testFrameTime, PerformanceOverlay::PerfOverlaySettings::kPercentDisplayThreshold).c_str());
 				ImGui::PopStyleColor();
 				if (ImGui::IsItemHovered()) {
 					if (auto _tt = Util::HoverTooltipWrapper()) {
@@ -1448,7 +1442,7 @@ std::vector<ColumnConfig> PerformanceOverlay::BuildDrawCallTableColumns(const Me
 
 	columns.push_back(ColumnConfig{
 		legends.frameTime.header,
-		MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.frameTime; }, [](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, PerformanceOverlay::PerfOverlayState::kFrameTimeGoodThreshold, PerformanceOverlay::PerfOverlayState::kFrameTimeWarningThreshold, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); }, [](float /*value*/, const DrawCallRow& row) { return Util::FormatMilliseconds(row.frameTime) + " (" + Util::FormatPercent(row.percent) + ")"; }, legends.frameTime.tooltip), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.percent < b.percent) : (a.percent > b.percent); }, [legends]() {
+		MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.frameTime; }, [](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, PerformanceOverlay::PerfOverlaySettings::kFrameTimeGoodThreshold, PerformanceOverlay::PerfOverlaySettings::kFrameTimeWarningThreshold, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); }, [](float /*value*/, const DrawCallRow& row) { return Util::FormatMilliseconds(row.frameTime) + " (" + Util::FormatPercent(row.percent) + ")"; }, legends.frameTime.tooltip), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.percent < b.percent) : (a.percent > b.percent); }, [legends]() {
 			 if (ImGui::IsItemHovered()) {
 				 if (auto _tt = Util::HoverTooltipWrapper()) {
 					 Util::DrawColoredMultiLineTooltip(legends.frameTime.tooltip);
@@ -1457,7 +1451,7 @@ std::vector<ColumnConfig> PerformanceOverlay::BuildDrawCallTableColumns(const Me
 
 	columns.push_back(ColumnConfig{
 		legends.costPerCall.header,
-		MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.costPerCall; }, [](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, PerformanceOverlay::PerfOverlayState::kCostPerCallGoodThreshold, PerformanceOverlay::PerfOverlayState::kCostPerCallWarningThreshold, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); }, [](float value, const DrawCallRow&) { return (value < PerformanceOverlay::PerfOverlayState::kMicrosecondThreshold && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); }, legends.costPerCall.tooltip), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall); }, [legends]() {
+		MakeMetricColumn(theme, [](const DrawCallRow& row) { return row.costPerCall; }, [](const auto& theme, float value, const DrawCallRow&) { return Util::GetThresholdColor(value, PerformanceOverlay::PerfOverlaySettings::kCostPerCallGoodThreshold, PerformanceOverlay::PerfOverlaySettings::kCostPerCallWarningThreshold, theme.StatusPalette.SuccessColor, theme.StatusPalette.Warning, theme.StatusPalette.Error); }, [](float value, const DrawCallRow&) { return (value < PerformanceOverlay::PerfOverlaySettings::kMicrosecondThreshold && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); }, legends.costPerCall.tooltip), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) { return asc ? (a.costPerCall < b.costPerCall) : (a.costPerCall > b.costPerCall); }, [legends]() {
 			 if (ImGui::IsItemHovered()) {
 				 if (auto _tt = Util::HoverTooltipWrapper()) {
 					 Util::DrawColoredMultiLineTooltip(legends.costPerCall.tooltip);
@@ -1490,7 +1484,7 @@ std::vector<ColumnConfig> PerformanceOverlay::BuildDrawCallTableColumns(const Me
 						 return theme.StatusPalette.SuccessColor;
 					 if (value > row.costPerCall)
 						 return theme.StatusPalette.Error;
-					 return theme.Palette.Text; }, [](float value, const DrawCallRow&) { return (value < PerformanceOverlay::PerfOverlayState::kMicrosecondThreshold && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); }, legends.testCostPerCall.tooltip), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
+					 return theme.Palette.Text; }, [](float value, const DrawCallRow&) { return (value < PerformanceOverlay::PerfOverlaySettings::kMicrosecondThreshold && value > 0.0f) ? Util::FormatMicroseconds(value * 1000.0f) : Util::FormatMilliseconds(value); }, legends.testCostPerCall.tooltip), [](const DrawCallRow& a, const DrawCallRow& b, bool asc) {
 				 float aVal = a.testCostPerCall.value_or(FLT_MAX);
 				 float bVal = b.testCostPerCall.value_or(FLT_MAX);
 				 return asc ? (aVal < bVal) : (aVal > bVal); }, [legends]() {
@@ -1866,22 +1860,6 @@ void PerformanceOverlay::UpdateSummaryTestData(float smoothedFrameTime, float ot
 // PERFORMANCE OVERLAY STATE MANAGEMENT
 // ============================================================================
 
-void PerformanceOverlay::PerfOverlayState::ResizeFrameTimeHistory(size_t newSize)
-{
-	if (frameTimeHistory.size() != newSize) {
-		frameTimeHistory.resize(newSize, 0.0f);
-		if (frameTimeHistoryIndex >= newSize) {
-			frameTimeHistoryIndex = 0;
-		}
-	}
-	if (postFGFrameTimeHistory.size() != newSize) {
-		postFGFrameTimeHistory.resize(newSize, 0.0f);
-		if (postFGFrameTimeHistoryIndex >= newSize) {
-			postFGFrameTimeHistoryIndex = 0;
-		}
-	}
-}
-
 void PerformanceOverlay::PerfOverlayState::UpdateFGFrameTime()
 {
 	// Defensive: Check for upscaling pointer
@@ -1898,8 +1876,8 @@ void PerformanceOverlay::PerfOverlayState::UpdateFGFrameTime()
 		postFGFps = 1000.0f / postFGFrameTimeMs;
 	} else {
 		// Fallback if FG time is not available
-		postFGFrameTimeMs = frameTimeMs / PerformanceOverlay::PerfOverlayState::kFrameGenerationMultiplier;
-		postFGFps = fps * PerformanceOverlay::PerfOverlayState::kFrameGenerationMultiplier;
+		postFGFrameTimeMs = frameTimeMs / PerformanceOverlay::PerfOverlaySettings::kFrameGenerationMultiplier;
+		postFGFps = fps * PerformanceOverlay::PerfOverlaySettings::kFrameGenerationMultiplier;
 	}
 
 	// Update post-FG smooth values when timer elapses
@@ -1909,8 +1887,7 @@ void PerformanceOverlay::PerfOverlayState::UpdateFGFrameTime()
 	}
 
 	// Update post-FG frametime history
-	postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
-	postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % postFGFrameTimeHistory.size();
+	postFGFrameTimeHistory.Push(postFGFrameTimeMs);
 }
 
 void PerformanceOverlay::PerfOverlayState::UpdateGraphValues()
@@ -1923,12 +1900,12 @@ void PerformanceOverlay::PerfOverlayState::UpdateGraphValues()
 		overlaySettings.FrameHistorySize,
 		overlaySettings.kMinFrameHistorySize,
 		overlaySettings.kMaxFrameHistorySize);
-	ResizeFrameTimeHistory(overlaySettings.FrameHistorySize);
+	frameTimeHistory.Resize(overlaySettings.FrameHistorySize);
+	postFGFrameTimeHistory.Resize(overlaySettings.FrameHistorySize);
 
 	// Insert latest frame time into circular buffer
-	float oldFrameTime = frameTimeHistory[frameTimeHistoryIndex];
-	frameTimeHistory[frameTimeHistoryIndex] = frameTimeMs;
-	frameTimeHistoryIndex = ((frameTimeHistoryIndex + 1) % overlaySettings.FrameHistorySize);
+	float oldFrameTime = frameTimeHistory.GetData()[frameTimeHistory.GetHeadIdx()];
+	frameTimeHistory.Push(frameTimeMs);
 
 	// Maintain instantaneous min/max tracking
 	if (frameTimeMs > maxFrameTime) {
@@ -1936,41 +1913,41 @@ void PerformanceOverlay::PerfOverlayState::UpdateGraphValues()
 	} else if (frameTimeMs < minFrameTime) {
 		minFrameTime = frameTimeMs;
 	} else if (oldFrameTime == minFrameTime) {
-		minFrameTime = *std::min_element(frameTimeHistory.begin(), frameTimeHistory.end());
+		minFrameTime = *std::ranges::min_element(frameTimeHistory.GetData());
 	} else if (oldFrameTime == maxFrameTime) {
-		maxFrameTime = *std::max_element(frameTimeHistory.begin(), frameTimeHistory.end());
+		maxFrameTime = *std::ranges::max_element(frameTimeHistory.GetData());
 	}
 
 	float avgFrameTime, stdDev, graphMin, graphMax;
 	// Calculate mean and standard deviation for normalized graph range
-	if (frameTimeHistory.empty()) {
+	if (frameTimeHistory.GetData().empty()) {
 		// Default to 60 FPS
 		avgFrameTime = kDefaultFrameTimeMs;
 		stdDev = 0.0f;
 		graphMin = 0.0f;
-		graphMax = PerformanceOverlay::PerfOverlayState::kGraphSpreadMultiplier * kDefaultFrameTimeMs;
+		graphMax = PerformanceOverlay::PerfOverlaySettings::kGraphSpreadMultiplier * kDefaultFrameTimeMs;
 	} else {
 		// Calculate average frame time
-		avgFrameTime = std::accumulate(frameTimeHistory.begin(), frameTimeHistory.end(), 0.0f) / frameTimeHistory.size();
+		avgFrameTime = std::accumulate(frameTimeHistory.GetData().begin(), frameTimeHistory.GetData().end(), 0.0f) / frameTimeHistory.GetData().size();
 
 		// Calculate standard deviation
 		float variance = 0.0f;
-		for (float ft : frameTimeHistory) {
+		for (float ft : frameTimeHistory.GetData()) {
 			float diff = ft - avgFrameTime;
 			variance += diff * diff;
 		}
-		variance /= frameTimeHistory.size();
+		variance /= frameTimeHistory.GetData().size();
 		stdDev = std::sqrt(variance);
 
 		// Calculate graph range
-		float spread = std::clamp(stdDev * PerformanceOverlay::PerfOverlayState::kGraphSpreadMultiplier, PerformanceOverlay::PerfOverlayState::kGraphMinSpread, PerformanceOverlay::PerfOverlayState::kGraphMaxSpread);
+		float spread = std::clamp(stdDev * PerformanceOverlay::PerfOverlaySettings::kGraphSpreadMultiplier, PerformanceOverlay::PerfOverlaySettings::kGraphMinSpread, PerformanceOverlay::PerfOverlaySettings::kGraphMaxSpread);
 		graphMin = std::max(0.0f, avgFrameTime - spread);
 		graphMax = avgFrameTime + spread;
 	}
 
 	// Exponential smoothing for stable graph scaling
-	smoothedMinFrameTime = smoothedMinFrameTime + kSmoothingFactor * (graphMin - smoothedMinFrameTime);
-	smoothedMaxFrameTime = smoothedMaxFrameTime + kSmoothingFactor * (graphMax - smoothedMaxFrameTime);
+	smoothedMinFrameTime = smoothedMinFrameTime + PerformanceOverlay::PerfOverlaySettings::kSmoothingFactor * (graphMin - smoothedMinFrameTime);
+	smoothedMaxFrameTime = smoothedMaxFrameTime + PerformanceOverlay::PerfOverlaySettings::kSmoothingFactor * (graphMax - smoothedMaxFrameTime);
 
 	if (isFrameGenerationActive) {
 		UpdateFGFrameTime();
@@ -1991,9 +1968,9 @@ void PerformanceOverlay::DrawPostFGFrameTimeGraph()
 	// Draw the graph
 	float graphWidth = ImGui::GetWindowWidth() * 0.9f;
 	ImGui::PlotLines("##postfgframetime",
-		perfOverlayState.postFGFrameTimeHistory.data(),
+		perfOverlayState.postFGFrameTimeHistory.GetData().data(),
 		settings.FrameHistorySize,
-		perfOverlayState.postFGFrameTimeHistoryIndex,
+		static_cast<int>(perfOverlayState.postFGFrameTimeHistory.GetHeadIdx()),
 		overlay_text,
 		perfOverlayState.smoothedMinFrameTime, perfOverlayState.smoothedMaxFrameTime,
 		ImVec2(graphWidth, 50.0f * settings.TextSize));

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -1902,9 +1902,8 @@ void PerformanceOverlay::UpdateGraphValues()
 	                  static_cast<float>(state.overlayTimingFrequency.QuadPart);
 	state.lastUpdateTime = now;
 
-	// WHAT DOES oldFrameTime EVEN MEAN???????
 	// Insert latest frame time into circular buffer
-	float oldFrameTime = state.frameTimeHistory.GetData()[state.frameTimeHistory.GetHeadIdx()];
+	float oldFrameTime = state.frameTimeHistory.GetData()[state.frameTimeHistory.GetHeadIdx()];  // what is the point of oldFrameTime?
 	state.frameTimeHistory.Push(state.frameTimeMs);
 
 	// Maintain instantaneous min/max tracking

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -109,7 +109,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ShowPostFGFrameTimeGraph,
 	UpdateInterval,
 	FrameHistorySize,
-	Size,
+	TextSize,
 	BackgroundOpacity,
 	ShowBorder,
 	Position,
@@ -194,12 +194,7 @@ void PerformanceOverlay::DrawSettings()
 		if (ImGui::CollapsingHeader("Appearance", ImGuiTreeNodeFlags_DefaultOpen)) {
 			ImGui::Indent();
 
-			const char* sizes[] = { "Small", "Medium", "Large" };
-			int currentSize = static_cast<int>(this->settings.Size);
-			if (ImGui::Combo("Text Size", &currentSize, sizes, IM_ARRAYSIZE(sizes))) {
-				this->settings.Size = static_cast<PerfOverlaySettings::TextSize>(currentSize);
-			}
-
+			ImGui::SliderFloat("Text Size", &this->settings.TextSize, 0.8f, 1.2f, "%.2f");
 			ImGui::SliderFloat("Background Opacity", &this->settings.BackgroundOpacity, 0.0f, 1.0f, "%.2f");
 			ImGui::Checkbox("Show Border", &this->settings.ShowBorder);
 			ImGui::SliderFloat("Update Interval", &this->settings.UpdateInterval, 0.001f, PerformanceOverlay::PerfOverlayState::kMaxUpdateInterval, "%.2f seconds");
@@ -222,8 +217,8 @@ void PerformanceOverlay::DataLoaded()
 {
 	// Initialize performance overlay state
 	this->perfOverlayState.initialized = false;
-	this->perfOverlayState.ResizeFrameTimeHistory(this->settings.FrameHistorySize, 0.0f);
-	this->perfOverlayState.ResizePostFGFrameTimeHistory(this->settings.FrameHistorySize, 0.0f);
+	this->perfOverlayState.frameTimeHistory.resize(this->settings.FrameHistorySize, 0.0f);
+	this->perfOverlayState.postFGFrameTimeHistory.resize(this->settings.FrameHistorySize, 0.0f);
 }
 
 void PerformanceOverlay::DrawOverlay()
@@ -276,9 +271,6 @@ void PerformanceOverlay::DrawOverlay()
 			ImGui::GetStyleColorVec4(ImGuiCol_WindowBg).z,
 			this->settings.BackgroundOpacity));
 
-	// Set text size based on user preference
-	this->perfOverlayState.textScale = this->perfOverlayState.CalculateTextScale();
-
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, this->settings.ShowBorder ? 1.0f : 0.0f);
 
 	// Set initial position if not already set
@@ -309,11 +301,11 @@ void PerformanceOverlay::DrawOverlay()
 		}
 		if (this->settings.ShowDrawCalls) {
 			// Draw calls table needs significant width for all columns
-			minWidth = std::max(minWidth, PerformanceOverlay::PerfOverlayState::kDrawCallsTableWidth * this->perfOverlayState.textScale);
+			minWidth = std::max(minWidth, PerformanceOverlay::PerfOverlayState::kDrawCallsTableWidth * this->settings.TextSize);
 		}
 		if (this->settings.ShowVRAM && menu->GetDXGIAdapter3()) {
 			// VRAM section needs width for the progress bar and text
-			minWidth = std::max(minWidth, PerformanceOverlay::PerfOverlayState::kVRAMSectionWidth * this->perfOverlayState.textScale);
+			minWidth = std::max(minWidth, PerformanceOverlay::PerfOverlayState::kVRAMSectionWidth * this->settings.TextSize);
 		}
 
 		// Add some padding for window borders and spacing
@@ -338,7 +330,7 @@ void PerformanceOverlay::DrawOverlay()
 	}
 
 	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4.0f, 1.0f));  // Tighter spacing
-	ImGui::SetWindowFontScale(this->perfOverlayState.textScale);
+	ImGui::SetWindowFontScale(this->settings.TextSize);
 
 	// Initialize Performance Counter if necessary
 	if (!this->perfOverlayState.initialized) {
@@ -376,10 +368,6 @@ void PerformanceOverlay::DrawOverlay()
 			this->perfOverlayState.smoothFps = this->perfOverlayState.fps;
 			this->perfOverlayState.smoothFrameTimeMs = this->perfOverlayState.frameTimeMs;  // TODO: is smoothFrameTimeMs smoothed at all?
 			this->perfOverlayState.updateTimer = 0.0f;
-		}
-
-		if (this->perfOverlayState.isFrameGenerationActive) {
-			this->perfOverlayState.UpdateFGFrameTime();
 		}
 
 		// Check if we should show collapsible sections (should swallow input only)
@@ -474,7 +462,7 @@ void PerformanceOverlay::DrawFPS()
 			this->perfOverlayState.frameTimeHistoryIndex,
 			overlay_text,
 			this->perfOverlayState.smoothedMinFrameTime, this->perfOverlayState.smoothedMaxFrameTime,
-			ImVec2(graphWidth, 50.0f * this->perfOverlayState.textScale));
+			ImVec2(graphWidth, 50.0f * this->settings.TextSize));
 
 		ImGui::PopStyleColor();
 
@@ -507,7 +495,7 @@ void PerformanceOverlay::DrawFPS()
 		}
 
 		// Show post-FG graph for both DLSS and FSR (FSR uses calculated data)
-		this->perfOverlayState.DrawPostFGFrameTimeGraph();
+		this->DrawPostFGFrameTimeGraph();
 	}
 }
 
@@ -1878,13 +1866,27 @@ void PerformanceOverlay::UpdateSummaryTestData(float smoothedFrameTime, float ot
 // PERFORMANCE OVERLAY STATE MANAGEMENT
 // ============================================================================
 
+void PerformanceOverlay::PerfOverlayState::ResizeFrameTimeHistory(size_t newSize)
+{
+	if (frameTimeHistory.size() != newSize) {
+		frameTimeHistory.resize(newSize, 0.0f);
+		if (frameTimeHistoryIndex >= newSize) {
+			frameTimeHistoryIndex = 0;
+		}
+	}
+	if (postFGFrameTimeHistory.size() != newSize) {
+		postFGFrameTimeHistory.resize(newSize, 0.0f);
+		if (postFGFrameTimeHistoryIndex >= newSize) {
+			postFGFrameTimeHistoryIndex = 0;
+		}
+	}
+}
+
 void PerformanceOverlay::PerfOverlayState::UpdateFGFrameTime()
 {
 	// Defensive: Check for upscaling pointer
 	if (!globals::upscaling)
 		return;
-
-	auto& overlay = globals::features::performanceOverlay;
 
 	// Get frametime directly from the Frame Generation system
 	float fgDeltaTime = globals::upscaling->GetFrameGenerationFrameTime();
@@ -1892,77 +1894,36 @@ void PerformanceOverlay::PerfOverlayState::UpdateFGFrameTime()
 	// Check if FSR frame generation is active (FSR doesn't provide timing data)
 	bool isFSRFrameGen = globals::fidelityFX && globals::fidelityFX->isFrameGenActive;
 	if (fgDeltaTime > 0.0f && !isFSRFrameGen) {
-		overlay.perfOverlayState.postFGFrameTimeMs = fgDeltaTime * 1000.0f;
-		overlay.perfOverlayState.postFGFps = 1000.0f / overlay.perfOverlayState.postFGFrameTimeMs;
-
-		// Update post-FG smooth values when timer elapses
-		if (overlay.perfOverlayState.updateTimer <= 0.0f) {
-			overlay.perfOverlayState.postFGSmoothFps = overlay.perfOverlayState.postFGFps;
-			overlay.perfOverlayState.postFGSmoothFrameTimeMs = overlay.perfOverlayState.postFGFrameTimeMs;
-		}
-
-		// Update post-FG frametime history
-		overlay.perfOverlayState.postFGFrameTimeHistory[overlay.perfOverlayState.postFGFrameTimeHistoryIndex] = overlay.perfOverlayState.postFGFrameTimeMs;
-		overlay.perfOverlayState.postFGFrameTimeHistoryIndex = (overlay.perfOverlayState.postFGFrameTimeHistoryIndex + 1) % overlay.settings.FrameHistorySize;
+		postFGFrameTimeMs = fgDeltaTime * 1000.0f;
+		postFGFps = 1000.0f / postFGFrameTimeMs;
 	} else {
 		// Fallback if FG time is not available
-		overlay.perfOverlayState.postFGFrameTimeMs = overlay.perfOverlayState.frameTimeMs / PerformanceOverlay::PerfOverlayState::kFrameGenerationMultiplier;
-		overlay.perfOverlayState.postFGFps = overlay.perfOverlayState.fps * PerformanceOverlay::PerfOverlayState::kFrameGenerationMultiplier;
-
-		if (overlay.perfOverlayState.updateTimer <= 0.0f) {
-			overlay.perfOverlayState.postFGSmoothFps = overlay.perfOverlayState.postFGFps;
-			overlay.perfOverlayState.postFGSmoothFrameTimeMs = overlay.perfOverlayState.postFGFrameTimeMs;
-		}
-
-		overlay.perfOverlayState.postFGFrameTimeHistory[overlay.perfOverlayState.postFGFrameTimeHistoryIndex] = overlay.perfOverlayState.postFGFrameTimeMs;
-		overlay.perfOverlayState.postFGFrameTimeHistoryIndex = (overlay.perfOverlayState.postFGFrameTimeHistoryIndex + 1) % overlay.settings.FrameHistorySize;
+		postFGFrameTimeMs = frameTimeMs / PerformanceOverlay::PerfOverlayState::kFrameGenerationMultiplier;
+		postFGFps = fps * PerformanceOverlay::PerfOverlayState::kFrameGenerationMultiplier;
 	}
-}
 
-void PerformanceOverlay::PerfOverlayState::UpdateFrameTimeHistorySizes()
-{
-	auto& overlay = globals::features::performanceOverlay;
-
-	overlay.settings.FrameHistorySize = std::clamp(
-		overlay.settings.FrameHistorySize,
-		overlay.settings.kMinFrameHistorySize,
-		overlay.settings.kMaxFrameHistorySize);
-
-	if (overlay.perfOverlayState.frameTimeHistory.size() != static_cast<size_t>(overlay.settings.FrameHistorySize)) {
-		overlay.perfOverlayState.ResizeFrameTimeHistory(overlay.settings.FrameHistorySize, 0.0f);
-		if (overlay.perfOverlayState.frameTimeHistoryIndex >= overlay.settings.FrameHistorySize) {
-			overlay.perfOverlayState.frameTimeHistoryIndex = 0;
-		}
+	// Update post-FG smooth values when timer elapses
+	if (updateTimer <= 0.0f) {
+		postFGSmoothFps = postFGFps;
+		postFGSmoothFrameTimeMs = postFGFrameTimeMs;
 	}
-	if (overlay.perfOverlayState.postFGFrameTimeHistory.size() != static_cast<size_t>(overlay.settings.FrameHistorySize)) {
-		overlay.perfOverlayState.ResizePostFGFrameTimeHistory(overlay.settings.FrameHistorySize, 0.0f);
-		if (overlay.perfOverlayState.postFGFrameTimeHistoryIndex >= overlay.settings.FrameHistorySize) {
-			overlay.perfOverlayState.postFGFrameTimeHistoryIndex = 0;
-		}
-	}
-}
 
-float PerformanceOverlay::PerfOverlayState::CalculateTextScale()
-{
-	auto& overlay = globals::features::performanceOverlay;
-	switch (overlay.settings.Size) {
-	case PerfOverlaySettings::TextSize::Small:
-		return 0.8f;
-	case PerfOverlaySettings::TextSize::Medium:
-		return 1.0f;
-	case PerfOverlaySettings::TextSize::Large:
-		return 1.2f;
-	}
-	return 1.0f;
+	// Update post-FG frametime history
+	postFGFrameTimeHistory[postFGFrameTimeHistoryIndex] = postFGFrameTimeMs;
+	postFGFrameTimeHistoryIndex = (postFGFrameTimeHistoryIndex + 1) % postFGFrameTimeHistory.size();
 }
 
 void PerformanceOverlay::PerfOverlayState::UpdateGraphValues()
 {
 	// Get settings from the singleton
-	const auto& overlaySettings = globals::features::performanceOverlay.settings;
+	auto& overlaySettings = globals::features::performanceOverlay.settings;
 
 	// Sync frame history buffer size with user settings
-	UpdateFrameTimeHistorySizes();
+	overlaySettings.FrameHistorySize = std::clamp(
+		overlaySettings.FrameHistorySize,
+		overlaySettings.kMinFrameHistorySize,
+		overlaySettings.kMaxFrameHistorySize);
+	ResizeFrameTimeHistory(overlaySettings.FrameHistorySize);
 
 	// Insert latest frame time into circular buffer
 	float oldFrameTime = frameTimeHistory[frameTimeHistoryIndex];
@@ -2010,15 +1971,19 @@ void PerformanceOverlay::PerfOverlayState::UpdateGraphValues()
 	// Exponential smoothing for stable graph scaling
 	smoothedMinFrameTime = smoothedMinFrameTime + kSmoothingFactor * (graphMin - smoothedMinFrameTime);
 	smoothedMaxFrameTime = smoothedMaxFrameTime + kSmoothingFactor * (graphMax - smoothedMaxFrameTime);
+
+	if (isFrameGenerationActive) {
+		UpdateFGFrameTime();
+	}
 }
 
-void PerformanceOverlay::PerfOverlayState::DrawPostFGFrameTimeGraph()
+void PerformanceOverlay::DrawPostFGFrameTimeGraph()
 {
 	// Prepare overlay text
 	char overlay_text[128];
 	snprintf(overlay_text, IM_ARRAYSIZE(overlay_text),
 		"Post-FG: %.2f ms (%.1f FPS)",
-		postFGSmoothFrameTimeMs, postFGSmoothFps);
+		perfOverlayState.postFGSmoothFrameTimeMs, perfOverlayState.postFGSmoothFps);
 
 	// Set graph colors - blue for post-FG
 	ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 0.5f, 1.0f, 1.0f));  // Blue line
@@ -2026,12 +1991,12 @@ void PerformanceOverlay::PerfOverlayState::DrawPostFGFrameTimeGraph()
 	// Draw the graph
 	float graphWidth = ImGui::GetWindowWidth() * 0.9f;
 	ImGui::PlotLines("##postfgframetime",
-		postFGFrameTimeHistory.data(),
-		globals::features::performanceOverlay.settings.FrameHistorySize,
-		postFGFrameTimeHistoryIndex,
+		perfOverlayState.postFGFrameTimeHistory.data(),
+		settings.FrameHistorySize,
+		perfOverlayState.postFGFrameTimeHistoryIndex,
 		overlay_text,
-		smoothedMinFrameTime, smoothedMaxFrameTime,
-		ImVec2(graphWidth, 50.0f * textScale));
+		perfOverlayState.smoothedMinFrameTime, perfOverlayState.smoothedMaxFrameTime,
+		ImVec2(graphWidth, 50.0f * settings.TextSize));
 
 	ImGui::PopStyleColor();
 

--- a/src/Features/PerformanceOverlay.h
+++ b/src/Features/PerformanceOverlay.h
@@ -88,9 +88,11 @@ class CircularBuffer
 public:
 	CircularBuffer(size_t size)
 	{
-		size = std::max(1, size);
+		size = std::max((size_t)1, size);
 		data.resize(size);
 	}
+	CircularBuffer() :
+		CircularBuffer(1) {}
 
 	void Resize(size_t newSize)
 	{
@@ -104,12 +106,14 @@ public:
 	void Push(const T& val)
 	{
 		data[headIdx++] = val;
-		headIdx %= data.size();
+		if (headIdx >= data.size())
+			headIdx = 0;
 	}
 
 	std::span<const T> GetData() { return { data }; }
 	size_t GetHeadIdx() { return headIdx; }
 };
+
 struct PerformanceOverlay : OverlayFeature
 {
 	// ============================================================================
@@ -175,16 +179,11 @@ struct PerformanceOverlay : OverlayFeature
 	struct PerfOverlayState
 	{
 		// Frame time history buffers
-		std::vector<float> frameTimeHistory;
-		std::vector<float> postFGFrameTimeHistory;
+		CircularBuffer<float> frameTimeHistory;
+		CircularBuffer<float> postFGFrameTimeHistory;
 
 		// State flags
-		bool initialized = false;
 		bool isFrameGenerationActive = false;  // TODO: this shouldn't be a tracked state
-
-		// History indices
-		int frameTimeHistoryIndex = 0;
-		int postFGFrameTimeHistoryIndex = 0;
 
 		// Performance counters
 		int64_t frequency;
@@ -213,31 +212,6 @@ struct PerformanceOverlay : OverlayFeature
 		float maxFrameTime = 0.0f;
 		float smoothedMinFrameTime = 0.0f;
 		float smoothedMaxFrameTime = 50.0f;
-
-		// Display settings
-		float textScale = 1.0f;
-
-		// Performance threshold constants
-		static constexpr float kSmoothingFactor = 0.15f;             // Smoothing factor: 0.1f = slow, 0.3f = fast.
-		static constexpr float kFrameTimeGoodThreshold = 2.0f;       // ms - Good performance threshold
-		static constexpr float kFrameTimeWarningThreshold = 5.0f;    // ms - Warning performance threshold
-		static constexpr float kCostPerCallGoodThreshold = 0.05f;    // ms/call - Good cost per call threshold
-		static constexpr float kCostPerCallWarningThreshold = 0.2f;  // ms/call - Warning cost per call threshold
-		static constexpr float kMicrosecondThreshold = 0.01f;        // ms - Threshold for showing microseconds
-		static constexpr float kPercentDisplayThreshold = 0.01f;     // Minimum percent difference to display
-		static constexpr float kGraphSpreadMultiplier = 2.0f;        // Standard deviation multiplier for graph range
-		static constexpr float kGraphMinSpread = 2.0f;               // ms - Minimum graph spread
-		static constexpr float kGraphMaxSpread = 20.0f;              // ms - Maximum graph spread
-		static constexpr float kFrameGenerationMultiplier = 2.0f;    // Frame generation doubles frame rate
-		static constexpr float kMaxUpdateInterval = 2.0f;            // seconds - Maximum update interval
-		static constexpr float kDefaultWindowPadding = 10.0f;        // pixels - Default window padding
-		static constexpr float kLabelPadding = 100.0f;               // pixels - Padding for labels
-		static constexpr float kDrawCallsTableWidth = 600.0f;        // pixels - Draw calls table width
-		static constexpr float kVRAMSectionWidth = 300.0f;           // pixels - VRAM section width
-		static constexpr float kWindowBorderPadding = 20.0f;         // pixels - Window border padding
-		static constexpr float kDefaultFrameTimeMs = 16.67f;         // ms - Default frame time (60 FPS)
-
-		void ResizeFrameTimeHistory(size_t newSize);
 
 		/**
 		* @brief Updates all runtime state related to the performance overlay graph.
@@ -268,6 +242,28 @@ struct PerformanceOverlay : OverlayFeature
 	// ============================================================================
 	struct PerfOverlaySettings
 	{
+		// Performance threshold constants
+		static constexpr float kSmoothingFactor = 0.15f;             // Smoothing factor: 0.1f = slow, 0.3f = fast.
+		static constexpr float kFrameTimeGoodThreshold = 2.0f;       // ms - Good performance threshold
+		static constexpr float kFrameTimeWarningThreshold = 5.0f;    // ms - Warning performance threshold
+		static constexpr float kCostPerCallGoodThreshold = 0.05f;    // ms/call - Good cost per call threshold
+		static constexpr float kCostPerCallWarningThreshold = 0.2f;  // ms/call - Warning cost per call threshold
+		static constexpr float kMicrosecondThreshold = 0.01f;        // ms - Threshold for showing microseconds
+		static constexpr float kPercentDisplayThreshold = 0.01f;     // Minimum percent difference to display
+		static constexpr float kGraphSpreadMultiplier = 2.0f;        // Standard deviation multiplier for graph range
+		static constexpr float kGraphMinSpread = 2.0f;               // ms - Minimum graph spread
+		static constexpr float kGraphMaxSpread = 20.0f;              // ms - Maximum graph spread
+		static constexpr float kFrameGenerationMultiplier = 2.0f;    // Frame generation doubles frame rate
+		static constexpr float kMaxUpdateInterval = 2.0f;            // seconds - Maximum update interval
+		static constexpr float kDefaultWindowPadding = 10.0f;        // pixels - Default window padding
+		static constexpr float kLabelPadding = 100.0f;               // pixels - Padding for labels
+		static constexpr float kDrawCallsTableWidth = 600.0f;        // pixels - Draw calls table width
+		static constexpr float kVRAMSectionWidth = 300.0f;           // pixels - VRAM section width
+		static constexpr float kWindowBorderPadding = 20.0f;         // pixels - Window border padding
+		static constexpr float kDefaultFrameTimeMs = 16.67f;         // ms - Default frame time (60 FPS)
+		static constexpr int kMinFrameHistorySize = 60;              // 60 frames = 1s @ 60fps. Reasonable minimum.
+		static constexpr int kMaxFrameHistorySize = 480;             // 480 frames = 10s @ 60fps or 2s @ 240fps. Reasonable maximum.
+
 		bool ShowInOverlay = true;  // was: Enabled
 		bool ShowDrawCalls = true;
 		bool ShowVRAM = true;
@@ -275,9 +271,7 @@ struct PerformanceOverlay : OverlayFeature
 		bool ShowPreFGFrameTimeGraph = true;
 		bool ShowPostFGFrameTimeGraph = true;
 		float UpdateInterval = 0.5f;
-		int FrameHistorySize = 120;                       // Default 120 frames = 2s @ 60fps. Clamped using static values to prevent config file values going outside of slider bounds.
-		static constexpr int kMinFrameHistorySize = 60;   // 60 frames = 1s @ 60fps. Reasonable minimum.
-		static constexpr int kMaxFrameHistorySize = 480;  // 480 frames = 10s @ 60fps or 2s @ 240fps. Reasonable maximum.
+		int FrameHistorySize = 120;  // Default 120 frames = 2s @ 60fps. Clamped using static values to prevent config file values going outside of slider bounds.
 		float TextSize = 1.0f;
 
 		float BackgroundOpacity = 0.5f;

--- a/src/Features/PerformanceOverlay.h
+++ b/src/Features/PerformanceOverlay.h
@@ -110,8 +110,8 @@ public:
 			headIdx = 0;
 	}
 
-	std::span<const T> GetData() { return { data }; }
-	size_t GetHeadIdx() { return headIdx; }
+	std::span<const T> GetData() const { return { data }; }
+	size_t GetHeadIdx() const { return headIdx; }
 };
 
 struct PerformanceOverlay : OverlayFeature

--- a/src/Features/PerformanceOverlay.h
+++ b/src/Features/PerformanceOverlay.h
@@ -133,6 +133,25 @@ struct PerformanceOverlay : OverlayFeature
 	// ============================================================================
 	// CORE PERFORMANCE DISPLAY FUNCTIONS
 	// ============================================================================
+	/**
+	* @brief Updates all runtime state related to the performance overlay graph.
+	*
+	* This function synchronizes the frame time history buffer, tracks min/max frame times,
+	* and computes the normalized Y-axis range for the frame time graph using statistical analysis.
+	*
+	* Steps performed:
+	*   1. Resizes the frameTimeHistory buffer if the user has changed the setting.
+	*   2. Inserts the latest frame time into the circular history buffer.
+	*   3. Updates instantaneous min/max frame time values, with full rescans if necessary.
+	*   4. Calculates the average (mean) and standard deviation of frame times in the buffer.
+	*   5. Sets the graph Y-axis range to be centered on the average, with a spread of ±2 standard deviations,
+	*      clamped to user-friendly minimum and maximum values.
+	*   6. Smooths the min/max Y-axis values for visual stability using exponential smoothing.
+	*
+	*
+	* No parameters; uses settings from the singleton.
+	*/
+	void UpdateGraphValues();
 	void DrawFPS();
 	void DrawVRAM();
 	void DrawPostFGFrameTimeGraph();
@@ -176,14 +195,14 @@ struct PerformanceOverlay : OverlayFeature
 	// PERFORMANCE OVERLAY STATE MANAGEMENT
 	// ============================================================================
 
-	struct PerfOverlayState
+	struct State
 	{
 		// Frame time history buffers
 		CircularBuffer<float> frameTimeHistory;
 		CircularBuffer<float> postFGFrameTimeHistory;
 
 		// State flags
-		bool isFrameGenerationActive = false;  // TODO: this shouldn't be a tracked state
+		bool isFrameGenerationActive = false;
 
 		// Performance counters
 		int64_t frequency;
@@ -212,35 +231,13 @@ struct PerformanceOverlay : OverlayFeature
 		float maxFrameTime = 0.0f;
 		float smoothedMinFrameTime = 0.0f;
 		float smoothedMaxFrameTime = 50.0f;
-
-		/**
-		* @brief Updates all runtime state related to the performance overlay graph.
-		*
-		* This function synchronizes the frame time history buffer, tracks min/max frame times,
-		* and computes the normalized Y-axis range for the frame time graph using statistical analysis.
-		*
-		* Steps performed:
-		*   1. Resizes the frameTimeHistory buffer if the user has changed the setting.
-		*   2. Inserts the latest frame time into the circular history buffer.
-		*   3. Updates instantaneous min/max frame time values, with full rescans if necessary.
-		*   4. Calculates the average (mean) and standard deviation of frame times in the buffer.
-		*   5. Sets the graph Y-axis range to be centered on the average, with a spread of ±2 standard deviations,
-		*      clamped to user-friendly minimum and maximum values.
-		*   6. Smooths the min/max Y-axis values for visual stability using exponential smoothing.
-		*
-		*
-		* No parameters; uses settings from the singleton.
-		*/
-		void UpdateGraphValues();
-		void UpdateFGFrameTime();
 	};
-
-	PerfOverlayState perfOverlayState;
+	State state;
 
 	// ============================================================================
 	// SETTINGS STRUCTURE
 	// ============================================================================
-	struct PerfOverlaySettings
+	struct Settings
 	{
 		// Performance threshold constants
 		static constexpr float kSmoothingFactor = 0.15f;             // Smoothing factor: 0.1f = slow, 0.3f = fast.
@@ -279,9 +276,7 @@ struct PerformanceOverlay : OverlayFeature
 		ImVec2 Position = ImVec2(10.f, 10.f);
 		bool PositionSet = false;
 	};
-
-public:
-	PerfOverlaySettings settings;
+	Settings settings;
 
 private:
 	// ============================================================================

--- a/src/Features/PerformanceOverlay.h
+++ b/src/Features/PerformanceOverlay.h
@@ -79,6 +79,37 @@ struct ColumnConfig
 	std::function<void()> headerTooltip;
 };
 
+template <typename T>
+class CircularBuffer
+{
+	std::vector<T> data = {};
+	size_t headIdx = 0;
+
+public:
+	CircularBuffer(size_t size)
+	{
+		size = std::max(1, size);
+		data.resize(size);
+	}
+
+	void Resize(size_t newSize)
+	{
+		if (data.size() == newSize)
+			return;
+		data.resize(newSize);
+		if (headIdx >= newSize)
+			headIdx = 0;
+	}
+
+	void Push(const T& val)
+	{
+		data[headIdx++] = val;
+		headIdx %= data.size();
+	}
+
+	std::span<const T> GetData() { return { data }; }
+	size_t GetHeadIdx() { return headIdx; }
+};
 struct PerformanceOverlay : OverlayFeature
 {
 	// ============================================================================
@@ -100,6 +131,7 @@ struct PerformanceOverlay : OverlayFeature
 	// ============================================================================
 	void DrawFPS();
 	void DrawVRAM();
+	void DrawPostFGFrameTimeGraph();
 
 	// ============================================================================
 	// A/B TESTING FUNCTIONS
@@ -139,6 +171,7 @@ struct PerformanceOverlay : OverlayFeature
 	// ============================================================================
 	// PERFORMANCE OVERLAY STATE MANAGEMENT
 	// ============================================================================
+
 	struct PerfOverlayState
 	{
 		// Frame time history buffers
@@ -204,12 +237,8 @@ struct PerformanceOverlay : OverlayFeature
 		static constexpr float kWindowBorderPadding = 20.0f;         // pixels - Window border padding
 		static constexpr float kDefaultFrameTimeMs = 16.67f;         // ms - Default frame time (60 FPS)
 
-		// Buffer management methods
-		void ResizeFrameTimeHistory(size_t size, float defaultValue = 0.0f) { frameTimeHistory.resize(size, defaultValue); }
-		void ResizePostFGFrameTimeHistory(size_t size, float defaultValue = 0.0f) { postFGFrameTimeHistory.resize(size, defaultValue); }
+		void ResizeFrameTimeHistory(size_t newSize);
 
-		// Methods that modify state
-		float CalculateTextScale();
 		/**
 		* @brief Updates all runtime state related to the performance overlay graph.
 		*
@@ -229,9 +258,7 @@ struct PerformanceOverlay : OverlayFeature
 		* No parameters; uses settings from the singleton.
 		*/
 		void UpdateGraphValues();
-		void UpdateFrameTimeHistorySizes();
 		void UpdateFGFrameTime();
-		void DrawPostFGFrameTimeGraph();
 	};
 
 	PerfOverlayState perfOverlayState;
@@ -251,13 +278,7 @@ struct PerformanceOverlay : OverlayFeature
 		int FrameHistorySize = 120;                       // Default 120 frames = 2s @ 60fps. Clamped using static values to prevent config file values going outside of slider bounds.
 		static constexpr int kMinFrameHistorySize = 60;   // 60 frames = 1s @ 60fps. Reasonable minimum.
 		static constexpr int kMaxFrameHistorySize = 480;  // 480 frames = 10s @ 60fps or 2s @ 240fps. Reasonable maximum.
-		enum class TextSize
-		{
-			Small,
-			Medium,
-			Large
-		};
-		TextSize Size = TextSize::Medium;
+		float TextSize = 1.0f;
 
 		float BackgroundOpacity = 0.5f;
 		bool ShowBorder = true;


### PR DESCRIPTION
- remove methods from the state class and make it a pure state struct
- move constants out of the state struct into the settings struct
- centralize all state update code in a single `UpdateGraphValues` method
- added `CircularBuffer` for abstraction
- other misc changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified and unified the performance overlay's timing and graph update logic.
  * Replaced enum-based text size selection with a float slider for more precise control.
  * Improved frame time history management using a circular buffer for smoother graph updates.
  * Renamed and reorganized settings and state structures for consistency and clarity.

* **New Features**
  * Added a float slider to adjust overlay text size continuously.
  * Introduced a new method for updating graph-related performance metrics and drawing frame time graphs.

* **Bug Fixes**
  * Enhanced accuracy and reliability of frame time and performance graphs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->