### PR TITLE
fix(upscaling): fix fg missing menu with TAA

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1504,12 +1504,7 @@ void Upscaling::PerformUpscaling()
 
 	// Disable dynamic resolution past this point
 	runtimeData.dynamicResolutionLock = 1;
-
-	// Disable jitter after upscaling
-	auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
-	GET_INSTANCE_MEMBER(BSImagespaceShaderISTemporalAA, imageSpaceManager);
-	BSImagespaceShaderISTemporalAA->taaEnabled = false;
-
+	
 	// Updates the PerFrame constant buffer so that dynamic resolution settings are disabled
 	UpdateCameraData();
 }
@@ -1653,6 +1648,9 @@ void Upscaling::Main_PostProcessing::thunk(RE::ImageSpaceManager* a1, uint32_t a
 	BSImagespaceShaderISTemporalAA->taaEnabled = upscaleMethod == UpscaleMethod::kTAA;
 
 	func(a1, a3, er8_);
+
+	// Disable TAA in some menus
+	BSImagespaceShaderISTemporalAA->taaEnabled = false;
 }
 
 void Upscaling::SetScissorRect::thunk(RE::BSGraphics::Renderer* This, int a_left, int a_top, int a_right, int a_bottom)

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1504,7 +1504,7 @@ void Upscaling::PerformUpscaling()
 
 	// Disable dynamic resolution past this point
 	runtimeData.dynamicResolutionLock = 1;
-	
+
 	// Updates the PerFrame constant buffer so that dynamic resolution settings are disabled
 	UpdateCameraData();
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporal Anti-Aliasing (TAA) is now automatically disabled in specific menus, ensuring a clearer, more consistent menu presentation.
  * Menus now consistently start with TAA turned off regardless of prior in-game TAA state.
  * Upscaling behavior remains unchanged during gameplay; only menu handling of TAA has been adjusted for consistency.
  * Eliminated a previous runtime path that altered TAA state unpredictably, improving stability in how TAA is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->