### PR TITLE
feat(sky sync): add switch sun path option

### DIFF
--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -19,7 +19,7 @@ void SkySync::DrawSettings()
 			SetSunAngle();
 
 		if (settings.SunPath == static_cast<int32_t>(SunPath::Custom)) {
-			if (ImGui::SliderFloat("Custom angle", &settings.CustomAngle, -90.0f, 90.0f, "%.0f"), ImGuiSliderFlags_AlwaysClamp)
+			if (ImGui::SliderFloat("Custom angle", &settings.CustomAngle, -90.0f, 90.0f, "%.0f", ImGuiSliderFlags_AlwaysClamp))
 				SetSunAngle();
 		}
 	}

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -11,18 +11,26 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 void SkySync::DrawSettings()
 {
 	ImGui::Checkbox("Enabled", &settings.Enabled);
+	
 	ImGui::Checkbox("Use alternate sun path", &settings.UseAlternateSunPath);
+	
 	if (settings.UseAlternateSunPath) {
-		ImGui::SliderInt("Sun path", &settings.SunPath, 0, static_cast<uint8_t>(SunPath::Count) - 1, SunPathNames[settings.SunPath]);
-		if (settings.SunPath == static_cast<int32_t>(SunPath::Custom))
-			ImGui::SliderFloat("Custom angle", &settings.CustomAngle, -90.0f, 90.0f, "%.0f");
+		if (ImGui::SliderInt("Sun path", &settings.SunPath, 0, static_cast<uint8_t>(SunPath::Count) - 1, SunPathNames[settings.SunPath]))
+			SetSunAngle();
+		
+		if (settings.SunPath == static_cast<int32_t>(SunPath::Custom)) {
+			if (ImGui::SliderFloat("Custom angle", &settings.CustomAngle, -90.0f, 90.0f, "%.0f"))
+				SetSunAngle();
+		}
 	}
+	
 	ImGui::SliderInt("Moon light source", &settings.MoonLightSource, 0, static_cast<uint8_t>(MoonLightSource::Count) - 1, MoonLightSourceNames[settings.MoonLightSource]);
 }
 
 void SkySync::LoadSettings(json& o_json)
 {
 	settings = o_json;
+	SetSunAngle();
 }
 
 void SkySync::SaveSettings(json& o_json)
@@ -109,6 +117,24 @@ void SkySync::Update(const RE::Sky* sky)
 
 	shadowFader.Update(sun, directions, intensities, isDayTime);
 }
+void SkySync::SetSunAngle()
+{
+	switch (static_cast<SunPath>(settings.SunPath)) {
+	case SunPath::Southern:
+		sunAngle = SouthernSunAngle;
+		break;
+	case SunPath::Northern:
+		sunAngle = NorthernSunAngle;
+		break;
+	case SunPath::Vanilla:
+		sunAngle = VanillaSunAngle;
+		break;
+	case SunPath::Custom:
+		sunAngle = 90.0f + settings.CustomAngle;
+		break;
+	default:;
+	}
+}
 
 void SkySync::SetSkyRotation(const RE::Sky* sky, RE::TESObjectCELL* cell)
 {
@@ -133,22 +159,6 @@ void SkySync::ProcessSun(const RE::Sun* sun, const float time, const float altit
 	float dist;
 
 	if (settings.UseAlternateSunPath) {
-		float sunAngle = 90.0f;
-		switch (static_cast<SunPath>(settings.SunPath)) {
-		case SunPath::Southern:
-			sunAngle -= 35.0f;
-			break;
-		case SunPath::Northern:
-			sunAngle += 35.0f;
-			break;
-		case SunPath::Vanilla:
-			sunAngle += 5.0f;
-			break;
-		case SunPath::Custom:
-			sunAngle += settings.CustomAngle;
-			break;
-		default:;
-		}
 		CalculateAlternateSunDirectionAndDistance(dir, dist, time, timings.sunrise, timings.sunset, sunAngle);
 	} else
 		CalculateSunDirectionAndDistance(sun, dir, dist);

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -24,12 +24,14 @@ void SkySync::DrawSettings()
 		}
 	}
 
