### PR TITLE
fix(VR): disable terrain blending

### DIFF
--- a/src/Features/TerrainBlending.h
+++ b/src/Features/TerrainBlending.h
@@ -97,5 +97,5 @@ public:
 			logger::info("[Terrain Blending] Installed hooks");
 		}
 	};
-	virtual bool SupportsVR() override { return true; };
+	virtual bool SupportsVR() override { return false; };
 };


### PR DESCRIPTION
Relates to issue #1414 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terrain Blending no longer reports VR support; VR usage with terrain blending is now disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->