### PR TITLE
chore(SSGI): set quarter res as default and revise presets

### DIFF
--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -93,7 +93,7 @@ void ScreenSpaceGI::DrawSettings()
 			if (auto _tt = Util::HoverTooltipWrapper())
 				ImGui::Text("1 Slice, 6 Steps, blur enabled, no GI\n");
 
-			ImGui::TableNextColumn();
+				ImGui::TableNextColumn();
 			if (ImGui::Button("Low", { -1, 0 })) {
 				settings.NumSlices = 10;
 				settings.NumSteps = 12;
@@ -109,25 +109,25 @@ void ScreenSpaceGI::DrawSettings()
 			if (ImGui::Button("Standard", { -1, 0 })) {
 				settings.NumSlices = 4;
 				settings.NumSteps = 8;
+				settings.ResolutionMode = 2;
+				settings.EnableBlur = true;
+				settings.EnableGI = true;
+				recompileFlag = true;
+			}
+			if (auto _tt = Util::HoverTooltipWrapper())
+				ImGui::Text("Quarter res and somewhat stable.");
+
+			ImGui::TableNextColumn();
+			if (ImGui::Button("High", { -1, 0 })) {
+				settings.NumSlices = 4;
+				settings.NumSteps = 8;
 				settings.ResolutionMode = 1;
 				settings.EnableBlur = true;
 				settings.EnableGI = true;
 				recompileFlag = true;
 			}
 			if (auto _tt = Util::HoverTooltipWrapper())
-				ImGui::Text("Half res and somewhat stable.");
-
-			ImGui::TableNextColumn();
-			if (ImGui::Button("Extreme", { -1, 0 })) {
-				settings.NumSlices = 4;
-				settings.NumSteps = 8;
-				settings.ResolutionMode = 0;
-				settings.EnableBlur = true;
-				settings.EnableGI = true;
-				recompileFlag = true;
-			}
-			if (auto _tt = Util::HoverTooltipWrapper())
-				ImGui::Text("Full res and clean.");
+				ImGui::Text("Half res and clean.");
 
 			ImGui::TableNextColumn();
 			if (ImGui::Button("Reference", { -1, 0 })) {

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -93,7 +93,7 @@ void ScreenSpaceGI::DrawSettings()
 			if (auto _tt = Util::HoverTooltipWrapper())
 				ImGui::Text("1 Slice, 6 Steps, blur enabled, no GI\n");
 
-				ImGui::TableNextColumn();
+			ImGui::TableNextColumn();
 			if (ImGui::Button("Low", { -1, 0 })) {
 				settings.NumSlices = 10;
 				settings.NumSteps = 12;

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -826,7 +826,7 @@ void ScreenSpaceGI::DrawSSGI(Texture2D* srcPrevAmbient)
 		lastFrameAccumTexIdx = !lastFrameAccumTexIdx;
 	}
 
-	// upsasmple
+	// upsample
 	if (settings.ResolutionMode != 0) {
 		resetViews();
 		srvs.at(0) = texWorkingDepth->srv.get();

--- a/src/Features/ScreenSpaceGI.h
+++ b/src/Features/ScreenSpaceGI.h
@@ -70,7 +70,7 @@ public:
 		// performance/quality
 		uint NumSlices = REL::Module::IsVR() ? 1u : 4u;  // AO preset for VR
 		uint NumSteps = REL::Module::IsVR() ? 6u : 8u;   // AO preset for VR
-		int ResolutionMode = 1;                          // 0-full, 1-half, 2-quarter
+		int ResolutionMode = 2;                          // 0-full, 1-half, 2-quarter - DBF default
 		// visual
 		float MinScreenRadius = 0.01f;
 		float AORadius = 256.f;


### PR DESCRIPTION
Normal preset + quarter res is what the "A Dragonborn's Fate" guide uses as default. This is a sensible default thanks to the way lower GPU cost and stable enough presentation.

The normal preset was updated to match this and Extreme is now named High, which is the only preset option using half res. Only Reference uses full res.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - None.

- **Chores**
  - Default Screen Space Global Illumination now uses quarter-scale to improve performance and reduce GPU usage; users can still choose quarter/half/full in graphics settings.
  - UI preset updates: "Extreme" renamed to "High"; "Standard" now uses quarter res and "High" uses half res; preset descriptions/tooltips updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->