### PR TITLE
refactor(pbr): centralize constants

### DIFF
--- a/package/Shaders/Common/PBR.hlsli
+++ b/package/Shaders/Common/PBR.hlsli
@@ -47,6 +47,18 @@ namespace PBR
 		static const uint LandTile5HasGlint = (1 << 17);
 	}
 
+	namespace Constants
+	{
+		static const float MinRoughness = 0.04f;
+		static const float MaxRoughness = 1.0f;
+		static const float MinGlintDensity = 1.0f;
+		static const float MaxGlintDensity = 40.0f;
+		static const float MinGlintRoughness = 0.005f;
+		static const float MaxGlintRoughness = 0.3f;
+		static const float MinGlintDensityRandomization = 0.0f;
+		static const float MaxGlintDensityRandomization = 5.0f;
+	}
+
 #if defined(GLINT)
 #	include "Common/Glints/Glints2023.hlsli"
 #else

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2105,15 +2105,15 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	pbrSurfaceProperties.Noise = screenNoise;
 
-	pbrSurfaceProperties.Roughness = clamp(rawRMAOS.x, 0.04, 1.0);
+	pbrSurfaceProperties.Roughness = clamp(rawRMAOS.x, PBR::Constants::MinRoughness, PBR::Constants::MaxRoughness);
 	pbrSurfaceProperties.Metallic = saturate(rawRMAOS.y);
 	pbrSurfaceProperties.AO = rawRMAOS.z;
 	pbrSurfaceProperties.F0 = lerp(saturate(rawRMAOS.w), Color::GammaToLinear(baseColor.xyz), pbrSurfaceProperties.Metallic);
 
 	pbrSurfaceProperties.GlintScreenSpaceScale = max(1, glintParameters.x);
-	pbrSurfaceProperties.GlintLogMicrofacetDensity = clamp(40.f - glintParameters.y, 1, 40);
-	pbrSurfaceProperties.GlintMicrofacetRoughness = clamp(glintParameters.z, 0.005, 0.3);
-	pbrSurfaceProperties.GlintDensityRandomization = clamp(glintParameters.w, 0, 5);
+	pbrSurfaceProperties.GlintLogMicrofacetDensity = clamp(PBR::Constants::MaxGlintDensity - glintParameters.y, PBR::Constants::MinGlintDensity, PBR::Constants::MaxGlintDensity);
+	pbrSurfaceProperties.GlintMicrofacetRoughness = clamp(glintParameters.z, PBR::Constants::MinGlintRoughness, PBR::Constants::MaxGlintRoughness);
+	pbrSurfaceProperties.GlintDensityRandomization = clamp(glintParameters.w, PBR::Constants::MinGlintDensityRandomization, PBR::Constants::MaxGlintDensityRandomization);
 
 #		if defined(GLINT)
 	float glintNoise = Random::R1Modified(float(SharedData::FrameCount), (Random::pcg2d(uint2(input.Position.xy)) / 4294967296.0).x);


### PR DESCRIPTION
Relates to issue #1353 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized tunable bounds for material roughness and glint parameters, replacing hard-coded limits with shared constants.
  * Standardized clamping ranges across lighting calculations for more consistent visuals.

* **Improvements**
  * More predictable material appearance at parameter extremes (roughness and glint).
  * Enables easier global tuning of visual parameters without behavior changes for typical settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->