### PR TITLE
chore(upscaling): revert fsr to typical settings

### DIFF
--- a/src/Features/Upscaling/FidelityFX.cpp
+++ b/src/Features/Upscaling/FidelityFX.cpp
@@ -302,7 +302,7 @@ void FidelityFX::Upscale(ID3D11Resource* a_upscalingTexture, ID3D11Resource* a_r
 		dispatchParameters.cameraNear = *globals::game::cameraNear;
 
 		dispatchParameters.enableSharpening = true;
-		dispatchParameters.sharpness = 0.0f;
+		dispatchParameters.sharpness = 0.5f;
 
 		dispatchParameters.cameraFovAngleVertical = Util::GetVerticalFOVRad();
 		dispatchParameters.viewSpaceToMetersFactor = 0.01428222656f;

--- a/src/Features/Upscaling/FidelityFX.cpp
+++ b/src/Features/Upscaling/FidelityFX.cpp
@@ -302,7 +302,7 @@ void FidelityFX::Upscale(ID3D11Resource* a_upscalingTexture, ID3D11Resource* a_r
 		dispatchParameters.cameraNear = *globals::game::cameraNear;
 
 		dispatchParameters.enableSharpening = true;
-		dispatchParameters.sharpness = 0.5f;
+		dispatchParameters.sharpness = 0.0f;
 
 		dispatchParameters.cameraFovAngleVertical = Util::GetVerticalFOVRad();
 		dispatchParameters.viewSpaceToMetersFactor = 0.01428222656f;

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -762,9 +762,7 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 			auto upscaleMethod = upscaling.GetUpscaleMethod();
 			if (temporal && upscaleMethod != Upscaling::UpscaleMethod::kTAA) {
 				auto renderSize = Util::ConvertToDynamic(screenSize, true);
-				data.MipBias = std::log2f(renderSize.x / screenSize.x);
-				if (upscaleMethod == Upscaling::UpscaleMethod::kDLSS)
-					data.MipBias -= 1.0f;
+				data.MipBias = std::log2f(renderSize.x / screenSize.x) - 1.0f;
 			} else {
 				data.MipBias = 0;
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved texture detail consistency during temporal rendering when using non-TAA upscalers (e.g., DLSS, FSR). This reduces blur, shimmering, and sudden detail pops by applying a consistent bias to texture level selection.
  * Enhances visual stability across resolutions, leading to sharper yet stable imagery in motion and fewer LOD flickers.
  * No settings changes required; benefits apply automatically when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->