### PR TITLE
chore(upscaling): add back upscale multiplier

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -204,7 +204,10 @@ void Upscaling::DrawSettings()
 			}
 
 			if (baseLabel) {
-				ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, 4, baseLabel);
+				// Format the label with preset name and resolution scale
+				std::string labelWithScale = std::format("{} ( {:.2f}x )", baseLabel, (resolutionScale.x + resolutionScale.y) * 0.5f);
+
+				ImGui::SliderInt("Upscale Preset", (int*)&settings.qualityMode, 0, 4, labelWithScale.c_str());
 			}
 
 			if (upscaleMethod == UpscaleMethod::kFSR) {

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -720,8 +720,15 @@ void Upscaling::ConfigureUpscaling(RE::BSGraphics::State* a_viewport)
 		auto renderWidth = static_cast<int>(screenWidth * resolutionScaleBase);
 		auto renderHeight = static_cast<int>(screenHeight * resolutionScaleBase);
 
-		resolutionScale.x = static_cast<float>(renderWidth) / static_cast<float>(screenWidth);
-		resolutionScale.y = static_cast<float>(renderHeight) / static_cast<float>(screenHeight);
+		// Use precise scale if the integer conversion doesn't change the dimensions
+		if (renderWidth == screenWidth && renderHeight == screenHeight) {
+			// For DLAA and other 1:1 modes, ensure exactly 1.0
+			resolutionScale.x = 1.0f;
+			resolutionScale.y = 1.0f;
+		} else {
+			resolutionScale.x = static_cast<float>(renderWidth) / static_cast<float>(screenWidth);
+			resolutionScale.y = static_cast<float>(renderHeight) / static_cast<float>(screenHeight);
+		}
 
 		auto phaseCount = GetJitterPhaseCount(renderWidth, screenWidth);
 

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -707,18 +707,18 @@ void Upscaling::ConfigureUpscaling(RE::BSGraphics::State* a_viewport)
 	auto screenHeight = static_cast<int>(screenSize.y);
 
 	if (upscaleMethod != UpscaleMethod::kNONE && upscaleMethod != UpscaleMethod::kTAA) {
-		float resolutionScaleBase = 1.0f;
+		float2 resolutionScaleBase = { 1.0f, 1.0f };
 
 		if (globals::game::isVR) {
-			resolutionScaleBase = 1.0f;
+			resolutionScaleBase = { 1.0f, 1.0f };
 		} else if (upscaleMethod == UpscaleMethod::kDLSS) {
 			resolutionScaleBase = streamline.GetInputResolutionScale((uint32_t)screenSize.x, (uint32_t)screenSize.y, settings.qualityMode);
 		} else if (upscaleMethod == UpscaleMethod::kFSR) {
 			resolutionScaleBase = fidelityFX.GetInputResolutionScale((uint32_t)screenSize.x, (uint32_t)screenSize.y, settings.qualityMode);
 		}
 
-		auto renderWidth = static_cast<int>(screenWidth * resolutionScaleBase);
-		auto renderHeight = static_cast<int>(screenHeight * resolutionScaleBase);
+		auto renderWidth = static_cast<int>(screenWidth * resolutionScaleBase.x);
+		auto renderHeight = static_cast<int>(screenHeight * resolutionScaleBase.y);
 
 		// Use precise scale if the integer conversion doesn't change the dimensions
 		if (renderWidth == screenWidth && renderHeight == screenHeight) {

--- a/src/Features/Upscaling/FidelityFX.cpp
+++ b/src/Features/Upscaling/FidelityFX.cpp
@@ -240,9 +240,10 @@ void FidelityFX::DestroyFSRResources()
 	}
 }
 
-float FidelityFX::GetInputResolutionScale([[maybe_unused]] uint32_t outputWidth, [[maybe_unused]] uint32_t outputHeight, uint32_t qualityMode)
+float2 FidelityFX::GetInputResolutionScale([[maybe_unused]] uint32_t outputWidth, [[maybe_unused]] uint32_t outputHeight, uint32_t qualityMode)
 {
-	return 1.0f / ffxFsr3GetUpscaleRatioFromQualityMode((FfxFsr3QualityMode)qualityMode);
+	float scale = 1.0f / ffxFsr3GetUpscaleRatioFromQualityMode((FfxFsr3QualityMode)qualityMode);
+	return { scale, scale };
 }
 
 FfxResource ffxGetResource(ID3D11Resource* dx11Resource,

--- a/src/Features/Upscaling/FidelityFX.h
+++ b/src/Features/Upscaling/FidelityFX.h
@@ -44,7 +44,7 @@ public:
 
 	void DestroyFSRResources();
 
-	float GetInputResolutionScale(uint32_t outputWidth, uint32_t outputHeight, uint32_t qualityMode);
+	float2 GetInputResolutionScale(uint32_t outputWidth, uint32_t outputHeight, uint32_t qualityMode);
 
 	void Upscale(ID3D11Resource* a_upscalingTexture, ID3D11Resource* a_reactiveMask, ID3D11Resource* a_transparencyCompositionMask, ID3D11Resource* a_motionVectors, float a_sharpness);
 

--- a/src/Features/Upscaling/Streamline.cpp
+++ b/src/Features/Upscaling/Streamline.cpp
@@ -398,6 +398,11 @@ float Streamline::GetInputResolutionScale(uint32_t outputWidth, uint32_t outputH
 		scaleY = (float)optimalSettings.optimalRenderHeight / (float)outputHeight;
 	}
 
+	// For DLAA, ensure exactly 1.0 scale
+	if (dlssMode == sl::DLSSMode::eDLAA) {
+		return 1.0f;
+	}
+
 	// Use the average scale (both should be the same for uniform scaling)
 	return (scaleX + scaleY) * 0.5f;
 }

--- a/src/Features/Upscaling/Streamline.cpp
+++ b/src/Features/Upscaling/Streamline.cpp
@@ -270,15 +270,8 @@ void Streamline::CheckFrameConstants()
 	}
 }
 
