### PR TITLE
fix(ui): change default imgui ini filename

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -160,7 +160,9 @@ void Menu::Init()
 	auto& imgui_io = ImGui::GetIO();
 	imgui_io.ConfigFlags = ImGuiConfigFlags_NavEnableKeyboard | ImGuiConfigFlags_NavEnableGamepad | ImGuiConfigFlags_DockingEnable;
 	imgui_io.BackendFlags = ImGuiBackendFlags_HasMouseCursors | ImGuiBackendFlags_RendererHasVtxOffset | ImGuiBackendFlags_HasGamepad;
-	imgui_io.IniFilename = "Data/SKSE/Plugins/CommunityShaders_ImGui.ini";
+
+	cachedIniPath = Util::PathHelpers::GetImGuiIniPath().string();
+	imgui_io.IniFilename = cachedIniPath.c_str();
 
 	// Enhanced font configuration for sharper text rendering
 	ImFontConfig font_config;

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -160,6 +160,7 @@ void Menu::Init()
 	auto& imgui_io = ImGui::GetIO();
 	imgui_io.ConfigFlags = ImGuiConfigFlags_NavEnableKeyboard | ImGuiConfigFlags_NavEnableGamepad | ImGuiConfigFlags_DockingEnable;
 	imgui_io.BackendFlags = ImGuiBackendFlags_HasMouseCursors | ImGuiBackendFlags_RendererHasVtxOffset | ImGuiBackendFlags_HasGamepad;
+	imgui_io.IniFilename = "Data/SKSE/Plugins/CommunityShaders_ImGui.ini";
 
 	// Enhanced font configuration for sharper text rendering
 	ImFontConfig font_config;

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -276,6 +276,8 @@ private:
 
 	float cachedFontSize = ThemeManager::Constants::DEFAULT_FONT_SIZE;  // Tracks whether font has been modified and may require reloading
 
+	std::string cachedIniPath;  // io.IniFilename must point to a string that lives for the duration of the runtime
+
 	// Menu navigation
 	std::string pendingFeatureSelection;  // Feature to select on next frame
 

--- a/src/Utils/FileSystem.cpp
+++ b/src/Utils/FileSystem.cpp
@@ -33,6 +33,11 @@ namespace Util
 			return GetDataPath() / "SKSE" / "Plugins" / "CommunityShaders";
 		}
 
+		std::filesystem::path GetImGuiIniPath()
+		{
+			return GetDataPath() / "SKSE" / "Plugins" / "CommunityShaders_ImGui.ini";
+		}
+
 		std::filesystem::path GetUserSettingsPath()
 		{
 			return GetCommunityShaderPath() / "UserSettings.json";

--- a/src/Utils/FileSystem.h
+++ b/src/Utils/FileSystem.h
@@ -39,6 +39,12 @@ namespace Util
 		std::filesystem::path GetCommunityShaderPath();
 
 		/**
+		 * Gets the CommunityShaders_ImGui.ini file path
+		 * @return Data / "SKSE" / "Plugins" / "CommunityShaders_ImGui.ini"
+		 */
+		std::filesystem::path GetImGuiIniPath();
+
+		/**
 		 * Gets the UserSettings.json file path
 		 * @return CommunityShaderPath / "UserSettings.json"
 		 */


### PR DESCRIPTION
By default imgui creates a `imgui.ini` file in the current directory of the executable, which would be fine if community shaders was the only one capable of creating an imgui context, but other plugins can do the same. To avoid potential conflicts with other plugins, and because it's good practice, this pr changes the default ini filename/path:
`imgui.ini` -> `Data/SKSE/Plugins/CommunityShaders_ImGui.ini`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The in-game ImGui overlay now persistently saves layout and UI preferences to a plugin-specific configuration file. Window positions, sizes, and other settings are retained across sessions, reducing reconfiguration and avoiding conflicts with other ImGui tools. Persistence is automatic after the first run; no user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->