### PR TITLE
chore: improved default sss settings

### DIFF
--- a/src/Features/SubsurfaceScattering.h
+++ b/src/Features/SubsurfaceScattering.h
@@ -20,9 +20,9 @@ public:
 	{
 		uint EnableCharacterLighting = false;
 		float CharacterLightingStrength = 1.0f;
-		int SSMode = 0;
+		int SSMode = 1;
 		DiffusionProfile BaseProfile{ 0.5f, 1.0f, { 0.48f, 0.41f, 0.28f }, { 0.56f, 0.56f, 0.56f } };
-		DiffusionProfile HumanProfile{ 1.0f, 1.0f, { 0.48f, 0.41f, 0.28f }, { 1.0f, 0.37f, 0.3f } };
+		DiffusionProfile HumanProfile{ 0.5f, 1.0f, { 0.48f, 0.41f, 0.28f }, { 1.0f, 0.37f, 0.3f } };
 		uint BurleySamples = 16;
 		float4 MeanFreePathBase = { 0.56f, 0.56f, 0.56f, 2.67f };
 		float4 MeanFreePathHuman = { 1.0f, 0.37f, 0.3f, 2.67f };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated default subsurface scattering mode to improve out-of-the-box rendering quality.
  - Tuned the default human skin diffusion profile by reducing the blur radius, yielding crisper surface details while preserving overall softness.
  - These changes affect the default appearance of skin and similar materials; users may notice subtly sharper features and a revised subsurface look without adjusting settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->