### PR TITLE
fix: resolve DirectX COM object memory leaks

### DIFF
--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -240,6 +240,10 @@ void Deferred::CopyShadowData()
 		};
 
 		context->PSSetShaderResources(18, ARRAYSIZE(srvs), srvs);
+
+		// Release COM object to prevent memory leak
+		if (shadowView)
+			shadowView->Release();
 	}
 }
 

--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -75,6 +75,14 @@ void CloudShadows::SkyShaderHacks()
 		auto cubemapDepth = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kCUBEMAP_REFLECTIONS];
 		context->PSSetShaderResources(17, 1, &cubemapDepth.depthSRV);
 
+		// Release COM objects to prevent memory leaks
+		for (int i = 0; i < 3; ++i) {
+			if (rtvs[i])
+				rtvs[i]->Release();
+		}
+		if (dsv)
+			dsv->Release();
+
 		overrideSky = false;
 	}
 }

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -343,8 +343,6 @@ void TruePBR::SetupGlintsTexture()
 		// Release COM objects to prevent memory leaks
 		if (old.shader)
 			old.shader->Release();
-		if (old.instance)
-			old.instance->Release();
 		for (auto& uav : old.uav) {
 			if (uav)
 				uav->Release();

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -339,6 +339,16 @@ void TruePBR::SetupGlintsTexture()
 
 		context->CSSetShader(old.shader, &old.instance, old.numInstances);
 		context->CSSetUnorderedAccessViews(0, ARRAYSIZE(old.uav), old.uav, nullptr);
+
+		// Release COM objects to prevent memory leaks
+		if (old.shader)
+			old.shader->Release();
+		if (old.instance)
+			old.instance->Release();
+		for (auto& uav : old.uav) {
+			if (uav)
+				uav->Release();
+		}
 	}
 
 	noiseGenProgram->Release();

--- a/src/Upscaling.cpp
+++ b/src/Upscaling.cpp
@@ -356,13 +356,6 @@ void Upscaling::Upscale()
 	ID3D11Resource* outputTextureResource;
 	outputTextureRTV->GetResource(&outputTextureResource);
 
-	// Now release the views after getting resources
-	inputTextureSRV->Release();
-	outputTextureRTV->Release();
-
-	if (dsv)
-		dsv->Release();
-
 	auto dispatchCount = Util::GetScreenDispatchCount(false);
 
 	{
@@ -440,6 +433,14 @@ void Upscaling::Upscale()
 	}
 
 	context->CopyResource(outputTextureResource, upscalingTexture->resource.get());
+
+	// Release COM objects to prevent memory leaks after all usage is complete
+	if (inputTextureSRV)
+		inputTextureSRV->Release();
+	if (outputTextureRTV)
+		outputTextureRTV->Release();
+	if (dsv)
+		dsv->Release();
 }
 
 void Upscaling::SharpenTAA()
@@ -465,13 +466,6 @@ void Upscaling::SharpenTAA()
 
 	ID3D11Resource* outputTextureResource;
 	outputTextureRTV->GetResource(&outputTextureResource);
-
-	// Now release the views after getting resources
-	inputTextureSRV->Release();
-	outputTextureRTV->Release();
-
-	if (dsv)
-		dsv->Release();
 
 	auto dispatchCount = Util::GetScreenDispatchCount(false);
 
@@ -505,6 +499,14 @@ void Upscaling::SharpenTAA()
 	state->EndPerfEvent();
 
 	context->CopyResource(outputTextureResource, upscalingTexture->resource.get());
+
+	// Release COM objects to prevent memory leaks after all usage is complete
+	if (inputTextureSRV)
+		inputTextureSRV->Release();
+	if (outputTextureRTV)
+		outputTextureRTV->Release();
+	if (dsv)
+		dsv->Release();
 
 	globals::game::stateUpdateFlags->set(RE::BSGraphics::ShaderFlags::DIRTY_RENDERTARGET);  // Run OMSetRenderTargets again
 }

--- a/src/Upscaling.cpp
+++ b/src/Upscaling.cpp
@@ -344,23 +344,24 @@ void Upscaling::Upscale()
 	ID3D11ShaderResourceView* inputTextureSRV;
 	context->PSGetShaderResources(0, 1, &inputTextureSRV);
 
-	inputTextureSRV->Release();
-
 	ID3D11RenderTargetView* outputTextureRTV;
 	ID3D11DepthStencilView* dsv;
 	context->OMGetRenderTargets(1, &outputTextureRTV, &dsv);
 	context->OMSetRenderTargets(0, nullptr, nullptr);
 
-	outputTextureRTV->Release();
-
-	if (dsv)
-		dsv->Release();
-
+	// Get resources before releasing the views
 	ID3D11Resource* inputTextureResource;
 	inputTextureSRV->GetResource(&inputTextureResource);
 
 	ID3D11Resource* outputTextureResource;
 	outputTextureRTV->GetResource(&outputTextureResource);
+
+	// Now release the views after getting resources
+	inputTextureSRV->Release();
+	outputTextureRTV->Release();
+
+	if (dsv)
+		dsv->Release();
 
 	auto dispatchCount = Util::GetScreenDispatchCount(false);
 
@@ -453,23 +454,24 @@ void Upscaling::SharpenTAA()
 	ID3D11ShaderResourceView* inputTextureSRV;
 	context->PSGetShaderResources(0, 1, &inputTextureSRV);
 
-	inputTextureSRV->Release();
-
 	ID3D11RenderTargetView* outputTextureRTV;
 	ID3D11DepthStencilView* dsv;
 	context->OMGetRenderTargets(1, &outputTextureRTV, &dsv);
 	context->OMSetRenderTargets(0, nullptr, nullptr);
 
-	outputTextureRTV->Release();
-
-	if (dsv)
-		dsv->Release();
-
+	// Get resources before releasing the views
 	ID3D11Resource* inputTextureResource;
 	inputTextureSRV->GetResource(&inputTextureResource);
 
 	ID3D11Resource* outputTextureResource;
 	outputTextureRTV->GetResource(&outputTextureResource);
+
+	// Now release the views after getting resources
+	inputTextureSRV->Release();
+	outputTextureRTV->Release();
+
+	if (dsv)
+		dsv->Release();
 
 	auto dispatchCount = Util::GetScreenDispatchCount(false);
 


### PR DESCRIPTION
- TruePBR: release compute shader state objects after use
- Upscaling: fix use-after-release by reordering resource access
- CloudShadows: release render target views from OMGetRenderTargets
- Deferred: release shader resource view from PSGetShaderResources

Prevents COM object leaks that were causing memory accumulation during PBR rendering, upscaling operations, and shadow processing.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management to prevent potential memory leaks and use-after-release issues when handling graphics resources.
  * Ensured proper release of graphics resources in several features, including shadow rendering, cloud shadows, physically-based rendering, and upscaling.
  * Adjusted resource release order to maintain stability and reliability during rendering operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->