### PR TITLE
garbage

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -21,7 +21,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	frameGenerationForceEnable,
 	streamlineLogLevel,
 	enableNISSharpening,
-	nisSharpness);
+	nisSharpness,
+	fsrTechnique);
 
 // D3D hook function pointers and implementations
 decltype(&CreateDXGIFactory) ptrCreateDXGIFactory;
@@ -189,17 +190,28 @@ void Upscaling::DrawSettings()
 	// Check the current upscale method
 	auto upscaleMethod = GetUpscaleMethod();
 
-	// Display upscaling settings if applicable
-	if (!globals::game::isVR) {
-		if (upscaleMethod != UpscaleMethod::kNONE && upscaleMethod != UpscaleMethod::kTAA) {
-			const char* upscalePresetsDLSS[] = { "Ultra Performance", "Performance", "Balanced", "Quality", "DLAA" };
-			const char* upscalePresets[] = { "Ultra Performance", "Performance", "Balanced", "Quality", "Native AA" };
+		// Display upscaling settings if applicable
+		if (!globals::game::isVR) {
+			if (upscaleMethod != UpscaleMethod::kNONE && upscaleMethod != UpscaleMethod::kTAA) {
+				const char* upscalePresetsDLSS[] = { "Ultra Performance", "Performance", "Balanced", "Quality", "DLAA" };
+				const char* upscalePresets[] = { "Ultra Performance", "Performance", "Balanced", "Quality", "Native AA" };
 
-			if (upscaleMethod == UpscaleMethod::kDLSS)
-				ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, 4, std::format("{}", upscalePresetsDLSS[4 - settings.qualityMode]).c_str());
-			else
-				ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, 4, std::format("{}", upscalePresets[4 - settings.qualityMode]).c_str());
-		}
+				if (upscaleMethod == UpscaleMethod::kDLSS)
+					ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, 4, std::format("{}", upscalePresetsDLSS[4 - settings.qualityMode]).c_str());
+				else
+					ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, 4, std::format("{}", upscalePresets[4 - settings.qualityMode]).c_str());
+			}
+
+			// FSR Technique selection (only for FSR)
+			if (upscaleMethod == UpscaleMethod::kFSR) {
+				const char* fsrTechniques[] = { "FSR3", "FSR4" };
+				ImGui::SliderInt("FSR Technique", (int*)&settings.fsrTechnique, 0, 1, fsrTechniques[settings.fsrTechnique]);
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					ImGui::Text("Select between FSR3 and FSR4 upscaling techniques.");
+					ImGui::Text("FSR4 requires AMD Radeon RX 9000 Series or newer.");
+					ImGui::Text("The actual FSR version used will be automatically selected based on hardware capabilities.");
+				}
+			}
 
 		// NIS Sharpening section
 		if (ImGui::TreeNodeEx("NIS Sharpening", ImGuiTreeNodeFlags_DefaultOpen)) {
@@ -606,8 +618,10 @@ void Upscaling::CheckResources(UpscaleMethod a_upscalemethod)
 		if (upscaleModeChanged) {
 			CreateUpscalingTextureResources(a_upscalemethod);
 
-			if (a_upscalemethod == UpscaleMethod::kFSR)
-				fidelityFX.CreateFSRResources();
+			if (a_upscalemethod == UpscaleMethod::kFSR) {
+				FidelityFX::FSRTechnique technique = static_cast<FidelityFX::FSRTechnique>(settings.fsrTechnique);
+				fidelityFX.CreateFSRResources(technique);
+			}
 			else if (a_upscalemethod == UpscaleMethod::kXESS)
 				xess.CreateXeSSResources();
 		}

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -58,6 +58,7 @@ public:
 		uint streamlineLogLevel = 0;   // 0=Off, 1=Default, 2=Verbose
 		uint enableNISSharpening = 1;  // 0=Off, 1=On
 		float nisSharpness = 0.3f;     // 0.0 to 1.0
+		uint fsrTechnique = 0;         // 0=FSR3, 1=FSR4
 	};
 
 	Settings settings;

--- a/src/Features/Upscaling/FidelityFX.cpp
+++ b/src/Features/Upscaling/FidelityFX.cpp
@@ -204,6 +204,9 @@ void FidelityFX::CreateFSRResources(FSRTechnique technique)
 	auto state = globals::state;
 	auto& upscaling = globals::features::upscaling;
 
