### PR TITLE
fix(sss): burley artifacts with effect blend

### DIFF
--- a/features/Subsurface Scattering/Shaders/SubsurfaceScattering/Burley.hlsli
+++ b/features/Subsurface Scattering/Shaders/SubsurfaceScattering/Burley.hlsli
@@ -108,7 +108,13 @@ float4 BurleyNormalizedSS(uint2 DTid, float2 texCoord, uint eyeIndex, float sssA
 		float2 sampleUV = texCoord + uvOffset;
 		float2 clampedUV = clamp(sampleUV, float2(0.0f, 0.0f), float2(1.0f, 1.0f));
 		uint2 samplePixcoord = uint2(clampedUV * SharedData::BufferDim.xy);
-		float3 sampleColor = Color::GammaToLinear(ColorTexture[samplePixcoord].xyz / max(AlbedoTexture[samplePixcoord].xyz, EPSILON_SSS_ALBEDO));
+		float maskSample = MaskTexture[samplePixcoord].x;
+		bool mask = maskSample > 1e-5f;
+
+		if (!mask)
+			continue;
+
+		float3 sampleColor = Color::GammaToLinear(ColorTexture[samplePixcoord].xyz * maskSample / max(AlbedoTexture[samplePixcoord].xyz, EPSILON_SSS_ALBEDO));
 		float sampleDepth = SharedData::GetScreenDepth(DepthTexture[samplePixcoord].x);
 		float3 sampleNormalVS = GBuffer::DecodeNormal(NormalTexture[samplePixcoord].xy);
 		float3 sampleNormalWS = normalize(mul(FrameBuffer::CameraViewInverse[eyeIndex], float4(sampleNormalVS, 0)).xyz);
@@ -116,12 +122,9 @@ float4 BurleyNormalizedSS(uint2 DTid, float2 texCoord, uint eyeIndex, float sssA
 		float deltaDepth = (sampleDepth - centerDepth) * 10.f / GAME_UNIT_TO_CM;  // convert to mm
 		float radiusSampledInMM = sqrt(radius * radius + deltaDepth * deltaDepth);
 
-		float maskSample = MaskTexture[samplePixcoord].x;
-		bool mask = maskSample > 1e-5f;
-
 		float3 diffusionProfile = GetBurleyProfile(diffuseMeanFreePath.xyz, s3d, radiusSampledInMM);
 		float normalWeight = sqrt(saturate(dot(sampleNormalWS, normalWS) * 0.5f + 0.5f));
-		float3 sampleWeight = mask ? (diffusionProfile / pdf) * normalWeight : 0.0f;
+		float3 sampleWeight = (diffusionProfile / pdf) * normalWeight * maskSample;
 
 		colorSum += sampleWeight * sampleColor;
 		weightSum += sampleWeight;
@@ -130,6 +133,7 @@ float4 BurleyNormalizedSS(uint2 DTid, float2 texCoord, uint eyeIndex, float sssA
 	colorSum *= any(weightSum == 0.0f) ? 0.0f : (1.0f / weightSum);
 	colorSum = lerp(colorSum, originalColor, saturate(centerWeight));
 	float3 color = Color::LinearToGamma(colorSum) * AlbedoTexture[DTid.xy].xyz;
+	color = lerp(centerColor.xyz, color, saturate(sssAmount));
 
 	float4 outColor = float4(color, ColorTexture[DTid.xy].w);
 	return outColor;

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -859,7 +859,7 @@ PS_OUTPUT main(PS_INPUT input)
 	psout.Reflectance = float4(psout.Diffuse.xyz, finalColor.w);
 	psout.Masks = float4(Color::RGBToLuminance(psout.Diffuse.xyz).xxx, finalColor.w);
 #else
-	psout.Albedo = float4(psout.Diffuse.xyz, finalColor.w);
+	psout.Albedo = float4(0, 0, 0, finalColor.w);
 	psout.Specular = float4(0, 0, 0, finalColor.w);
 	psout.Reflectance = float4(0, 0, 0, finalColor.w);
 	psout.Masks = float4(0, 0, 0, finalColor.w);


### PR DESCRIPTION
This pull request makes targeted changes to the subsurface scattering shader and the effect shader to improve masking behavior and compositing of colors. The main updates focus on more accurate masking in the Burley subsurface scattering implementation and a change to the default output of the albedo channel in the effect shader.

**Subsurface Scattering Improvements:**

* Improved masking logic in `BurleyNormalizedSS` by skipping samples where the mask is near zero, ensuring only relevant samples contribute to the scattering calculation. The sample color and weight are now both modulated by the mask value for more accurate results.
* Added a blend between the computed subsurface scattering color and the center color based on `sssAmount` for smoother compositing.

**Effect Shader Output Adjustment:**

* Changed the default output of the `Albedo` channel to zero in the effect shader when a specific preprocessor condition is not met, likely to prevent unintended color contributions in certain rendering passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subsurface scattering now supports masking, allowing selective areas to participate for more precise, art-directable results.
  * Added smooth blending control via sssAmount for more natural transitions between base and scattered color.

* **Bug Fixes**
  * Corrected Albedo output in certain pipelines to prevent unintended diffusion color leaking into the Albedo channel, improving consistency across views and exports.

* **Refactor**
  * Streamlined subsurface scattering accumulation by removing redundant mask evaluations and integrating masking directly into sample weighting and color computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->