### PR TITLE
fix(sss): prevent divide 0 albedo when blend decals

### DIFF
--- a/features/Subsurface Scattering/Shaders/SubsurfaceScattering/Burley.hlsli
+++ b/features/Subsurface Scattering/Shaders/SubsurfaceScattering/Burley.hlsli
@@ -59,7 +59,7 @@ float4 BurleyNormalizedSS(uint2 DTid, float2 texCoord, uint eyeIndex, float sssA
 	}
 
 	float4 surfaceAlbedo = AlbedoTexture[DTid];
-	float3 originalColor = Color::GammaToLinear(centerColor.xyz / max(surfaceAlbedo.xyz, EPSILON_SSS_ALBEDO));
+	float3 originalColor = Color::GammaToLinear(centerColor.xyz / lerp(1.0, max(surfaceAlbedo.xyz, EPSILON_SSS_ALBEDO), sssAmount));
 
 	float4 diffuseMeanFreePath = humanProfile ? MeanFreePathHuman : MeanFreePathBase;
 	diffuseMeanFreePath.xyz = float3(max(diffuseMeanFreePath.x, 1e-5f), max(diffuseMeanFreePath.y, 1e-5f), max(diffuseMeanFreePath.z, 1e-5f));
@@ -108,7 +108,12 @@ float4 BurleyNormalizedSS(uint2 DTid, float2 texCoord, uint eyeIndex, float sssA
 		float2 sampleUV = texCoord + uvOffset;
 		float2 clampedUV = clamp(sampleUV, float2(0.0f, 0.0f), float2(1.0f, 1.0f));
 		uint2 samplePixcoord = uint2(clampedUV * SharedData::BufferDim.xy);
-		float3 sampleColor = Color::GammaToLinear(ColorTexture[samplePixcoord].xyz / max(AlbedoTexture[samplePixcoord].xyz, EPSILON_SSS_ALBEDO));
+		float sampleMask = MaskTexture[samplePixcoord].x;
+		bool mask = sampleMask > 1e-5f;
+		if (!mask)
+			continue;
+
+		float3 sampleColor = Color::GammaToLinear(ColorTexture[samplePixcoord].xyz / lerp(1.0, max(AlbedoTexture[samplePixcoord].xyz, EPSILON_SSS_ALBEDO), sampleMask));
 		float sampleDepth = SharedData::GetScreenDepth(DepthTexture[samplePixcoord].x);
 		float3 sampleNormalVS = GBuffer::DecodeNormal(NormalTexture[samplePixcoord].xy);
 		float3 sampleNormalWS = normalize(mul(FrameBuffer::CameraViewInverse[eyeIndex], float4(sampleNormalVS, 0)).xyz);
@@ -116,12 +121,9 @@ float4 BurleyNormalizedSS(uint2 DTid, float2 texCoord, uint eyeIndex, float sssA
 		float deltaDepth = (sampleDepth - centerDepth) * 10.f / GAME_UNIT_TO_CM;  // convert to mm
 		float radiusSampledInMM = sqrt(radius * radius + deltaDepth * deltaDepth);
 
-		float maskSample = MaskTexture[samplePixcoord].x;
-		bool mask = maskSample > 1e-5f;
-
 		float3 diffusionProfile = GetBurleyProfile(diffuseMeanFreePath.xyz, s3d, radiusSampledInMM);
 		float normalWeight = sqrt(saturate(dot(sampleNormalWS, normalWS) * 0.5f + 0.5f));
-		float3 sampleWeight = mask ? (diffusionProfile / pdf) * normalWeight : 0.0f;
+		float3 sampleWeight = (diffusionProfile / pdf) * normalWeight;
 
 		colorSum += sampleWeight * sampleColor;
 		weightSum += sampleWeight;
@@ -129,7 +131,7 @@ float4 BurleyNormalizedSS(uint2 DTid, float2 texCoord, uint eyeIndex, float sssA
 
 	colorSum *= any(weightSum == 0.0f) ? 0.0f : (1.0f / weightSum);
 	colorSum = lerp(colorSum, originalColor, saturate(centerWeight));
-	float3 color = Color::LinearToGamma(colorSum) * AlbedoTexture[DTid.xy].xyz;
+	float3 color = Color::LinearToGamma(colorSum) * lerp(1.0f, AlbedoTexture[DTid.xy].xyz, sssAmount);
 
 	float4 outColor = float4(color, ColorTexture[DTid.xy].w);
 	return outColor;


### PR DESCRIPTION
This pull request updates the subsurface scattering shader logic in `Burley.hlsli` to improve color normalization and mask handling. The changes make the subsurface scattering effect more robust by using mask-driven blending for albedo normalization and sample inclusion, leading to more accurate rendering results.

**Subsurface Scattering Improvements**

* Albedo normalization now uses a blend between `1.0` and the albedo value based on `sssAmount`, rather than always normalizing by the albedo, which improves color accuracy in regions with low subsurface scattering.
* Sample inclusion in the scattering computation is now gated by a mask value, ensuring only relevant pixels contribute to the effect. The mask is checked before processing each sample.
* Sample color normalization uses mask-driven blending, similar to the center pixel, for consistency and better handling of masked regions.
* The final output color is now blended between `1.0` and the albedo based on `sssAmount`, rather than always multiplying by the albedo, which helps maintain correct color in non-scattering regions.

**Code Clean-up**

* Removed redundant mask logic from the sample weight calculation, since samples are now filtered by the mask earlier in the loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Subsurface Scattering now supports per-pixel masking, skipping contributions in fully masked areas for cleaner results.
  - Intensity smoothly scales with the SSS amount, providing more predictable control.
  - Color contribution blends with albedo based on SSS settings and mask, improving realism and reducing over-tinting.
  - Sampling weights are more consistent, enhancing visual stability across samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->