### PR TITLE
fix(SkySync): fix CPU side moon luminance calcs

### DIFF
--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -348,6 +348,9 @@ void SkySync::ShadowFader::SetLighting(const RE::Sun* sun, RE::NiPoint3 dir, flo
 	m.entry[1][0] = -dir.y;
 	m.entry[2][0] = -dir.z;
 
+	RE::NiUpdateData updateData; 
+	sun->light->Update(updateData);
+
 	intensity = std::clamp(intensity, 0.0f, 1.0f);
 	sun->light->GetLightRuntimeData().fade = intensity;
 	volumetricLightingIntensityFactor = intensity;
@@ -394,7 +397,7 @@ void SkySync::ClimateTimings::Update(const RE::TESClimate* climate)
 
 void SkySync::Sky_OnNewClimate::thunk(RE::Sky* sky)
 {
-	if (auto& singleton = globals::features::skySync; sky && singleton.settings.Enabled)
+	if (auto& singleton = globals::features::skySync; singleton.settings.Enabled && sky && sky->currentClimate)
 		singleton.timings.Update(sky->currentClimate);
 	func(sky);
 }

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -348,7 +348,7 @@ void SkySync::ShadowFader::SetLighting(const RE::Sun* sun, RE::NiPoint3 dir, flo
 	m.entry[1][0] = -dir.y;
 	m.entry[2][0] = -dir.z;
 
-	RE::NiUpdateData updateData; 
+	RE::NiUpdateData updateData;
 	sun->light->Update(updateData);
 
 	intensity = std::clamp(intensity, 0.0f, 1.0f);


### PR DESCRIPTION
* added call to update after setting local rotation to update world rotation, fixes incorrect light level calcs on CPU
* added extra null check to OnNewClimate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lighting updates for smoother transitions after changes to the sun's rotation.
  * Enhanced climate synchronization reliability by ensuring features are only updated when enabled and all necessary data is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->