### PR TITLE
refactor: unify multiple EnvBRDF calls

### DIFF
--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -1,3 +1,4 @@
+#include "Common/BRDF.hlsli"
 
 #if defined(SKYLIGHTING)
 #	include "Skylighting/Skylighting.hlsli"
@@ -7,17 +8,6 @@ namespace DynamicCubemaps
 {
 	TextureCube<float4> EnvReflectionsTexture : register(t30);
 	TextureCube<float4> EnvTexture : register(t31);
-
-	// https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
-	half2 EnvBRDFApprox(half Roughness, half NoV)
-	{
-		const half4 c0 = { -1, -0.0275, -0.572, 0.022 };
-		const half4 c1 = { 1, 0.0425, 1.04, -0.04 };
-		half4 r = Roughness * c0 + c1;
-		half a004 = min(r.x * r.x, exp2(-9.28 * NoV)) * r.x + r.y;
-		half2 AB = half2(-1.04, 1.04) * a004 + r.zw;
-		return AB;
-	}
 
 #if !defined(WATER)
 
@@ -87,7 +77,7 @@ namespace DynamicCubemaps
 
 		float level = roughness * 7.0;
 
-		float2 specularBRDF = EnvBRDFApprox(roughness, NoV);
+		float2 specularBRDF = BRDF::EnvBRDFApprox(roughness, NoV);
 
 		// Horizon specular occlusion
 		// https://marmosetco.tumblr.com/post/81245981087

--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -77,7 +77,7 @@ namespace DynamicCubemaps
 
 		float level = roughness * 7.0;
 
-		float2 specularBRDF = BRDF::EnvBRDFApprox(roughness, NoV);
+		float2 specularBRDF = BRDF::EnvBRDF(roughness, NoV);
 
 		// Horizon specular occlusion
 		// https://marmosetco.tumblr.com/post/81245981087

--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -255,8 +255,8 @@ namespace Hair
 			specularLobeWeightPrimary = 0;
 			specularLobeWeightSecondary = 0;
 
-			const float2 specularBRDFPrimary = BRDF::EnvBRDFApproxLazarov(roughnessPrimary, NdotVshifted);
-			const float2 specularBRDFSecondary = BRDF::EnvBRDFApproxLazarov(roughnessSecondary, NdotVshifted2);
+			const float2 specularBRDFPrimary = BRDF::EnvBRDFApprox(roughnessPrimary, NdotVshifted);
+			const float2 specularBRDFSecondary = BRDF::EnvBRDFApprox(roughnessSecondary, NdotVshifted2);
 
 			const float3 F0 = HairF0();
 			specularLobeWeightPrimary = F0 * specularBRDFPrimary.x + specularBRDFPrimary.y;

--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -255,8 +255,8 @@ namespace Hair
 			specularLobeWeightPrimary = 0;
 			specularLobeWeightSecondary = 0;
 
-			const float2 specularBRDFPrimary = BRDF::EnvBRDFApprox(roughnessPrimary, NdotVshifted);
-			const float2 specularBRDFSecondary = BRDF::EnvBRDFApprox(roughnessSecondary, NdotVshifted2);
+			const float2 specularBRDFPrimary = BRDF::EnvBRDF(roughnessPrimary, NdotVshifted);
+			const float2 specularBRDFSecondary = BRDF::EnvBRDF(roughnessSecondary, NdotVshifted2);
 
 			const float3 F0 = HairF0();
 			specularLobeWeightPrimary = F0 * specularBRDFPrimary.x + specularBRDFPrimary.y;

--- a/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
+++ b/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
@@ -1,19 +1,9 @@
+#include "Common/BRDF.hlsli"
 #include "WetnessEffects/optimized-ggx.hlsli"
 
 namespace WetnessEffects
 {
 	Texture2D<float4> TexPrecipOcclusion : register(t70);
-
-	// https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
-	float2 EnvBRDFApproxWater(float3 F0, float Roughness, float NoV)
-	{
-		const float4 c0 = { -1, -0.0275, -0.572, 0.022 };
-		const float4 c1 = { 1, 0.0425, 1.04, -0.04 };
-		float4 r = Roughness * c0 + c1;
-		float a004 = min(r.x * r.x, exp2(-9.28 * NoV)) * r.x + r.y;
-		float2 AB = float2(-1.04, 1.04) * a004 + r.zw;
-		return AB;
-	}
 
 	// https://github.com/BelmuTM/Noble/blob/master/LICENSE.txt
 
@@ -157,7 +147,7 @@ namespace WetnessEffects
 		float3 specularIrradiance = 1.0;
 #endif
 
-		float2 specularBRDF = EnvBRDFApproxWater(0.02, roughness, NoV);
+		float2 specularBRDF = BRDF::EnvBRDFApprox(roughness, NoV);
 
 		// Horizon specular occlusion
 		// https://marmosetco.tumblr.com/post/81245981087

--- a/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
+++ b/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
@@ -147,7 +147,7 @@ namespace WetnessEffects
 		float3 specularIrradiance = 1.0;
 #endif
 
-		float2 specularBRDF = BRDF::EnvBRDFApprox(roughness, NoV);
+		float2 specularBRDF = BRDF::EnvBRDF(roughness, NoV);
 
 		// Horizon specular occlusion
 		// https://marmosetco.tumblr.com/post/81245981087

--- a/package/Shaders/Common/BRDF.hlsli
+++ b/package/Shaders/Common/BRDF.hlsli
@@ -235,7 +235,7 @@ namespace BRDF
         return float2(k1, k0);
 	}
 
-    float2 EnvBRDFApprox(float roughness, float NdotV)
+    float2 EnvBRDF(float roughness, float NdotV)
 	{
 #   if defined(ENV_BRDF_HIRVONEN)
 		return EnvBRDFApproxHirvonen(roughness, NdotV);

--- a/package/Shaders/Common/BRDF.hlsli
+++ b/package/Shaders/Common/BRDF.hlsli
@@ -211,6 +211,38 @@ namespace BRDF
 		float2 AB = float2(-1.04, 1.04) * a004 + r.zw;
 		return AB;
 	}
+
+    // [Hirvonen et al. 2019 "Accurate Real-Time Specular Reflections with Radiance Caching"]
+    float2 EnvBRDFApproxHirvonen(float roughness, float NdotV)
+	{
+		const float2x2 m0 = float2x2(0.99044, -1.28514, 1.29678, -0.755907);
+        const float3x3 m1 = float3x3(1, 2.92338, 59.4188, 20.3225, -27.0302, 222.592, 121.563, 626.13, 316.627);
+        const float2x2 m2 = float2x2(0.0365463, 3.32707, 9.0632, -9.04756);
+        const float3x3 m3 = float3x3(1, 3.59685, -1.36772, 9.04401, -16.3174, 9.22949, 5.56589, 19.7886, -20.2123);
+
+        float a = roughness * roughness;
+        float a2 = a * a;
+        float a3 = a * a2;
+        float c = NdotV;
+        float c2 = c * c;
+        float c3 = c * c2;
+
+        float k0 = dot(float2(1.0, a), mul(m0, float2(1.0, c)));
+        k0 /= dot(float3(1.0, a, a3), mul(m1, float3(1.0, c, c3)));
+        float k1 = dot(float2(1.0, a), mul(m2, float2(1.0, c)));
+        k1 /= dot(float3(1.0, a, a3), mul(m3, float3(1.0, c2, c3)));
+
+        return float2(k1, k0);
+	}
+
+    float2 EnvBRDFApprox(float roughness, float NdotV)
+	{
+#   if defined(ENV_BRDF_HIRVONEN)
+		return EnvBRDFApproxHirvonen(roughness, NdotV);
+#   else
+        return EnvBRDFApproxLazarov(roughness, NdotV);
+#   endif
+	}
 }
 
 #endif  // __BRDF_DEPENDENCY_HLSL__

