### PR TITLE
fix(ibl): add ibl to reflection normalization

### DIFF
--- a/features/IBL/Shaders/IBL/IBL.hlsli
+++ b/features/IBL/Shaders/IBL/IBL.hlsli
@@ -9,9 +9,9 @@
 
 namespace ImageBasedLighting
 {
-#if defined(IBL_AMBIENTCOMPOSITE)
-	Texture2D<sh2> DiffuseIBLTexture : register(t8);
-	Texture2D<sh2> DiffuseSkyIBLTexture : register(t9);
+#if defined(IBL_DEFERRED)
+	Texture2D<sh2> DiffuseIBLTexture : register(t14);
+	Texture2D<sh2> DiffuseSkyIBLTexture : register(t15);
 #else
 	Texture2D<sh2> DiffuseIBLTexture : register(t76);
 	Texture2D<sh2> DiffuseSkyIBLTexture : register(t77);
@@ -40,7 +40,7 @@ namespace ImageBasedLighting
 		return float3(colorR, colorG, colorB) / Math::PI;
 	}
 
-#if defined(SKYLIGHTING)
+#if defined(SKYLIGHTING) && !defined(INTERIOR)
 	float3 GetIBLColor(float3 rayDir, float skylighting)
 #else
 	float3 GetIBLColor(float3 rayDir)

--- a/package/Shaders/DeferredCompositeCS.hlsl
+++ b/package/Shaders/DeferredCompositeCS.hlsl
@@ -39,6 +39,15 @@ Texture2D<float4> SsgiYTexture : register(t11);
 Texture2D<float4> SsgiCoCgTexture : register(t12);
 Texture2D<float4> SsgiSpecularTexture : register(t13);
 
+#if defined(IBL)
+#	if !defined(DYNAMIC_CUBEMAPS)
+#		undef IBL
+#	else
+#		define IBL_DEFERRED
+#		include "IBL/IBL.hlsli"
+#	endif
+#endif
+
 void SampleSSGI(uint2 pixCoord, float3 normalWS, out float ao, out float3 il)
 {
 	ao = 1 - SsgiAoTexture[pixCoord];
@@ -188,6 +197,15 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, out float ao, out float3 il, i
 
         float specularIrradianceLuminance = Color::RGBToLuminance(Color::GammaToLinear(EnvTexture.SampleLevel(LinearSampler, R, 15)));
 
+		#		if defined(IBL)
+		float3 iblColor = 0;
+		if (SharedData::iblSettings.EnableDiffuseIBL && SharedData::iblSettings.EnableInterior) {
+			directionalAmbientColorSpecular *= SharedData::iblSettings.DALCAmount;
+			iblColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-R), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+			float iblColorLuminance = Color::RGBToLuminance(iblColor);
+			directionalAmbientColorSpecular += iblColorLuminance;
+		}
+#		endif
         specularIrradiance = (specularIrradiance / max(specularIrradianceLuminance, 0.001)) * directionalAmbientColorSpecular;
 
         finalIrradiance += specularIrradiance;
@@ -204,6 +222,15 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, out float ao, out float3 il, i
 		skylightingSpecular = Skylighting::mixSpecular(SharedData::skylightingSettings, skylightingSpecular);
 
 		directionalAmbientColorSpecular *= skylightingSpecular;
+#		if defined(IBL)
+		float3 iblColor = 0;
+		if (SharedData::iblSettings.EnableDiffuseIBL) {
+			directionalAmbientColorSpecular *= SharedData::iblSettings.DALCAmount;
+			iblColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-R, skylightingSpecular), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+			float iblColorLuminance = Color::RGBToLuminance(iblColor);
+			directionalAmbientColorSpecular += iblColorLuminance;
+		}
+#		endif
 
 		float3 specularIrradiance = 1;
 
@@ -227,6 +254,15 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, out float ao, out float3 il, i
 
 		finalIrradiance = lerp(specularIrradiance, specularIrradianceReflections, skylightingSpecular);
 #	else
