### PR TITLE
fix(path): use real filesystem paths

### DIFF
--- a/src/FeatureIssues.cpp
+++ b/src/FeatureIssues.cpp
@@ -416,7 +416,7 @@ namespace FeatureIssues
 		// Common cleanup actions section
 		ImGui::TextColored(theme.Palette.Text, "Cleanup Actions:");
 		if (ImGui::Button("Open Features Folder")) {
-			std::filesystem::path featuresPath = Util::PathHelpers::GetFeaturesPath();
+			std::filesystem::path featuresPath = Util::PathHelpers::GetFeaturesRealPath();
 			ShellExecuteA(NULL, "open", featuresPath.string().c_str(), NULL, NULL, SW_SHOWNORMAL);
 		}
 		if (auto _tt = Util::HoverTooltipWrapper()) {
@@ -424,7 +424,7 @@ namespace FeatureIssues
 		}
 		ImGui::SameLine();
 		if (ImGui::Button("Open Shaders Directory")) {
-			std::filesystem::path shadersPath = Util::PathHelpers::GetShadersPath();
+			std::filesystem::path shadersPath = Util::PathHelpers::GetShadersRealPath();
 			ShellExecuteA(NULL, "open", shadersPath.string().c_str(), NULL, NULL, SW_SHOWNORMAL);
 		}
 		if (auto _tt = Util::HoverTooltipWrapper()) {

--- a/src/Utils/FileSystem.cpp
+++ b/src/Utils/FileSystem.cpp
@@ -1,5 +1,6 @@
 #include "FileSystem.h"
 #include <fstream>
+#include <psapi.h>
 
 namespace Util
 {
@@ -45,6 +46,49 @@ namespace Util
 		std::filesystem::path GetFeatureShaderPath(const std::string& featureName)
 		{
 			return GetShadersPath() / featureName;
+		}
+
+		std::filesystem::path GetCurrentModuleRealPath()
+		{
+			try {
+				HMODULE selfModule = nullptr;
+				if (!GetModuleHandleExW(
+						GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+						reinterpret_cast<LPCWSTR>(&GetCurrentModuleRealPath),
+						&selfModule)) {
+					return {};
+				}
+				wchar_t buffer[MAX_PATH]{};
+				DWORD size = GetModuleFileNameExW(GetCurrentProcess(), selfModule, buffer, MAX_PATH);
+				if (size == 0 || size == MAX_PATH) {
+					throw std::runtime_error("Failed to get module filename");
+				}
+				return std::filesystem::path(buffer);
+			} catch (const std::exception& e) {
+				logger::error("GetCurrentModuleRealPath: Exception caught: {}", e.what());
+				return {};
+			}
+		}
+
+		std::filesystem::path GetRootRealPath()
+		{
+			static std::filesystem::path cachedPath = []() {
+				std::filesystem::path dllPath = GetCurrentModuleRealPath();
+				if (dllPath.empty())
+					return std::filesystem::path{};
+				return dllPath.parent_path().parent_path().parent_path();
+			}();
+			return cachedPath;
+		}
+
+		std::filesystem::path GetShadersRealPath()
+		{
+			return GetRootRealPath() / "Shaders";
+		}
+
+		std::filesystem::path GetFeaturesRealPath()
+		{
+			return GetRootRealPath() / "Features";
 		}
 	}
 

--- a/src/Utils/FileSystem.cpp
+++ b/src/Utils/FileSystem.cpp
@@ -88,7 +88,7 @@ namespace Util
 
 		std::filesystem::path GetFeaturesRealPath()
 		{
-			return GetRootRealPath() / "Features";
+			return GetShadersRealPath() / "Features";
 		}
 	}
 

--- a/src/Utils/FileSystem.h
+++ b/src/Utils/FileSystem.h
@@ -62,8 +62,8 @@ namespace Util
 		 * Returns the real file system path to the current DLL module.
 		 *
 		 * This is useful when running under Mod Organizer 2 (MO2), which uses a virtual file system (VFS).
-		 * Accessing files relative to the game's Data directory via VFS (e.g. "Data/Shaders") may not work 
-		 * outside the game process (e.g. from Windows Explorer or ShellExecute), since those paths don't 
+		 * Accessing files relative to the game's Data directory via VFS (e.g. "Data/Shaders") may not work
+		 * outside the game process (e.g. from Windows Explorer or ShellExecute), since those paths don't
 		 * exist on disk. This function bypasses VFS and returns the actual DLL path on disk.
 		 *
 		 * @return Absolute file system path to the current DLL module.

