### PR TITLE
fix(VR): use smart pointers

### DIFF
--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -1351,7 +1351,7 @@ void VR::EnsureOverlayInitialized()
 		logger::error("IVROverlay is nullptr after GetIVROverlay");
 		return;
 	}
-	Util::CreateOverlayTextureAndRTV(globals::d3d::device, kOverlayWidth, kOverlayHeight, &menuTexture, &menuRTV);
+	Util::CreateOverlayTextureAndRTV(globals::d3d::device, kOverlayWidth, kOverlayHeight, menuTexture.put(), menuRTV.put());
 	std::string key = "communityshaders.menu";
 	std::string name = "Community Shaders Menu";
 	vr::EVROverlayError err = overlay->CreateOverlay(key.c_str(), name.c_str(), &menuOverlayHandle);
@@ -1368,7 +1368,7 @@ void VR::EnsureOverlayInitialized()
 	err = overlay->CreateOverlay(controllerKey.c_str(), controllerName.c_str(), &menuControllerOverlayHandle);
 	if (err == vr::VROverlayError_None) {
 		logger::debug("CreateOverlay succeeded for menuControllerOverlayHandle: 0x{:X}", menuControllerOverlayHandle);
-		Util::CreateOverlayTextureAndRTV(globals::d3d::device, kOverlayWidth, kOverlayHeight, &menuControllerTexture, &menuControllerRTV);
+		Util::CreateOverlayTextureAndRTV(globals::d3d::device, kOverlayWidth, kOverlayHeight, menuControllerTexture.put(), menuControllerRTV.put());
 		Util::SetOverlayInputFlags(overlay, menuControllerOverlayHandle);
 		overlay->SetOverlayWidthInMeters(menuControllerOverlayHandle, 1.0f);
 	} else {
@@ -1382,22 +1382,10 @@ void VR::EnsureOverlayInitialized()
 
 void VR::CleanupOverlayTextures()
 {
-	if (menuRTV) {
-		menuRTV->Release();
-		menuRTV = nullptr;
-	}
-	if (menuTexture) {
-		menuTexture->Release();
-		menuTexture = nullptr;
-	}
-	if (menuControllerRTV) {
-		menuControllerRTV->Release();
-		menuControllerRTV = nullptr;
-	}
-	if (menuControllerTexture) {
-		menuControllerTexture->Release();
-		menuControllerTexture = nullptr;
-	}
+	menuRTV = nullptr;
+	menuTexture = nullptr;
+	menuControllerRTV = nullptr;
+	menuControllerTexture = nullptr;
 }
 
 void VR::DestroyOverlay()
@@ -1422,8 +1410,8 @@ void VR::DestroyOverlay()
 void VR::RecreateOverlayTexturesIfNeeded()
 {
 	CleanupOverlayTextures();
-	Util::CreateOverlayTextureAndRTV(globals::d3d::device, kOverlayWidth, kOverlayHeight, &menuTexture, &menuRTV);
-	Util::CreateOverlayTextureAndRTV(globals::d3d::device, kOverlayWidth, kOverlayHeight, &menuControllerTexture, &menuControllerRTV);
+	Util::CreateOverlayTextureAndRTV(globals::d3d::device, kOverlayWidth, kOverlayHeight, menuTexture.put(), menuRTV.put());
+	Util::CreateOverlayTextureAndRTV(globals::d3d::device, kOverlayWidth, kOverlayHeight, menuControllerTexture.put(), menuControllerRTV.put());
 }
 
 void VR::SubmitOverlayFrame()
@@ -1460,13 +1448,14 @@ void VR::SubmitOverlayFrame()
 	UpdateOverlayDrag();
 	auto& enabled = globals::menu->IsEnabled;
 	auto& overlayVisible = globals::menu->overlayVisible;
-	if ((enabled || overlayVisible || settings.kAutoHideSeconds > 0) && menuOverlayHandle != vr::k_ulOverlayHandleInvalid && menuTexture && menuRTV) {
+	if ((enabled || overlayVisible || settings.kAutoHideSeconds > 0) && menuOverlayHandle != vr::k_ulOverlayHandleInvalid && menuTexture.get() && menuRTV.get()) {
 		// Copy ImGui output to overlay texture
 		ID3D11RenderTargetView* oldRTV = nullptr;
 		globals::d3d::context->OMGetRenderTargets(1, &oldRTV, nullptr);
-		globals::d3d::context->OMSetRenderTargets(1, &menuRTV, nullptr);
+		ID3D11RenderTargetView* menuRTVPtr = menuRTV.get();
+		globals::d3d::context->OMSetRenderTargets(1, &menuRTVPtr, nullptr);
 		float clearColor[4] = { 0, 0, 0, 0 };
-		globals::d3d::context->ClearRenderTargetView(menuRTV, clearColor);
+		globals::d3d::context->ClearRenderTargetView(menuRTV.get(), clearColor);
 		// Re-render ImGui for HMD overlay
 		ImGui::Render();
 		ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
@@ -1478,11 +1467,11 @@ void VR::SubmitOverlayFrame()
 		bool hmdBeingDragged = settings.EnableDragToReposition && overlayDragState.dragging &&
 		                       (overlayDragState.mode == OverlayDragState::DragMode::HMD ||
 								   overlayDragState.mode == OverlayDragState::DragMode::FixedWorld);
-		Util::ApplyHighlightTintToTexture(menuTexture, hmdBeingDragged, settings.dragHighlightColor);
+		Util::ApplyHighlightTintToTexture(menuTexture.get(), hmdBeingDragged, settings.dragHighlightColor);
 
 		// Update overlay position and submit to SteamVR
 		UpdateVROverlayPosition();
-		vr::Texture_t tex = { menuTexture, vr::TextureType_DirectX, vr::ColorSpace_Auto };
+		vr::Texture_t tex = { menuTexture.get(), vr::TextureType_DirectX, vr::ColorSpace_Auto };
 		if (settings.attachMode == AttachMode::HMDOnly || settings.attachMode == AttachMode::Both) {
 			Util::SetOverlayInputFlags(gameOverlay, menuOverlayHandle);
 			vr::EVROverlayError err = cleanOverlay->SetOverlayTexture(menuOverlayHandle, &tex);
@@ -1499,22 +1488,25 @@ void VR::SubmitOverlayFrame()
 		// Controller overlay
 		if (settings.attachMode == AttachMode::ControllerOnly || settings.attachMode == AttachMode::Both) {
 			// Copy the same ImGui output to controller overlay texture
-			globals::d3d::context->OMSetRenderTargets(1, &menuControllerRTV, nullptr);
-			globals::d3d::context->ClearRenderTargetView(menuControllerRTV, clearColor);
+			ID3D11RenderTargetView* menuControllerRTVPtr = menuControllerRTV.get();
+			globals::d3d::context->OMSetRenderTargets(1, &menuControllerRTVPtr, nullptr);
+			globals::d3d::context->ClearRenderTargetView(menuControllerRTV.get(), clearColor);
 			// Re-render ImGui for controller overlay
 			ImGui::Render();
 			ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
 			globals::d3d::context->OMSetRenderTargets(1, &oldRTV, nullptr);
+			if (oldRTV)
+				oldRTV->Release();
 
 			// Apply highlight tint to controller overlay if it's being dragged
 			bool controllerBeingDragged = overlayDragState.dragging &&
 			                              overlayDragState.mode == OverlayDragState::DragMode::Controller;
-			Util::ApplyHighlightTintToTexture(menuControllerTexture, controllerBeingDragged, settings.dragHighlightColor);
+			Util::ApplyHighlightTintToTexture(menuControllerTexture.get(), controllerBeingDragged, settings.dragHighlightColor);
 
 			// Position controller overlay and submit
 			UpdateVROverlayControllerPosition();
 
-			vr::Texture_t controllerTex = { menuControllerTexture, vr::TextureType_DirectX, vr::ColorSpace_Auto };
+			vr::Texture_t controllerTex = { menuControllerTexture.get(), vr::TextureType_DirectX, vr::ColorSpace_Auto };
 			Util::SetOverlayInputFlags(gameOverlay, menuControllerOverlayHandle);
 			vr::EVROverlayError err = cleanOverlay->SetOverlayTexture(menuControllerOverlayHandle, &controllerTex);
 			if (err != vr::VROverlayError_None) {

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -1380,14 +1380,6 @@ void VR::EnsureOverlayInitialized()
 // PRIVATE IMPLEMENTATION
 //=============================================================================
 
-void VR::CleanupOverlayTextures()
-{
-	menuRTV = nullptr;
-	menuTexture = nullptr;
-	menuControllerRTV = nullptr;
-	menuControllerTexture = nullptr;
-}
-
 void VR::DestroyOverlay()
 {
 	RE::BSOpenVR* openvr = RE::BSOpenVR::GetSingleton();
@@ -1404,12 +1396,11 @@ void VR::DestroyOverlay()
 		overlay->DestroyOverlay(menuControllerOverlayHandle);
 		menuControllerOverlayHandle = vr::k_ulOverlayHandleInvalid;
 	}
-	CleanupOverlayTextures();
 }
 
 void VR::RecreateOverlayTexturesIfNeeded()
 {
-	CleanupOverlayTextures();
+	// Smart pointers automatically release existing resources when put() assigns new ones
 	Util::CreateOverlayTextureAndRTV(globals::d3d::device, kOverlayWidth, kOverlayHeight, menuTexture.put(), menuRTV.put());
 	Util::CreateOverlayTextureAndRTV(globals::d3d::device, kOverlayWidth, kOverlayHeight, menuControllerTexture.put(), menuControllerRTV.put());
 }
@@ -1460,8 +1451,6 @@ void VR::SubmitOverlayFrame()
 		ImGui::Render();
 		ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
 		globals::d3d::context->OMSetRenderTargets(1, &oldRTV, nullptr);
-		if (oldRTV)
-			oldRTV->Release();
 
 		// Apply highlight tint to HMD overlay if it's being dragged
 		bool hmdBeingDragged = settings.EnableDragToReposition && overlayDragState.dragging &&
@@ -1495,8 +1484,6 @@ void VR::SubmitOverlayFrame()
 			ImGui::Render();
 			ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
 			globals::d3d::context->OMSetRenderTargets(1, &oldRTV, nullptr);
-			if (oldRTV)
-				oldRTV->Release();
 
 			// Apply highlight tint to controller overlay if it's being dragged
 			bool controllerBeingDragged = overlayDragState.dragging &&
@@ -1519,6 +1506,10 @@ void VR::SubmitOverlayFrame()
 		} else if (menuControllerOverlayHandle != vr::k_ulOverlayHandleInvalid) {
 			gameOverlay->HideOverlay(menuControllerOverlayHandle);
 		}
+
+		// Release oldRTV after all usage is complete to prevent use-after-free
+		if (oldRTV)
+			oldRTV->Release();
 	} else {
 		if (menuOverlayHandle != vr::k_ulOverlayHandleInvalid) {
 			gameOverlay->HideOverlay(menuOverlayHandle);

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <winrt/base.h>
 using namespace DirectX::SimpleMath;
 
 /**
@@ -482,10 +483,10 @@ public:
 	// OpenVR overlay handles and DirectX 11 rendering resources
 	vr::VROverlayHandle_t menuOverlayHandle = vr::k_ulOverlayHandleInvalid;
 	vr::VROverlayHandle_t menuControllerOverlayHandle = vr::k_ulOverlayHandleInvalid;
-	ID3D11Texture2D* menuTexture = nullptr;
-	ID3D11RenderTargetView* menuRTV = nullptr;
-	ID3D11Texture2D* menuControllerTexture = nullptr;
-	ID3D11RenderTargetView* menuControllerRTV = nullptr;
+	winrt::com_ptr<ID3D11Texture2D> menuTexture;
+	winrt::com_ptr<ID3D11RenderTargetView> menuRTV;
+	winrt::com_ptr<ID3D11Texture2D> menuControllerTexture;
+	winrt::com_ptr<ID3D11RenderTargetView> menuControllerRTV;
 
 	// Engine hook integration points
 	bool* gDepthBufferCulling = nullptr;

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -587,7 +587,6 @@ public:
 	// PRIVATE IMPLEMENTATION
 	//=============================================================================
 
-	void CleanupOverlayTextures();
 	void DetectOpenVRInfo();
 	bool IsOpenVRCompatible() const;
 };


### PR DESCRIPTION
Should fix issues with raw pointer access to overlays textures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved reliability and resource management for VR overlays by adopting smart pointers for texture and render target resources.
  * Enhanced stability and reduced risk of resource leaks and premature resource release during VR overlay rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->