### PR TITLE
fix(extended translucency): apply extra data and implicit alpha

### DIFF
--- a/src/Features/ExtendedTranslucency.cpp
+++ b/src/Features/ExtendedTranslucency.cpp
@@ -5,11 +5,13 @@
 #include "../Util.h"
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
-	ExtendedTranslucency::MaterialParams,
+	ExtendedTranslucency::Settings,
 	AlphaMode,
 	AlphaReduction,
 	AlphaSoftness,
-	AlphaStrength);
+	AlphaStrength,
+	SkinnedOnly
+);
 
 const RE::BSFixedString ExtendedTranslucency::NiExtraDataName_AnisotropicAlphaMaterial = "AnisotropicAlphaMaterial";
 
@@ -38,21 +40,21 @@ void ExtendedTranslucency::BSLightingShader_SetupGeometry(RE::BSRenderPass* pass
 
 	const auto* data = pass->geometry->GetExtraData(NiExtraDataName_AnisotropicAlphaMaterial);
 	if (!data) {
-		// If there is no extra data for explict settings, use the default material model from global user settings
+		// If there is no extra data for explicit settings, use the default material model from global user settings
 		// And respect the SkinnedOnly setting
 		const auto& feature = globals::features::extendedTranslucency;
-		if (!feature.SkinnedOnly || pass->geometry->GetGeometryRuntimeData().skinInstance != nullptr) {
+		if (!feature.settings.SkinnedOnly || pass->geometry->GetGeometryRuntimeData().skinInstance != nullptr) {
 			SetFeatureDescriptor(MaterialModel::DescriptorUseDefault);
 		}
 	} else {
 		// Read explicit material model from extra data
 		if (data->GetRTTI() == globals::rtti::NiIntegerExtraDataRTTI.get()) {
 			uint32_t material = static_cast<uint32_t>(static_cast<const RE::NiIntegerExtraData*>(data)->value) & ExtraFeatureDescriptorMask;
-			// Promopt `Disabled` in settings to `DescriptorDisabled` in shader
+			// Promote `Disabled` in settings to `DescriptorDisabled` in shader
 			material = material == MaterialModel::Disabled ? MaterialModel::DescriptorDisabled : material;
 			SetFeatureDescriptor(material);
 		} else {
-			// logging is too expensive here, treat type error as disable, should should only happen for modders
+			// logging is too expensive here, treat type error as disable, should only happen for modders
 		}
 	}
 }
@@ -105,7 +107,7 @@ void ExtendedTranslucency::DrawSettings()
 				"  - Isotropic Fabric: Imaginary fabric weaved from threads in one direction, respect normal map, also works well for layer of glass panels.\n"
 				"  - Anisotropic Fabric: Common fabric weaved from tangent and birnormal direction, ignores normal map.\n");
 		}
-		if (ImGui::Checkbox("Skinned Mesh Only", &SkinnedOnly)) {
+		if (ImGui::Checkbox("Skinned Mesh Only", &settings.SkinnedOnly)) {
 			changed = true;
 		}
 		if (auto _tt = Util::HoverTooltipWrapper()) {
@@ -142,19 +144,16 @@ void ExtendedTranslucency::DrawSettings()
 void ExtendedTranslucency::LoadSettings(json& o_json)
 {
 	settings = o_json;
-	SkinnedOnly = o_json.value("SkinnedOnly", true);
 }
 
 void ExtendedTranslucency::SaveSettings(json& o_json)
 {
 	o_json = settings;
-	o_json["SkinnedOnly"] = SkinnedOnly;
 }
 
 void ExtendedTranslucency::RestoreDefaultSettings()
 {
 	settings = {};
-	SkinnedOnly = true;
 }
 
 std::pair<std::string, std::vector<std::string>> ExtendedTranslucency::GetFeatureSummary()

--- a/src/Features/ExtendedTranslucency.cpp
+++ b/src/Features/ExtendedTranslucency.cpp
@@ -10,8 +10,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	AlphaReduction,
 	AlphaSoftness,
 	AlphaStrength,
-	SkinnedOnly
-);
+	SkinnedOnly);
 
 const RE::BSFixedString ExtendedTranslucency::NiExtraDataName_AnisotropicAlphaMaterial = "AnisotropicAlphaMaterial";
 

