### PR TITLE
fix(sss): disable burley, broken

### DIFF
--- a/src/Features/SubsurfaceScattering.cpp
+++ b/src/Features/SubsurfaceScattering.cpp
@@ -30,9 +30,10 @@ void SubsurfaceScattering::DrawSettings()
 			ImGui::SliderFloat("Strength", &settings.CharacterLightingStrength, 0, 5, "%.2f");
 		}
 
-		ImGui::RadioButton("Separable SSS", &settings.SSMode, 0);
-		ImGui::SameLine();
-		ImGui::RadioButton("Burley", &settings.SSMode, 1);
+		// Burley currently broken, disabled
+		// ImGui::RadioButton("Separable SSS", &settings.SSMode, 0);
+		// ImGui::SameLine();
+		// ImGui::RadioButton("Burley", &settings.SSMode, 1);
 
 		if (settings.SSMode == 0) {
 			if (ImGui::TreeNodeEx("Base Profile", ImGuiTreeNodeFlags_DefaultOpen)) {

--- a/src/Features/SubsurfaceScattering.h
+++ b/src/Features/SubsurfaceScattering.h
@@ -20,7 +20,7 @@ public:
 	{
 		uint EnableCharacterLighting = false;
 		float CharacterLightingStrength = 1.0f;
-		int SSMode = 1;
+		int SSMode = 0;
 		DiffusionProfile BaseProfile{ 0.5f, 1.0f, { 0.48f, 0.41f, 0.28f }, { 0.56f, 0.56f, 0.56f } };
 		DiffusionProfile HumanProfile{ 0.5f, 1.0f, { 0.48f, 0.41f, 0.28f }, { 1.0f, 0.37f, 0.3f } };
 		uint BurleySamples = 16;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Disabled the broken “Burley” subsurface scattering mode to prevent visual issues.
  - Removed the subsurface scattering mode selector from the settings UI to avoid choosing unsupported modes.

- Chores
  - Updated the default subsurface scattering mode to “Separable” for new installations or fresh settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->