--- a/package/Shaders/Common/PBR.hlsli
+++ b/package/Shaders/Common/PBR.hlsli
@@ -334,7 +334,7 @@ namespace PBR
 			specular += GetSpecularDirectLightMultiplierMicrofacet(surfaceProperties.Roughness, surfaceProperties.F0, satNdotL, satNdotV, satNdotH, satVdotH, F) * lightProperties.LightColor * satNdotL;
 #endif
 
-			float2 specularBRDF = BRDF::EnvBRDFApproxLazarov(surfaceProperties.Roughness, satNdotV);
+			float2 specularBRDF = BRDF::EnvBRDFApprox(surfaceProperties.Roughness, satNdotV);
 			specular *= 1 + surfaceProperties.F0 * (1 / (specularBRDF.x + specularBRDF.y) - 1);
 
 #if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
@@ -432,7 +432,7 @@ namespace PBR
 			}
 #endif
 
-			float2 specularBRDF = BRDF::EnvBRDFApproxLazarov(surfaceProperties.Roughness, NdotV);
+			float2 specularBRDF = BRDF::EnvBRDFApprox(surfaceProperties.Roughness, NdotV);
 			specularLobeWeight = surfaceProperties.F0 * specularBRDF.x + specularBRDF.y;
 
 			diffuseLobeWeight *= (1 - specularLobeWeight);
