### PR TITLE
fix(dynamic cubemaps): use same cubemap for non/deferred

### DIFF
--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -45,7 +45,7 @@ namespace DynamicCubemaps
 
 #		if defined(SKYLIGHTING)
 		if (SharedData::InInterior) {
-			float3 specularIrradiance = Color::GammaToLinear(EnvReflectionsTexture.SampleLevel(SampColorSampler, R, level).xyz);
+			float3 specularIrradiance = Color::GammaToLinear(EnvTexture.SampleLevel(SampColorSampler, R, level).xyz);
 
 			finalIrradiance += specularIrradiance;
 			return finalIrradiance;
@@ -102,7 +102,7 @@ namespace DynamicCubemaps
 
 #		if defined(SKYLIGHTING)
 		if (SharedData::InInterior) {
-			float3 specularIrradiance = Color::GammaToLinear(EnvReflectionsTexture.SampleLevel(SampColorSampler, R, level).xyz);
+			float3 specularIrradiance = Color::GammaToLinear(EnvTexture.SampleLevel(SampColorSampler, R, level).xyz);
 
 			finalIrradiance += specularIrradiance;
 


### PR DESCRIPTION
in deferredcomposite pass it uses envtexture for interior dynamic cubemaps, but not in nondeferred lighting pass. this pr fixes this inconsistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of specular lighting when inside interior environments, resulting in more realistic reflections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->