### PR TITLE
perf(ISL): shift size bias calc to CPU

### DIFF
--- a/features/Inverse Square Lighting/Shaders/InverseSquareLighting/InverseSquareLighting.hlsli
+++ b/features/Inverse Square Lighting/Shaders/InverseSquareLighting/InverseSquareLighting.hlsli
@@ -12,7 +12,7 @@ namespace InverseSquareLighting
 		float isEnabled = 1.0f - float((light.lightFlags & LightLimitFix::LightFlags::Disabled) != 0);
 		float isInvSq = float((light.lightFlags & LightLimitFix::LightFlags::InverseSquare) != 0);
 
-		float invSq = SCALED_UNITS_SQ * rcp(distance * distance + SCALED_UNITS_SQ * light.size * light.size / 2.0f);
+		float invSq = SCALED_UNITS_SQ * rcp(distance * distance + light.sizeBias);
 		float t = saturate((light.radius - distance) * light.fadeZone);
 		float fastSmoothstep = t * t * (3.0f - 2.0f * t);
 		invSq *= fastSmoothstep;

--- a/features/Light Limit Fix/Shaders/LightLimitFix/Common.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/Common.hlsli
@@ -38,7 +38,7 @@ struct Light
 	float radius;
 	float invRadius;
 	float fadeZone;
-	float size;
+	float sizeBias;
 	float4 positionWS[2];
 	float4 positionVS[2];
 	uint4 roomFlags;

--- a/src/Features/InverseSquareLighting.cpp
+++ b/src/Features/InverseSquareLighting.cpp
@@ -63,7 +63,7 @@ void InverseSquareLighting::ProcessLight(LightLimitFix::LightData& light, RE::BS
 		runtimeData->radius = light.radius;
 		light.invRadius = 1.f / light.radius;
 		light.fadeZone = 1.f / (light.radius * std::clamp(FadeZoneBase * light.invRadius, 0.f, 1.f));
-		light.size = runtimeData->size;
+		light.sizeBias = ScaledUnitsSq * runtimeData->size * runtimeData->size * 0.5f;
 		light.color /= std::max(0.001f, std::max(light.color.x, std::max(light.color.y, light.color.z)));
 		light.color *= intensity;
 		light.fade = intensity;

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -53,7 +53,7 @@ public:
 		float radius;
 		float invRadius;
 		float fadeZone;
-		float size;
+		float sizeBias;
 		PositionOpt positionWS[2];
 		PositionOpt positionVS[2];
 		uint128_t roomFlags = uint32_t(0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed light size-related properties to improve consistency across lighting features. This change does not affect user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->