+	// Query available versions first to get version IDs
+	QueryVersion();
+
 	ffx::CreateContextDescUpscale createUpscaling;
 	createUpscaling.maxRenderSize.width = (uint)state->screenSize.x;
 	createUpscaling.maxRenderSize.height = (uint)state->screenSize.y;
@@ -224,19 +227,39 @@ void FidelityFX::CreateFSRResources(FSRTechnique technique)
 	ffx::CreateBackendDX12Desc backendDesc{};
 	backendDesc.device = upscaling.sharedD3D12Device.get();
 
-	// Log the selected FSR technique
+	// Determine which version ID to use based on technique selection
+	uint64_t selectedVersionId = 0;
 	if (technique == FSRTechnique::kFSR4) {
-		logger::info("[FidelityFX] Requesting FSR4 upscaling (requires AMD Radeon RX 9000 Series or newer)");
-		logger::info("[FidelityFX] Note: FSR version will be automatically selected based on hardware capabilities");
+		if (fsr4VersionId != 0) {
+			selectedVersionId = fsr4VersionId;
+			logger::info("[FidelityFX] Requesting FSR4 upscaling (version ID: {})", selectedVersionId);
+		} else {
+			selectedVersionId = fsr3VersionId;
+			logger::warn("[FidelityFX] FSR4 not available, falling back to FSR3 (version ID: {})", selectedVersionId);
+		}
 	} else {
-		logger::info("[FidelityFX] Requesting FSR3 upscaling");
+		selectedVersionId = fsr3VersionId;
+		logger::info("[FidelityFX] Requesting FSR3 upscaling (version ID: {})", selectedVersionId);
 	}
 
-	if (ffx::CreateContext(upscalingContext, nullptr, createUpscaling, backendDesc) != ffx::ReturnCode::Ok)
-		logger::critical("[FidelityFX] Failed to create FSR API context");
+	// Create version override if we have a specific version ID
+	ffx::CreateContextDescOverrideVersion versionOverride{};
+	if (selectedVersionId != 0) {
+		versionOverride.versionId = selectedVersionId;
+		logger::info("[FidelityFX] Using version override: {}", selectedVersionId);
+	}
 
-	// Query version information after context creation
-	QueryVersion();
+	// Create context with or without version override
+	ffx::ReturnCode result;
+	if (selectedVersionId != 0) {
+		result = ffx::CreateContext(upscalingContext, nullptr, createUpscaling, backendDesc, versionOverride);
+	} else {
+		result = ffx::CreateContext(upscalingContext, nullptr, createUpscaling, backendDesc);
+	}
+
+	if (result != ffx::ReturnCode::Ok) {
+		logger::critical("[FidelityFX] Failed to create FSR API context with version ID: {}", selectedVersionId);
+	}
 }
 
 void FidelityFX::DestroyFSRResources()
@@ -351,9 +374,31 @@ void FidelityFX::QueryVersion()
 
 			// Second query to get actual data
 			if (ffxModule.Query(nullptr, &upscalerQuery.header) == (ffxReturnCode_t)ffx::ReturnCode::Ok) {
+				// Store version IDs for FSR3 and FSR4 selection
+				for (uint64_t i = 0; i < upscalerCount; i++) {
+					if (upscalerNames[i]) {
+						std::string versionName = upscalerNames[i];
+						logger::info("[FidelityFX] Available upscaler version {}: {} (ID: {})", i, versionName, upscalerIds[i]);
+						
+						// Try to identify FSR3 and FSR4 versions by name
+						if (versionName.find("FSR3") != std::string::npos || versionName.find("3.") != std::string::npos) {
+							fsr3VersionId = upscalerIds[i];
+							logger::info("[FidelityFX] FSR3 version ID: {}", fsr3VersionId);
+						}
+						if (versionName.find("FSR4") != std::string::npos || versionName.find("4.") != std::string::npos) {
+							fsr4VersionId = upscalerIds[i];
+							logger::info("[FidelityFX] FSR4 version ID: {}", fsr4VersionId);
+						}
+					}
+				}
+				
+				// Use first available version as default if we couldn't identify specific versions
 				if (upscalerCount > 0 && upscalerNames[0]) {
 					versionInfo = upscalerNames[0];
-					logger::info("[FidelityFX] Upscaler version: {}", versionInfo);
+					if (fsr3VersionId == 0) {
+						fsr3VersionId = upscalerIds[0]; // Default to first available
+					}
+					logger::info("[FidelityFX] Default upscaler version: {}", versionInfo);
 				}
 			}
 		}

