### PR TITLE
fix(sss): fix burley sss from some effect shaders

### DIFF
--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -853,14 +853,14 @@ PS_OUTPUT main(PS_INPUT input)
 	psout.MotionVectors = float4(screenMotionVector, 0.0, psout.Diffuse.w);
 #		endif
 
+	psout.Albedo = float4(psout.Diffuse.xyz, finalColor.w);
+
 #if defined(MULTBLEND) || defined(MULTBLEND_DECAL)
 	psout.Specular = float4(psout.Diffuse.xyz, finalColor.w);
-	psout.Albedo = float4(psout.Diffuse.xyz, finalColor.w);
 	psout.Reflectance = float4(psout.Diffuse.xyz, finalColor.w);
 	psout.Masks = float4(Color::RGBToLuminance(psout.Diffuse.xyz).xxx, finalColor.w);
 #else
 	psout.Specular = float4(0, 0, 0, finalColor.w);
-	psout.Albedo = float4(0, 0, 0, finalColor.w);
 	psout.Reflectance = float4(0, 0, 0, finalColor.w);
 	psout.Masks = float4(0, 0, 0, finalColor.w);
 #endif

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -98,7 +98,7 @@ void Deferred::SetupResources()
 		// TEMPORAL_AA_WATER_2
 
 		// Albedo
-		SetupRenderTarget(ALBEDO, texDesc, srvDesc, rtvDesc, uavDesc, DXGI_FORMAT_R8G8B8A8_UNORM, D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE);
+		SetupRenderTarget(ALBEDO, texDesc, srvDesc, rtvDesc, uavDesc, DXGI_FORMAT_R11G11B10_FLOAT, D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE);
 		// Specular
 		SetupRenderTarget(SPECULAR, texDesc, srvDesc, rtvDesc, uavDesc, DXGI_FORMAT_R11G11B10_FLOAT, D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE);
 		// Reflectance


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensures Albedo consistently matches Diffuse RGB with correct alpha across all rendering paths, eliminating inconsistencies and visual artifacts.
  - Improves visual quality by using a higher-precision format for the Albedo buffer, reducing banding and preserving color detail.

- Refactor
  - Simplifies Albedo assignment logic in the deferred pipeline by consolidating it to a single, unconditional write, reducing branching and potential edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->