-	ImGui::SliderInt("Moon light source", &settings.MoonLightSource, 0, static_cast<uint8_t>(MoonLightSource::Count) - 1, MoonLightSourceNames[settings.MoonLightSource]);
+	ImGui::SliderInt("Moon light source", &settings.MoonLightSource, 0, static_cast<uint8_t>(MoonLightSource::Count) - 1, MoonLightSourceNames[settings.MoonLightSource], ImGuiSliderFlags_AlwaysClamp);
 }
 
 void SkySync::LoadSettings(json& o_json)
 {
 	settings = o_json;
+	settings.MoonLightSource = std::clamp(settings.MoonLightSource, static_cast<int32_t>(MoonLightSource::Brightest), static_cast<int32_t>(MoonLightSource::Secunda));
+	settings.SunPath = std::clamp(settings.SunPath, static_cast<int32_t>(SunPath::Southern), static_cast<int32_t>(SunPath::Custom));
 	SetSunAngle();
 }
 
@@ -119,7 +121,6 @@ void SkySync::Update(const RE::Sky* sky)
 }
 void SkySync::SetSunAngle()
 {
-	settings.SunPath = std::clamp(settings.SunPath, static_cast<int32_t>(SunPath::Southern), static_cast<int32_t>(SunPath::Custom));
 	switch (static_cast<SunPath>(settings.SunPath)) {
 	case SunPath::Southern:
 		sunAngle = SouthernSunAngle;

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -15,11 +15,11 @@ void SkySync::DrawSettings()
 	ImGui::Checkbox("Use alternate sun path", &settings.UseAlternateSunPath);
 	
 	if (settings.UseAlternateSunPath) {
-		if (ImGui::SliderInt("Sun path", &settings.SunPath, 0, static_cast<uint8_t>(SunPath::Count) - 1, SunPathNames[settings.SunPath]))
+		if (ImGui::SliderInt("Sun path", &settings.SunPath, 0, static_cast<uint8_t>(SunPath::Count) - 1, SunPathNames[settings.SunPath], ImGuiSliderFlags_AlwaysClamp))
 			SetSunAngle();
 		
 		if (settings.SunPath == static_cast<int32_t>(SunPath::Custom)) {
-			if (ImGui::SliderFloat("Custom angle", &settings.CustomAngle, -90.0f, 90.0f, "%.0f"))
+			if (ImGui::SliderFloat("Custom angle", &settings.CustomAngle, -90.0f, 90.0f, "%.0f"), ImGuiSliderFlags_AlwaysClamp)
 				SetSunAngle();
 		}
 	}
@@ -119,6 +119,7 @@ void SkySync::Update(const RE::Sky* sky)
 }
 void SkySync::SetSunAngle()
 {
+	settings.SunPath = std::clamp(settings.SunPath, static_cast<int>(SunPath::Southern), static_cast<int>(SunPath::Custom));
 	switch (static_cast<SunPath>(settings.SunPath)) {
 	case SunPath::Southern:
 		sunAngle = SouthernSunAngle;

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -4,12 +4,19 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	SkySync::Settings,
 	Enabled,
 	UseAlternateSunPath,
-	MoonLightSource)
+	MoonLightSource,
+	SunPath,
+	CustomAngle)
 
 void SkySync::DrawSettings()
 {
 	ImGui::Checkbox("Enabled", &settings.Enabled);
 	ImGui::Checkbox("Use alternate sun path", &settings.UseAlternateSunPath);
+	if (settings.UseAlternateSunPath) {
+		ImGui::SliderInt("Sun path", &settings.SunPath, 0, static_cast<uint8_t>(SunPath::Count) - 1, SunPathNames[settings.SunPath]);
+		if (settings.SunPath == static_cast<int32_t>(SunPath::Custom))
+			ImGui::SliderFloat("Custom angle", &settings.CustomAngle, -90.0f, 90.0f, "%.0f");
+	}
 	ImGui::SliderInt("Moon light source", &settings.MoonLightSource, 0, static_cast<uint8_t>(MoonLightSource::Count) - 1, MoonLightSourceNames[settings.MoonLightSource]);
 }
 
@@ -125,9 +132,25 @@ void SkySync::ProcessSun(const RE::Sun* sun, const float time, const float altit
 	RE::NiPoint3 dir;
 	float dist;
 
-	if (settings.UseAlternateSunPath)
-		CalculateAlternateSunDirectionAndDistance(dir, dist, time, timings.sunrise, timings.sunset);
-	else
+	if (settings.UseAlternateSunPath) {
+		float sunAngle = 90.0f;
+		switch (static_cast<SunPath>(settings.SunPath)) {
+		case SunPath::Southern:
+			sunAngle -= 35.0f;
+			break;
+		case SunPath::Northern:
+			sunAngle += 35.0f;
+			break;
+		case SunPath::Vanilla:
+			sunAngle += 5.0f;
+			break;
+		case SunPath::Custom:
+			sunAngle += settings.CustomAngle;
+			break;
+		default:;
+		}
+		CalculateAlternateSunDirectionAndDistance(dir, dist, time, timings.sunrise, timings.sunset, sunAngle);
+	} else
 		CalculateSunDirectionAndDistance(sun, dir, dist);
 
 	rawDirections[static_cast<int>(Caster::Sun)] = dir;
@@ -198,13 +221,13 @@ inline void SkySync::CalculateSunDirectionAndDistance(const RE::Sun* sun, RE::Ni
 	}
 }
 
-inline void SkySync::CalculateAlternateSunDirectionAndDistance(RE::NiPoint3& outDir, float& outDist, const float time, const float sunrise, const float sunset)
+inline void SkySync::CalculateAlternateSunDirectionAndDistance(RE::NiPoint3& outDir, float& outDist, const float time, const float sunrise, const float sunset, const float sunAngle)
 {
 	const float phi = DirectX::XM_PI * ((time - sunrise) / (sunset - sunrise));
 	float sinPhi, cosPhi;
 	DirectX::XMScalarSinCosEst(&sinPhi, &cosPhi, phi);
 
-	constexpr float tiltRadians = DirectX::XMConvertToRadians(SunArcTiltAngle);
+	float tiltRadians = DirectX::XMConvertToRadians(sunAngle);
 	float cosTilt, sinTilt;
 	DirectX::XMScalarSinCosEst(&sinTilt, &cosTilt, tiltRadians);
 

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -119,7 +119,7 @@ void SkySync::Update(const RE::Sky* sky)
 }
 void SkySync::SetSunAngle()
 {
-	settings.SunPath = std::clamp(settings.SunPath, static_cast<int>(SunPath::Southern), static_cast<int>(SunPath::Custom));
+	settings.SunPath = std::clamp(settings.SunPath, static_cast<int32_t>(SunPath::Southern), static_cast<int32_t>(SunPath::Custom));
 	switch (static_cast<SunPath>(settings.SunPath)) {
 	case SunPath::Southern:
 		sunAngle = SouthernSunAngle;

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -43,6 +43,7 @@ void SkySync::SaveSettings(json& o_json)
 void SkySync::RestoreDefaultSettings()
 {
 	settings = {};
+	SetSunAngle();
 }
 
 void SkySync::PostPostLoad()
@@ -248,7 +249,7 @@ inline void SkySync::CalculateAlternateSunDirectionAndDistance(RE::NiPoint3& out
 	if (const float length = outDir.Unitize(); length < FLT_EPSILON)
 		outDir = { 0.0f, 0.0f, 1.0f };
 
-	const float elevationRatio = std::clamp(-outDir.y / cosTilt, 0.0f, 1.0f);
+	const float elevationRatio = std::max(sinPhi, 0.0f);
 	outDist = std::lerp(SunHorizonDistance, SunPeakDistance, elevationRatio);
 }
 

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -11,19 +11,19 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 void SkySync::DrawSettings()
 {
 	ImGui::Checkbox("Enabled", &settings.Enabled);
-	
+
 	ImGui::Checkbox("Use alternate sun path", &settings.UseAlternateSunPath);
-	
+
 	if (settings.UseAlternateSunPath) {
 		if (ImGui::SliderInt("Sun path", &settings.SunPath, 0, static_cast<uint8_t>(SunPath::Count) - 1, SunPathNames[settings.SunPath]))
 			SetSunAngle();
-		
+
 		if (settings.SunPath == static_cast<int32_t>(SunPath::Custom)) {
 			if (ImGui::SliderFloat("Custom angle", &settings.CustomAngle, -90.0f, 90.0f, "%.0f"))
 				SetSunAngle();
 		}
 	}
-	
+
 	ImGui::SliderInt("Moon light source", &settings.MoonLightSource, 0, static_cast<uint8_t>(MoonLightSource::Count) - 1, MoonLightSourceNames[settings.MoonLightSource]);
 }
 

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -149,6 +149,10 @@ private:
 	static constexpr float SunScaleFactor = 48.0f / 2048.0f;
 	static constexpr float MinElevation = 0.25f;
 
+	static constexpr float SouthernSunAngle = 90.0f - 35.0f;
+	static constexpr float NorthernSunAngle = 90.0f + 35.0f;
+	static constexpr float VanillaSunAngle = 90.0f + 5.0f;
+
 	static constexpr float SecundaIntensityFactor = 0.67f;
 	static constexpr float NewMoonIntensityFactor = 0.05f;
 	static constexpr float CrescentMoonIntensityFactor = 0.25f;
@@ -163,6 +167,7 @@ private:
 
 	bool moonAndStarsLoaded = false;
 	RE::TESObjectCELL* currentCell = nullptr;
+	float sunAngle = 90.0f;
 	float currentSkyRotation = D3D11_FLOAT32_MAX;
 	float masserPhaseIntensityFactor = 0.0f;
 	float secundaPhaseIntensityFactor = 0.0f;
@@ -177,6 +182,8 @@ private:
 	void DisableOnConflict(std::string_view conflictName);
 
 	void Update(const RE::Sky* sky);
+
+	void SetSunAngle();
 
 	void SetSkyRotation(const RE::Sky* sky, RE::TESObjectCELL* cell);
 

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -16,7 +16,7 @@ public:
 		return {
 			"Synchronizes volumetric lighting and shadows with the actual sun and moon positions in the sky.",
 			{ "Fixes the mismatch between the positions of the sun and moons and the lighting direction",
-				"Includes an configurable alternative sun path for more realistic and dramatic lighting",
+				"Includes a configurable alternative sun path for more realistic and dramatic lighting",
 				"Smoothly switches the light source between the sun and moons based on visibility",
 				"Moon light source can be switched between Masser, Secunda, or the brightest",
 				"Automatic calculation of moon lighting intensity based on moon phase",

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -16,7 +16,7 @@ public:
 		return {
 			"Synchronizes volumetric lighting and shadows with the actual sun and moon positions in the sky.",
 			{ "Fixes the mismatch between the positions of the sun and moons and the lighting direction",
-				"Includes an optional alternative southern sun path for more realistic and dramatic lighting",
+				"Includes an configurable alternative sun path for more realistic and dramatic lighting",
 				"Smoothly switches the light source between the sun and moons based on visibility",
 				"Moon light source can be switched between Masser, Secunda, or the brightest",
 				"Automatic calculation of moon lighting intensity based on moon phase",

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -29,6 +29,8 @@ public:
 		bool Enabled = true;
 		bool UseAlternateSunPath = true;
 		int32_t MoonLightSource = 0;
+		int32_t SunPath = 0;
+		float CustomAngle = -35.0f;
 	};
 
 	Settings settings;
@@ -90,7 +92,17 @@ private:
 		None
 	};
 
+	enum class SunPath : uint8_t
+	{
+		Southern,
+		Northern,
+		Vanilla,
+		Custom,
+		Count
+	};
+
 	const char* MoonLightSourceNames[static_cast<uint8_t>(MoonLightSource::Count)] = { "Brightest", "Masser", "Secunda" };
+	const char* SunPathNames[static_cast<uint8_t>(SunPath::Count)] = { "Southern Sky", "Northern Sky", "Vanilla", "Custom" };
 
 	struct ClimateTimings
 	{
@@ -132,7 +144,6 @@ private:
 	};
 
 	static constexpr float RenderDistance = 325000.0f;
-	static constexpr float SunArcTiltAngle = 55.0f;
 	static constexpr float SunHorizonDistance = 280.0f;
 	static constexpr float SunPeakDistance = 400.0f;
 	static constexpr float SunScaleFactor = 48.0f / 2048.0f;
@@ -175,7 +186,7 @@ private:
 
 	static void CalculateSunDirectionAndDistance(const RE::Sun* sun, RE::NiPoint3& outDir, float& outDistance);
 
-	static void CalculateAlternateSunDirectionAndDistance(RE::NiPoint3& outDir, float& outDist, float time, float sunrise, float sunset);
+	static void CalculateAlternateSunDirectionAndDistance(RE::NiPoint3& outDir, float& outDist, float time, float sunrise, float sunset, float sunAngle);
 
 	static RE::NiPoint3 GetApparentDirection(const RE::NiPoint3& dir, float altitude);
 


### PR DESCRIPTION
* adds option to select between northern, southern, vanilla-ish, or custom sun paths where the user can choose their own angle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Alternate Sun Path options: Southern, Northern, Vanilla, and Custom.
  * When Alternate Sun Path is enabled, a Sun Path selector appears; choosing Custom reveals a Custom Angle slider (-90° to 90°).
  * Default path angles apply automatically and the chosen path + custom angle persist across sessions.

* **Bug Fixes**
  * Sun angle now refreshes immediately when changing paths, restoring defaults, or loading settings.
  * Moon light and sun-related sliders are clamped to valid ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->