### PR TITLE
feat(ibl): lerp sky ibl using skylighting

### DIFF
--- a/features/IBL/Shaders/IBL/DiffuseIBLCS.hlsl
+++ b/features/IBL/Shaders/IBL/DiffuseIBLCS.hlsl
@@ -3,13 +3,8 @@
 #include "Common/SharedData.hlsli"
 #include "Common/Spherical Harmonics/SphericalHarmonics.hlsli"
 
-TextureCube<float4> ReflectionTexture : register(t0);
+TextureCube<float4> EnvTexture : register(t0);
 RWTexture2D<sh2> IBLTexture : register(u0);
-
-#if defined(DYNAMIC_CUBEMAPS)
-TextureCube<float3> EnvTexture : register(t1);
-TextureCube<float3> EnvReflectionsTexture : register(t2);
-#endif
 
 SamplerState LinearSampler : register(s0);
 
@@ -40,21 +35,7 @@ void main(uint3 dispatchID : SV_DispatchThreadID, uint groupIndex : SV_GroupInde
 	float3 rayDir = SphericalHarmonics::GetUniformSphereSample(sampleCoord.x, sampleCoord.y);
 
 	// Sample cubemap with optimized direction
-#if defined(DYNAMIC_CUBEMAPS)
-	float3 color = 0;
-	const float dcAmount = saturate(SharedData::iblSettings.DynamicCubemapsAmount);
-	if (dcAmount <= 0.001f) {
-		color = ReflectionTexture.SampleLevel(LinearSampler, -rayDir, 0).xyz;
-	} else if (dcAmount >= 0.999f) {
-		color = EnvReflectionsTexture.SampleLevel(LinearSampler, -rayDir, 0).xyz;
-	} else {
-		const float3 base = ReflectionTexture.SampleLevel(LinearSampler, -rayDir, 0).xyz;
-		const float3 dynamicCubemap = EnvReflectionsTexture.SampleLevel(LinearSampler, -rayDir, 0).xyz;
-		color = lerp(base, dynamicCubemap, dcAmount);
-	}
-#else
-	float3 color = ReflectionTexture.SampleLevel(LinearSampler, -rayDir, 0).xyz;
-#endif
+	float3 color = EnvTexture.SampleLevel(LinearSampler, -rayDir, 0).xyz;
 
 	// Compute spherical harmonics basis for this direction
 	sh2 sh = SphericalHarmonics::Evaluate(rayDir);

--- a/features/IBL/Shaders/IBL/IBL.hlsli
+++ b/features/IBL/Shaders/IBL/IBL.hlsli
@@ -46,20 +46,22 @@ namespace ImageBasedLighting
 	float3 GetIBLColor(float3 rayDir)
 #endif
 	{
+		float3 color = 0;
 		if (SharedData::InInterior)
 		{
-			return GetDiffuseIBL(rayDir);
+			color = GetDiffuseIBL(rayDir);
 		}
 		else
 #if defined(SKYLIGHTING)
 		{
-			return lerp(GetDiffuseIBL(rayDir), GetSkyDiffuseIBL(rayDir), skylighting);
+			color = lerp(GetDiffuseIBL(rayDir), GetSkyDiffuseIBL(rayDir), skylighting);
 		}
 #else
 		{
-			return GetSkyDiffuseIBL(rayDir);
+			color = GetSkyDiffuseIBL(rayDir);
 		}
 #endif
+		return color;
 	}
 
 #if defined(LIGHTING)

--- a/features/IBL/Shaders/IBL/IBL.hlsli
+++ b/features/IBL/Shaders/IBL/IBL.hlsli
@@ -11,12 +11,12 @@ namespace ImageBasedLighting
 {
 #if defined(IBL_AMBIENTCOMPOSITE)
 	Texture2D<sh2> DiffuseIBLTexture : register(t8);
-#elif defined(IBL_DEFERRED)
-	Texture2D<sh2> DiffuseIBLTexture : register(t14);
+	Texture2D<sh2> DiffuseSkyIBLTexture : register(t9);
 #else
 	Texture2D<sh2> DiffuseIBLTexture : register(t76);
-	TextureCube<float4> StaticDiffuseIBLTexture : register(t77);
-	TextureCube<float4> StaticSpecularIBLTexture : register(t78);
+	Texture2D<sh2> DiffuseSkyIBLTexture : register(t77);
+	TextureCube<float4> StaticDiffuseIBLTexture : register(t78);
+	TextureCube<float4> StaticSpecularIBLTexture : register(t79);
 #endif
 	float3 GetDiffuseIBL(float3 rayDir)
 	{
@@ -29,6 +29,39 @@ namespace ImageBasedLighting
 		return float3(colorR, colorG, colorB) / Math::PI;
 	}
 
+	float3 GetSkyDiffuseIBL(float3 rayDir)
+	{
+		sh2 shR = DiffuseSkyIBLTexture.Load(int3(0, 0, 0));
+		sh2 shG = DiffuseSkyIBLTexture.Load(int3(1, 0, 0));
+		sh2 shB = DiffuseSkyIBLTexture.Load(int3(2, 0, 0));
+		float colorR = SphericalHarmonics::SHHallucinateZH3Irradiance(shR, rayDir);
+		float colorG = SphericalHarmonics::SHHallucinateZH3Irradiance(shG, rayDir);
+		float colorB = SphericalHarmonics::SHHallucinateZH3Irradiance(shB, rayDir);
+		return float3(colorR, colorG, colorB) / Math::PI;
+	}
+
+#if defined(SKYLIGHTING)
+	float3 GetIBLColor(float3 rayDir, float skylighting)
+#else
+	float3 GetIBLColor(float3 rayDir)
+#endif
+	{
+		if (SharedData::InInterior)
+		{
+			return GetDiffuseIBL(rayDir);
+		}
+		else
+#if defined(SKYLIGHTING)
+		{
+			return lerp(GetDiffuseIBL(rayDir), GetSkyDiffuseIBL(rayDir), skylighting);
+		}
+#else
+		{
+			return GetSkyDiffuseIBL(rayDir);
+		}
+#endif
+	}
+
 #if defined(LIGHTING)
 	float3 GetStaticDiffuseIBL(float3 N, SamplerState samp)
 	{
@@ -39,7 +72,7 @@ namespace ImageBasedLighting
 	float3 GetFogIBLColor(float3 fogColor)
 	{
 		float3 directionalAmbientColor = max(0, mul(SharedData::DirectionalAmbient, float4(float3(0, 0, 0), 1.0))).xyz;
-		float3 iblColor = directionalAmbientColor * SharedData::iblSettings.DALCAmount + Color::Saturation(GetDiffuseIBL(float3(0, 0, 0)), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+		float3 iblColor = directionalAmbientColor * SharedData::iblSettings.DALCAmount + Color::Saturation(GetSkyDiffuseIBL(float3(0, 0, 0)), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 		if (SharedData::iblSettings.PreserveFogLuminance) {
 			const float fogLuminance = Color::RGBToLuminance(fogColor);
 			const float iblLuminance = Color::RGBToLuminance(iblColor);

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -179,11 +179,11 @@ namespace SharedData
 		uint EnableDiffuseIBL;
 		uint PreserveFogLuminance;
 		uint UseStaticIBL;
+		uint EnableInterior;
 		float DiffuseIBLScale;
 		float DALCAmount;
 		float IBLSaturation;
 		float FogAmount;
-		float DynamicCubemapsAmount;
 	};
 
 	struct ExtendedTranslucencySettings

--- a/package/Shaders/DistantTree.hlsl
+++ b/package/Shaders/DistantTree.hlsl
@@ -239,7 +239,7 @@ PS_OUTPUT main(PS_INPUT input)
 #				if defined(IBL)
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
 		directionalAmbientColor *= SharedData::iblSettings.DALCAmount;
-		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetDiffuseIBL(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 	}
 #				endif
 	diffuseColor += directionalAmbientColor;
@@ -267,7 +267,7 @@ PS_OUTPUT main(PS_INPUT input)
 #			if defined(IBL)
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
 		directionalAmbientColor *= SharedData::iblSettings.DALCAmount;
-		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetDiffuseIBL(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 	}
 #			endif
 	diffuseColor += directionalAmbientColor;

--- a/package/Shaders/DistantTree.hlsl
+++ b/package/Shaders/DistantTree.hlsl
@@ -6,6 +6,10 @@
 #include "Common/SharedData.hlsli"
 #include "Common/VR.hlsli"
 
+#if !defined(DYNAMIC_CUBEMAPS) && defined(IBL)
+#	undef IBL
+#endif
+
 struct VS_INPUT
 {
 	float3 Position : POSITION0;
@@ -239,7 +243,11 @@ PS_OUTPUT main(PS_INPUT input)
 #				if defined(IBL)
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
 		directionalAmbientColor *= SharedData::iblSettings.DALCAmount;
+#					if defined(SKYLIGHTING)
+		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal, 1.0), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+#					else
 		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+#					endif
 	}
 #				endif
 	diffuseColor += directionalAmbientColor;
@@ -267,7 +275,11 @@ PS_OUTPUT main(PS_INPUT input)
 #			if defined(IBL)
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
 		directionalAmbientColor *= SharedData::iblSettings.DALCAmount;
+#					if defined(SKYLIGHTING)
+		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal, 1.0), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+#					else
 		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+#					endif
 	}
 #			endif
 	diffuseColor += directionalAmbientColor;

--- a/package/Shaders/DistantTree.hlsl
+++ b/package/Shaders/DistantTree.hlsl
@@ -240,18 +240,18 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 normal = -normalize(cross(ddx, ddy));
 
 	float3 directionalAmbientColor = max(0, mul(SharedData::DirectionalAmbient, float4(normal, 1.0)));
-#				if defined(IBL)
+#			if defined(IBL)
+	float3 iblColor = 0;
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
-		directionalAmbientColor = Color::GammaToLinear(directionalAmbientColor);
 		directionalAmbientColor *= SharedData::iblSettings.DALCAmount;
 #					if defined(SKYLIGHTING)
-		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal, 1.0), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+		iblColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal, 1.0), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #					else
-		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+		iblColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #					endif
-		directionalAmbientColor = Color::LinearToGamma(directionalAmbientColor);
+		directionalAmbientColor += Color::LinearToGamma(iblColor);
 	}