-void Streamline::Upscale(ID3D11Resource* a_upscalingTexture, ID3D11Resource* a_reactiveMask, ID3D11Resource* a_transparencyCompositionMask, ID3D11Resource* a_motionVectors)
+void Streamline::SetDLSSOptions()
 {
-	CheckFrameConstants();
-
-	auto state = globals::state;
-
-	auto renderer = globals::game::renderer;
-	auto& depthTexture = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
-
 	sl::DLSSOptions dlssOptions{};
 
 	// Map quality mode to DLSS mode
@@ -301,6 +294,8 @@ void Streamline::Upscale(ID3D11Resource* a_upscalingTexture, ID3D11Resource* a_r
 		break;
 	}
 
+	auto state = globals::state;
+
 	dlssOptions.outputWidth = (uint)state->screenSize.x;
 	dlssOptions.outputHeight = (uint)state->screenSize.y;
 	dlssOptions.colorBuffersHDR = sl::Boolean::eTrue;
@@ -318,6 +313,17 @@ void Streamline::Upscale(ID3D11Resource* a_upscalingTexture, ID3D11Resource* a_r
 	if (SL_FAILED(result, slDLSSSetOptions(viewport, dlssOptions))) {
 		logger::critical("[Streamline] Could not enable DLSS");
 	}
+}
+
+void Streamline::Upscale(ID3D11Resource* a_upscalingTexture, ID3D11Resource* a_reactiveMask, ID3D11Resource* a_transparencyCompositionMask, ID3D11Resource* a_motionVectors)
+{
+	CheckFrameConstants();
+	SetDLSSOptions();
+
+	auto state = globals::state;
+
+	auto renderer = globals::game::renderer;
+	auto& depthTexture = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
 
 	{
 		auto screenSize = state->screenSize;
@@ -352,7 +358,7 @@ void Streamline::Upscale(ID3D11Resource* a_upscalingTexture, ID3D11Resource* a_r
 	slEvaluateFeature(sl::kFeatureDLSS, *frameToken, inputs, _countof(inputs), globals::d3d::context);
 }
 
-float Streamline::GetInputResolutionScale(uint32_t outputWidth, uint32_t outputHeight, uint32_t qualityMode)
+float2 Streamline::GetInputResolutionScale(uint32_t outputWidth, uint32_t outputHeight, uint32_t qualityMode)
 {
 	sl::DLSSMode dlssMode;
 	switch (qualityMode) {
@@ -382,7 +388,7 @@ float Streamline::GetInputResolutionScale(uint32_t outputWidth, uint32_t outputH
 	sl::Result result = slDLSSGetOptimalSettings(dlssOptions, optimalSettings);
 	if (result != sl::Result::eOk) {
 		logger::critical("[Streamline] Failed to get DLSS optimal settings, error code: {}", (int)result);
-		return 1.0f;
+		return { 1.0f, 1.0f };
 	}
 
 	float scaleX;
@@ -398,13 +404,8 @@ float Streamline::GetInputResolutionScale(uint32_t outputWidth, uint32_t outputH
 		scaleY = (float)optimalSettings.optimalRenderHeight / (float)outputHeight;
 	}
 
-	// For DLAA, ensure exactly 1.0 scale
-	if (dlssMode == sl::DLSSMode::eDLAA) {
-		return 1.0f;
-	}
-
-	// Use the average scale (both should be the same for uniform scaling)
-	return (scaleX + scaleY) * 0.5f;
+	// Return separate X and Y scales for more precision
+	return { scaleX, scaleY };
 }
 
 /**

--- a/src/Features/Upscaling/Streamline.h
+++ b/src/Features/Upscaling/Streamline.h
@@ -80,9 +80,11 @@ public:
 
 	void CheckFrameConstants();
 
+	void SetDLSSOptions();
+
 	void Upscale(ID3D11Resource* a_upscalingTexture, ID3D11Resource* a_reactiveMask, ID3D11Resource* a_transparencyCompositionMask, ID3D11Resource* a_motionVectors);
 
-	float GetInputResolutionScale(uint32_t outputWidth, uint32_t outputHeight, uint32_t qualityPreset);
+	float2 GetInputResolutionScale(uint32_t outputWidth, uint32_t outputHeight, uint32_t qualityPreset);
 
 	void DestroyDLSSResources();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upscale Preset label now shows the preset name plus the average resolution scale for clearer feedback.

* **Bug Fixes**
  * Resolution scaling now uses per-axis render-to-screen ratios with a 1:1 shortcut when sizes match.
  * Paused vs. unpaused states and quality modes yield correct per-axis scales.
  * Improved handling for DLSS/FidelityFX scaling to avoid unintended neutral scaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->