### PR TITLE
fix(hair): typo in code

### DIFF
--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -119,7 +119,7 @@ namespace Hair
 		float cosThetaD = sqrt((1 + cosThetaL * cosThetaV + NdotV * NdotL) / 2.0);
 
 		const float3 Lp = L - NdotL * N;
-		const float3 Vp = V - NdotL * N;
+		const float3 Vp = V - NdotV * N;
 		const float cosPhi = dot(Lp, Vp) * rsqrt(dot(Lp, Lp) * dot(Vp, Vp) + EPSILON_DIVISION);
 		const float cosHalfPhi = sqrt(saturate(0.5 + 0.5 * cosPhi));
 

--- a/package/Shaders/Common/PBR.hlsli
+++ b/package/Shaders/Common/PBR.hlsli
@@ -227,7 +227,7 @@ namespace PBR
 		float cosThetaD = sqrt((1 + cosThetaL * cosThetaV + NdotV * NdotL) / 2.0);
 
 		const float3 Lp = L - NdotL * N;
-		const float3 Vp = V - NdotL * N;
+		const float3 Vp = V - NdotV * N;
 		const float cosPhi = dot(Lp, Vp) * rsqrt(dot(Lp, Lp) * dot(Vp, Vp) + EPSILON_DIVISION);
 		const float cosHalfPhi = sqrt(saturate(0.5 + 0.5 * cosPhi));
 


### PR DESCRIPTION
This pull request corrects a calculation in both the hair and PBR shader code to ensure the view vector is projected correctly onto the tangent plane. The change updates the computation of the projected view vector, which should improve the accuracy of specular reflection calculations.

Shader math correction:

* In both `features/Hair Specular/Shaders/Hair/Hair.hlsli` (`namespace Hair`) and `package/Shaders/Common/PBR.hlsli` (`namespace PBR`), the calculation of the projected view vector `Vp` was changed from `V - NdotL * N` to `V - NdotV * N`. This ensures the view vector is projected using its own normal component rather than the light's, fixing a subtle bug in the specular reflection math. [[1]](diffhunk://#diff-508e74cab61936ef1d00e075cda4ce61bfed1374fd9a8e2d50c2184d07797c4aL122-R122) [[2]](diffhunk://#diff-41774ff79a8b75c6ccf9d0491dba60c4c20e6e57c9e4e311c593978ce139ff5eL230-R230)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved hair rendering realism with refined lighting response in the Marschner model.

- Bug Fixes
  - Corrected the hair shading calculation to use a view-based projection, improving highlight placement and color fidelity.
  - Reduces shading artifacts and enhances consistency across different viewing and lighting angles.

- Chores
  - Internal shader adjustments with no changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->