### PR TITLE
fix(upscaling): fix mipbias sometimes being wrong

### DIFF
--- a/src/Features/Upscaling/FidelityFX.cpp
+++ b/src/Features/Upscaling/FidelityFX.cpp
@@ -302,7 +302,7 @@ void FidelityFX::Upscale(ID3D11Resource* a_upscalingTexture, ID3D11Resource* a_r
 		dispatchParameters.cameraNear = *globals::game::cameraNear;
 
 		dispatchParameters.enableSharpening = true;
-		dispatchParameters.sharpness = 0.5f;
+		dispatchParameters.sharpness = 0.0f;
 
 		dispatchParameters.cameraFovAngleVertical = Util::GetVerticalFOVRad();
 		dispatchParameters.viewSpaceToMetersFactor = 0.01428222656f;

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -707,7 +707,7 @@ void State::SetAdapterDescription(const std::wstring& description)
 	adapterDescription = converter.to_bytes(description);
 }
 
-void State::UpdateSharedData(bool a_inWorld, bool a_prepass)
+void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] bool a_prepass)
 {
 	{
 		SharedDataCB data{};
@@ -764,8 +764,8 @@ void State::UpdateSharedData(bool a_inWorld, bool a_prepass)
 
 		if (upscaling.loaded) {
 			auto upscaleMethod = upscaling.GetUpscaleMethod();
-			if (temporal && (a_inWorld || a_prepass) && upscaleMethod != Upscaling::UpscaleMethod::kTAA) {
-				auto renderSize = Util::ConvertToDynamic(screenSize);
+			if (temporal && upscaleMethod != Upscaling::UpscaleMethod::kTAA) {
+				auto renderSize = Util::ConvertToDynamic(screenSize, true);
 				data.MipBias = std::log2f(renderSize.x / screenSize.x);
 				if (upscaleMethod == Upscaling::UpscaleMethod::kDLSS)
 					data.MipBias -= 1.0f;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent texture sharpness when upscaling or switching anti-aliasing, preventing lingering blur/sharpen artifacts.
  * Ensured correct render size is applied during upscaling for stable image quality across scenes and menus.
  * Resolved cases where texture mip bias could persist after upscaling was disabled, eliminating unintended softness.
  * Reduced visual popping by making LOD transitions more consistent when toggling temporal effects or upscaling options.
  * Lowered default upscaling sharpening intensity to remove excessive sharpness while preserving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->