### PR TITLE
feat(VR): separate interior/exterior options for depth buffer culling

### DIFF
--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -29,7 +29,8 @@ constexpr int kOverlayHeight = 1080;
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	VR::Settings,
-	EnableDepthBufferCulling,
+	EnableDepthBufferCullingInterior,
+	EnableDepthBufferCullingExterior,
 	MinOccludeeBoxExtent,
 	VRMenuScale,
 	VRMenuPositioningMethod,
@@ -110,8 +111,13 @@ void VR::PostPostLoad()
 
 void VR::DataLoaded()
 {
-	*gDepthBufferCulling = settings.EnableDepthBufferCulling;
+	*gDepthBufferCulling = settings.EnableDepthBufferCullingExterior;
 	*gMinOccludeeBoxExtent = settings.MinOccludeeBoxExtent;
+}
+
+void VR::EarlyPrepass()
+{
+	*gDepthBufferCulling = globals::game::tes->interiorCell ? settings.EnableDepthBufferCullingInterior : settings.EnableDepthBufferCullingExterior;
 }
 
 //=============================================================================
@@ -551,13 +557,18 @@ namespace
 		auto& vr = globals::features::vr;
 		VR::Settings& settings = vr.settings;
 		if (ImGui::CollapsingHeader("General Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
-			ImGui::Checkbox("Enable Depth Buffer Culling", &settings.EnableDepthBufferCulling);
+			ImGui::Checkbox("Enable Depth Buffer Culling in Exteriors", &settings.EnableDepthBufferCullingExterior);
 			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text("Enables depth buffer culling for VR performance optimization.");
+				ImGui::Text("Improves performance in exteriors, recommended ON.");
 			}
-			ImGui::SliderFloat("Min Occludee Box Extent", &settings.MinOccludeeBoxExtent, 0.0f, 1000.0f, "%.1f");
+			ImGui::Checkbox("Enable Depth Buffer Culling in Interiors", &settings.EnableDepthBufferCullingInterior);
 			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text("Minimum box extent for occlusion culling in VR.");
+				ImGui::Text("Improves performance in interiors, recommended OFF due to occasional visual glitches.");
+			}
+			if (ImGui::SliderFloat("Min Occludee Box Extent", &settings.MinOccludeeBoxExtent, 0.0f, 1000.0f, "%.1f"))
+				*vr.gMinOccludeeBoxExtent = settings.MinOccludeeBoxExtent;
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text("Minimum bounding box dimensions for object occlusion culling. Lower values improve performance but may result in visual artifacts.");
 			}
 		}
 	}

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -313,8 +313,8 @@ public:
 	{
 		// Performance optimization settings
 		bool EnableDepthBufferCullingExterior = true;  ///< Enable depth buffer culling for VR performance
-		bool EnableDepthBufferCullingInterior = false;  
-		float MinOccludeeBoxExtent = 10.0f;    ///< Minimum bounding box size for occlusion culling
+		bool EnableDepthBufferCullingInterior = false;
+		float MinOccludeeBoxExtent = 10.0f;  ///< Minimum bounding box size for occlusion culling
 
 		// VR Menu Overlay positioning settings
 		float VRMenuScale = Config::kDefaultMenuScale;  ///< Scale factor for overlay UI (0.5-2.0)

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -2,7 +2,6 @@
 #include "Menu.h"
 #include "OverlayFeature.h"
 #include <algorithm>
-#include <atomic>
 #include <d3d11.h>
 #include <imgui_impl_dx11.h>
 #include <magic_enum.hpp>
@@ -281,6 +280,7 @@ public:
 
 	virtual void PostPostLoad() override;
 	virtual void DataLoaded() override;
+	virtual void EarlyPrepass() override;
 
 	virtual void LoadSettings(json& o_json) override;
 	virtual void SaveSettings(json& o_json) override;
@@ -312,7 +312,8 @@ public:
 	struct Settings
 	{
 		// Performance optimization settings
-		bool EnableDepthBufferCulling = true;  ///< Enable depth buffer culling for VR performance
+		bool EnableDepthBufferCullingExterior = true;  ///< Enable depth buffer culling for VR performance
+		bool EnableDepthBufferCullingInterior = false;  
 		float MinOccludeeBoxExtent = 10.0f;    ///< Minimum bounding box size for occlusion culling
 
 		// VR Menu Overlay positioning settings


### PR DESCRIPTION
* adds separate controls to enable/disable depth buffer culling in interiors and exteriors - interiors benefit the least and have unavoidable occasional but distracting visual glitches due to the technique used
* fixes the regression where both the enabled/disabled state and gMinOccludeeBoxExtent were no longer being set when changing settings in the UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate options to enable depth buffer culling for interior and exterior environments in VR settings.
  * Updated the VR settings interface to provide two distinct checkboxes for controlling depth buffer culling in interiors and exteriors, each with its own tooltip.

* **Improvements**
  * The minimum occludee box extent slider now applies changes immediately when adjusted.
  * Enhanced runtime logic to respect the new separate culling settings based on environment type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->