### PR TITLE
fix(ISL): corrected CPU side luminance calcs

### DIFF
--- a/src/Features/InverseSquareLighting.cpp
+++ b/src/Features/InverseSquareLighting.cpp
@@ -110,7 +110,7 @@ float InverseSquareLighting::BSLight_GetLuminance::thunk(RE::BSLight* bsLight, R
 
 	const float dist = niLight->world.translate.GetDistance(*targetPosition);
 	const float attenuation = GetAttenuation(dist, runtimeData->radius, runtimeData->size);
-	const float luminance = (runtimeData->diffuse.red + runtimeData->diffuse.green + runtimeData->diffuse.blue) * runtimeData->fade * attenuation * (1.0f / 3.0f);
+	const float luminance = (runtimeData->diffuse.red + runtimeData->diffuse.green + runtimeData->diffuse.blue) * runtimeData->fade * 4 * attenuation * (1.0f / 3.0f);
 	bsLight->luminance = luminance;
 
 	return luminance;


### PR DESCRIPTION
* adds missing 4x multiplier to fade on CPU side light level calcs - now correctly matches visuals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted lighting calculations to increase luminance, resulting in brighter lighting effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->