+#		if defined(IBL)
+		float3 iblColor = 0;
+		if (SharedData::iblSettings.EnableDiffuseIBL) {
+			directionalAmbientColorSpecular *= SharedData::iblSettings.DALCAmount;
+			iblColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-R), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
+			float iblColorLuminance = Color::RGBToLuminance(iblColor);
+			directionalAmbientColorSpecular += iblColorLuminance;
+		}
+#		endif
 		float3 specularIrradianceReflections = Color::GammaToLinear(EnvReflectionsTexture.SampleLevel(LinearSampler, R, level));
 
         float specularIrradianceReflectionsLuminance = Color::RGBToLuminance(Color::GammaToLinear(EnvReflectionsTexture.SampleLevel(LinearSampler, R, 15)));

--- a/package/Shaders/DeferredCompositeCS.hlsl
+++ b/package/Shaders/DeferredCompositeCS.hlsl
@@ -39,15 +39,6 @@ Texture2D<float4> SsgiYTexture : register(t11);
 Texture2D<float4> SsgiCoCgTexture : register(t12);
 Texture2D<float4> SsgiSpecularTexture : register(t13);
 
-#if defined(IBL)
-#	if !defined(DYNAMIC_CUBEMAPS)
-#		undef IBL
-#	else
-#		define IBL_DEFERRED
-#		include "IBL/IBL.hlsli"
-#	endif
-#endif
-
 void SampleSSGI(uint2 pixCoord, float3 normalWS, out float ao, out float3 il)
 {
 	ao = 1 - SsgiAoTexture[pixCoord];
@@ -79,6 +70,15 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, out float ao, out float3 il, i
 	ao *= 1 - hq_spec.a;
 	il += hq_spec.rgb;
 }
+#endif
+
+#if defined(IBL)
+#	if !defined(DYNAMIC_CUBEMAPS)
+#		undef IBL
+#	else
+#		define IBL_DEFERRED
+#		include "IBL/IBL.hlsli"
+#	endif
 #endif
 
 [numthreads(8, 8, 1)] void main(uint3 dispatchID : SV_DispatchThreadID) {

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2746,8 +2746,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		else
 			iblColor += Color::Saturation(ImageBasedLighting::GetIBLColor(-ambientNormal), SharedData::iblSettings.IBLSaturation) * SharedData::iblSettings.DiffuseIBLScale;
 #		endif
-		iblColor = Color::LinearToGamma(iblColor);
-		directionalAmbientColor += iblColor;
+			iblColor = Color::LinearToGamma(iblColor);
+			directionalAmbientColor += iblColor;
 		}
 	}
 #	endif

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -433,11 +433,13 @@ void Deferred::DeferredPasses()
 
 	auto& terrainBlending = globals::features::terrainBlending;
 
