### PR TITLE
feat(ibl): apply ibl on fog, pre-apply lambertian and change default settings

### DIFF
--- a/features/IBL/Shaders/IBL/IBL.hlsli
+++ b/features/IBL/Shaders/IBL/IBL.hlsli
@@ -21,7 +21,7 @@ namespace ImageBasedLighting
 		float colorR = SphericalHarmonics::SHHallucinateZH3Irradiance(shR, rayDir);
 		float colorG = SphericalHarmonics::SHHallucinateZH3Irradiance(shG, rayDir);
 		float colorB = SphericalHarmonics::SHHallucinateZH3Irradiance(shB, rayDir);
-		return float3(colorR, colorG, colorB);
+		return float3(colorR, colorG, colorB) / Math::PI;
 	}
 
 	float3 GetFogIBLColor(float3 fogColor)

--- a/features/IBL/Shaders/IBL/IBL.hlsli
+++ b/features/IBL/Shaders/IBL/IBL.hlsli
@@ -28,6 +28,16 @@ namespace ImageBasedLighting
 	{
 		float3 directionalAmbientColor = max(0, mul(SharedData::DirectionalAmbient, float4(float3(0, 0, 0), 1.0))).xyz;
 		float3 iblColor = directionalAmbientColor * SharedData::iblSettings.DALCAmount + Color::Saturation(GetDiffuseIBL(float3(0, 0, 0)), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+		if (SharedData::iblSettings.PreserveFogLuminance) {
+			const float fogLuminance = Color::RGBToLuminance2(fogColor);
+			const float iblLuminance = Color::RGBToLuminance2(iblColor);
+			if (iblLuminance > 0) {
+				const float scale = fogLuminance / iblLuminance;
+				iblColor *= scale;
+			} else {
+				iblColor = fogColor;
+			}
+		}
 		return lerp(fogColor, iblColor, SharedData::iblSettings.FogAmount);
 	}
 }

--- a/features/IBL/Shaders/IBL/IBL.hlsli
+++ b/features/IBL/Shaders/IBL/IBL.hlsli
@@ -26,7 +26,8 @@ namespace ImageBasedLighting
 
 	float3 GetFogIBLColor(float3 fogColor)
 	{
-		float3 iblColor = Color::Saturation(GetDiffuseIBL(float3(0, 0, 0)), SharedData::iblSettings.IBLSaturation) * Math::PI;
-		return lerp(fogColor, fogColor * iblColor, SharedData::iblSettings.FogAmount * SharedData::iblSettings.DiffuseIBLScale);
+		float3 directionalAmbientColor = Color::Ambient(max(0, mul(SharedData::DirectionalAmbient, float4(float3(0, 0, 0), 1.0))));
+		float3 iblColor = directionalAmbientColor * SharedData::iblSettings.DALCAmount + Color::Saturation(GetDiffuseIBL(float3(0, 0, 0)), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+		return lerp(fogColor, iblColor, SharedData::iblSettings.FogAmount);
 	}
 }

--- a/features/IBL/Shaders/IBL/IBL.hlsli
+++ b/features/IBL/Shaders/IBL/IBL.hlsli
@@ -26,7 +26,7 @@ namespace ImageBasedLighting
 
 	float3 GetFogIBLColor(float3 fogColor)
 	{
-		float3 directionalAmbientColor = Color::Ambient(max(0, mul(SharedData::DirectionalAmbient, float4(float3(0, 0, 0), 1.0))));
+		float3 directionalAmbientColor = max(0, mul(SharedData::DirectionalAmbient, float4(float3(0, 0, 0), 1.0))).xyz;
 		float3 iblColor = directionalAmbientColor * SharedData::iblSettings.DALCAmount + Color::Saturation(GetDiffuseIBL(float3(0, 0, 0)), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 		return lerp(fogColor, iblColor, SharedData::iblSettings.FogAmount);
 	}

--- a/features/IBL/Shaders/IBL/IBL.hlsli
+++ b/features/IBL/Shaders/IBL/IBL.hlsli
@@ -1,3 +1,4 @@
+#include "Common/Color.hlsli"
 #include "Common/Math.hlsli"
 #include "Common/Random.hlsli"
 #include "Common/SharedData.hlsli"
@@ -21,5 +22,11 @@ namespace ImageBasedLighting
 		float colorG = SphericalHarmonics::SHHallucinateZH3Irradiance(shG, rayDir);
 		float colorB = SphericalHarmonics::SHHallucinateZH3Irradiance(shB, rayDir);
 		return float3(colorR, colorG, colorB);
+	}
+
+	float3 GetFogIBLColor(float3 fogColor)
+	{
+		float3 iblColor = Color::Saturation(GetDiffuseIBL(float3(0, 0, 0)), SharedData::iblSettings.IBLSaturation) * Math::PI;
+		return lerp(fogColor, fogColor * iblColor, SharedData::iblSettings.FogAmount * SharedData::iblSettings.DiffuseIBLScale);
 	}
 }

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -178,12 +178,13 @@ namespace SharedData
 	struct IBLSettings
 	{
 		uint EnableDiffuseIBL;
+		uint SampleUnderHorizonFromDynCube;
+		uint PreserveFogLuminance;
+		uint pad;
 		float DiffuseIBLScale;
 		float DALCAmount;
 		float IBLSaturation;
 		float FogAmount;
-		uint SampleUnderHorizonFromDynCube;
-		uint2 pad;
 	};
 
 	struct ExtendedTranslucencySettings

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -181,8 +181,9 @@ namespace SharedData
 		float DiffuseIBLScale;
 		float DALCAmount;
 		float IBLSaturation;
