### PR TITLE
fix(extended translucency): pass right perframe buffer

### DIFF
--- a/src/FeatureBuffer.cpp
+++ b/src/FeatureBuffer.cpp
@@ -47,5 +47,5 @@ std::pair<unsigned char*, size_t> GetFeatureBufferData(bool a_inWorld)
 		globals::features::hairSpecular.settings,
 		globals::features::terrainVariation.settings,
 		globals::features::ibl.settings,
-		globals::features::extendedTranslucency.settings);
+		globals::features::extendedTranslucency.GetCommonBufferData());
 }


### PR DESCRIPTION
this pr makes sure extended translucency sending correct buffer structure into shareddata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the data source for the extended translucency feature to improve consistency and maintainability. No visible changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->