-#				endif
+#			endif
 	diffuseColor += directionalAmbientColor;
 
 	psout.Diffuse.xyz = diffuseColor * baseColor.xyz;
@@ -275,15 +275,15 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float3 directionalAmbientColor = mul(SharedData::DirectionalAmbient, float4(normal, 1.0));
 #			if defined(IBL)
+	float3 iblColor = 0;
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
-		directionalAmbientColor = Color::GammaToLinear(directionalAmbientColor);
 		directionalAmbientColor *= SharedData::iblSettings.DALCAmount;
 #					if defined(SKYLIGHTING)
-		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal, 1.0), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+		iblColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal, 1.0), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #					else
-		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+		iblColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #					endif
-		directionalAmbientColor = Color::LinearToGamma(directionalAmbientColor);
+		directionalAmbientColor += Color::LinearToGamma(iblColor);
 	}
 #			endif
 	diffuseColor += directionalAmbientColor;

--- a/package/Shaders/DistantTree.hlsl
+++ b/package/Shaders/DistantTree.hlsl
@@ -242,12 +242,14 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 directionalAmbientColor = max(0, mul(SharedData::DirectionalAmbient, float4(normal, 1.0)));
 #				if defined(IBL)
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
+		directionalAmbientColor = Color::GammaToLinear(directionalAmbientColor);
 		directionalAmbientColor *= SharedData::iblSettings.DALCAmount;
 #					if defined(SKYLIGHTING)
 		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal, 1.0), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #					else
 		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #					endif