+		float FogAmount;
 		uint SampleUnderHorizonFromDynCube;
-		uint3 pad;
+		uint2 pad;
 	};
 
 	struct ExtendedTranslucencySettings

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -795,9 +795,8 @@ PS_OUTPUT main(PS_INPUT input)
 #		else
 	float3 fogColor = input.FogParam.xyz;
 #			if defined(IBL)
-	if (SharedData::iblSettings.EnableDiffuseIBL) {
-		float3 iblFogColor = Color::Saturation(ImageBasedLighting::GetDiffuseIBL(float3(0, 0, 0)), SharedData::iblSettings.IBLSaturation);
-		fogColor = lerp(fogColor, fogColor * iblFogColor, SharedData::iblSettings.FogAmount * SharedData::iblSettings.DiffuseIBLScale);
+	if (SharedData::iblSettings.EnableDiffuseIBL && !SharedData::InInterior) {
+		fogColor = ImageBasedLighting::GetFogIBLColor(fogColor);
 	}
 #			endif
 	float3 blendedColor = lerp(lightColor, fogColor, input.FogParam.www);

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -793,7 +793,14 @@ PS_OUTPUT main(PS_INPUT input)
 #		elif defined(MULTBLEND) || defined(MULTBLEND_DECAL)
 	float3 blendedColor = lerp(lightColor, 1.0.xxx, saturate(1.5 * input.FogParam.w).xxx);
 #		else
-	float3 blendedColor = lerp(lightColor, input.FogParam.xyz, input.FogParam.www);
+	float3 fogColor = input.FogParam.xyz;
+#			if defined(IBL)
+	if (SharedData::iblSettings.EnableDiffuseIBL) {
+		float3 iblFogColor = Color::Saturation(ImageBasedLighting::GetDiffuseIBL(float3(0, 0, 0)), SharedData::iblSettings.IBLSaturation);
+		fogColor = lerp(fogColor, fogColor * iblFogColor, SharedData::iblSettings.FogAmount * SharedData::iblSettings.DiffuseIBLScale);
+	}
+#			endif
+	float3 blendedColor = lerp(lightColor, fogColor, input.FogParam.www);
 #		endif
 #	else
 	float3 blendedColor = lightColor.xyz;

--- a/package/Shaders/ISSAOComposite.hlsl
+++ b/package/Shaders/ISSAOComposite.hlsl
@@ -125,6 +125,10 @@ float SimplexNoise(float3 v)
 									 dot(p2, x2), dot(p3, x3)));
 }
 
