### PR TITLE
fix(VR): fix exiting menu using controllers

### DIFF
--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -1554,18 +1554,27 @@ void VR::UpdateOverlayMenuStateFromInput()
 		return;
 	}
 
-	// Check if we're in a valid menu state for input
-	bool inValidMenuState = globals::game::ui &&
-	                        (globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || globals::game::ui->IsMenuOpen(RE::TweenMenu::MENU_NAME));
+	// Compute whether the game's UI menus we care about are open. Do this early so
+	// downstream logic can reuse the result and we only check the UI once.
+	bool uiMenusOpen = globals::game::ui &&
+	                   (globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || globals::game::ui->IsMenuOpen(RE::TweenMenu::MENU_NAME));
+
+	// Valid menu state means either one of those UI menus is open, or our menu is
+	// enabled (but only if the game's UI system is present).
+	bool inValidMenuState = uiMenusOpen || (globals::game::ui && isEnabled);
 
 	if (!inValidMenuState)
 		return;
 
-	// Define menu state mappings
+	// Define menu state mappings. The `allowWhenUIMenusClosed` flag controls whether
+	// a mapping is allowed to run when our menu is enabled but the game's UI menus
+	// are not reported open. This prevents 'open' controls from firing in that state
+	// while still allowing 'close' actions.
 	struct MenuStateMapping
 	{
 		std::function<bool()> condition;
 		std::function<void()> action;
+		bool allowWhenUIMenusClosed = false;
 	};
 
 	// Generic combo checking function - makes the system truly extensible
@@ -1616,7 +1625,8 @@ void VR::UpdateOverlayMenuStateFromInput()
 		{ [&]() {
 			 return CheckCombo(settings.VRMenuCloseKeys) && isEnabled;
 		 },
-			[&]() { isEnabled = false; } },
+			[&]() { isEnabled = false; },
+			true },
 
 		// Open VR overlay when closed
 		{ [&]() {
@@ -1631,8 +1641,15 @@ void VR::UpdateOverlayMenuStateFromInput()
 			[&]() { overlayEnabled = false; } }
 	};
 
-	// Process mappings in order
+	// Process mappings in order. If our menu is enabled but the game's UI menus
+	// are not open, only allow mappings explicitly marked with
+	// allowWhenUIMenusClosed (close actions).
+	bool onlyAllowClose = isEnabled && !uiMenusOpen;
+
 	for (const auto& mapping : mappings) {
+		if (onlyAllowClose && !mapping.allowWhenUIMenusClosed)
+			continue;
+
 		if (mapping.condition()) {
 			mapping.action();
 			break;  // Only execute one action per frame


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable detection of open/closed UI menus, reducing unintended actions.
  * Closing the Community Shaders menu now works even if UI menus appear closed.
  * Prevents mappings from triggering when menus are disabled, improving consistency.
  * Preserves one-action-per-frame behavior to avoid duplicate inputs.

* **Refactor**
  * Streamlined input mapping logic for clearer, more maintainable behavior without changing public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->