@@ -441,7 +441,7 @@ namespace PBR
 #if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 			[branch] if ((PBRFlags & Flags::TwoLayer) != 0)
 			{
-				float2 coatSpecularBRDF = BRDF::EnvBRDFApproxLazarov(surfaceProperties.CoatRoughness, NdotV);
+				float2 coatSpecularBRDF = BRDF::EnvBRDFApprox(surfaceProperties.CoatRoughness, NdotV);
 				float3 coatSpecularLobeWeight = surfaceProperties.CoatF0 * coatSpecularBRDF.x + coatSpecularBRDF.y;
 				coatSpecularLobeWeight *= 1 + surfaceProperties.CoatF0 * (1 / (coatSpecularBRDF.x + coatSpecularBRDF.y) - 1);
 
@@ -484,7 +484,7 @@ namespace PBR
 		const float wetnessF0 = 0.02;
 
 		float NdotV = saturate(abs(dot(N, V)) + EPSILON_DOT_CLAMP);
-		float2 specularBRDF = BRDF::EnvBRDFApproxLazarov(roughness, NdotV);
+		float2 specularBRDF = BRDF::EnvBRDFApprox(roughness, NdotV);
 		float3 specularLobeWeight = wetnessF0 * specularBRDF.x + specularBRDF.y;
 
 		// Horizon specular occlusion

--- a/package/Shaders/Common/PBR.hlsli
+++ b/package/Shaders/Common/PBR.hlsli
@@ -334,7 +334,7 @@ namespace PBR
 			specular += GetSpecularDirectLightMultiplierMicrofacet(surfaceProperties.Roughness, surfaceProperties.F0, satNdotL, satNdotV, satNdotH, satVdotH, F) * lightProperties.LightColor * satNdotL;
 #endif
 
-			float2 specularBRDF = BRDF::EnvBRDFApprox(surfaceProperties.Roughness, satNdotV);
+			float2 specularBRDF = BRDF::EnvBRDF(surfaceProperties.Roughness, satNdotV);
 			specular *= 1 + surfaceProperties.F0 * (1 / (specularBRDF.x + specularBRDF.y) - 1);
 
 #if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
@@ -432,7 +432,7 @@ namespace PBR
 			}
 #endif
 
-			float2 specularBRDF = BRDF::EnvBRDFApprox(surfaceProperties.Roughness, NdotV);
+			float2 specularBRDF = BRDF::EnvBRDF(surfaceProperties.Roughness, NdotV);
 			specularLobeWeight = surfaceProperties.F0 * specularBRDF.x + specularBRDF.y;
 
 			diffuseLobeWeight *= (1 - specularLobeWeight);
