### PR TITLE
fix: fix vanilla vegetation normals direction

### DIFF
--- a/package/Shaders/Common/FrameBuffer.hlsli
+++ b/package/Shaders/Common/FrameBuffer.hlsli
@@ -112,6 +112,12 @@ namespace FrameBuffer
 		return mul(CameraView[a_eyeIndex], newPosition).xyz;
 	}
 
+	float3 ViewToWorld(float3 x, bool is_position = true, uint a_eyeIndex = 0)
+	{
+		float4 newPosition = float4(x, (float)is_position);
+		return mul(CameraViewInverse[a_eyeIndex], newPosition).xyz;
+	}
+
 	float2 ViewToUV(float3 x, bool is_position = true, uint a_eyeIndex = 0)
 	{
 		float4 newPosition = float4(x, (float)is_position);

--- a/package/Shaders/DistantTree.hlsl
+++ b/package/Shaders/DistantTree.hlsl
@@ -237,7 +237,7 @@ PS_OUTPUT main(PS_INPUT input)
 	normal.xyz = normalize(FrameBuffer::WorldToView(normal.xyz));
 	normal.z = -abs(normal.z);
 	normal.xyz = normalize(FrameBuffer::ViewToWorld(normal.xyz));
-	
+
 #			if !defined(SSGI)
 	float3 directionalAmbientColor = max(0, mul(SharedData::DirectionalAmbient, float4(normal, 1.0)));
 #				if defined(IBL)

--- a/package/Shaders/DistantTree.hlsl
+++ b/package/Shaders/DistantTree.hlsl
@@ -234,9 +234,9 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 ddx = ddx_coarse(input.WorldPosition.xyz);
 	float3 ddy = ddy_coarse(input.WorldPosition.xyz);
 	float3 normal = -normalize(cross(ddx, ddy));
-	normal.xyz = normalize(FrameBuffer::WorldToView(normal.xyz));
+	normal.xyz = normalize(FrameBuffer::WorldToView(normal.xyz, false, eyeIndex));
 	normal.z = -abs(normal.z);
-	normal.xyz = normalize(FrameBuffer::ViewToWorld(normal.xyz));
+	normal.xyz = normalize(FrameBuffer::ViewToWorld(normal.xyz, false, eyeIndex));
 
 #			if !defined(SSGI)
 	float3 directionalAmbientColor = max(0, mul(SharedData::DirectionalAmbient, float4(normal, 1.0)));

--- a/package/Shaders/DistantTree.hlsl
+++ b/package/Shaders/DistantTree.hlsl
@@ -233,8 +233,11 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float3 ddx = ddx_coarse(input.WorldPosition.xyz);
 	float3 ddy = ddy_coarse(input.WorldPosition.xyz);
-	float3 normal = normalize(cross(ddx, ddy));
-
+	float3 normal = -normalize(cross(ddx, ddy));
+	normal.xyz = normalize(FrameBuffer::WorldToView(normal.xyz));
+	normal.z = -abs(normal.z);
+	normal.xyz = normalize(FrameBuffer::ViewToWorld(normal.xyz));
+	
 #			if !defined(SSGI)
 	float3 directionalAmbientColor = max(0, mul(SharedData::DirectionalAmbient, float4(normal, 1.0)));
 #				if defined(IBL)

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1009,9 +1009,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	// Fix incorrect normals without flipping everything
 #if defined(TREE_ANIM)
-	tbnTr[2] = normalize(FrameBuffer::WorldToView(tbnTr[2]));
+	tbnTr[2].xyz = normalize(FrameBuffer::WorldToView(tbnTr[2].xyz));
 	tbnTr[2].z = -abs(tbnTr[2].z);
-	tbnTr[2] = normalize(FrameBuffer::ViewToWorld(tbnTr[2]));
+	tbnTr[2].xyz  = normalize(FrameBuffer::ViewToWorld(tbnTr[2].xyz));
 #endif
 
 #	endif  // defined (SKINNED) || !defined (MODELSPACENORMALS)

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1007,6 +1007,13 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	float3x3 tbnTr = transpose(tbn);
 
+	// Fix incorrect normals without flipping everything
+#if defined(TREE_ANIM)
+	tbnTr[2] = normalize(FrameBuffer::WorldToView(tbnTr[2]));
+	tbnTr[2].z = -abs(tbnTr[2].z);
+	tbnTr[2] = normalize(FrameBuffer::ViewToWorld(tbnTr[2]));
+#endif
+
 #	endif  // defined (SKINNED) || !defined (MODELSPACENORMALS)
 
 #	if !defined(TRUE_PBR)

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1009,9 +1009,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	// Fix incorrect normals without flipping everything
 #if defined(TREE_ANIM)
-	tbnTr[2].xyz = normalize(FrameBuffer::WorldToView(tbnTr[2].xyz));
+	tbnTr[2].xyz = normalize(FrameBuffer::WorldToView(tbnTr[2].xyz, false, eyeIndex));
 	tbnTr[2].z = -abs(tbnTr[2].z);
-	tbnTr[2].xyz  = normalize(FrameBuffer::ViewToWorld(tbnTr[2].xyz));
+	tbnTr[2].xyz  = normalize(FrameBuffer::ViewToWorld(tbnTr[2].xyz, false, eyeIndex));
 #endif
 
 #	endif  // defined (SKINNED) || !defined (MODELSPACENORMALS)

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -883,9 +883,9 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 ddx = ddx_coarse(input.WorldPosition);
 	float3 ddy = ddy_coarse(input.WorldPosition);
 	float3 normal = -normalize(cross(ddx, ddy));
-	normal.xyz = normalize(FrameBuffer::WorldToView(normal.xyz));
+	normal.xyz = normalize(FrameBuffer::WorldToView(normal.xyz, false, eyeIndex));
 	normal.z = -abs(normal.z);
-	normal.xyz = normalize(FrameBuffer::ViewToWorld(normal.xyz));
+	normal.xyz = normalize(FrameBuffer::ViewToWorld(normal.xyz, false, eyeIndex));
 
 	normal = normalize(float3(normal.xy, max(0, normal.z)));
 

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -883,7 +883,10 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 ddx = ddx_coarse(input.WorldPosition);
 	float3 ddy = ddy_coarse(input.WorldPosition);
 	float3 normal = -normalize(cross(ddx, ddy));
-
+	normal.xyz = normalize(FrameBuffer::WorldToView(normal.xyz));
+	normal.z = -abs(normal.z);
+	normal.xyz = normalize(FrameBuffer::ViewToWorld(normal.xyz));
+	
 	normal = normalize(float3(normal.xy, max(0, normal.z)));
 
 	float3 vertexColor = input.VertexColor.xyz;

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -886,7 +886,7 @@ PS_OUTPUT main(PS_INPUT input)
 	normal.xyz = normalize(FrameBuffer::WorldToView(normal.xyz));
 	normal.z = -abs(normal.z);
 	normal.xyz = normalize(FrameBuffer::ViewToWorld(normal.xyz));
-	
+
 	normal = normalize(float3(normal.xy, max(0, normal.z)));
 
 	float3 vertexColor = input.VertexColor.xyz;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normal orientation for animated trees, grass, and distant foliage to reduce shading flips, dark/light popping, and banding when moving the camera or in VR, yielding more stable visuals.

* **New Features**
  * Added view↔world space conversion in shaders to enable more consistent and accurate lighting for vegetation and similar geometry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->