--- a/src/Features/ExtendedTranslucency.cpp
+++ b/src/Features/ExtendedTranslucency.cpp
@@ -15,31 +15,45 @@ const RE::BSFixedString ExtendedTranslucency::NiExtraDataName_AnisotropicAlphaMa
 
 void ExtendedTranslucency::BSLightingShader_SetupGeometry(RE::BSRenderPass* pass)
 {
-	globals::state->permutationData.ExtraFeatureDescriptor &= ~(ExtraFeatureDescriptorMask << ExtraFeatureDescriptorShift);
-	// TODO: PERFORMANCE: Caching the feature descriptor in map<RE::BSGeometry*, uint> if this get more complex
-	auto& unknownProperty = pass->geometry->GetGeometryRuntimeData().properties[RE::BSGeometry::States::kProperty];
-	auto alphaProperty = unknownProperty && unknownProperty->GetRTTI() == globals::rtti::NiAlphaPropertyRTTI.get() ? static_cast<RE::NiAlphaProperty*>(unknownProperty.get()) : nullptr;
-	auto& feature = globals::features::extendedTranslucency;
-	// Check alpha property exists and blending is enabled
-	if (alphaProperty && alphaProperty->GetAlphaBlending() && (pass->geometry->GetGeometryRuntimeData().skinInstance != nullptr || !feature.SkinnedOnly)) {
-		if (auto* data = pass->geometry->GetExtraData(NiExtraDataName_AnisotropicAlphaMaterial)) {
-			if (data->GetRTTI() == globals::rtti::NiIntegerExtraDataRTTI.get()) {
-				uint32_t material = static_cast<uint32_t>(static_cast<RE::NiIntegerExtraData*>(data)->value) & ExtraFeatureDescriptorMask;
-				if (material == MaterialModel::Disabled) {
-					// MaterialModel::Disabled (0) is the flag when this extra does not exist
-					// And it will let the effect use default settings instead of force disable it
-					// Ensure this is disabled by using the ForceDisabled flag
-					material = MaterialModel::ForceDisabled;
-				}
-				globals::state->permutationData.ExtraFeatureDescriptor |= (material << ExtraFeatureDescriptorShift);
+	auto SetFeatureDescriptor = [](int material) {
+		auto& descriptor = globals::state->permutationData.ExtraFeatureDescriptor;
+		static constexpr int mask = ExtraFeatureDescriptorMask << ExtraFeatureDescriptorShift;
+		static constexpr int shift = ExtraFeatureDescriptorShift;
+		descriptor = (descriptor & ~mask) | (material << shift);
+	};
 
-				// TODO: Per-material settings from Nif
-				// Mods supporting this feature should adjust their alpha value in texture already
-				// And the texture should be adjusted based on full strength param
-			}
+	// Clear the ExtraFeatureDescriptor to disable this effect on default
+	SetFeatureDescriptor(MaterialModel::DescriptorDisabled);
+
+	auto& property0 = pass->geometry->GetGeometryRuntimeData().properties[0];
+	auto& property1 = pass->geometry->GetGeometryRuntimeData().properties[1];
+	auto alphaProperty = property0 && property0->GetRTTI() == globals::rtti::NiAlphaPropertyRTTI.get() ? static_cast<RE::NiAlphaProperty*>(property0.get()) : nullptr;
+	auto lightProperty = property1 && property1->GetRTTI() == globals::rtti::BSLightingShaderPropertyRTTI.get() ? static_cast<RE::BSLightingShaderProperty*>(property1.get()) : nullptr;
+
+	// This effect only matters when alpha property exists and blending is enabled
+	// Geometries with alpha < 1 have an implicit alpha blend property
+	if (!(lightProperty && lightProperty->alpha < 0.999f) && (!alphaProperty || !alphaProperty->GetAlphaBlending())) {
+		return;
+	}
+
+	const auto* data = pass->geometry->GetExtraData(NiExtraDataName_AnisotropicAlphaMaterial);
+	if (!data) {
+		// If there is no extra data for explict settings, use the default material model from global user settings
+		// And respect the SkinnedOnly setting
+		const auto& feature = globals::features::extendedTranslucency;
+		if (!feature.SkinnedOnly || pass->geometry->GetGeometryRuntimeData().skinInstance != nullptr) {
+			SetFeatureDescriptor(MaterialModel::DescriptorUseDefault);
 		}
 	} else {
-		globals::state->permutationData.ExtraFeatureDescriptor |= ((MaterialModel::ForceDisabled) << ExtraFeatureDescriptorShift);
+		// Read explicit material model from extra data
+		if (data->GetRTTI() == globals::rtti::NiIntegerExtraDataRTTI.get()) {
+			uint32_t material = static_cast<uint32_t>(static_cast<const RE::NiIntegerExtraData*>(data)->value) & ExtraFeatureDescriptorMask;
+			// Promopt `Disabled` in settings to `DescriptorDisabled` in shader
+			material = material == MaterialModel::Disabled ? MaterialModel::DescriptorDisabled : material;
+			SetFeatureDescriptor(material);
+		} else {
+			// logging is too expensive here, treat type error as disable, should should only happen for modders
+		}
 	}
 }
 
@@ -70,23 +84,25 @@ void ExtendedTranslucency::PostPostLoad()
 void ExtendedTranslucency::DrawSettings()
 {
 	if (ImGui::TreeNodeEx("Translucent Material", ImGuiTreeNodeFlags_DefaultOpen)) {
-		static const char* AlphaModeNames[4] = {
-			"Disabled",
-			"Rim Light",
-			"Isotropic Fabric",
-			"Anisotropic Fabric"
+		static constexpr const char* AlphaModeNames[] = {
+			"0 - Disabled",
+			"1 - Rim Edge",
+			"2 - Isotropic Fabric, Glass, ...",
+			"3 - Anisotropic Fabric",
 		};
 
+		static constexpr int AlphaModeSize = static_cast<int>(std::size(AlphaModeNames));
+
 		bool changed = false;
-		if (ImGui::Combo("Default Material Model", (int*)&settings.AlphaMode, AlphaModeNames, 4)) {
+		if (ImGui::Combo("Default Material Model", (int*)&settings.AlphaMode, AlphaModeNames, AlphaModeSize)) {
 			changed = true;
 		}
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
-				"Anisotropic transluency will make the surface more opaque when you view it parallel to the surface.\n"
-				"  - Disabled: No anisotropic transluency\n"
-				"  - Rim Light: Naive rim light effect\n"
-				"  - Isotropic Fabric: Imaginary fabric weaved from threads in one direction, respect normal map.\n"
+				"Anisotropic transluency will adjust the opacity based on your view angle to the translucent surface.\n"
+				"  - Disabled: No anisotropic transluency, flat alpha.\n"
+				"  - Rim Edge: Naive rim light effect with no physics model, the edge of the geometry is always opaque even its full transparent.\n"
+				"  - Isotropic Fabric: Imaginary fabric weaved from threads in one direction, respect normal map, also works well for layer of glass panels.\n"
 				"  - Anisotropic Fabric: Common fabric weaved from tangent and birnormal direction, ignores normal map.\n");
 		}
 		if (ImGui::Checkbox("Skinned Mesh Only", &SkinnedOnly)) {
@@ -96,7 +112,7 @@ void ExtendedTranslucency::DrawSettings()
 			ImGui::Text("Control if this effect should only apply to skinned mesh, check this option if your are seeing undesired effect on random objects.");
 		}
 
-		if (ImGui::SliderFloat("Transparency Increase", &settings.AlphaReduction, 0.f, 1.f)) {
+		if (ImGui::SliderFloat("Transparency Increase", &settings.AlphaReduction, 0, 1.f)) {
 			changed = true;
 		}
 		if (auto _tt = Util::HoverTooltipWrapper()) {
@@ -138,6 +154,7 @@ void ExtendedTranslucency::SaveSettings(json& o_json)
 void ExtendedTranslucency::RestoreDefaultSettings()
 {
 	settings = {};
+	SkinnedOnly = true;
 }
 
 std::pair<std::string, std::vector<std::string>> ExtendedTranslucency::GetFeatureSummary()
@@ -145,7 +162,7 @@ std::pair<std::string, std::vector<std::string>> ExtendedTranslucency::GetFeatur
 	return {
 		"Extended Translucency provides realistic rendering of thin fabric and other translucent materials.\n"
 		"This feature supports multiple material models for different types of translucent surfaces.",
-		{ "Multiple translucency material models (rim light, isotropic/anisotropic fabric)",
+		{ "Multiple translucency material models (rim edge, isotropic/anisotropic fabric)",
 			"Realistic fabric translucency with directional light transmission",
 			"Per-material override support via NIF extra data",
 			"Configurable transparency and softness controls",

--- a/src/Features/ExtendedTranslucency.h
+++ b/src/Features/ExtendedTranslucency.h
@@ -40,7 +40,8 @@ struct ExtendedTranslucency final : Feature
 	static constexpr uint32_t ExtraFeatureDescriptorShift = 6;
 	static constexpr uint32_t ExtraFeatureDescriptorMask = 7;
 
-	struct alignas(16) MaterialParams
+	// Settings in both CPU and GPU constant buffer
+	struct alignas(16) PerFrame
 	{
 		uint32_t AlphaMode = MaterialModel::AnisotropicFabric;
 		float AlphaReduction = 0.15f;
@@ -48,8 +49,16 @@ struct ExtendedTranslucency final : Feature
 		float AlphaStrength = 0.f;
 	};
 
-	MaterialParams settings;
-	bool SkinnedOnly = true;
+	// Settings only in CPU
+	struct Settings : PerFrame
+	{
+		bool SkinnedOnly = true;
+	};
+
+	Settings settings;
+
+	const PerFrame& GetCommonBufferData() { return settings; }
+
 
 	static const RE::BSFixedString NiExtraDataName_AnisotropicAlphaMaterial;
 };

--- a/src/Features/ExtendedTranslucency.h
+++ b/src/Features/ExtendedTranslucency.h
@@ -59,6 +59,5 @@ struct ExtendedTranslucency final : Feature
 
 	const PerFrame& GetCommonBufferData() { return settings; }
 
-
 	static const RE::BSFixedString NiExtraDataName_AnisotropicAlphaMaterial;
 };

--- a/src/Features/ExtendedTranslucency.h
+++ b/src/Features/ExtendedTranslucency.h
@@ -5,10 +5,14 @@
 
 struct ExtendedTranslucency final : Feature
 {
+	static constexpr std::string_view MOD_ID = "150755"sv;
+
 	virtual inline std::string GetName() override { return "Extended Translucency"; }
 	virtual inline std::string GetShortName() override { return "ExtendedTranslucency"; }
-	virtual inline std::string_view GetShaderDefineName() override { return "EXTENDED_TRANSLUCENCY"; }
-	virtual inline std::string_view GetCategory() const override { return "Materials"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
+	virtual inline std::string_view GetShaderDefineName() override { return "EXTENDED_TRANSLUCENCY"sv; }
+	virtual inline std::string_view GetCategory() const override { return "Materials"sv; }
+	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override;
 	virtual bool HasShaderDefine(RE::BSShader::Type shaderType) override { return RE::BSShader::Type::Lighting == shaderType; };
 	virtual void PostPostLoad() override;
 	virtual void DrawSettings() override;
@@ -17,12 +21,6 @@ struct ExtendedTranslucency final : Feature
 	virtual void RestoreDefaultSettings() override;
 	virtual bool SupportsVR() override { return true; };
 
-	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override;
-
-	// Future proof function for UI refactoring
-	std::string GetFeatureDescription() { return "Realistic rendering of thin fabric and other translucent materials"; }  // Feature description for settings page
-	std::string GetFeatureModLink() { return "https://www.nexusmods.com/skyrimspecialedition/mods/150755"; }
-
 	static void BSLightingShader_SetupGeometry(RE::BSRenderPass* pass);
 
 	struct Hooks;
@@ -30,11 +28,13 @@ struct ExtendedTranslucency final : Feature
 	// TODO: Support more material model like glasses or arcylic
 	enum MaterialModel : uint32_t
 	{
-		Disabled = 0,           // In ExtraFeatureDescriptor, this value means 'Default' instead of 'Disabled'
+		Disabled = 0,           // In user settings, 0 means 'Disabled'
 		RimLight = 1,           // Similar effect like rim light
 		IsotropicFabric = 2,    // 1D fabric model, respect normal map
 		AnisotropicFabric = 3,  // 2D fabric model alone tangent and binormal, ignores normal map
-		ForceDisabled = 4,      // In ExtraFeatureDescriptor, value >= 4 means 'Disabled'
+
+		DescriptorUseDefault = 0,  // In ExtraFeatureDescriptor, 0 means 'UseDefault' instead of 'Disabled'
+		DescriptorDisabled = 7,    // In ExtraFeatureDescriptor, value >= 5 means 'Disabled'
 	};
 
 	static constexpr uint32_t ExtraFeatureDescriptorShift = 6;


### PR DESCRIPTION
- nif setting should ignore SkinnedMeshOnly
- meshes with lightingShaderProperty.alpha < 1 have implicit alpha and should not be ignored for easy testing
Also clarified the cpu code for translating nif setting into descriptor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved clarity and maintainability of translucency effect logic and condition checks.
  * Enhanced enum values and documentation for material model settings.
  * Separated CPU/GPU shared settings from CPU-only settings for better modularity.

* **New Features**
  * Added a dynamic mod link for easier access to feature information.

* **Style**
  * Updated UI labels and tooltips for alpha modes to be more descriptive and consistent.
  * Revised terminology from "rim light" to "rim edge" throughout the interface.

* **Bug Fixes**
  * Adjusted transparency slider to use integer minimum for improved usability.

* **Chores**
  * Restoring default settings now explicitly enables the "Skinned Only" option.
  * Simplified settings load/save by handling entire settings struct directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->