+#	if defined(IBL)
+#		include "IBL/IBL.hlsli"
+#	endif
+
 PS_OUTPUT main(PS_INPUT input)
 {
 	PS_OUTPUT psout;
@@ -170,6 +174,12 @@ PS_OUTPUT main(PS_INPUT input)
 	float fogDistanceFactor = (2 * CameraNearFar.x * CameraNearFar.y) / ((CameraNearFar.y + CameraNearFar.x) - (2 * (1.01 * depth - 0.01) - 1) * (CameraNearFar.y - CameraNearFar.x));
 	float fogFactor = min(FogParam.w, pow(saturate(fogDistanceFactor * FogParam.y - FogParam.x), FogParam.z));
 	float3 fogColor = lerp(FogNearColor.xyz, FogFarColor.xyz, fogFactor);
+#		if defined(IBL)
+	if (SharedData::iblSettings.EnableDiffuseIBL) {
+		float3 iblColor = Color::Saturation(ImageBasedLighting::GetDiffuseIBL(float3(0, 0, 0)), SharedData::iblSettings.IBLSaturation);
+		fogColor = lerp(fogColor, fogColor * iblColor, SharedData::iblSettings.FogAmount * SharedData::iblSettings.DiffuseIBLScale);
+	}
+#		endif
 	if (depth < 0.999999) {
 		composedColor.xyz = FogNearColor.w * lerp(composedColor.xyz, fogColor, fogFactor);
 	}

--- a/package/Shaders/ISSAOComposite.hlsl
+++ b/package/Shaders/ISSAOComposite.hlsl
@@ -175,9 +175,8 @@ PS_OUTPUT main(PS_INPUT input)
 	float fogFactor = min(FogParam.w, pow(saturate(fogDistanceFactor * FogParam.y - FogParam.x), FogParam.z));
 	float3 fogColor = lerp(FogNearColor.xyz, FogFarColor.xyz, fogFactor);
 #		if defined(IBL)
-	if (SharedData::iblSettings.EnableDiffuseIBL) {
-		float3 iblColor = Color::Saturation(ImageBasedLighting::GetDiffuseIBL(float3(0, 0, 0)), SharedData::iblSettings.IBLSaturation);
-		fogColor = lerp(fogColor, fogColor * iblColor, SharedData::iblSettings.FogAmount * SharedData::iblSettings.DiffuseIBLScale);
+	if (SharedData::iblSettings.EnableDiffuseIBL && !SharedData::InInterior) {
+		fogColor = ImageBasedLighting::GetFogIBLColor(fogColor);
 	}
 #		endif
 	if (depth < 0.999999) {

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -3114,9 +3114,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	color.xyz = Color::LinearToGamma(Color::GammaToLinear(color.xyz) + specularColor);
 	float3 fogColor = input.FogParam.xyz;
 #		if defined(IBL)
-	if (SharedData::iblSettings.EnableDiffuseIBL) {
-		float3 iblFogColor = Color::Saturation(ImageBasedLighting::GetDiffuseIBL(float3(0, 0, 0)), SharedData::iblSettings.IBLSaturation);
-		fogColor = lerp(fogColor, fogColor * iblFogColor, SharedData::iblSettings.FogAmount * SharedData::iblSettings.DiffuseIBLScale);
+	if (SharedData::iblSettings.EnableDiffuseIBL && !SharedData::InInterior) {
+		fogColor = ImageBasedLighting::GetFogIBLColor(fogColor);
 	}
 #		endif
 	if (FrameBuffer::FrameParams.y && FrameBuffer::FrameParams.z)

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -3112,8 +3112,15 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 #	if !defined(DEFERRED)
 	color.xyz = Color::LinearToGamma(Color::GammaToLinear(color.xyz) + specularColor);
+	float3 fogColor = input.FogParam.xyz;
+#		if defined(IBL)
+	if (SharedData::iblSettings.EnableDiffuseIBL) {
+		float3 iblFogColor = Color::Saturation(ImageBasedLighting::GetDiffuseIBL(float3(0, 0, 0)), SharedData::iblSettings.IBLSaturation);
+		fogColor = lerp(fogColor, fogColor * iblFogColor, SharedData::iblSettings.FogAmount * SharedData::iblSettings.DiffuseIBLScale);
+	}
+#		endif
 	if (FrameBuffer::FrameParams.y && FrameBuffer::FrameParams.z)
-		color.xyz = lerp(color.xyz, input.FogParam.xyz, input.FogParam.w);
+		color.xyz = lerp(color.xyz, fogColor, input.FogParam.w);
 #	endif
 
 #	if defined(TESTCUBEMAP) && defined(ENVMAP) && defined(DYNAMIC_CUBEMAPS)

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -1156,16 +1156,21 @@ PS_OUTPUT main(PS_INPUT input)
 #					else
 	float specularFraction = lerp(1, fresnel, distanceFactor);
 	float3 finalColorPreFog = lerp(diffuseOutput.refractionDiffuseColor, specularColor, specularFraction) + sunColor * depthControl.w;
-	finalColorPreFog = lerp(finalColorPreFog, input.FogParam.xyz * PosAdjust[eyeIndex].w, input.FogParam.w);
+	float3 preFogColor = input.FogParam.xyz;
+#						if defined(IBL)
+	if (SharedData::iblSettings.EnableDiffuseIBL && !SharedData::InInterior) {
+		preFogColor = ImageBasedLighting::GetFogIBLColor(preFogColor);
+	}
+#						endif
+	finalColorPreFog = lerp(finalColorPreFog, preFogColor * PosAdjust[eyeIndex].w, input.FogParam.w);
 
 	float3 refractionColor = diffuseOutput.refractionColor;
 
 	float fogFactor = min(FogParam.w, pow(saturate(-diffuseOutput.depth * FogParam.y - FogParam.x), FogParam.z));
 	float3 fogColor = lerp(FogNearColor.xyz, FogFarColor.xyz, fogFactor);
 #						if defined(IBL)
-	if (SharedData::iblSettings.EnableDiffuseIBL) {
-		float3 iblColor = Color::Saturation(ImageBasedLighting::GetDiffuseIBL(float3(0, 0, 0)), SharedData::iblSettings.IBLSaturation);
-		fogColor = lerp(fogColor, fogColor * iblColor, SharedData::iblSettings.FogAmount * SharedData::iblSettings.DiffuseIBLScale);
+	if (SharedData::iblSettings.EnableDiffuseIBL && !SharedData::InInterior) {
+		fogColor = ImageBasedLighting::GetFogIBLColor(fogColor);
 	}
 #						endif
 	refractionColor = lerp(refractionColor, fogColor, fogFactor);

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -984,6 +984,10 @@ float3 GetSunColor(float3 normal, float3 viewDirection)
 #			include "InverseSquareLighting/InverseSquareLighting.hlsli"
 #		endif
 
+#		if defined(IBL)
+#			include "IBL/IBL.hlsli"
+#		endif
+
 PS_OUTPUT main(PS_INPUT input)
 {
 	PS_OUTPUT psout;
@@ -1158,6 +1162,12 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float fogFactor = min(FogParam.w, pow(saturate(-diffuseOutput.depth * FogParam.y - FogParam.x), FogParam.z));
 	float3 fogColor = lerp(FogNearColor.xyz, FogFarColor.xyz, fogFactor);
+#						if defined(IBL)
+	if (SharedData::iblSettings.EnableDiffuseIBL) {
+		float3 iblColor = Color::Saturation(ImageBasedLighting::GetDiffuseIBL(float3(0, 0, 0)), SharedData::iblSettings.IBLSaturation);
+		fogColor = lerp(fogColor, fogColor * iblColor, SharedData::iblSettings.FogAmount * SharedData::iblSettings.DiffuseIBLScale);
+	}
+#						endif
 	refractionColor = lerp(refractionColor, fogColor, fogFactor);
 
 	float3 finalColor = lerp(refractionColor, finalColorPreFog, diffuseOutput.refractionMul);

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -1144,7 +1144,13 @@ PS_OUTPUT main(PS_INPUT input)
 #					if defined(VC)
 	float specularFraction = lerp(1, fresnel * diffuseOutput.refractionMul, distanceFactor);
 	float3 finalColorPreFog = lerp(diffuseColor, specularColor, specularFraction) + sunColor * depthControl.w;
-	float3 finalColor = lerp(finalColorPreFog, input.FogParam.xyz * PosAdjust[eyeIndex].w, input.FogParam.w);
+	float3 fogColor = input.FogParam.xyz;
+#						if defined(IBL)
+	if (SharedData::iblSettings.EnableDiffuseIBL && !SharedData::InInterior) {
+		fogColor = ImageBasedLighting::GetFogIBLColor(fogColor);
+	}
+#						endif
+	float3 finalColor = lerp(finalColorPreFog, fogColor * PosAdjust[eyeIndex].w, input.FogParam.w);
 #						if defined(WETNESS_EFFECTS) && defined(DEBUG_WETNESS_EFFECTS)
 	// DEBUG MODE: Override water color with debug visualization
 	float3 debugColor = WetnessEffects::GetDebugWetnessColorStandard(waterData.rippleInfo, 2.0, 3.0);

--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -21,7 +21,7 @@ void IBL::DrawSettings()
 	ImGui::SliderFloat("Diffuse IBL Scale", &settings.DiffuseIBLScale, 0.0f, 10.0f, "%.2f");
 	ImGui::SliderFloat("Diffuse IBL Saturation", &settings.IBLSaturation, 0.0f, 2.0f, "%.2f");
 	ImGui::SliderFloat("DALC Amount", &settings.DALCAmount, 0.0f, 1.0f, "%.2f");
-	ImGui::SliderFloat("Affects Fog Amount", &settings.FogAmount, 0.0f, 1.0f, "%.2f");
+	ImGui::SliderFloat("Fog Mix", &settings.FogAmount, 0.0f, 1.0f, "%.2f");
 	ImGui::Checkbox("Preserve Fog Luminance", (bool*)&settings.PreserveFogLuminance);
 	ImGui::Checkbox("[EXP] Sample Under Horizon From Dynamic Cubemaps", (bool*)&settings.SampleUnderHorizonFromDynCube);
 	if (auto _tt = Util::HoverTooltipWrapper()) {

--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -8,11 +8,12 @@
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	IBL::Settings,
 	EnableDiffuseIBL,
+	SampleUnderHorizonFromDynCube,
+	PreserveFogLuminance,
 	DiffuseIBLScale,
 	DALCAmount,
 	IBLSaturation,
-	FogAmount,
-	SampleUnderHorizonFromDynCube)
+	FogAmount)
 
 void IBL::DrawSettings()
 {
@@ -21,6 +22,7 @@ void IBL::DrawSettings()
 	ImGui::SliderFloat("Diffuse IBL Saturation", &settings.IBLSaturation, 0.0f, 2.0f, "%.2f");
 	ImGui::SliderFloat("DALC Amount", &settings.DALCAmount, 0.0f, 1.0f, "%.2f");
 	ImGui::SliderFloat("Affects Fog Amount", &settings.FogAmount, 0.0f, 1.0f, "%.2f");
+	ImGui::Checkbox("Preserve Fog Luminance", (bool*)&settings.PreserveFogLuminance);
 	ImGui::Checkbox("[EXP] Sample Under Horizon From Dynamic Cubemaps", (bool*)&settings.SampleUnderHorizonFromDynCube);
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text(

--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -11,6 +11,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	DiffuseIBLScale,
 	DALCAmount,
 	IBLSaturation,
+	FogAmount,
 	SampleUnderHorizonFromDynCube)
 
 void IBL::DrawSettings()
@@ -19,6 +20,7 @@ void IBL::DrawSettings()
 	ImGui::SliderFloat("Diffuse IBL Scale", &settings.DiffuseIBLScale, 0.0f, 10.0f, "%.2f");
 	ImGui::SliderFloat("Diffuse IBL Saturation", &settings.IBLSaturation, 0.0f, 2.0f, "%.2f");
 	ImGui::SliderFloat("DALC Amount", &settings.DALCAmount, 0.0f, 1.0f, "%.2f");
+	ImGui::SliderFloat("Affects Fog Amount", &settings.FogAmount, 0.0f, 1.0f, "%.2f");
 	ImGui::Checkbox("[EXP] Sample Under Horizon From Dynamic Cubemaps", (bool*)&settings.SampleUnderHorizonFromDynCube);
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text(

--- a/src/Features/IBL.h
+++ b/src/Features/IBL.h
@@ -47,9 +47,9 @@ public:
 		uint SampleUnderHorizonFromDynCube = 0;
 		uint PreserveFogLuminance = 0;
 		uint pad;
-		float DiffuseIBLScale = 0.5f;
-		float DALCAmount = 0.5f;
-		float IBLSaturation = 0.65f;
+		float DiffuseIBLScale = 1.0f;
+		float DALCAmount = 0.33f;
+		float IBLSaturation = 1.0f;
 		float FogAmount = 0.0f;
 	} settings;
 

--- a/src/Features/IBL.h
+++ b/src/Features/IBL.h
@@ -44,12 +44,13 @@ public:
 	struct alignas(16) Settings
 	{
 		uint EnableDiffuseIBL = 1;
+		uint SampleUnderHorizonFromDynCube = 0;
+		uint PreserveFogLuminance = 0;
+		uint pad;
 		float DiffuseIBLScale = 0.5f;
 		float DALCAmount = 0.5f;
 		float IBLSaturation = 0.65f;
 		float FogAmount = 0.0f;
-		uint SampleUnderHorizonFromDynCube = 0;
-		uint pad[2];
 	} settings;
 
 	ID3D11ComputeShader* GetDiffuseIBLCS();

--- a/src/Features/IBL.h
+++ b/src/Features/IBL.h
@@ -47,8 +47,9 @@ public:
 		float DiffuseIBLScale = 0.5f;
 		float DALCAmount = 0.5f;
 		float IBLSaturation = 0.65f;
+		float FogAmount = 0.0f;
 		uint SampleUnderHorizonFromDynCube = 0;
-		uint pad[3];
+		uint pad[2];
 	} settings;
 
 	ID3D11ComputeShader* GetDiffuseIBLCS();


### PR DESCRIPTION
This pull request enhances the integration of Image-Based Lighting (IBL) with fog rendering in the shader pipeline. The main change is the introduction of a new `FogAmount` parameter and associated logic to blend IBL effects into fog color, making fog appearance more physically accurate and responsive to lighting settings. These changes are implemented across multiple shaders and exposed in the IBL settings UI.

**IBL and Fog Integration:**

* Added a new `FogAmount` parameter to the `IBLSettings` struct, allowing control over how much IBL affects fog color. This is exposed in the user interface as "Affects Fog Amount". [[1]](diffhunk://#diff-ac5120e12a70b96d04e43768cf291f613c3184cd2a2b5d7273b7e8c3d3e69041R50-R52) [[2]](diffhunk://#diff-812c99694216d6c71752b796f8804075cf5652d1f32787207a1ff33e0f173c1eR184-R186) [[3]](diffhunk://#diff-1067f4a4afb271d76cef2c8a214fd0d4a15c8849dff514358f01cbf29e579c71R14) [[4]](diffhunk://#diff-1067f4a4afb271d76cef2c8a214fd0d4a15c8849dff514358f01cbf29e579c71R23)
* Introduced the `GetFogIBLColor` function in `IBL.hlsli` to compute a fog color that blends the original fog color with IBL contributions, controlled by the new `FogAmount` parameter. [[1]](diffhunk://#diff-ab75a482e91720df10c60b5e78d290ca4bf90f709fd2679cb604ab047b129fe8R26-R32) [[2]](diffhunk://#diff-ab75a482e91720df10c60b5e78d290ca4bf90f709fd2679cb604ab047b129fe8R1)

**Shader Modifications for Fog Rendering:**

* Updated fog color calculations in multiple shaders (`Effect.hlsl`, `Lighting.hlsl`, `ISSAOComposite.hlsl`, `Water.hlsl`) to use `GetFogIBLColor` when IBL is enabled and not in interior scenes, ensuring consistent fog-IBL blending throughout the rendering pipeline. [[1]](diffhunk://#diff-2fd4b9665d3c8ae4d680920b9ae4a64e4408e0bfd835e1fa591193f0761dc24dL796-R802) [[2]](diffhunk://#diff-fee9ea921e49c9a517b9ba5e6d3ff9bae2bd4dbbe5a91bfef21d64c4bb06b2a3R3115-R3122) [[3]](diffhunk://#diff-3ac79c6c390032ba373a22747511347234226013eea9778989e33c65f1fe1aa8R177-R181) [[4]](diffhunk://#diff-7658478ba5b493920e66baf995c3b454632d429f101e18835b52ab94fd121de8L1143-R1153) [[5]](diffhunk://#diff-7658478ba5b493920e66baf995c3b454632d429f101e18835b52ab94fd121de8L1155-R1181)

**Codebase and Dependency Updates:**

* Included `IBL/IBL.hlsli` in additional shader files to support the new fog-IBL blending logic. [[1]](diffhunk://#diff-3ac79c6c390032ba373a22747511347234226013eea9778989e33c65f1fe1aa8R128-R131) [[2]](diffhunk://#diff-7658478ba5b493920e66baf995c3b454632d429f101e18835b52ab94fd121de8R987-R990)
* Adjusted struct padding in `IBLSettings` to account for the new parameter. [[1]](diffhunk://#diff-ac5120e12a70b96d04e43768cf291f613c3184cd2a2b5d7273b7e8c3d3e69041R50-R52) [[2]](diffhunk://#diff-812c99694216d6c71752b796f8804075cf5652d1f32787207a1ff33e0f173c1eR184-R186)

These changes collectively improve the realism and configurability of fog in scenes using IBL, allowing for more nuanced and dynamic atmospheric effects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional IBL-driven fog color for more natural ambient blending in outdoor scenes.
  * New "Fog Mix" slider (0–1) to control IBL influence on fog.
  * New "Preserve Fog Luminance" checkbox to keep fog brightness when blending.
  * IBL fog blending applied consistently across lighting, water, SSAO composite, and effect passes.
  * Automatically falls back to original fog color when IBL is disabled or when indoors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->