### PR TITLE
fix: fix minor ui issues

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -249,6 +249,12 @@ void Upscaling::DrawSettings()
 				ImGui::PopStyleColor();
 			}
 
+			if (!settings.frameGenerationMode && d3d12SwapChainActive) {
+				ImGui::PushStyleColor(ImGuiCol_Text, Util::Colors::GetWarning());
+				ImGui::Text("Warning: Requires restart");
+				ImGui::PopStyleColor();
+			}
+
 			std::string enabledLabel = "Enabled";
 			const char* toggleModes[] = { "Disabled", "Enabled" };
 			const char* toggleModesFG[] = { "Disabled", enabledLabel.c_str() };

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -396,7 +396,7 @@ void Menu::DrawFooter()
 	ImGui::SameLine();
 	ImGui::BulletText(std::format("D3D12 Swap Chain: {}", globals::features::upscaling.d3d12SwapChainActive ? "Active" : "Inactive").c_str());
 	ImGui::SameLine();
-	ImGui::Text(std::format("GPU: {}", globals::state->adapterDescription.c_str()).c_str());
+	ImGui::BulletText(std::format("GPU: {}", globals::state->adapterDescription.c_str()).c_str());
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Upscaling settings now show a “Warning: Requires restart” message in cases where frame generation is off but a compatible display mode is active, helping users know when changes need a restart.

- Style
  - Footer update: the GPU info is now displayed as a bullet point for clearer alignment and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->