### PR TITLE
fix(hair): remove pbr lighting mult for hair

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -3104,7 +3104,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 #		if defined(HAIR) && defined(CS_HAIR)
 	if (SharedData::hairSpecularSettings.Enabled) {
-		outputAlbedo = indirectDiffuseLobeWeight * Color::PBRLightingScale;
+		outputAlbedo = indirectDiffuseLobeWeight;
 	}
 #		endif
 


### PR DESCRIPTION
This pull request makes a targeted adjustment to the hair rendering logic in the `Lighting.hlsl` shader. Specifically, it removes the multiplication by `Color::PBRLightingScale` when calculating `outputAlbedo` for hair with enabled specular settings, likely to correct or simplify the lighting calculation.

Shader logic update:

* In `Lighting.hlsl`, the calculation of `outputAlbedo` for hair with specular enabled now uses only `indirectDiffuseLobeWeight`, removing the previous scaling by `Color::PBRLightingScale`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected hair rendering albedo calculation to remove an unintended lighting scale, producing more accurate hair color and brightness.
  * Improves visual consistency of hair across different lighting conditions and scenes.
  * Reduces cases where hair appeared washed out or overly dim when hair rendering is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->