+		directionalAmbientColor = Color::LinearToGamma(directionalAmbientColor);
 	}
 #				endif
 	diffuseColor += directionalAmbientColor;
@@ -274,12 +276,14 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 directionalAmbientColor = mul(SharedData::DirectionalAmbient, float4(normal, 1.0));
 #			if defined(IBL)
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
+		directionalAmbientColor = Color::GammaToLinear(directionalAmbientColor);
 		directionalAmbientColor *= SharedData::iblSettings.DALCAmount;
 #					if defined(SKYLIGHTING)
 		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal, 1.0), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #					else
 		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #					endif
+		directionalAmbientColor = Color::LinearToGamma(directionalAmbientColor);
 	}
 #			endif
 	diffuseColor += directionalAmbientColor;

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -11,6 +11,10 @@
 
 #define EFFECT
 
+#if !defined(DYNAMIC_CUBEMAPS) && defined(IBL)
+#	undef IBL
+#endif
+
 struct VS_INPUT
 {
 	float4 Position : POSITION0;

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -550,9 +550,8 @@ float3 GetLightingColor(float3 msPosition, float3 worldPosition, float4 screenPo
 		float3 ambientColor = max(0, mul(SharedData::DirectionalAmbient, float4(0, 0, 1, 1)));
 
 #		if defined(IBL)
-		if (SharedData::iblSettings.EnableDiffuseIBL && !SharedData::InInterior) {
+		if (SharedData::iblSettings.EnableDiffuseIBL && (!SharedData::InInterior || SharedData::iblSettings.EnableInterior)) {
 			ambientColor *= SharedData::iblSettings.DALCAmount;
-			ambientColor += Color::Saturation(ImageBasedLighting::GetDiffuseIBL(float3(0, 0, -1)), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 		}
 #		endif
 
@@ -574,6 +573,19 @@ float3 GetLightingColor(float3 msPosition, float3 worldPosition, float4 screenPo
 		color = Color::GammaToLinear(color);
 		color *= skylightingDiffuse;
 		color = Color::LinearToGamma(color);
+#		endif
+
+#		if defined(IBL)
+		if (SharedData::iblSettings.EnableDiffuseIBL) {
+			if (!SharedData::InInterior || SharedData::iblSettings.EnableInterior)
+			{
+#			if defined(SKYLIGHTING)
+				color += Color::Saturation(ImageBasedLighting::GetIBLColor(-worldNormal, skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+#			else
+				color += Color::Saturation(ImageBasedLighting::GetIBLColor(-worldNormal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+#			endif
+			}
+		}
 #		endif
 
 		if (!SharedData::InInterior){

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -580,9 +580,9 @@ float3 GetLightingColor(float3 msPosition, float3 worldPosition, float4 screenPo
 			if (!SharedData::InInterior || SharedData::iblSettings.EnableInterior)
 			{
 #			if defined(SKYLIGHTING)
-				color += Color::Saturation(ImageBasedLighting::GetIBLColor(-worldNormal, skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+				color += Color::Saturation(ImageBasedLighting::GetIBLColor(float3(0, 0, -1), skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #			else
-				color += Color::Saturation(ImageBasedLighting::GetIBLColor(-worldNormal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+				color += Color::Saturation(ImageBasedLighting::GetIBLColor(float3(0, 0, -1)), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #			endif
 			}
 		}

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -583,11 +583,13 @@ float3 GetLightingColor(float3 msPosition, float3 worldPosition, float4 screenPo
 		if (SharedData::iblSettings.EnableDiffuseIBL) {
 			if (!SharedData::InInterior || SharedData::iblSettings.EnableInterior)
 			{
+				color = Color::GammaToLinear(color);
 #			if defined(SKYLIGHTING)
 				color += Color::Saturation(ImageBasedLighting::GetIBLColor(float3(0, 0, -1), skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #			else
 				color += Color::Saturation(ImageBasedLighting::GetIBLColor(float3(0, 0, -1)), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #			endif
+				color = Color::LinearToGamma(color);
 			}
 		}
 #		endif

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -580,16 +580,16 @@ float3 GetLightingColor(float3 msPosition, float3 worldPosition, float4 screenPo
 #		endif
 
 #		if defined(IBL)
+		float3 iblColor = 0;
 		if (SharedData::iblSettings.EnableDiffuseIBL) {
 			if (!SharedData::InInterior || SharedData::iblSettings.EnableInterior)
 			{
-				color = Color::GammaToLinear(color);
 #			if defined(SKYLIGHTING)
-				color += Color::Saturation(ImageBasedLighting::GetIBLColor(float3(0, 0, -1), skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+				iblColor += Color::Saturation(ImageBasedLighting::GetIBLColor(float3(0, 0, -1), skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #			else
-				color += Color::Saturation(ImageBasedLighting::GetIBLColor(float3(0, 0, -1)), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+				iblColor += Color::Saturation(ImageBasedLighting::GetIBLColor(float3(0, 0, -1)), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #			endif
-				color = Color::LinearToGamma(color);
+				color += Color::LinearToGamma(iblColor);
 			}
 		}
 #		endif

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2740,11 +2740,13 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
 		if ((!SharedData::InInterior || SharedData::iblSettings.EnableInterior) && !(SharedData::iblSettings.UseStaticIBL && !inWorld && !inReflection))
 		{
+		directionalAmbientColor = Color::GammaToLinear(directionalAmbientColor);
 #		if defined(SKYLIGHTING)
 			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-ambientNormal, skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #		else
 			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-ambientNormal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #		endif
+		directionalAmbientColor = Color::LinearToGamma(directionalAmbientColor);
 		}
 	}
 #	endif

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -15,8 +15,8 @@
 #	define SKIN
 #endif
 
-#if defined(HAIR) && defined(CS_HAIR)
-#	define DYNAMIC_CUBEMAPS
+#if !defined(DYNAMIC_CUBEMAPS) && defined(IBL)
+#	undef IBL
 #endif
 
 #if (defined(TREE_ANIM) || defined(LANDSCAPE)) && !defined(VC)
@@ -2718,9 +2718,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
 		if (SharedData::iblSettings.UseStaticIBL && !inWorld && !inReflection) {
 			directionalAmbientColor = ImageBasedLighting::GetStaticDiffuseIBL(ambientNormal, SampColorSampler);
-		} else if (!SharedData::InInterior) {
+		} else if (!SharedData::InInterior || SharedData::iblSettings.EnableInterior) {
 			directionalAmbientColor *= SharedData::iblSettings.DALCAmount;
-			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetDiffuseIBL(-ambientNormal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 		}
 	}
 #	endif
@@ -2734,6 +2733,19 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		skylightingDiffuse = saturate(skylightingDiffuse);
 		skylightingDiffuse = lerp(1.0, skylightingDiffuse, skylightingFadeOutFactor);
 		skylightingDiffuse = Skylighting::mixDiffuse(SharedData::skylightingSettings, skylightingDiffuse);
+	}
+#	endif
+
+#	if defined(IBL)
+	if (SharedData::iblSettings.EnableDiffuseIBL) {
+		if ((!SharedData::InInterior || SharedData::iblSettings.EnableInterior) && !(SharedData::iblSettings.UseStaticIBL && !inWorld && !inReflection))
+		{
+#		if defined(SKYLIGHTING)
+			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-ambientNormal, skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+#		else
+			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-ambientNormal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+#		endif
+		}
 	}
 #	endif
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2737,16 +2737,17 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #	endif
 
 #	if defined(IBL)
+	float3 iblColor = 0;
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
 		if ((!SharedData::InInterior || SharedData::iblSettings.EnableInterior) && !(SharedData::iblSettings.UseStaticIBL && !inWorld && !inReflection))
 		{
-		directionalAmbientColor = Color::GammaToLinear(directionalAmbientColor);
 #		if defined(SKYLIGHTING)
-			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-ambientNormal, skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+			iblColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-ambientNormal, skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #		else
-			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-ambientNormal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+			iblColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-ambientNormal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #		endif
-		directionalAmbientColor = Color::LinearToGamma(directionalAmbientColor);
+		iblColor = Color::LinearToGamma(iblColor);
+		directionalAmbientColor += iblColor;
 		}
 	}
 #	endif
@@ -3105,10 +3106,18 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	}
 #		endif
 
+#	if defined(IBL) && defined(SKYLIGHTING)
+	directionalAmbientColor -= iblColor;
+#	endif
+
 	directionalAmbientColor *= outputAlbedo;
 
 #	if defined(SKYLIGHTING)
 	Skylighting::applySkylighting(color.xyz, directionalAmbientColor, skylightingDiffuse);
+#	endif
+
+#	if defined(IBL) && defined(SKYLIGHTING)
+	directionalAmbientColor += iblColor * outputAlbedo;
 #	endif
 
 #	if !defined(DEFERRED)

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -734,11 +734,13 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
 		if (!SharedData::InInterior || SharedData::iblSettings.EnableInterior)
 		{
+			directionalAmbientColor = Color::GammaToLinear(directionalAmbientColor);
 #					if defined(SKYLIGHTING)
 			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal, skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #					else
 			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #					endif
+			directionalAmbientColor = Color::LinearToGamma(directionalAmbientColor);
 		}
 	}
 #				endif
@@ -932,11 +934,13 @@ PS_OUTPUT main(PS_INPUT input)
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
 		if (!SharedData::InInterior || SharedData::iblSettings.EnableInterior)
 		{
+			directionalAmbientColor = Color::GammaToLinear(directionalAmbientColor);
 #				if defined(SKYLIGHTING)
 			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal, skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #				else
 			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #				endif
+			directionalAmbientColor = Color::LinearToGamma(directionalAmbientColor);
 		}
 	}
 #			endif

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -731,30 +731,38 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #				endif  // SKYLIGHTING
 
 #				if defined(IBL)
+	float3 iblColor = 0;
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
 		if (!SharedData::InInterior || SharedData::iblSettings.EnableInterior)
 		{
-			directionalAmbientColor = Color::GammaToLinear(directionalAmbientColor);
 #					if defined(SKYLIGHTING)
-			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal, skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+			iblColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal, skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #					else
-			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+			iblColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #					endif
-			directionalAmbientColor = Color::LinearToGamma(directionalAmbientColor);
+			iblColor = Color::LinearToGamma(iblColor);
+			directionalAmbientColor += iblColor;
 		}
 	}
 #				endif
 
 	diffuseColor += directionalAmbientColor;
 
+#				if defined(IBL) && defined(SKYLIGHTING)
+	directionalAmbientColor -= iblColor;
+#				endif
 	diffuseColor *= albedo;
 	diffuseColor += max(0, sss * subsurfaceColor * SharedData::grassLightingSettings.SubsurfaceScatteringAmount);
 
 	directionalAmbientColor *= albedo;
 
-#	if defined(SKYLIGHTING)
+#				if defined(SKYLIGHTING)
 	Skylighting::applySkylighting(diffuseColor, directionalAmbientColor, skylightingDiffuse);
-#	endif
+#				endif
+
+#				if defined(IBL) && defined(SKYLIGHTING)
+	directionalAmbientColor += iblColor * albedo;
+#				endif
 
 	specularColor += lightsSpecularColor;
 	specularColor *= specColor.w * SharedData::grassLightingSettings.SpecularStrength;
@@ -931,16 +939,17 @@ PS_OUTPUT main(PS_INPUT input)
 #			endif  // SKYLIGHTING
 
 #			if defined(IBL)
+	float3 iblColor = 0;
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
 		if (!SharedData::InInterior || SharedData::iblSettings.EnableInterior)
 		{
-			directionalAmbientColor = Color::GammaToLinear(directionalAmbientColor);
-#				if defined(SKYLIGHTING)
-			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal, skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
-#				else
-			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
-#				endif
-			directionalAmbientColor = Color::LinearToGamma(directionalAmbientColor);
+#					if defined(SKYLIGHTING)
+			iblColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal, skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+#					else
+			iblColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+#					endif
+			iblColor = Color::LinearToGamma(iblColor);
+			directionalAmbientColor += iblColor;
 		}
 	}
 #			endif
@@ -950,11 +959,18 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 albedo = baseColor.xyz * vertexColor;
 
 	diffuseColor *= albedo;
+#			if defined(IBL) && defined(SKYLIGHTING)
+	directionalAmbientColor -= iblColor;
+#			endif
 	directionalAmbientColor *= albedo;
 
-#	if defined(SKYLIGHTING)
+#			if defined(SKYLIGHTING)
 	Skylighting::applySkylighting(diffuseColor, directionalAmbientColor, skylightingDiffuse);
-#	endif
+#			endif
+
+#			if defined(IBL) && defined(SKYLIGHTING)
+	directionalAmbientColor += iblColor * albedo;
+#			endif
 
 	psout.Diffuse.xyz = diffuseColor;
 

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -11,6 +11,10 @@
 #	define GRASS
 #endif  // GRASS_LIGHTING
 
+#if !defined(DYNAMIC_CUBEMAPS) && defined(IBL)
+#	undef IBL
+#endif
+
 struct VS_INPUT
 {
 	float4 Position : POSITION0;

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -705,9 +705,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float3 directionalAmbientColor = max(0, mul(SharedData::DirectionalAmbient, float4(normal, 1.0)));
 
 #				if defined(IBL)
-	if (SharedData::iblSettings.EnableDiffuseIBL && !SharedData::InInterior) {
+	if (SharedData::iblSettings.EnableDiffuseIBL && (!SharedData::InInterior || SharedData::iblSettings.EnableInterior)) {
 		directionalAmbientColor *= SharedData::iblSettings.DALCAmount;
-		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetDiffuseIBL(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 	}
 #				endif  // IBL
 
@@ -726,6 +725,19 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		skylightingDiffuse = Skylighting::mixDiffuse(SharedData::skylightingSettings, skylightingDiffuse);
 	}
 #				endif  // SKYLIGHTING
+
+#				if defined(IBL)
+	if (SharedData::iblSettings.EnableDiffuseIBL) {
+		if (!SharedData::InInterior || SharedData::iblSettings.EnableInterior)
+		{
+#					if defined(SKYLIGHTING)
+			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal, skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+#					else
+			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+#					endif
+		}
+	}
+#				endif
 
 	diffuseColor += directionalAmbientColor;
 
@@ -891,9 +903,8 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 directionalAmbientColor = max(0, mul(SharedData::DirectionalAmbient, float4(normal, 1.0)));
 
 #			if defined(IBL)
-	if (SharedData::iblSettings.EnableDiffuseIBL && !SharedData::InInterior) {
+	if (SharedData::iblSettings.EnableDiffuseIBL && (!SharedData::InInterior || SharedData::iblSettings.EnableInterior)) {
 		directionalAmbientColor *= SharedData::iblSettings.DALCAmount;
-		directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetDiffuseIBL(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 	}
 #			endif  // IBL
 
@@ -912,6 +923,19 @@ PS_OUTPUT main(PS_INPUT input)
 		skylightingDiffuse = Skylighting::mixDiffuse(SharedData::skylightingSettings, skylightingDiffuse);
 	}
 #			endif  // SKYLIGHTING
+
+#			if defined(IBL)
+	if (SharedData::iblSettings.EnableDiffuseIBL) {
+		if (!SharedData::InInterior || SharedData::iblSettings.EnableInterior)
+		{
+#				if defined(SKYLIGHTING)
+			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal, skylightingDiffuse), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+#				else
+			directionalAmbientColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-normal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+#				endif
+		}
+	}
+#			endif
 
 	diffuseColor += directionalAmbientColor;
 

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -421,8 +421,6 @@ void Deferred::DeferredPasses()
 	auto [ssgi_ao, ssgi_y, ssgi_cocg, ssgi_gi_spec] = ssgi.GetOutputTextures();
 	bool ssgi_hq_spec = ssgi.settings.EnableExperimentalSpecularGI;
 
-	auto& ibl = globals::features::ibl;
-
 	auto dispatchCount = Util::GetScreenDispatchCount(true);
 
 	auto& sss = globals::features::subsurfaceScattering;

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -439,7 +439,7 @@ void Deferred::DeferredPasses()
 	{
 		TracyD3D11Zone(globals::state->tracyCtx, "Deferred Composite");
 
-		ID3D11ShaderResourceView* srvs[15]{
+		ID3D11ShaderResourceView* srvs[14]{
 			specular.SRV,
 			albedo.SRV,
 			normalRoughness.SRV,
@@ -454,7 +454,6 @@ void Deferred::DeferredPasses()
 			ssgi_hq_spec ? nullptr : ssgi_y,
 			ssgi_hq_spec ? nullptr : ssgi_cocg,
 			ssgi_hq_spec ? ssgi_gi_spec : nullptr,
-			ibl.loaded ? ibl.diffuseIBLTexture->srv.get() : nullptr,
 		};
 
 		if (dynamicCubemaps.loaded)
@@ -473,7 +472,7 @@ void Deferred::DeferredPasses()
 
 	// Clear
 	{
-		ID3D11ShaderResourceView* views[15]{ nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
+		ID3D11ShaderResourceView* views[14]{ nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
 		context->CSSetShaderResources(0, ARRAYSIZE(views), views);
 
 		ID3D11UnorderedAccessView* uavs[3]{ nullptr, nullptr, nullptr };
@@ -637,9 +636,6 @@ ID3D11ComputeShader* Deferred::GetComputeMainComposite()
 
 		if (globals::features::screenSpaceGI.loaded)
 			defines.push_back({ "SSGI", nullptr });
-
-		if (globals::features::ibl.loaded)
-			defines.push_back({ "IBL", nullptr });
 
 		if (REL::Module::IsVR())
 			defines.push_back({ "FRAMEBUFFER", nullptr });

--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -25,19 +25,13 @@ void IBL::DrawSettings()
 	ImGui::SliderFloat("Diffuse IBL Scale", &settings.DiffuseIBLScale, 0.0f, 10.0f, "%.2f");
 	ImGui::SliderFloat("Diffuse IBL Saturation", &settings.IBLSaturation, 0.0f, 2.0f, "%.2f");
 	ImGui::SliderFloat("DALC Amount", &settings.DALCAmount, 0.0f, 1.0f, "%.2f");
+	ImGui::Checkbox("Enable Interior", (bool*)&settings.EnableInterior);
 	ImGui::Checkbox("Use Static IBL For Out-of-World Objects", (bool*)&settings.UseStaticIBL);
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text("Enables the use of static IBL textures for objects that are not in the world (e.g. inventory items).");
 	}
 	ImGui::SliderFloat("Fog Mix", &settings.FogAmount, 0.0f, 1.0f, "%.2f");
 	ImGui::Checkbox("Preserve Fog Luminance", (bool*)&settings.PreserveFogLuminance);
-	ImGui::SliderFloat("Dynamic Cubemaps Amount", &settings.DynamicCubemapsAmount, 0.0f, 1.0f, "%.2f");
-	if (auto _tt = Util::HoverTooltipWrapper()) {
-		ImGui::Text(
-			"Samples from dynamic cubemaps.\n"
-			"Requires the Dynamic Cubemaps feature to be enabled.\n"
-			"May cause dynamic cubemaps sampling accumulation issues under certain conditions.");
-	}
 }
 
 void IBL::LoadSettings(json& o_json)
@@ -62,8 +56,9 @@ void IBL::EarlyPrepass()
 
 		// Set PS shader resource
 		{
-			std::array<ID3D11ShaderResourceView*, 3> srvs = {
+			std::array<ID3D11ShaderResourceView*, 4> srvs = {
 				diffuseIBLTexture->srv.get(),
+				diffuseSkyIBLTexture->srv.get(),
 				staticDiffuseIBLTexture->srv.get(),
 				staticSpecularIBLTexture->srv.get()
 			};
@@ -75,28 +70,24 @@ void IBL::EarlyPrepass()
 void IBL::Prepass()
 {
 	auto context = globals::d3d::context;
-
+	auto state = globals::state;
 	auto renderer = globals::game::renderer;
-	auto& reflections = renderer->GetRendererData().cubemapRenderTargets[RE::RENDER_TARGET_CUBEMAP::kREFLECTIONS];
 
 	auto& dynamicCubemaps = globals::features::dynamicCubemaps;
 
 	auto& envTexture = dynamicCubemaps.envTexture;
 	auto& envReflectionsTexture = dynamicCubemaps.envReflectionsTexture;
 
-	std::array<ID3D11ShaderResourceView*, 3> srvs = {
-		reflections.SRV,
-		(dynamicCubemaps.loaded && envTexture) ? envTexture->srv.get() : nullptr,
-		(dynamicCubemaps.loaded && envReflectionsTexture) ? envReflectionsTexture->srv.get() : nullptr
-	};
-	std::array<ID3D11UnorderedAccessView*, 1> uavs = { diffuseIBLTexture->uav.get() };
-	std::array<ID3D11SamplerState*, 1> samplers = { Deferred::GetSingleton()->linearSampler };
-
 	// Unset PS shader resource
 	{
-		ID3D11ShaderResourceView* srv = nullptr;
-		context->PSSetShaderResources(76, 1, &srv);
+		ID3D11ShaderResourceView* srvs[2]{ nullptr, nullptr };
+		context->PSSetShaderResources(76, 2, srvs);
 	}
+
+	state->BeginPerfEvent("IBL");
+	std::array<ID3D11ShaderResourceView*, 1> srvs = { (dynamicCubemaps.loaded && envTexture) ? envTexture->srv.get() : nullptr };
+	std::array<ID3D11UnorderedAccessView*, 1> uavs = { diffuseIBLTexture->uav.get() };
+	std::array<ID3D11SamplerState*, 1> samplers = { Deferred::GetSingleton()->linearSampler };
 
 	// IBL
 	{
@@ -106,6 +97,16 @@ void IBL::Prepass()
 		context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
 		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
 		context->CSSetShader(GetDiffuseIBLCS(), nullptr, 0);
+		context->Dispatch(1, 1, 1);
+	}
+
+	// IBL with sky
+	{
+		srvs.at(0) = (dynamicCubemaps.loaded && envReflectionsTexture) ? envReflectionsTexture->srv.get() : nullptr;
+		uavs.at(0) = diffuseSkyIBLTexture->uav.get();
+
+		context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
+		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
 		context->Dispatch(1, 1, 1);
 	}
 
@@ -120,11 +121,12 @@ void IBL::Prepass()
 		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
 		context->CSSetShader(nullptr, nullptr, 0);
 	}
+	state->EndPerfEvent();
 
 	// Set PS shader resource
 	{
-		ID3D11ShaderResourceView* srv = diffuseIBLTexture->srv.get();
-		context->PSSetShaderResources(76, 1, &srv);
+		ID3D11ShaderResourceView* srvs[2]{ diffuseIBLTexture->srv.get(), diffuseSkyIBLTexture->srv.get() };
+		context->PSSetShaderResources(76, 2, srvs);
 	}
 }
 
@@ -161,6 +163,9 @@ void IBL::SetupResources()
 		diffuseIBLTexture = new Texture2D(texDesc);
 		diffuseIBLTexture->CreateSRV(srvDesc);
 		diffuseIBLTexture->CreateUAV(uavDesc);
+		diffuseSkyIBLTexture = new Texture2D(texDesc);
+		diffuseSkyIBLTexture->CreateSRV(srvDesc);
+		diffuseSkyIBLTexture->CreateUAV(uavDesc);
 	}
 
 	auto device = globals::d3d::device;

--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -13,11 +13,11 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	EnableDiffuseIBL,
 	PreserveFogLuminance,
 	UseStaticIBL,
+	EnableInterior,
 	DiffuseIBLScale,
 	DALCAmount,
 	IBLSaturation,
-	FogAmount,
-	DynamicCubemapsAmount)
+	FogAmount)
 
 void IBL::DrawSettings()
 {
@@ -62,7 +62,7 @@ void IBL::EarlyPrepass()
 				staticDiffuseIBLTexture->srv.get(),
 				staticSpecularIBLTexture->srv.get()
 			};
-			context->PSSetShaderResources(76, 3, srvs.data());
+			context->PSSetShaderResources(76, 4, srvs.data());
 		}
 	}
 }
@@ -71,7 +71,6 @@ void IBL::Prepass()
 {
 	auto context = globals::d3d::context;
 	auto state = globals::state;
-	auto renderer = globals::game::renderer;
 
 	auto& dynamicCubemaps = globals::features::dynamicCubemaps;
 
@@ -80,8 +79,8 @@ void IBL::Prepass()
 
 	// Unset PS shader resource
 	{
-		ID3D11ShaderResourceView* srvs[2]{ nullptr, nullptr };
-		context->PSSetShaderResources(76, 2, srvs);
+		ID3D11ShaderResourceView* views[2]{ nullptr, nullptr };
+		context->PSSetShaderResources(76, 2, views);
 	}
 
 	state->BeginPerfEvent("IBL");
@@ -125,8 +124,8 @@ void IBL::Prepass()
 
 	// Set PS shader resource
 	{
-		ID3D11ShaderResourceView* srvs[2]{ diffuseIBLTexture->srv.get(), diffuseSkyIBLTexture->srv.get() };
-		context->PSSetShaderResources(76, 2, srvs);
+		ID3D11ShaderResourceView* views[2]{ diffuseIBLTexture->srv.get(), diffuseSkyIBLTexture->srv.get() };
+		context->PSSetShaderResources(76, 2, views);
 	}
 }
 

--- a/src/Features/IBL.h
+++ b/src/Features/IBL.h
@@ -39,7 +39,7 @@ public:
 	virtual void SetupResources() override;
 	virtual void ClearShaderCache() override;
 
-	struct alignas(16) Settings
+	struct Settings
 	{
 		uint EnableDiffuseIBL = 1;
 		uint PreserveFogLuminance = 0;

--- a/src/Features/IBL.h
+++ b/src/Features/IBL.h
@@ -25,6 +25,7 @@ public:
 	bool HasShaderDefine(RE::BSShader::Type) override { return true; };
 
 	Texture2D* diffuseIBLTexture = nullptr;
+	Texture2D* diffuseSkyIBLTexture = nullptr;
 	ID3D11ComputeShader* diffuseIBLCS = nullptr;
 
 	virtual void RestoreDefaultSettings() override;
@@ -43,11 +44,11 @@ public:
 		uint EnableDiffuseIBL = 1;
 		uint PreserveFogLuminance = 0;
 		uint UseStaticIBL = 1;
+		uint EnableInterior = 0;
 		float DiffuseIBLScale = 1.0f;
 		float DALCAmount = 0.33f;
 		float IBLSaturation = 1.0f;
 		float FogAmount = 0.0f;
-		float DynamicCubemapsAmount = 0.0f;
 	} settings;
 
 	eastl::unique_ptr<Texture2D> staticDiffuseIBLTexture = nullptr;


### PR DESCRIPTION
This pull request introduces significant improvements and refactoring to the Image-Based Lighting (IBL) shader system, focusing on better separation of sky and interior lighting, improved flexibility for enabling IBL in interiors, and code cleanup related to dynamic cubemaps. The changes streamline IBL handling, add support for sky-specific IBL textures, and ensure more consistent and configurable lighting behavior across different rendering scenarios.

**IBL and Skylighting Improvements:**

- Added a new `GetSkyDiffuseIBL` function and associated textures in `ImageBasedLighting`, enabling separate handling of sky-based diffuse IBL and blending with interior IBL based on context. Introduced a unified `GetIBLColor` function to blend between interior and sky IBL, with support for a `skylighting` parameter when enabled. [[1]](diffhunk://#diff-ab75a482e91720df10c60b5e78d290ca4bf90f709fd2679cb604ab047b129fe8L14-R19) [[2]](diffhunk://#diff-ab75a482e91720df10c60b5e78d290ca4bf90f709fd2679cb604ab047b129fe8R32-R66)
- Updated shader code in multiple files to use `GetIBLColor` and blend IBL contributions based on whether the pixel is in an interior or exterior, factoring in the new `EnableInterior` setting. This includes `Lighting.hlsl`, `RunGrass.hlsl`, `DistantTree.hlsl`, and `Effect.hlsl`. [[1]](diffhunk://#diff-fee9ea921e49c9a517b9ba5e6d3ff9bae2bd4dbbe5a91bfef21d64c4bb06b2a3L2721-L2723) [[2]](diffhunk://#diff-fee9ea921e49c9a517b9ba5e6d3ff9bae2bd4dbbe5a91bfef21d64c4bb06b2a3R2739-R2754) [[3]](diffhunk://#diff-fee9ea921e49c9a517b9ba5e6d3ff9bae2bd4dbbe5a91bfef21d64c4bb06b2a3R3109-R3122) [[4]](diffhunk://#diff-eec9fbd5eed4cf5cb24e394ce938975405b77a79250582d1fb804c70bb4b085cL708-L710) [[5]](diffhunk://#diff-eec9fbd5eed4cf5cb24e394ce938975405b77a79250582d1fb804c70bb4b085cR733-R753) [[6]](diffhunk://#diff-eec9fbd5eed4cf5cb24e394ce938975405b77a79250582d1fb804c70bb4b085cR763-R766) [[7]](diffhunk://#diff-eec9fbd5eed4cf5cb24e394ce938975405b77a79250582d1fb804c70bb4b085cL894-L896) [[8]](diffhunk://#diff-eec9fbd5eed4cf5cb24e394ce938975405b77a79250582d1fb804c70bb4b085cR941-R974) [[9]](diffhunk://#diff-e4ca9792b48a5eda4d61b3e65c322e9816539696775608396e47379c86d71d83R244-R252) [[10]](diffhunk://#diff-e4ca9792b48a5eda4d61b3e65c322e9816539696775608396e47379c86d71d83R278-R286) [[11]](diffhunk://#diff-2fd4b9665d3c8ae4d680920b9ae4a64e4408e0bfd835e1fa591193f0761dc24dL553-L555) [[12]](diffhunk://#diff-2fd4b9665d3c8ae4d680920b9ae4a64e4408e0bfd835e1fa591193f0761dc24dR582-R596)

**Shader Resource and Texture Refactoring:**

- Refactored resource bindings and texture usage for IBL: replaced `ReflectionTexture` with `EnvTexture`, removed dynamic cubemap texture bindings, and updated resource registers for sky and static IBL textures to improve clarity and consistency. [[1]](diffhunk://#diff-b165532ce90bdc28d915b624a35ae264e152dfaac1e4489385bac40a1acb5be5L6-L13) [[2]](diffhunk://#diff-b165532ce90bdc28d915b624a35ae264e152dfaac1e4489385bac40a1acb5be5L43-R38) [[3]](diffhunk://#diff-ab75a482e91720df10c60b5e78d290ca4bf90f709fd2679cb604ab047b129fe8L14-R19)

**Configuration and Flexibility Enhancements:**

- Added a new `EnableInterior` field to the `iblSettings` struct, allowing IBL to be enabled in interior scenes when desired. Updated all relevant shader logic to respect this flag.
- Updated preprocessor logic to ensure that IBL is only enabled when dynamic cubemaps are available, preventing accidental use in unsupported configurations. [[1]](diffhunk://#diff-fee9ea921e49c9a517b9ba5e6d3ff9bae2bd4dbbe5a91bfef21d64c4bb06b2a3L18-R19) [[2]](diffhunk://#diff-eec9fbd5eed4cf5cb24e394ce938975405b77a79250582d1fb804c70bb4b085cR14-R17) [[3]](diffhunk://#diff-e4ca9792b48a5eda4d61b3e65c322e9816539696775608396e47379c86d71d83R9-R12) [[4]](diffhunk://#diff-2fd4b9665d3c8ae4d680920b9ae4a64e4408e0bfd835e1fa591193f0761dc24dR14-R17)

**Deferred Rendering Pipeline Cleanup:**

- Removed unused IBL texture bindings and references from the deferred rendering pipeline, reducing the number of shader resource views and simplifying resource management. [[1]](diffhunk://#diff-9aac6da5ffddefdc30f39c54292a44554017c23a5a6fd47a0656fde591fd88c8L424-L425) [[2]](diffhunk://#diff-9aac6da5ffddefdc30f39c54292a44554017c23a5a6fd47a0656fde591fd88c8L442-R440) [[3]](diffhunk://#diff-9aac6da5ffddefdc30f39c54292a44554017c23a5a6fd47a0656fde591fd88c8L457) [[4]](diffhunk://#diff-9aac6da5ffddefdc30f39c54292a44554017c23a5a6fd47a0656fde591fd88c8L476-R473)

**Minor Adjustments and Cleanups:**

- Removed the unused `DynamicCubemapsAmount` field from `iblSettings` and cleaned up conditional logic related to dynamic cubemaps throughout the codebase. [[1]](diffhunk://#diff-812c99694216d6c71752b796f8804075cf5652d1f32787207a1ff33e0f173c1eR182-L186) [[2]](diffhunk://#diff-b165532ce90bdc28d915b624a35ae264e152dfaac1e4489385bac40a1acb5be5L6-L13) [[3]](diffhunk://#diff-b165532ce90bdc28d915b624a35ae264e152dfaac1e4489385bac40a1acb5be5L43-R38)

These changes collectively modernize the IBL system, provide more granular control over lighting in different environments, and lay the groundwork for future improvements in both performance and visual fidelity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Skylight-based diffuse IBL for more natural outdoor ambient lighting.
  - New “Enable Interior” option to control IBL indoors.
- Refactor
  - Simplified IBL pipeline to a single environment source, ensuring consistent results across scenes (trees, grass, general lighting, and fog).
  - IBL is automatically disabled when dynamic cubemaps aren’t available to prevent visual artifacts.
- Chores
  - Removed the Dynamic Cubemaps Amount control and legacy reflection paths.
  - Added additional IBL resources behind the scenes to support skylighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->