### PR TITLE
refactor(ibl): smooth blend dynamic cubemaps

### DIFF
--- a/features/IBL/Shaders/IBL/DiffuseIBLCS.hlsl
+++ b/features/IBL/Shaders/IBL/DiffuseIBLCS.hlsl
@@ -40,12 +40,20 @@ void main(uint3 dispatchID : SV_DispatchThreadID, uint groupIndex : SV_GroupInde
 	float3 rayDir = SphericalHarmonics::GetUniformSphereSample(sampleCoord.x, sampleCoord.y);
 
 	// Sample cubemap with optimized direction
-	float3 color = ReflectionTexture.SampleLevel(LinearSampler, -rayDir, 0).xyz;
 #if defined(DYNAMIC_CUBEMAPS)
-	if (SharedData::iblSettings.DynamicCubemapsAmount > 0.0f) {
-		float3 dcColor = EnvReflectionsTexture.SampleLevel(LinearSampler, -rayDir, 0);
-		color = lerp(color, dcColor, SharedData::iblSettings.DynamicCubemapsAmount);
+	float3 color = 0;
+	const float dcAmount = saturate(SharedData::iblSettings.DynamicCubemapsAmount);
+	if (dcAmount <= 0.001f) {
+		color = ReflectionTexture.SampleLevel(LinearSampler, -rayDir, 0).xyz;
+	} else if (dcAmount >= 0.999f) {
+		color = EnvReflectionsTexture.SampleLevel(LinearSampler, -rayDir, 0).xyz;
+	} else {
+		const float3 base = ReflectionTexture.SampleLevel(LinearSampler, -rayDir, 0).xyz;
+		const float3 dynamicCubemap = EnvReflectionsTexture.SampleLevel(LinearSampler, -rayDir, 0).xyz;
+		color = lerp(base, dynamicCubemap, dcAmount);
 	}
+#else
+	float3 color = ReflectionTexture.SampleLevel(LinearSampler, -rayDir, 0).xyz;
 #endif
 
 	// Compute spherical harmonics basis for this direction

--- a/features/IBL/Shaders/IBL/DiffuseIBLCS.hlsl
+++ b/features/IBL/Shaders/IBL/DiffuseIBLCS.hlsl
@@ -43,7 +43,7 @@ void main(uint3 dispatchID : SV_DispatchThreadID, uint groupIndex : SV_GroupInde
 	float3 color = ReflectionTexture.SampleLevel(LinearSampler, -rayDir, 0).xyz;
 #if defined(DYNAMIC_CUBEMAPS)
 	if (SharedData::iblSettings.DynamicCubemapsAmount > 0.0f) {
-		float3 dcColor = EnvTexture.SampleLevel(LinearSampler, -rayDir, 0);
+		float3 dcColor = EnvReflectionsTexture.SampleLevel(LinearSampler, -rayDir, 0);
 		color = lerp(color, dcColor, SharedData::iblSettings.DynamicCubemapsAmount);
 	}
 #endif

--- a/features/IBL/Shaders/IBL/DiffuseIBLCS.hlsl
+++ b/features/IBL/Shaders/IBL/DiffuseIBLCS.hlsl
@@ -42,17 +42,11 @@ void main(uint3 dispatchID : SV_DispatchThreadID, uint groupIndex : SV_GroupInde
 	// Sample cubemap with optimized direction
 	float3 color = ReflectionTexture.SampleLevel(LinearSampler, -rayDir, 0).xyz;
 #if defined(DYNAMIC_CUBEMAPS)
-	// Optimized condition check using faster comparisons
-	if (rayDir.z >= 0 && SharedData::iblSettings.SampleUnderHorizonFromDynCube) {
-		float absZ = abs(rayDir.z);
-		if (absZ > abs(rayDir.x) && absZ > abs(rayDir.y)) {
-			color = EnvTexture.SampleLevel(LinearSampler, -rayDir, 0);
-		}
+	if (SharedData::iblSettings.DynamicCubemapsAmount > 0.0f) {
+		float3 dcColor = EnvTexture.SampleLevel(LinearSampler, -rayDir, 0);
+		color = lerp(color, dcColor, SharedData::iblSettings.DynamicCubemapsAmount);
 	}
 #endif
-
-	// Apply gamma correction
-	color = Color::GammaToLinear(color);
 
 	// Compute spherical harmonics basis for this direction
 	sh2 sh = SphericalHarmonics::Evaluate(rayDir);

--- a/features/IBL/Shaders/IBL/IBL.hlsli
+++ b/features/IBL/Shaders/IBL/IBL.hlsli
@@ -29,8 +29,8 @@ namespace ImageBasedLighting
 		float3 directionalAmbientColor = max(0, mul(SharedData::DirectionalAmbient, float4(float3(0, 0, 0), 1.0))).xyz;
 		float3 iblColor = directionalAmbientColor * SharedData::iblSettings.DALCAmount + Color::Saturation(GetDiffuseIBL(float3(0, 0, 0)), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 		if (SharedData::iblSettings.PreserveFogLuminance) {
-			const float fogLuminance = Color::RGBToLuminance2(fogColor);
-			const float iblLuminance = Color::RGBToLuminance2(iblColor);
+			const float fogLuminance = Color::RGBToLuminance(fogColor);
+			const float iblLuminance = Color::RGBToLuminance(iblColor);
 			if (iblLuminance > 0) {
 				const float scale = fogLuminance / iblLuminance;
 				iblColor *= scale;

--- a/package/Shaders/AmbientCompositeCS.hlsl
+++ b/package/Shaders/AmbientCompositeCS.hlsl
@@ -69,11 +69,6 @@ void SampleSSGI(uint2 pixCoord, float3 normalWS, out float ao, out float3 il)
 
 	float3 linAlbedo = Color::GammaToLinear(albedo);
 	float3 linDirectionalAmbientColor = Color::GammaToLinear(directionalAmbientColor);
-#if defined(IBL)
-	if (SharedData::iblSettings.EnableDiffuseIBL) {
-		linDirectionalAmbientColor = directionalAmbientColor;
-	}
-#endif
 	float3 linDiffuseColor = Color::GammaToLinear(diffuseColor);
 	float3 originalDiffuseColor = linDiffuseColor;
 

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -178,13 +178,13 @@ namespace SharedData
 	struct IBLSettings
 	{
 		uint EnableDiffuseIBL;
-		uint SampleUnderHorizonFromDynCube;
 		uint PreserveFogLuminance;
-		uint pad;
 		float DiffuseIBLScale;
 		float DALCAmount;
 		float IBLSaturation;
 		float FogAmount;
+		float DynamicCubemapsAmount;
+		float pad;
 	};
 
 	struct ExtendedTranslucencySettings

--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -8,12 +8,12 @@
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	IBL::Settings,
 	EnableDiffuseIBL,
-	SampleUnderHorizonFromDynCube,
 	PreserveFogLuminance,
 	DiffuseIBLScale,
 	DALCAmount,
 	IBLSaturation,
-	FogAmount)
+	FogAmount,
+	DynamicCubemapsAmount)
 
 void IBL::DrawSettings()
 {
@@ -23,13 +23,12 @@ void IBL::DrawSettings()
 	ImGui::SliderFloat("DALC Amount", &settings.DALCAmount, 0.0f, 1.0f, "%.2f");
 	ImGui::SliderFloat("Fog Mix", &settings.FogAmount, 0.0f, 1.0f, "%.2f");
 	ImGui::Checkbox("Preserve Fog Luminance", (bool*)&settings.PreserveFogLuminance);
-	ImGui::Checkbox("[EXP] Sample Under Horizon From Dynamic Cubemaps", (bool*)&settings.SampleUnderHorizonFromDynCube);
+	ImGui::SliderFloat("Dynamic Cubemaps Amount", &settings.DynamicCubemapsAmount, 0.0f, 1.0f, "%.2f");
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text(
-			"Samples under the horizon from dynamic cubemaps.\n"
-			"Enables the use of dynamic cubemaps for IBL.\n"
+			"Samples from dynamic cubemaps.\n"
 			"Requires the Dynamic Cubemaps feature to be enabled.\n"
-			"Warning: may cause dynamic cubemaps sampling accumulation issues.");
+			"May cause dynamic cubemaps sampling accumulation issues under certain conditions.");
 	}
 }
 

--- a/src/Features/IBL.h
+++ b/src/Features/IBL.h
@@ -41,13 +41,13 @@ public:
 	struct alignas(16) Settings
 	{
 		uint EnableDiffuseIBL = 1;
-		uint SampleUnderHorizonFromDynCube = 0;
 		uint PreserveFogLuminance = 0;
-		uint pad;
 		float DiffuseIBLScale = 1.0f;
 		float DALCAmount = 0.33f;
 		float IBLSaturation = 1.0f;
 		float FogAmount = 0.0f;
+		float DynamicCubemapsAmount = 0.0f;
+		float pad = 0.0f;
 	} settings;
 
 	ID3D11ComputeShader* GetDiffuseIBLCS();


### PR DESCRIPTION
This pull request refactors the handling of dynamic cubemaps in the image-based lighting (IBL) system. It removes the old experimental "SampleUnderHorizonFromDynCube" flag and introduces a new, more flexible `DynamicCubemapsAmount` parameter. This allows dynamic cubemap blending to be smoothly controlled via a slider, improving usability and code clarity. Associated shader logic and UI elements have been updated to reflect this change, and some minor code cleanups were performed.

**Dynamic Cubemap Feature Refactor:**

* Removed the `SampleUnderHorizonFromDynCube` flag from IBL settings and replaced it with a new `DynamicCubemapsAmount` float parameter for more granular blending control (`IBL::Settings`, `SharedData::IBLSettings`, `IBL.h`, `SharedData.hlsli`) [[1]](diffhunk://#diff-ac5120e12a70b96d04e43768cf291f613c3184cd2a2b5d7273b7e8c3d3e69041L44-R50) [[2]](diffhunk://#diff-812c99694216d6c71752b796f8804075cf5652d1f32787207a1ff33e0f173c1eL181-R187) [[3]](diffhunk://#diff-1067f4a4afb271d76cef2c8a214fd0d4a15c8849dff514358f01cbf29e579c71L11-R16).
* Updated the UI in `IBL::DrawSettings()` to use a slider for `DynamicCubemapsAmount` instead of a checkbox, with revised tooltip text for clarity (`IBL.cpp`).

**Shader Logic Updates:**

* Refactored the diffuse IBL shader code to blend between static and dynamic cubemap samples based on the new `DynamicCubemapsAmount` value, removing the previous horizon-based sampling logic (`DiffuseIBLCS.hlsl`).

**Code Cleanup and Consistency:**

* Removed unnecessary gamma correction and conditional logic in ambient composite shader, simplifying color handling (`AmbientCompositeCS.hlsl`).
* Updated luminance computation to use the correct function for consistency in fog luminance preservation (`IBL.hlsli`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Dynamic Cubemaps Amount slider (0–1) to control blending of dynamic reflections.

* **Changes**
  * Replaced the previous horizon-based checkbox with the continuous amount slider.
  * Dynamic reflections now blend smoothly between base and dynamic cubemaps based on the slider.
  * Adjusted fog/ambient luminance handling and removed a post-sample gamma correction, which may subtly affect scene brightness/contrast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->