### PR TITLE
fix(pbr): clamp roughness at a bigger value

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2105,7 +2105,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	pbrSurfaceProperties.Noise = screenNoise;
 
-	pbrSurfaceProperties.Roughness = clamp(rawRMAOS.x, 0.005, 1.0);
+	pbrSurfaceProperties.Roughness = clamp(rawRMAOS.x, 0.04, 1.0);
 	pbrSurfaceProperties.Metallic = saturate(rawRMAOS.y);
 	pbrSurfaceProperties.AO = rawRMAOS.z;
 	pbrSurfaceProperties.F0 = lerp(saturate(rawRMAOS.w), Color::GammaToLinear(baseColor.xyz), pbrSurfaceProperties.Metallic);


### PR DESCRIPTION
clamp roughness at a bigger value. 0.005 is still too small for ggx to generate visible specular.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted the minimum roughness value used in rendering calculations, which may affect the visual appearance of surfaces in scenes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->