+	auto& ibl = globals::features::ibl;
+
 	// Deferred Composite
 	{
 		TracyD3D11Zone(globals::state->tracyCtx, "Deferred Composite");
 
-		ID3D11ShaderResourceView* srvs[14]{
+		ID3D11ShaderResourceView* srvs[16]{
 			specular.SRV,
 			albedo.SRV,
 			normalRoughness.SRV,
@@ -452,6 +454,8 @@ void Deferred::DeferredPasses()
 			ssgi_hq_spec ? nullptr : ssgi_y,
 			ssgi_hq_spec ? nullptr : ssgi_cocg,
 			ssgi_hq_spec ? ssgi_gi_spec : nullptr,
+			ibl.loaded ? ibl.diffuseIBLTexture->srv.get() : nullptr,
+			ibl.loaded ? ibl.diffuseSkyIBLTexture->srv.get() : nullptr,
 		};
 
 		if (dynamicCubemaps.loaded)
@@ -470,7 +474,7 @@ void Deferred::DeferredPasses()
 
 	// Clear
 	{
-		ID3D11ShaderResourceView* views[14]{ nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
+		ID3D11ShaderResourceView* views[16]{ nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
 		context->CSSetShaderResources(0, ARRAYSIZE(views), views);
 
 		ID3D11UnorderedAccessView* uavs[3]{ nullptr, nullptr, nullptr };
@@ -634,6 +638,9 @@ ID3D11ComputeShader* Deferred::GetComputeMainComposite()
 
 		if (globals::features::screenSpaceGI.loaded)
 			defines.push_back({ "SSGI", nullptr });
+		
+		if (globals::features::ibl.loaded)
+			defines.push_back({ "IBL", nullptr });
 
 		if (REL::Module::IsVR())
 			defines.push_back({ "FRAMEBUFFER", nullptr });
@@ -656,6 +663,9 @@ ID3D11ComputeShader* Deferred::GetComputeMainCompositeInterior()
 
 		if (globals::features::screenSpaceGI.loaded)
 			defines.push_back({ "SSGI", nullptr });
+
+		if (globals::features::ibl.loaded)
+			defines.push_back({ "IBL", nullptr });
 
 		if (REL::Module::IsVR())
 			defines.push_back({ "FRAMEBUFFER", nullptr });

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -638,7 +638,7 @@ ID3D11ComputeShader* Deferred::GetComputeMainComposite()
 
 		if (globals::features::screenSpaceGI.loaded)
 			defines.push_back({ "SSGI", nullptr });
-		
+
 		if (globals::features::ibl.loaded)
 			defines.push_back({ "IBL", nullptr });
 


### PR DESCRIPTION
This pull request integrates Image-Based Lighting (IBL) into the deferred composite rendering pipeline, with careful handling for dynamic cubemaps and interior/exterior conditions. The changes ensure that IBL resources are correctly bound and sampled in shaders, and that the compute shader pipeline is aware of IBL support. The most significant updates are as follows:

**IBL Integration into Deferred Composite Pipeline:**

* Added support for IBL in the deferred composite compute shader by including the appropriate shader code (`IBL.hlsli`) and defining `IBL_DEFERRED` when dynamic cubemaps are enabled. This ensures the correct IBL textures and logic are used only when supported.
* Updated resource bindings in `Deferred.cpp` to include IBL textures (`diffuseIBLTexture`, `diffuseSkyIBLTexture`) in the shader resource views passed to the compute shader, and increased the resource view array size accordingly. [[1]](diffhunk://#diff-9aac6da5ffddefdc30f39c54292a44554017c23a5a6fd47a0656fde591fd88c8R436-R442) [[2]](diffhunk://#diff-9aac6da5ffddefdc30f39c54292a44554017c23a5a6fd47a0656fde591fd88c8R457-R458) [[3]](diffhunk://#diff-9aac6da5ffddefdc30f39c54292a44554017c23a5a6fd47a0656fde591fd88c8L473-R477)

**Shader Logic and Resource Binding Adjustments:**

* Modified IBL texture register assignments in `IBL.hlsli` for the deferred path to use new slots (`t14`, `t15`), avoiding conflicts with other passes.
* Improved `GetIBLColor` in `IBL.hlsli` to only use skylighting when not in interior mode, ensuring correct lighting calculations based on scene context.

**Compute Shader Conditional Compilation:**

* Updated compute shader creation in `Deferred.cpp` to add the `IBL` define when IBL is enabled, ensuring the shader is compiled with IBL support only when needed. [[1]](diffhunk://#diff-9aac6da5ffddefdc30f39c54292a44554017c23a5a6fd47a0656fde591fd88c8R642-R644) [[2]](diffhunk://#diff-9aac6da5ffddefdc30f39c54292a44554017c23a5a6fd47a0656fde591fd88c8R667-R669)

**IBL Sampling in Deferred Composite Shader:**

* Inserted logic in `DeferredCompositeCS.hlsl` to sample IBL contributions for specular and diffuse lighting, gated by runtime settings and interior/exterior conditions. This ensures IBL is only applied when enabled and appropriate for the scene. [[1]](diffhunk://#diff-2cda606b807f9b6138bddb9dc3769390bab781d366aef670edfbd2fa83b9d330R200-R208) [[2]](diffhunk://#diff-2cda606b807f9b6138bddb9dc3769390bab781d366aef670edfbd2fa83b9d330R225-R233) [[3]](diffhunk://#diff-2cda606b807f9b6138bddb9dc3769390bab781d366aef670edfbd2fa83b9d330R257-R265)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Image-Based Lighting (IBL) added to the deferred composite, improving ambient and specular lighting fidelity.
  - Deferred pipeline now includes additional diffuse and specular IBL texture support for richer illumination.
  - Skylighting behavior refined: skylight parameter usage is now conditioned to preserve correct interior/skylighting interactions.

- **Style**
  - Minor shader formatting adjustments with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->