### PR TITLE
fix: remove water clamp

### DIFF
--- a/package/Shaders/ISWaterBlend.hlsl
+++ b/package/Shaders/ISWaterBlend.hlsl
@@ -28,6 +28,22 @@ cbuffer PerGeometry : register(b2)
 	float4 NearFar_Menu_DistanceFactor : packoffset(c0);
 };
 
+float3 LogToLinear(float3 logColor)
+{
+    const float linearRange = 14.0f;
+    const float linearGrey = 0.18f;
+    const float exposureGrey = 444.0f;
+    return exp2((logColor - exposureGrey / 1023.0) * linearRange) * linearGrey;
+}
+
+float3 LinearToLog(float3 linearColor)
+{
+    const float linearRange = 14.0f;
+    const float linearGrey = 0.18f;
+    const float exposureGrey = 444.0f;
+    return saturate(log2(linearColor) / linearRange - log2(linearGrey) / linearRange + exposureGrey / 1023.0f);
+}
+
 PS_OUTPUT main(PS_INPUT input)
 {
 	PS_OUTPUT psout;
@@ -45,6 +61,7 @@ PS_OUTPUT main(PS_INPUT input)
 		FrameBuffer::GetPreviousDynamicResolutionAdjustedScreenPosition(motionScreenPosition);
 	float4 waterHistory =
 		waterHistoryTex.Sample(waterHistorySampler, motionAdjustedScreenPosition).xyzw;
+	waterHistory.xyz = LogToLinear(waterHistory.xyz) - LogToLinear(0);
 
 	float3 finalColor = sourceColor;
 	if (
@@ -67,7 +84,7 @@ PS_OUTPUT main(PS_INPUT input)
 		finalColor = lerp(sourceColor, waterHistory.xyz, historyFactor);
 	}
 
-	psout.Color1 = float4(finalColor, 1);
+	psout.Color1 = float4(LinearToLog(finalColor + LogToLinear(0)), 1);
 	psout.Color = finalColor;
 
 	return psout;

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -1173,7 +1173,7 @@ PS_OUTPUT main(PS_INPUT input)
 
 #				endif
 #			endif
-	psout.Lighting = saturate(float4(finalColor, isSpecular));
+	psout.Lighting = float4(finalColor, isSpecular);
 #		endif
 
 #		if defined(STENCIL)

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1537,7 +1537,7 @@ namespace SIE
 				// { "BSImagespaceShaderISDisplayDepth", static_cast<uint32_t>(ISDisplayDepth) },
 				// { "BSImagespaceShaderAlphaBlend", static_cast<uint32_t>(ISAlphaBlend) },
 				// { "BSImagespaceShaderWaterFlow", static_cast<uint32_t>(ISWaterFlow) },
-				// { "BSImagespaceShaderISWaterBlend", static_cast<uint32_t>(ISWaterBlend) },
+				{ "BSImagespaceShaderISWaterBlend", static_cast<uint32_t>(ISWaterBlend) },
 				// { "BSImagespaceShaderGreyScale", static_cast<uint32_t>(ISCopyGrayScale) },
 				// { "BSImagespaceShaderCopy", static_cast<uint32_t>(ISCopy) },
 				// { "BSImagespaceShaderCopyScaleBias", static_cast<uint32_t>(ISCopyScaleBias) },


### PR DESCRIPTION
This pull request introduces improvements to water blending shader logic and color space handling, along with a minor change to shader registration. The main focus is on implementing log-to-linear and linear-to-log color conversions in the `ISWaterBlend` shader, ensuring more accurate color blending and output. Additionally, the water blend shader is now registered in the shader cache, and there is a small change to output handling in the water shader.

**Shader logic and color space conversions:**

* Added `LogToLinear` and `LinearToLog` helper functions to `package/Shaders/ISWaterBlend.hlsl` for converting between logarithmic and linear color spaces. These are used to improve color accuracy during blending operations.
* Updated the main pixel shader in `ISWaterBlend.hlsl` to use log-to-linear conversion for `waterHistory` and linear-to-log conversion for the final output color, ensuring consistent color space throughout blending. [[1]](diffhunk://#diff-94a92dd65dda396f132c00b2632cbec2fe36472a7ba65db197e59b807d1fb289R64) [[2]](diffhunk://#diff-94a92dd65dda396f132c00b2632cbec2fe36472a7ba65db197e59b807d1fb289L70-R87)

**Shader output handling:**

* Removed the `saturate` function from the lighting output in `Water.hlsl`, which may affect the range of lighting values written by the shader.

**Shader registration:**

* Registered `BSImagespaceShaderISWaterBlend` in the shader cache by uncommenting its entry in `src/ShaderCache.cpp`, making the water blend shader available for use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled the water blend shader, making its effect available in-game.
- Improvements
  - Enhanced water rendering by processing colors in linear space and encoding outputs correctly, improving color fidelity and consistency.
  - Expanded dynamic range for water lighting by removing previous clamping, allowing brighter highlights and more nuanced specular detail (especially noticeable in HDR).
- Bug Fixes
  - Reduced color banding and artifacts in water history blending through more accurate color-space handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->