--- a/src/Features/Upscaling/FidelityFX.cpp
+++ b/src/Features/Upscaling/FidelityFX.cpp
@@ -199,7 +199,7 @@ void FidelityFX::Present(bool a_useFrameGeneration)
 	isFrameGenActive = a_useFrameGeneration;
 }
 
-void FidelityFX::CreateFSRResources()
+void FidelityFX::CreateFSRResources(FSRTechnique technique)
 {
 	auto state = globals::state;
 	auto& upscaling = globals::features::upscaling;
@@ -224,8 +224,16 @@ void FidelityFX::CreateFSRResources()
 	ffx::CreateBackendDX12Desc backendDesc{};
 	backendDesc.device = upscaling.sharedD3D12Device.get();
 
+	// Log the selected FSR technique
+	if (technique == FSRTechnique::kFSR4) {
+		logger::info("[FidelityFX] Requesting FSR4 upscaling (requires AMD Radeon RX 9000 Series or newer)");
+		logger::info("[FidelityFX] Note: FSR version will be automatically selected based on hardware capabilities");
+	} else {
+		logger::info("[FidelityFX] Requesting FSR3 upscaling");
+	}
+
 	if (ffx::CreateContext(upscalingContext, nullptr, createUpscaling, backendDesc) != ffx::ReturnCode::Ok)
-		logger::critical("[FidelityFX] Failed to create FSR3 API context");
+		logger::critical("[FidelityFX] Failed to create FSR API context");
 
 	// Query version information after context creation
 	QueryVersion();
@@ -319,7 +327,7 @@ void FidelityFX::QueryVersion()
 	versionInfo.clear();
 
 	// Query upscaler versions if available
-	if (featureFSR3) {
+	if (featureFSR3 || featureFSR4) {
 		ffxQueryDescGetVersions upscalerQuery{};
 		upscalerQuery.header.type = FFX_API_QUERY_DESC_TYPE_GET_VERSIONS;
 		upscalerQuery.header.pNext = nullptr;

--- a/src/Features/Upscaling/FidelityFX.h
+++ b/src/Features/Upscaling/FidelityFX.h
@@ -38,6 +38,10 @@ public:
 	// Track if FidelityFX is currently being used for frame generation
 	bool isFrameGenActive = false;
 
+	// Available FSR version IDs
+	uint64_t fsr3VersionId = 0;
+	uint64_t fsr4VersionId = 0;
+
 	// Cached DLL version info for FidelityFX plugin directory
 	static std::vector<std::pair<std::string, std::string>> dllVersions;
 

--- a/src/Features/Upscaling/FidelityFX.h
+++ b/src/Features/Upscaling/FidelityFX.h
@@ -19,6 +19,12 @@ class FidelityFX
 public:
 	static constexpr const wchar_t* PluginDir = L"Data\\Shaders\\Upscaling\\FidelityFX";
 
+	enum class FSRTechnique
+	{
+		kFSR3 = 0,
+		kFSR4 = 1
+	};
+
 	HMODULE module = nullptr;
 
 	ffx::Context swapChainContext{};
@@ -27,6 +33,7 @@ public:
 
 	bool featureFSR3FG = false;
 	bool featureFSR3 = false;
+	bool featureFSR4 = false;
 
 	// Track if FidelityFX is currently being used for frame generation
 	bool isFrameGenActive = false;
@@ -41,7 +48,7 @@ public:
 	void SetupFrameGeneration();
 	void Present(bool a_useFrameGeneration);
 
-	void CreateFSRResources();
+	void CreateFSRResources(FSRTechnique technique = FSRTechnique::kFSR3);
 	void DestroyFSRResources();
 	float GetInputResolutionScale(uint32_t outputWidth, uint32_t outputHeight, uint32_t qualityPreset);
 	void Upscale(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an FSR Technique option in Upscaling settings, allowing users to choose between FSR3 and FSR4.
  * When FSR is selected, a new slider with a tooltip explains the options and relevant hardware notes.
  * The chosen technique is saved in settings and used during upscaling, with automatic fallback to FSR3 if FSR4 isn’t available.
  * Applies to the non-VR path and integrates with existing upscaling workflows (DLSS/XeSS/FSR).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->