### PR TITLE
fix(upscaling): fix screenshots when upscaling enabled

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -352,6 +352,12 @@ void Upscaling::RestoreDefaultSettings()
 	settings = {};
 }
 
+void Upscaling::DataLoaded()
+{
+	// Fix screenshots fix from Engine Fixes
+	RE::GetINISetting("bUseTAA:Display")->data.b = false;
+}
+
 void Upscaling::Load()
 {
 	*(uintptr_t*)&ptrD3D11CreateDeviceAndSwapChainUpscaling = SKSE::PatchIAT(hk_D3D11CreateDeviceAndSwapChainUpscaling, "d3d11.dll", "D3D11CreateDeviceAndSwapChain");

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -93,6 +93,7 @@ public:
 	virtual void SaveSettings(json& o_json) override;
 	virtual void LoadSettings(json& o_json) override;
 	virtual void RestoreDefaultSettings() override;
+	virtual void DataLoaded() override;
 
 	/**
 	 * @brief Installs Direct3D-related hooks for device and factory creation.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically disables TAA after data loads when upscaling is active, preventing visual artifacts and blur.
  * Resolves issues affecting screenshot clarity during upscaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->