### PR TITLE
fix(upscaling): fix upscaling freezes

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -602,6 +602,8 @@ void Upscaling::CheckResources(UpscaleMethod a_upscalemethod)
 				xess.CreateXeSSResources();
 		}
 
+		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
 		previousUpscaleMode = a_upscalemethod;
 		previousFrameGenMode = (settings.frameGenerationMode && d3d12SwapChainActive);
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when switching upscaling or frame generation modes by introducing a brief delay after resources are reinitialized. This reduces flicker, visual artifacts, and rare crashes during mode changes. Users may notice a very short pause when applying a new upscaling method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->