### PR TITLE
fix(ui): fix save settings conflicts & welcome screen

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -112,6 +112,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	SkipCompilationKey,
 	EffectToggleKey,
 	OverlayToggleKey,
+	FirstTimeSetupCompleted,
 	Theme)
 
 bool IsEnabled = false;

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -208,7 +208,7 @@ public:
 		uint32_t SkipCompilationKey = VK_ESCAPE;
 		uint32_t EffectToggleKey = VK_MULTIPLY;  // toggle all effects
 		uint32_t OverlayToggleKey = VK_F10;      // Global overlay toggle key for all overlays
-		bool FirstTimeSetupCompleted = false;   // Track if first-time setup has been completed
+		bool FirstTimeSetupCompleted = false;    // Track if first-time setup has been completed
 		ThemeSettings Theme;
 	};
 	const ThemeSettings& GetTheme() const { return settings.Theme; }                // Provide read-only access to the Theme.

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -208,6 +208,7 @@ public:
 		uint32_t SkipCompilationKey = VK_ESCAPE;
 		uint32_t EffectToggleKey = VK_MULTIPLY;  // toggle all effects
 		uint32_t OverlayToggleKey = VK_F10;      // Global overlay toggle key for all overlays
+		bool FirstTimeSetupCompleted = false;   // Track if first-time setup has been completed
 		ThemeSettings Theme;
 	};
 	const ThemeSettings& GetTheme() const { return settings.Theme; }                // Provide read-only access to the Theme.

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -453,10 +453,10 @@ void HomePageRenderer::MarkFirstTimeSetupComplete()
 	// Set the flag in the Menu settings
 	auto menu = Menu::GetSingleton();
 	menu->GetSettings().FirstTimeSetupCompleted = true;
-	
+
 	// Immediately save settings to ensure the flag is persisted
 	// This prevents the welcome screen from showing again even if user doesn't manually save
 	globals::state->Save();
-	
+
 	isFirstTimeSetupShown = true;  // Mark as shown this session
 }

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -1,24 +1,14 @@
 #include "HomePageRenderer.h"
 #include "PCH.h"
 
-#include <filesystem>
-#include <format>
-#include <fstream>
 #include <imgui.h>
-#include <nlohmann/json.hpp>
-#include <ranges>
-#include <sstream>
 
-#include "Feature.h"
 #include "Globals.h"
 #include "Menu.h"
 #include "Menu/ThemeManager.h"
 #include "Plugin.h"
-#include "SettingsOverrideManager.h"
 #include "State.h"
 #include "Util.h"
-
-using json = nlohmann::json;
 
 // Static member definitions
 bool HomePageRenderer::isFirstTimeSetupShown = false;
@@ -427,8 +417,8 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	bool shouldClose = ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_Escape);
 
 	if (ImGui::Button("Continue", ImVec2(continueButtonWidth, 30)) || shouldClose) {
-		// No need to apply any hotkey - user has already set it or it defaults to VK_END
 		MarkFirstTimeSetupComplete();
+		// Note: Settings are automatically saved to ensure welcome screen won't show again
 	}
 
 	// Center the help text
@@ -453,70 +443,20 @@ bool HomePageRenderer::ShouldShowFirstTimeSetup()
 		return false;
 	}
 
