### PR TITLE
fix: fix compile error if snow shader on

### DIFF
--- a/src/State.cpp
+++ b/src/State.cpp
@@ -610,11 +610,7 @@ void State::ModifyShaderLookup(const RE::BSShader& a_shader, uint& a_vertexDescr
 					a_pixelDescriptor &= ~(uint32_t)SIE::ShaderCache::LightingShaderFlags::AdditionalAlphaMask;
 				}
 
-				static auto enableImprovedSnow = RE::GetINISetting("bEnableImprovedSnow:Display");
-				static bool vr = REL::Module::IsVR();
-
-				if (vr || !enableImprovedSnow->GetBool())
-					a_pixelDescriptor &= ~((uint32_t)SIE::ShaderCache::LightingShaderFlags::Snow);
+				a_pixelDescriptor &= ~((uint32_t)SIE::ShaderCache::LightingShaderFlags::Snow);
 
 				if (deferred->deferredPass || a_forceDeferred)
 					a_pixelDescriptor |= (uint32_t)SIE::ShaderCache::LightingShaderFlags::Deferred;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized snow handling in lighting, ensuring consistent visuals across all settings and VR.
  * Eliminates configuration-dependent behavior, reducing artifacts like missing or overly masked snow.
  * Provides more predictable shading in snowy scenes and improves visual consistency across devices and profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->