### PR TITLE
fix: use proper filename settingsuser.json

### DIFF
--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -453,15 +453,15 @@ bool HomePageRenderer::ShouldShowFirstTimeSetup()
 		return false;
 	}
 
-	// Check if first-time setup has been completed by looking at UserSettings.json
+	// Check if first-time setup has been completed by looking at SettingsUser.json
 	std::filesystem::path userSettingsPath = Util::PathHelpers::GetUserSettingsPath();
 
-	// If UserSettings.json doesn't exist at all, this is definitely a first-time launch
+	// If SettingsUser.json doesn't exist at all, this is definitely a first-time launch
 	if (!std::filesystem::exists(userSettingsPath)) {
 		return true;
 	}
 
-	// If UserSettings.json exists, check if FirstTimeSetupCompleted flag is set
+	// If SettingsUser.json exists, check if FirstTimeSetupCompleted flag is set
 	try {
 		std::ifstream file(userSettingsPath);
 		if (!file.is_open()) {

--- a/src/Utils/FileSystem.cpp
+++ b/src/Utils/FileSystem.cpp
@@ -40,7 +40,7 @@ namespace Util
 
 		std::filesystem::path GetUserSettingsPath()
 		{
-			return GetCommunityShaderPath() / "UserSettings.json";
+			return GetCommunityShaderPath() / "SettingsUser.json";
 		}
 
 		std::filesystem::path GetInterfacePath()

--- a/src/Utils/FileSystem.h
+++ b/src/Utils/FileSystem.h
@@ -45,8 +45,8 @@ namespace Util
 		std::filesystem::path GetImGuiIniPath();
 
 		/**
-		 * Gets the UserSettings.json file path
-		 * @return CommunityShaderPath / "UserSettings.json"
+		 * Gets the SettingsUser.json file path
+		 * @return CommunityShaderPath / "SettingsUser.json"
 		 */
 		std::filesystem::path GetUserSettingsPath();
 


### PR DESCRIPTION
when i made the menu startup window system i got the usersettings.json wrong, it is supposed to be settingsuser.json. this is now rectified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the settings file path used by the app to resolve inconsistencies that could prevent user settings from loading in some cases.

* **Documentation**
  * Updated in-app and developer-facing references to reflect the corrected settings path for consistency.

* **Chores**
  * Aligned internal references to the settings location to ensure uniform behavior across features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->