-	// Check if first-time setup has been completed by looking at SettingsUser.json
-	std::filesystem::path userSettingsPath = Util::PathHelpers::GetUserSettingsPath();
-
-	// If SettingsUser.json doesn't exist at all, this is definitely a first-time launch
-	if (!std::filesystem::exists(userSettingsPath)) {
-		return true;
-	}
-
-	// If SettingsUser.json exists, check if FirstTimeSetupCompleted flag is set
-	try {
-		std::ifstream file(userSettingsPath);
-		if (!file.is_open()) {
-			return true;  // If we can't read the file, assume first time
-		}
-
-		nlohmann::json settings;
-		file >> settings;
-		file.close();
-
-		// Check if FirstTimeSetupCompleted exists and is true
-		if (settings.contains("FirstTimeSetupCompleted") &&
-			settings["FirstTimeSetupCompleted"].is_boolean() &&
-			settings["FirstTimeSetupCompleted"] == true) {
-			return false;  // Setup already completed
-		}
-
-		return true;  // Field doesn't exist or is false, show setup
-
-	} catch (const std::exception&) {
-		// If there's any error reading the file, assume first time
-		return true;
-	}
+	// Check if first-time setup has been completed using the Menu settings
+	auto menu = Menu::GetSingleton();
+	return !menu->GetSettings().FirstTimeSetupCompleted;
 }
 
 void HomePageRenderer::MarkFirstTimeSetupComplete()
 {
-	std::filesystem::path userSettingsPath = Util::PathHelpers::GetUserSettingsPath();
-
-	try {
-		nlohmann::json settings;
-
-		// Read existing settings if file exists
-		if (std::filesystem::exists(userSettingsPath)) {
-			std::ifstream file(userSettingsPath);
-			if (file.is_open()) {
-				file >> settings;
-				file.close();
-			}
-		}
-
-		// Set the FirstTimeSetupCompleted flag
-		settings["FirstTimeSetupCompleted"] = true;
-
-		// Write back to file
-		std::filesystem::create_directories(userSettingsPath.parent_path());
-		std::ofstream outFile(userSettingsPath);
-		if (outFile.is_open()) {
-			outFile << settings.dump(2);
-			outFile.close();
-		}
-
-	} catch (const std::exception&) {
-		// If we can't write the file, just mark as shown this session to avoid repeated popups
-	}
-
+	// Set the flag in the Menu settings
+	auto menu = Menu::GetSingleton();
+	menu->GetSettings().FirstTimeSetupCompleted = true;
+	
+	// Immediately save settings to ensure the flag is persisted
+	// This prevents the welcome screen from showing again even if user doesn't manually save
+	globals::state->Save();
+	
 	isFirstTimeSetupShown = true;  // Mark as shown this session
 }

--- a/src/Menu/HomePageRenderer.h
+++ b/src/Menu/HomePageRenderer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <functional>
 #include <string>
 
 class HomePageRenderer

--- a/src/Utils/FileSystem.cpp
+++ b/src/Utils/FileSystem.cpp
@@ -38,11 +38,6 @@ namespace Util
 			return GetDataPath() / "SKSE" / "Plugins" / "CommunityShaders_ImGui.ini";
 		}
 
-		std::filesystem::path GetUserSettingsPath()
-		{
-			return GetCommunityShaderPath() / "SettingsUser.json";
-		}
-
 		std::filesystem::path GetInterfacePath()
 		{
 			return GetDataPath() / "Interface" / "CommunityShaders";

--- a/src/Utils/FileSystem.h
+++ b/src/Utils/FileSystem.h
@@ -45,12 +45,6 @@ namespace Util
 		std::filesystem::path GetImGuiIniPath();
 
 		/**
-		 * Gets the SettingsUser.json file path
-		 * @return CommunityShaderPath / "SettingsUser.json"
-		 */
-		std::filesystem::path GetUserSettingsPath();
-
-		/**
 		 * Gets the CommunityShaders Interface directory path
 		 * @return Data / "Interface" / "CommunityShaders"
 		 */


### PR DESCRIPTION
Fixes race condition where welcome screen completion could overwrite saved user settings, and welcome screen randomly reappearing due to flag being lost during settings saves.

Changes:
- Integrated FirstTimeSetupCompleted flag into Menu settings system
- Removed direct JSON file manipulation from HomePageRenderer
- Added auto-save on welcome screen completion
- Cleaned up unused includes and duplicate utility functions
- Ensures consistent settings persistence across restarts


<img width="309" height="92" alt="image" src="https://github.com/user-attachments/assets/c2a3dd0d-d809-4262-a841-2b10a4f853a7" />