@@ -441,7 +441,7 @@ namespace PBR
 #if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 			[branch] if ((PBRFlags & Flags::TwoLayer) != 0)
 			{
-				float2 coatSpecularBRDF = BRDF::EnvBRDFApprox(surfaceProperties.CoatRoughness, NdotV);
+				float2 coatSpecularBRDF = BRDF::EnvBRDF(surfaceProperties.CoatRoughness, NdotV);
 				float3 coatSpecularLobeWeight = surfaceProperties.CoatF0 * coatSpecularBRDF.x + coatSpecularBRDF.y;
 				coatSpecularLobeWeight *= 1 + surfaceProperties.CoatF0 * (1 / (coatSpecularBRDF.x + coatSpecularBRDF.y) - 1);
 
@@ -484,7 +484,7 @@ namespace PBR
 		const float wetnessF0 = 0.02;
 
 		float NdotV = saturate(abs(dot(N, V)) + EPSILON_DOT_CLAMP);
-		float2 specularBRDF = BRDF::EnvBRDFApprox(roughness, NdotV);
+		float2 specularBRDF = BRDF::EnvBRDF(roughness, NdotV);
 		float3 specularLobeWeight = wetnessF0 * specularBRDF.x + specularBRDF.y;
 
 		// Horizon specular occlusion


### PR DESCRIPTION
This pull request refactors how the environment BRDF approximation is handled across multiple shader files, centralizing the logic in `BRDF.hlsli` and introducing a new, more accurate approximation method. The main change is the replacement of hardcoded and duplicated BRDF approximation functions with a unified `BRDF::EnvBRDFApprox` function, which now supports both the existing Lazarov method and the new Hirvonen method via a compile-time switch. This improves maintainability, consistency, and enables future extensibility.

**BRDF approximation refactor and centralization:**

* Added `BRDF::EnvBRDFApprox` and `BRDF::EnvBRDFApproxHirvonen` functions to `package/Shaders/Common/BRDF.hlsli`, allowing selection between Lazarov and Hirvonen methods based on the `ENV_BRDF_HIRVONEN` macro.
* Removed local/hardcoded BRDF approximation functions from `features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli` and `features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli`, and replaced their usage with calls to the centralized `BRDF::EnvBRDFApprox`. [[1]](diffhunk://#diff-8887259ce76bb9a04099e42aab4344b8436faf67a00cc72440aa77c090478004L11-L21) [[2]](diffhunk://#diff-8161efed4bb8b8f83f05b422aa79bb4aa7634aa48c9ae60b230fefe5110f4928R1-L17)

**Shader code consistency and usage updates:**

* Updated all usages of environment BRDF approximation in `DynamicCubemaps`, `WetnessEffects`, `Hair`, and `PBR` namespaces to call the new unified `BRDF::EnvBRDFApprox` function, removing references to the old `EnvBRDFApproxLazarov` and local variants. [[1]](diffhunk://#diff-8887259ce76bb9a04099e42aab4344b8436faf67a00cc72440aa77c090478004L90-R80) [[2]](diffhunk://#diff-8161efed4bb8b8f83f05b422aa79bb4aa7634aa48c9ae60b230fefe5110f4928L160-R150) [[3]](diffhunk://#diff-508e74cab61936ef1d00e075cda4ce61bfed1374fd9a8e2d50c2184d07797c4aL258-R259) [[4]](diffhunk://#diff-41774ff79a8b75c6ccf9d0491dba60c4c20e6e57c9e4e311c593978ce139ff5eL337-R337) [[5]](diffhunk://#diff-41774ff79a8b75c6ccf9d0491dba60c4c20e6e57c9e4e311c593978ce139ff5eL435-R435) [[6]](diffhunk://#diff-41774ff79a8b75c6ccf9d0491dba60c4c20e6e57c9e4e311c593978ce139ff5eL444-R444) [[7]](diffhunk://#diff-41774ff79a8b75c6ccf9d0491dba60c4c20e6e57c9e4e311c593978ce139ff5eL487-R487)

**Code maintainability improvements:**

* Added `#include "Common/BRDF.hlsli"` to affected shader files to ensure access to the centralized BRDF functions. [[1]](diffhunk://#diff-8887259ce76bb9a04099e42aab4344b8436faf67a00cc72440aa77c090478004R1) [[2]](diffhunk://#diff-8161efed4bb8b8f83f05b422aa79bb4aa7634aa48c9ae60b230fefe5110f4928R1-L17)

These changes make the codebase easier to maintain and extend, while also enabling the use of more accurate BRDF approximations for specular reflection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a selectable environment BRDF approximation option (Hirvonen/Lazarov) to improve specular evaluation across materials.

- Refactor
  - Unified environment BRDF lookups across PBR, dynamic cubemaps, hair, and wetness effects.
  - Removed duplicated helper implementations for consistent specular behavior.

- Bug Fixes
  - Minor adjustments to specular highlights; visual differences may appear with varying roughness and view angle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->