### PR TITLE
feat(UI): allow tooltips for disabled elements

### DIFF
--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -30,7 +30,7 @@ namespace Util
 {
 	HoverTooltipWrapper::HoverTooltipWrapper()
 	{
-		hovered = ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal);
+		hovered = ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal | ImGuiHoveredFlags_AllowWhenDisabled);
 		if (hovered) {
 			ImGui::BeginTooltip();
 			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where tooltips did not appear for disabled buttons, inputs, and other controls. Tooltips now show on hover even when controls are disabled, improving guidance and discoverability without altering hover timing. This enhances accessibility and ensures consistent behavior across the interface. No behavior changes to enabled items are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->