### PR TITLE
feat(extended translucency): "scattering volume" material 

### DIFF
--- a/features/Extended Translucency/Shaders/ExtendedTranslucency/ExtendedTranslucency.hlsli
+++ b/features/Extended Translucency/Shaders/ExtendedTranslucency/ExtendedTranslucency.hlsli
@@ -6,7 +6,8 @@ namespace ExtendedTranslucency
 		static const uint RimLight = 1;
 		static const uint IsotropicFabric = 2;
 		static const uint AnisotropicFabric = 3;
-		static const uint Disabled = 4;  // Any value >= 4
+		static const uint ScatteringVolume = 4;
+		static const uint Disabled = 5;  // Any value >= 5
 	}
 
 	bool IsValidMaterial(uint Material)
@@ -39,6 +40,11 @@ namespace ExtendedTranslucency
 		float3 v = view;
 		float a0 = 1 - sqrt(1.0 - alpha);
 		return a0 * (length(cross(v, t)) + length(cross(v, b))) / (abs(dot(v, n)) + 0.001) - a0 * a0;
+	}
+
+	float GetViewDependentAlphaScatteringVolume(float alpha, float3 view, float3 normal)
+	{
+		return 1.0 - pow(1.0 - alpha, dot(view, normal));
 	}
 
 	float SoftClamp(float alpha, float limit)

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -3205,7 +3205,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	[branch] if (ExtendedTranslucency::IsValidMaterial(AlphaMaterialModel))
 	{
-		if (alpha >= 0.0156862754 && alpha < 1.0) {
+		if (alpha >= 0.0156862754 && alpha <= 1.0 - 0.0156862754) {
 			float originalAlpha = alpha;
 			alpha = alpha * (1.0 - AlphaMaterialReduction);
 			[branch] if (AlphaMaterialModel == ExtendedTranslucency::MaterialModel::AnisotropicFabric)
@@ -3219,6 +3219,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 			else if (AlphaMaterialModel == ExtendedTranslucency::MaterialModel::IsotropicFabric)
 			{
 				alpha = ExtendedTranslucency::GetViewDependentAlphaFabric1D(alpha, viewDirection, worldNormal.xyz);
+			}
+			else if (AlphaMaterialModel == ExtendedTranslucency::MaterialModel::ScatteringVolume)
+			{
+				alpha = ExtendedTranslucency::GetViewDependentAlphaScatteringVolume(alpha, viewDirection, worldNormal.xyz);
 			}
 			else
 			{

--- a/src/Features/ExtendedTranslucency.cpp
+++ b/src/Features/ExtendedTranslucency.cpp
@@ -90,6 +90,7 @@ void ExtendedTranslucency::DrawSettings()
 			"1 - Rim Edge",
 			"2 - Isotropic Fabric, Glass, ...",
 			"3 - Anisotropic Fabric",
+			"4 - Scattering Volume",
 		};
 
 		static constexpr int AlphaModeSize = static_cast<int>(std::size(AlphaModeNames));
@@ -104,7 +105,8 @@ void ExtendedTranslucency::DrawSettings()
 				"  - Disabled: No anisotropic transluency, flat alpha.\n"
 				"  - Rim Edge: Naive rim light effect with no physics model, the edge of the geometry is always opaque even its full transparent.\n"
 				"  - Isotropic Fabric: Imaginary fabric weaved from threads in one direction, respect normal map, also works well for layer of glass panels.\n"
-				"  - Anisotropic Fabric: Common fabric weaved from tangent and birnormal direction, ignores normal map.\n");
+				"  - Anisotropic Fabric: Common fabric weaved from tangent and birnormal direction, ignores normal map.\n"
+				"  - Scattering Volume: A **volumn** (instead of a layer) of light scattering or absoring material, it fade the geometry out at its edge instead of strength them like other material.\n");
 		}
 		if (ImGui::Checkbox("Skinned Mesh Only", &settings.SkinnedOnly)) {
 			changed = true;
@@ -160,7 +162,7 @@ std::pair<std::string, std::vector<std::string>> ExtendedTranslucency::GetFeatur
 	return {
 		"Extended Translucency provides realistic rendering of thin fabric and other translucent materials.\n"
 		"This feature supports multiple material models for different types of translucent surfaces.",
-		{ "Multiple translucency material models (rim edge, isotropic/anisotropic fabric)",
+		{ "Multiple translucency material models (rim edge, isotropic/anisotropic fabric, scattering volume)",
 			"Realistic fabric translucency with directional light transmission",
 			"Per-material override support via NIF extra data",
 			"Configurable transparency and softness controls",

--- a/src/Features/ExtendedTranslucency.h
+++ b/src/Features/ExtendedTranslucency.h
@@ -32,6 +32,7 @@ struct ExtendedTranslucency final : Feature
 		RimLight = 1,           // Similar effect like rim light
 		IsotropicFabric = 2,    // 1D fabric model, respect normal map
 		AnisotropicFabric = 3,  // 2D fabric model alone tangent and binormal, ignores normal map
+		ScatteringVolume = 4,   // Fade out at the edge, models a ball of fog (light decays in exponential on distance)
 
 		DescriptorUseDefault = 0,  // In ExtraFeatureDescriptor, 0 means 'UseDefault' instead of 'Disabled'
 		DescriptorDisabled = 7,    // In ExtraFeatureDescriptor, value >= 5 means 'Disabled'


### PR DESCRIPTION
  Adding a new material model to the feature: ScatteringVolume
  This material is modeled after a ball of smoke, which scattering light exponentially
  through it.

  It is unique because its the first material model that "fade out" the mesh,
  instead of strengthening its edges.

  This material was originally designed for `Ghost`, or `SetActorAlpha`.
  But it does not work out of the box yet:
  1. The EffectShader of a regular ghost is way too strong, making it hard to see difference in the mesh's rendering.
  2. We disabled this effect in SKIN shader to avoid rendering issue with makeup and face details.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new "Scattering Volume" material mode for extended translucency effects.
  * Included "Scattering Volume" option in the material model selection with updated descriptive tooltips.

* **Improvements**
  * Improved alpha handling for anisotropic materials with view-dependent alpha adjustments.
  * Refined transparency behavior for scattering volume materials with view-dependent fading.

* **Bug Fixes**
  * Ensured alpha values are properly clamped for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->