### PR TITLE
fix(skylighting): fix skylighting render passes

### DIFF
--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -525,7 +525,6 @@ void Skylighting::RenderOcclusion()
 				}
 				if (precipObject) {
 					precip->SetupMask();
-					precip->SetupMask();  // Calling setup twice fixes an issue when it is raining
 					auto effect = precipObject->GetGeometryRuntimeData().properties[RE::BSGeometry::States::kEffect];
 					auto shaderProp = netimmerse_cast<RE::BSShaderProperty*>(effect.get());
 					auto particleShaderProperty = netimmerse_cast<RE::BSParticleShaderProperty*>(shaderProp);
@@ -594,7 +593,6 @@ void Skylighting::RenderOcclusion()
 				PrecipitationShaderDirection = { PrecipitationShaderDirectionF.x, PrecipitationShaderDirectionF.y, PrecipitationShaderDirectionF.z };
 
 				precip->SetupMask();
-				precip->SetupMask();  // Calling setup twice fixes an issue when it is raining
 
 				BSParticleShaderRainEmitter* rain = new BSParticleShaderRainEmitter;
 				{
@@ -614,6 +612,9 @@ void Skylighting::RenderOcclusion()
 				PrecipitationShaderDirection = originalParticleShaderDirection;
 
 				precipitation = precipitationCopy;
+
+				static REL::Relocation<void(RE::Precipitation*, RE::NiPointer<RE::NiCamera>)> _computeProjection { REL::RelocationID(25643, 26185) };
+				_computeProjection(precip, precip->occlusionData.camera);
 
 				state->EndPerfEvent();
 			}

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -592,6 +592,8 @@ void Skylighting::RenderOcclusion()
 
 				PrecipitationShaderDirection = { PrecipitationShaderDirectionF.x, PrecipitationShaderDirectionF.y, PrecipitationShaderDirectionF.z };
 
+				static REL::Relocation<void(RE::Precipitation*, RE::NiPointer<RE::NiCamera>)> _computeProjection { REL::RelocationID(25643, 26185) };
+				_computeProjection(precip, precip->occlusionData.camera);
 				precip->SetupMask();
 
 				BSParticleShaderRainEmitter* rain = new BSParticleShaderRainEmitter;
@@ -613,7 +615,6 @@ void Skylighting::RenderOcclusion()
 
 				precipitation = precipitationCopy;
 
-				static REL::Relocation<void(RE::Precipitation*, RE::NiPointer<RE::NiCamera>)> _computeProjection { REL::RelocationID(25643, 26185) };
 				_computeProjection(precip, precip->occlusionData.camera);
 
 				state->EndPerfEvent();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improves precipitation visuals by updating occlusion before mask setup, reducing artifacts where rain/snow failed to respect scene occlusion.
  * Removes a redundant mask setup, lowering render overhead during precipitation and preventing double-processing glitches.
  * Ensures projection is refreshed after restoring precipitation state, minimizing flicker or popping when weather/occlusion changes.
  * Provides more consistent camera-aligned precipitation behavior, enhancing visual stability across scenes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->