### PR TITLE
feat(UI): add shader cache duration

### DIFF
--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -38,7 +38,7 @@ void SettingsTabRenderer::RenderShadersTab()
 			shaderCache->SetDiskCache(useDiskCache);
 		}
 		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text("Disabling this stops shaders from being loaded from disk, as well as stops shaders from being saved to it.");
+			ImGui::Text("Disables loading shaders from disk and prevents saving compiled shaders to disk cache.");
 		}
 
 		bool useAsync = shaderCache->IsAsync();
@@ -47,6 +47,11 @@ void SettingsTabRenderer::RenderShadersTab()
 		}
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Skips a shader being replaced if it hasn't been compiled yet. Also makes compilation blazingly fast!");
+		}
+
+		if (shaderCache->GetTotalTasks() > 0) {
+			ImGui::Text("Last shader cache build duration: %s",
+				shaderCache->GetShaderStatsString(true, true).c_str());
 		}
 
 		ImGui::EndTabItem();

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -2057,9 +2057,9 @@ namespace SIE
 		return ShaderCompilationTask::Status::Pending;
 	}
 
-	std::string ShaderCache::GetShaderStatsString(bool a_timeOnly)
+	std::string ShaderCache::GetShaderStatsString(bool a_timeOnly, bool a_elapsedOnly)
 	{
-		return compilationSet.GetStatsString(a_timeOnly);
+		return compilationSet.GetStatsString(a_timeOnly, a_elapsedOnly);
 	}
 
 	inline bool ShaderCache::IsShaderSourceAvailable(const RE::BSShader& shader)
@@ -2614,14 +2614,22 @@ namespace SIE
 		return std::max(remaining / rate, 0.0);
 	}
 
-	std::string CompilationSet::GetStatsString(bool a_timeOnly)
+	std::string CompilationSet::GetStatsString(bool a_timeOnly, bool a_elapsedOnly)
 	{
 		double totalMs = static_cast<double>(totalTime.QuadPart) * 1000.0 / frequency.QuadPart;
 
-		if (a_timeOnly)
-			return fmt::format("{}/{}",
-				GetHumanTime(totalMs),
-				GetHumanTime(GetEta() + totalMs));
+		if (a_timeOnly) {
+			if (a_elapsedOnly) {
+				// Only elapsed
+				return GetHumanTime(totalMs);
+			} else {
+				// Elapsed + estimated
+				return fmt::format("{}/{}",
+					GetHumanTime(totalMs),
+					GetHumanTime(GetEta() + totalMs));
+			}
+		}
+
 		return fmt::format("{}/{} (successful/total)\tfailed: {}\tcachehits: {}\nElapsed/Estimated Time: {}/{}",
 			(std::uint64_t)completedTasks,
 			(std::uint64_t)totalTasks,

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -260,7 +260,7 @@ namespace SIE
 		void Clear();
 		std::string GetHumanTime(double a_totalMs);
 		double GetEta();
-		std::string GetStatsString(bool a_timeOnly = false);
+		std::string GetStatsString(bool a_timeOnly = false, bool a_elapsedOnly = false);
 		std::atomic<uint64_t> completedTasks = 0;
 		std::atomic<uint64_t> totalTasks = 0;
 		std::atomic<uint64_t> failedTasks = 0;
@@ -396,7 +396,7 @@ namespace SIE
 		ID3DBlob* GetCompletedShader(const SIE::ShaderCompilationTask& a_task);
 		ID3DBlob* GetCompletedShader(ShaderClass shaderClass, const RE::BSShader& shader, uint32_t descriptor);
 		ShaderCompilationTask::Status GetShaderStatus(const std::string& a_key);
-		std::string GetShaderStatsString(bool a_timeOnly = false);
+		std::string GetShaderStatsString(bool a_timeOnly = false, bool a_elapsedOnly = false);
 
 		RE::BSGraphics::VertexShader* GetVertexShader(const RE::BSShader& shader, uint32_t descriptor);
 		RE::BSGraphics::PixelShader* GetPixelShader(const RE::BSShader& shader,


### PR DESCRIPTION
Added an a_elapsedOnly argument to GetStatsString to easily allow the addition of the feature without doing any formatting on the original one to remove the estimated part. Also improved wording for a tooltip.