### PR TITLE
fix(ibl): crash when dynamic cubemaps disabled

### DIFF
--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -69,10 +69,10 @@ void IBL::Prepass()
 
 	auto& dynamicCubemaps = globals::features::dynamicCubemaps;
 
-	const auto& envTexture = dynamicCubemaps.envTexture;
-	const auto& envReflectionsTexture = dynamicCubemaps.envReflectionsTexture;
+	auto& envTexture = dynamicCubemaps.envTexture;
+	auto& envReflectionsTexture = dynamicCubemaps.envReflectionsTexture;
 
-	std::array<ID3D11ShaderResourceView*, 3> srvs = { reflections.SRV, envTexture->srv.get(), envReflectionsTexture->srv.get() };
+	std::array<ID3D11ShaderResourceView*, 3> srvs = { reflections.SRV, dynamicCubemaps.loaded ? envTexture->srv.get() : nullptr, dynamicCubemaps.loaded ? envReflectionsTexture->srv.get() : nullptr };
 	std::array<ID3D11UnorderedAccessView*, 1> uavs = { diffuseIBLTexture->uav.get() };
 	std::array<ID3D11SamplerState*, 1> samplers = { Deferred::GetSingleton()->linearSampler };
 

--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -72,7 +72,11 @@ void IBL::Prepass()
 	auto& envTexture = dynamicCubemaps.envTexture;
 	auto& envReflectionsTexture = dynamicCubemaps.envReflectionsTexture;
 
-	std::array<ID3D11ShaderResourceView*, 3> srvs = { reflections.SRV, dynamicCubemaps.loaded ? envTexture->srv.get() : nullptr, dynamicCubemaps.loaded ? envReflectionsTexture->srv.get() : nullptr };
+	std::array<ID3D11ShaderResourceView*, 3> srvs = {
+		reflections.SRV,
+		(dynamicCubemaps.loaded && envTexture) ? envTexture->srv.get() : nullptr,
+		(dynamicCubemaps.loaded && envReflectionsTexture) ? envReflectionsTexture->srv.get() : nullptr
+	};
 	std::array<ID3D11UnorderedAccessView*, 1> uavs = { diffuseIBLTexture->uav.get() };
 	std::array<ID3D11SamplerState*, 1> samplers = { Deferred::GetSingleton()->linearSampler };
 


### PR DESCRIPTION
This pull request updates the IBL prepass logic to better handle cases where dynamic cubemaps are not loaded, preventing potential null dereferences in shader resource views.

Resource management improvements:

* In `src/Features/IBL.cpp`, the assignment of `envTexture` and `envReflectionsTexture` is changed from `const auto&` to `auto&` to allow modification if needed.
* When constructing the `srvs` array, the shader resource views for environment textures are now conditionally set to `nullptr` if `dynamicCubemaps.loaded` is false, improving robustness against missing resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Environment textures are now only bound when dynamic cubemaps are available, preventing flickering or incorrect reflections during loading.

* **Performance**
  * Avoids unnecessary binding of environment resources when not loaded, reducing GPU work and improving stability during startup and scene changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->