### PR TITLE
chore: "fix(pbr): metal low-light rendering fixed, improved cubemaps"

### DIFF
--- a/package/Shaders/DeferredCompositeCS.hlsl
+++ b/package/Shaders/DeferredCompositeCS.hlsl
@@ -96,22 +96,18 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, out float ao, out float3 il, i
 
 	float3 reflectance = ReflectanceTexture[dispatchID.xy];
 
-	// Luminance-based threshold to reduce noise compared to hard thresholds of 0.0
-	if (dot(reflectance, float3(0.299, 0.587, 0.114)) > 0.001) {
+	if (reflectance.x > 0.0 || reflectance.y > 0.0 || reflectance.z > 0.0) {
 		float3 normalWS = normalize(mul(FrameBuffer::CameraViewInverse[eyeIndex], float4(normalVS, 0)).xyz);
 
 		float wetnessMask = MasksTexture[dispatchID.xy].z;
 
 		normalWS = lerp(normalWS, float3(0, 0, 1), wetnessMask);
 
-		// Actual camera-to-pixel direction
-		float3 V = normalize(FrameBuffer::CameraPosAdjust[eyeIndex].xyz - positionWS.xyz);
+		float3 V = normalize(positionWS.xyz);
 		float3 R = reflect(V, normalWS);
 
-		float roughness = max(1.0 - glossiness, 0.02); // Prevent perfect mirrors
-
-		// Use perceptual roughness mapping for better visual distribution
-		float level = roughness * roughness * 7.0;
+		float roughness = 1.0 - glossiness;
+		float level = roughness * 7.0;
 
 		sh2 specularLobe = SphericalHarmonics::FauxSpecularLobe(normalWS, -V, roughness);
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2986,8 +2986,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	specularColorPBR += indirectSpecularLobeWeight * directionalAmbientColor;
 #			endif
 #		else
-	// In deferred mode, metallic materials need ambient specular lighting
-	specularColorPBR += indirectSpecularLobeWeight * directionalAmbientColor;
 	indirectDiffuseLobeWeight *= vertexColor;
 #		endif
 


### PR DESCRIPTION
Reverts doodlum/skyrim-community-shaders#1404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved specular reflections and roughness response for more consistent, physically plausible highlights across materials.
  - Removed unintended ambient specular boost in deferred/non-PBR rendering, reducing over-bright or washed-out highlights.
- Refactor
  - Streamlined specular evaluation logic (reflectance gating and view-direction handling) for more predictable lighting results and better alignment across rendering paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->