--- a/src/Utils/FileSystem.h
+++ b/src/Utils/FileSystem.h
@@ -59,28 +59,35 @@ namespace Util
 		std::filesystem::path GetFeatureShaderPath(const std::string& featureName);
 
 		/**
-		 * Gets the real path to the current .dll module in the file system (outside VFS)
-		 * @return Real path to CS root directory
+		 * Returns the real file system path to the current DLL module.
+		 *
+		 * This is useful when running under Mod Organizer 2 (MO2), which uses a virtual file system (VFS).
+		 * Accessing files relative to the game's Data directory via VFS (e.g. "Data/Shaders") may not work 
+		 * outside the game process (e.g. from Windows Explorer or ShellExecute), since those paths don't 
+		 * exist on disk. This function bypasses VFS and returns the actual DLL path on disk.
+		 *
+		 * @return Absolute file system path to the current DLL module.
 		 */
 		std::filesystem::path GetCurrentModuleRealPath();
 
 		/**
-		 * Gets the path to the real CS root directory (outside VFS)
-		 * @return Real path to CS root directory
+		 * Returns the real root directory of the mod, relative to the DLL path.
+		  * @return <mod_root>.
 		 */
 		std::filesystem::path GetRootRealPath();
 
 		/**
-		 * Gets the main Shaders directory path in CS root directory (outside VFS)
-		 * @return CS root directory / "Shaders"
+		 * Returns the real path to the Shaders directory located in the mod's root folder.
+		 * @return  <mod_root> / "Shaders"
 		 */
 		std::filesystem::path GetShadersRealPath();
 
 		/**
-		 * Gets the Features directory path in CS root directory where INI files are stored (outside VFS)
-		 * @return CS root directory / "Shaders" / "Features"
+		 * Returns the real path to the Features directory containing feature INI files.
+		 * @return  <mod_root> / "Shaders" / "Features"
 		 */
 		std::filesystem::path GetFeaturesRealPath();
+
 	}
 
 	/**

--- a/src/Utils/FileSystem.h
+++ b/src/Utils/FileSystem.h
@@ -57,6 +57,30 @@ namespace Util
 		 * @return Shaders / "{featureName}"
 		 */
 		std::filesystem::path GetFeatureShaderPath(const std::string& featureName);
+
+		/**
+		 * Gets the real path to the current .dll module in the file system (outside VFS)
+		 * @return Real path to CS root directory
+		 */
+		std::filesystem::path GetCurrentModuleRealPath();
+
+		/**
+		 * Gets the path to the real CS root directory (outside VFS)
+		 * @return Real path to CS root directory
+		 */
+		std::filesystem::path GetRootRealPath();
+
+		/**
+		 * Gets the main Shaders directory path in CS root directory (outside VFS)
+		 * @return CS root directory / "Shaders"
+		 */
+		std::filesystem::path GetShadersRealPath();
+
+		/**
+		 * Gets the Features directory path in CS root directory where INI files are stored (outside VFS)
+		 * @return CS root directory / "Shaders" / "Features"
+		 */
+		std::filesystem::path GetFeaturesRealPath();
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes #1174 , where the "Open Features Folder" and "Open Shaders Directory" buttons failed to open their respective directories when using Mod Organizer 2 (MO2).

**Changes made:**
Added new real-path helper functions:
- GetCurrentModuleRealPath
- GetRootRealPath
- GetShadersRealPath
- GetFeaturesRealPath

The main idea is to find the current executable module in the process and return the absolute path to it in the file system.
Replaced old GetFeaturesPath and GetShadersPath (which returned VFS paths) with real filesystem paths for folder-opening operations.

**Examples:**
- For Mod Organizer 2: `C:\Users\user\AppData\Local\ModOrganizer\Skyrim Special Edition\mods\<mod_name>` (returns the path to the CS folder in the current instance of MO2);
- For Vortex: `C:\Games\The Elder Scrolls V - Skyrim\Data` (returns the path to the Data folder).

In other cases, the location of the CS folder with the .dll module.

**Why this matters:**
MO2 uses a virtual file system (VFS), which makes game files visible only within the game process. When Explorer tries to open a VFS path, it fails because that path doesn't exist on the real filesystem. This PR ensures that paths used with ShellExecuteA point to real files, solving the issue under MO2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved folder-opening functionality in the UI to use more reliable methods for locating the Features and Shaders directories, ensuring accurate access even in complex modding environments.

* **Bug Fixes**
  * Enhanced path resolution to prevent issues when accessing folders outside of the game's main directory, particularly when using mod managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->