### PR TITLE
chore: remove hdr shader hacks

### DIFF
--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -107,21 +107,6 @@ void Deferred::SetupResources()
 		SetupRenderTarget(NORMALROUGHNESS, texDesc, srvDesc, rtvDesc, uavDesc, DXGI_FORMAT_R10G10B10A2_UNORM, D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE);
 		// Masks
 		SetupRenderTarget(MASKS, texDesc, srvDesc, rtvDesc, uavDesc, DXGI_FORMAT_R8G8B8A8_UNORM, D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE);
-
-		texDesc.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
-		texDesc.Width = 2;
-		texDesc.Height = 2;
-
-		adaptationTextures[0] = new Texture2D(texDesc);
-		adaptationTextures[1] = new Texture2D(texDesc);
-
-		srvDesc.Format = texDesc.Format;
-		adaptationTextures[0]->CreateSRV(srvDesc);
-		adaptationTextures[1]->CreateSRV(srvDesc);
-
-		rtvDesc.Format = texDesc.Format;
-		adaptationTextures[0]->CreateRTV(rtvDesc);
-		adaptationTextures[1]->CreateRTV(rtvDesc);
 	}
 
 	{
@@ -196,13 +181,6 @@ void Deferred::SetupResources()
 		prevDiffuseAmbientTexture = new Texture2D(texDesc);
 		prevDiffuseAmbientTexture->CreateSRV(srvDesc);
 		prevDiffuseAmbientTexture->CreateUAV(uavDesc);
-	}
-
-	// Testing code for imagespace shaders
-	{
-		auto device = globals::d3d::device;
-		auto context = globals::d3d::context;
-		DirectX::CreateDDSTextureFromFile(device, context, L"Data\\Shaders\\LUT.dds", nullptr, lutTexture.put());
 	}
 }
 
@@ -771,61 +749,6 @@ ID3D11ComputeShader* Deferred::GetComputeMainCompositeInterior()
 		mainCompositeInteriorCS = static_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\DeferredCompositeCS.hlsl", defines, "cs_5_0"));
 	}
 	return mainCompositeInteriorCS;
-}
-
-void Deferred::HDRShaderHacks()
-{
-	if (globals::state->currentShader && globals::state->currentShader->shaderType.get() == RE::BSShader::Type::ImageSpace) {
-		const auto& isShader = static_cast<const RE::BSImagespaceShader&>(*globals::state->currentShader);
-
-		enum class ShaderAction
-		{
-			Adaptation,
-			HDR
-		};
-
-		static const ankerl::unordered_dense::map<std::string_view, ShaderAction> shaderMap{
-			{ "BSImagespaceShaderHDRDownSample4LightAdapt", ShaderAction::Adaptation },
-			{ "BSImagespaceShaderHDRDownSample16LightAdapt", ShaderAction::Adaptation },
-			{ "BSImagespaceShaderHDRTonemapBlendCinematic", ShaderAction::HDR },
-			{ "BSImagespaceShaderHDRTonemapBlendCinematicFade", ShaderAction::HDR }
-		};
-
-		auto it = shaderMap.find(isShader.name);
-		if (it != shaderMap.cend()) {
-			switch (it->second) {
-			case ShaderAction::Adaptation:
-				BindAdaptationShader();
-				break;
-			case ShaderAction::HDR:
-				BindHDRShader();
-				break;
-			}
-		}
-	}
-}
-
-void Deferred::BindAdaptationShader()
-{
-	uint frameSwap = (globals::state->frameCount % 2);
-
-	auto srv = adaptationTextures[frameSwap]->srv.get();
-	globals::d3d::context->PSSetShaderResources(1, 1, &srv);
-
-	auto rtv = adaptationTextures[!frameSwap]->rtv.get();
-	globals::d3d::context->OMSetRenderTargets(1, &rtv, nullptr);
-}
-
-void Deferred::BindHDRShader()
-{
-	uint frameSwap = (globals::state->frameCount % 2);
-
-	auto srv = adaptationTextures[!frameSwap]->srv.get();
-	globals::d3d::context->PSSetShaderResources(2, 1, &srv);
-
-	auto view = lutTexture.get();
-	if (view)
-		globals::d3d::context->PSSetShaderResources(100, 1, &view);
 }
 
 void Deferred::Hooks::Main_RenderShadowMaps::thunk()

--- a/src/Deferred.h
+++ b/src/Deferred.h
@@ -35,12 +35,6 @@ public:
 
 	ID3D11ComputeShader* GetComputeMainCompositeInterior();
 
-	void HDRShaderHacks();
-
-	void BindAdaptationShader();
-
-	void BindHDRShader();
-
 	ID3D11BlendState* deferredBlendStates[7][2][13][2];
 	ID3D11BlendState* forwardBlendStates[7][2][13][2];
 
@@ -79,9 +73,6 @@ public:
 	ID3D11ComputeShader* copyShadowCS = nullptr;
 	Buffer* perShadow = nullptr;
 	ID3D11ShaderResourceView* shadowView = nullptr;
-
-	Texture2D* adaptationTextures[2];
-	winrt::com_ptr<ID3D11ShaderResourceView> lutTexture = nullptr;
 
 	struct Hooks
 	{

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -38,8 +38,6 @@ void State::Draw()
 
 		truePBR->SetShaderResouces(context);
 
-		globals::deferred->HDRShaderHacks();
-
 		if (permutationData != permutationDataPrevious) {
 			permutationCB->Update(permutationData);
 			permutationDataPrevious = permutationData;


### PR DESCRIPTION
Removes LUT texture and adaptation texture changes because being replaced with PP anyway and not sure how well that stuff works anyway

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined post-processing by removing legacy HDR adaptation and LUT handling, reducing resource usage and simplifying the rendering path.
  - Eliminated outdated shader-binding logic related to HDR/adaptation to improve maintainability and consistency.
- Chores
  - Cleaned up unused hooks and resources tied to the deprecated HDR/adaptation workflow.
  - Simplified internal state handling without altering existing graphics settings or user workflows.
  - No impact on feature availability; rendering behavior remains consistent with current settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->