### PR TITLE
fix: adjust IsInterior to consider kNoSky or kFixedDimensions flags

### DIFF
--- a/src/Utils/Game.cpp
+++ b/src/Utils/Game.cpp
@@ -305,7 +305,7 @@ namespace Util
 		auto tes = RE::TES::GetSingleton();
 		if (tes && !tes->interiorCell) {
 			if (auto worldSpace = tes->GetRuntimeData2().worldSpace) {
-				if (!worldSpace->flags.all(RE::TESWorldSpace::Flag::kNoSky)) {
+				if (!worldSpace->flags.any(RE::TESWorldSpace::Flag::kNoSky, RE::TESWorldSpace::Flag::kFixedDimensions)) {
 					return false;
 				}
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Improved detection of interior spaces, including fixed-dimension areas, reducing misclassified locations.
  - Enhances ambience, audio, lighting, and weather handling in affected areas for more consistent behavior.
  - Improves loading behavior, map markers, and fast-travel restrictions where locations should function as interiors.

- Chores
  - Internal logic updated with no changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->