### PR TITLE
chore: add more incompatible DLLs

### DIFF
--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -167,7 +167,10 @@ bool Load()
 	const std::array incompatibleDLLs = {
 		L"Data/SKSE/Plugins/ShaderTools.dll",
 		L"Data/SKSE/Plugins/SSEShaderTools.dll",
-		L"Data/SKSE/Plugins/SkyrimUpscaler.dll"
+		L"Data/SKSE/Plugins/SkyrimUpscaler.dll",
+		L"Data/SKSE/Plugins/EVLaS.dll",
+		L"Data/SKSE/Plugins/AELAS.dll",
+		L"Data/SKSE/Plugins/SSEReShadeHelper.dll"
 	};
 
 	for (const auto dll : incompatibleDLLs) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved conflict detection by recognizing additional incompatible plugins (e.g., EVLaS, AELAS, SSE ReShade Helper, Skyrim Upscaler). If detected at startup, the app now shows a clear error message and disables conflicting features, reducing crashes and unexpected behavior. This helps you quickly identify problematic setups and ensures more stable, predictable launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->