### PR TITLE
feat: add average FPS to performance overlay

### DIFF
--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -392,7 +392,12 @@ void PerformanceOverlay::DrawFPS()
 		ImGui::TableNextColumn();
 		ImGui::Text(this->state.isFrameGenerationActive ? "Raw FPS:" : "FPS:");
 		ImGui::TableNextColumn();
-		ImGui::Text("%.1f (%.2f ms)", this->state.smoothFps, this->state.smoothFrameTimeMs);
+		float avgFrameTime = std::accumulate(this->state.frameTimeHistory.GetData().begin(),
+								 this->state.frameTimeHistory.GetData().end(), 0.0f) /
+		                     this->state.frameTimeHistory.GetData().size();
+		float avgFps = avgFrameTime > 0.0f ? 1000.0f / avgFrameTime : 0.0f;
+
+		ImGui::Text("%.1f (%.2f ms) | Avg: %.1f", this->state.smoothFps, this->state.smoothFrameTimeMs, avgFps);
 
 		if (this->state.isFrameGenerationActive) {
 			ImGui::TableNextColumn();

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -392,12 +392,19 @@ void PerformanceOverlay::DrawFPS()
 		ImGui::TableNextColumn();
 		ImGui::Text(this->state.isFrameGenerationActive ? "Raw FPS:" : "FPS:");
 		ImGui::TableNextColumn();
-		float avgFrameTime = std::accumulate(this->state.frameTimeHistory.GetData().begin(),
-								 this->state.frameTimeHistory.GetData().end(), 0.0f) /
-		                     this->state.frameTimeHistory.GetData().size();
-		float avgFps = avgFrameTime > 0.0f ? 1000.0f / avgFrameTime : 0.0f;
 
-		ImGui::Text("%.1f (%.2f ms) | Avg: %.1f", this->state.smoothFps, this->state.smoothFrameTimeMs, avgFps);
+		// Check if buffer is full for the avg
+		auto frameData = this->state.frameTimeHistory.GetData();
+		size_t validFrameCount = std::count_if(frameData.begin(), frameData.end(), [](float ft) { return ft > 0.0f; });
+		bool bufferIsFull = validFrameCount == frameData.size();
+
+		if (bufferIsFull) {
+			float avgFrameTime = std::accumulate(frameData.begin(), frameData.end(), 0.0f) / frameData.size();
+			float avgFps = (avgFrameTime > 0.001f) ? 1000.0f / avgFrameTime : 0.0f;
+			ImGui::Text("%.1f (%.2f ms) | Avg: %.1f", this->state.smoothFps, this->state.smoothFrameTimeMs, avgFps);
+		} else {
+			ImGui::Text("%.1f (%.2f ms)", this->state.smoothFps, this->state.smoothFrameTimeMs);
+		}
 
 		if (this->state.isFrameGenerationActive) {
 			ImGui::TableNextColumn();

--- a/src/Features/PerformanceOverlay.h
+++ b/src/Features/PerformanceOverlay.h
@@ -258,8 +258,8 @@ struct PerformanceOverlay : OverlayFeature
 		static constexpr float kVRAMSectionWidth = 300.0f;           // pixels - VRAM section width
 		static constexpr float kWindowBorderPadding = 20.0f;         // pixels - Window border padding
 		static constexpr float kDefaultFrameTimeMs = 16.67f;         // ms - Default frame time (60 FPS)
-		static constexpr int kMinFrameHistorySize = 60;              // 60 frames = 1s @ 60fps. Reasonable minimum.
-		static constexpr int kMaxFrameHistorySize = 480;             // 480 frames = 10s @ 60fps or 2s @ 240fps. Reasonable maximum.
+		static constexpr int kMinFrameHistorySize = 120;             // 2s @ 60fps, 0.5s @ 240fps
+		static constexpr int kMaxFrameHistorySize = 1800;            // 30s @ 60fps, 7.5s @ 240fps
 
 		bool ShowInOverlay = true;  // was: Enabled
 		bool ShowDrawCalls = true;
@@ -268,7 +268,7 @@ struct PerformanceOverlay : OverlayFeature
 		bool ShowPreFGFrameTimeGraph = true;
 		bool ShowPostFGFrameTimeGraph = true;
 		float UpdateInterval = 0.5f;
-		int FrameHistorySize = 120;  // Default 120 frames = 2s @ 60fps. Clamped using static values to prevent config file values going outside of slider bounds.
+		int FrameHistorySize = 600;  // 10s @ 60fps, 2.5s @ 240fps
 		float TextSize = 1.0f;
 
 		float BackgroundOpacity = 0.5f;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Performance overlay now shows average frame time (ms) and average FPS alongside current readings — visible once enough history is collected.
* **Chores / Settings**
  * Frame-history window ranges and default size widened to provide longer averaging options (min, max, and default increased).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->