### PR TITLE
chore(emat): auto detect terrain parallax

### DIFF
--- a/package/Shaders/Common/Permutation.hlsli
+++ b/package/Shaders/Common/Permutation.hlsli
@@ -72,6 +72,7 @@ namespace Permutation
 		static const int THLand3HasDisplacement = (1 << 3);
 		static const int THLand4HasDisplacement = (1 << 4);
 		static const int THLand5HasDisplacement = (1 << 5);
+		static const int THLandHasDisplacement = (1 << 6);
 	}
 
 	cbuffer PerShader : register(b4)

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1234,7 +1234,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TRUE_PBR)
 	if (SharedData::extendedMaterialSettings.EnableParallax) {
 #			else
-	if (SharedData::extendedMaterialSettings.EnableTerrainParallax || Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLandHasDisplacement) {
+	if (SharedData::extendedMaterialSettings.EnableTerrainParallax || (SharedData::extendedMaterialSettings.EnableParallax && Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLandHasDisplacement)) {
 #			endif
 		mipLevels[0] = ExtendedMaterials::GetMipLevel(uv, TexColorSampler);
 		mipLevels[1] = ExtendedMaterials::GetMipLevel(uv, TexLandColor2Sampler);
@@ -2346,7 +2346,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TRUE_PBR)
 	if (SharedData::extendedMaterialSettings.EnableParallax){
 #			else
-	if (SharedData::extendedMaterialSettings.EnableTerrainParallax || Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLandHasDisplacement){
+	if (SharedData::extendedMaterialSettings.EnableTerrainParallax || (SharedData::extendedMaterialSettings.EnableParallax && Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLandHasDisplacement)){
 #			endif		
 #			if defined(TERRAIN_VARIATION)
 			float weights[6];
@@ -2608,7 +2608,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TRUE_PBR)
 	if (SharedData::extendedMaterialSettings.EnableParallax)
 #			else
-	if (SharedData::extendedMaterialSettings.EnableTerrainParallax || Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLandHasDisplacement)
+	if (SharedData::extendedMaterialSettings.EnableTerrainParallax || (SharedData::extendedMaterialSettings.EnableParallax && Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLandHasDisplacement))
 #			endif#					if defined(TERRAIN_VARIATION)
 				parallaxShadow = ExtendedMaterials::GetParallaxSoftShadowMultiplierTerrain(input, uv, mipLevels, lightDirectionTS, sh0, parallaxShadowQuality, screenNoise, displacementParams, sharedOffset, dx, dy);
 #					else

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2605,11 +2605,12 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 			[branch] if (SharedData::extendedMaterialSettings.EnableParallax)
 				parallaxShadow = ExtendedMaterials::GetParallaxSoftShadowMultiplier(uv, mipLevel, lightDirectionTS, sh0, TexParallaxSampler, SampParallaxSampler, 0, parallaxShadowQuality, screenNoise, displacementParams);
 #				elif defined(LANDSCAPE)
-#			if defined(TRUE_PBR)
-	if (SharedData::extendedMaterialSettings.EnableParallax)
-#			else
-	if (SharedData::extendedMaterialSettings.EnableTerrainParallax || (SharedData::extendedMaterialSettings.EnableParallax && Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLandHasDisplacement))
-#			endif#					if defined(TERRAIN_VARIATION)
+#					if defined(TRUE_PBR)
+					if (SharedData::extendedMaterialSettings.EnableParallax)
+#					else
+					if (SharedData::extendedMaterialSettings.EnableTerrainParallax || (SharedData::extendedMaterialSettings.EnableParallax && Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLandHasDisplacement))
+#					endif
+#					if defined(TERRAIN_VARIATION)
 				parallaxShadow = ExtendedMaterials::GetParallaxSoftShadowMultiplierTerrain(input, uv, mipLevels, lightDirectionTS, sh0, parallaxShadowQuality, screenNoise, displacementParams, sharedOffset, dx, dy);
 #					else
 				parallaxShadow = ExtendedMaterials::GetParallaxSoftShadowMultiplierTerrain(input, uv, mipLevels, lightDirectionTS, sh0, parallaxShadowQuality, screenNoise, displacementParams);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2347,7 +2347,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	if (SharedData::extendedMaterialSettings.EnableParallax){
 #			else
 	if (SharedData::extendedMaterialSettings.EnableTerrainParallax){
-#			endif		
+#			endif
 #			if defined(TERRAIN_VARIATION)
 			float weights[6];
 			// Initialize weights array

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1231,7 +1231,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		endif
 
 #		if defined(EMAT)
+#			if defined(TRUE_PBR)
+	if (SharedData::extendedMaterialSettings.EnableParallax) {
+#			else
 	if (SharedData::extendedMaterialSettings.EnableTerrainParallax) {
+#			endif
 		mipLevels[0] = ExtendedMaterials::GetMipLevel(uv, TexColorSampler);
 		mipLevels[1] = ExtendedMaterials::GetMipLevel(uv, TexLandColor2Sampler);
 		mipLevels[2] = ExtendedMaterials::GetMipLevel(uv, TexLandColor3Sampler);
@@ -2339,8 +2343,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	{
 		float3 dirLightDirectionTS = mul(refractedDirLightDirection, tbn).xyz;
 #		if defined(LANDSCAPE)
-		[branch] if (SharedData::extendedMaterialSettings.EnableTerrainParallax)
-		{
+#			if defined(TRUE_PBR)
+	if (SharedData::extendedMaterialSettings.EnableParallax){
+#			else
+	if (SharedData::extendedMaterialSettings.EnableTerrainParallax){
+#			endif		
 #			if defined(TERRAIN_VARIATION)
 			float weights[6];
 			// Initialize weights array
@@ -2598,8 +2605,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 			[branch] if (SharedData::extendedMaterialSettings.EnableParallax)
 				parallaxShadow = ExtendedMaterials::GetParallaxSoftShadowMultiplier(uv, mipLevel, lightDirectionTS, sh0, TexParallaxSampler, SampParallaxSampler, 0, parallaxShadowQuality, screenNoise, displacementParams);
 #				elif defined(LANDSCAPE)
-			[branch] if (SharedData::extendedMaterialSettings.EnableTerrainParallax)
-#					if defined(TERRAIN_VARIATION)
+#			if defined(TRUE_PBR)
+	if (SharedData::extendedMaterialSettings.EnableParallax)
+#			else
+	if (SharedData::extendedMaterialSettings.EnableTerrainParallax)
+#			endif#					if defined(TERRAIN_VARIATION)
 				parallaxShadow = ExtendedMaterials::GetParallaxSoftShadowMultiplierTerrain(input, uv, mipLevels, lightDirectionTS, sh0, parallaxShadowQuality, screenNoise, displacementParams, sharedOffset, dx, dy);
 #					else
 				parallaxShadow = ExtendedMaterials::GetParallaxSoftShadowMultiplierTerrain(input, uv, mipLevels, lightDirectionTS, sh0, parallaxShadowQuality, screenNoise, displacementParams);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2347,7 +2347,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	if (SharedData::extendedMaterialSettings.EnableParallax){
 #			else
 	if (SharedData::extendedMaterialSettings.EnableTerrainParallax || (SharedData::extendedMaterialSettings.EnableParallax && Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLandHasDisplacement)){
-#			endif		
+#			endif
 #			if defined(TERRAIN_VARIATION)
 			float weights[6];
 			// Initialize weights array

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1234,7 +1234,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TRUE_PBR)
 	if (SharedData::extendedMaterialSettings.EnableParallax) {
 #			else
-	if (SharedData::extendedMaterialSettings.EnableTerrainParallax) {
+	if (SharedData::extendedMaterialSettings.EnableTerrainParallax || Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLandHasDisplacement) {
 #			endif
 		mipLevels[0] = ExtendedMaterials::GetMipLevel(uv, TexColorSampler);
 		mipLevels[1] = ExtendedMaterials::GetMipLevel(uv, TexLandColor2Sampler);
@@ -2346,7 +2346,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TRUE_PBR)
 	if (SharedData::extendedMaterialSettings.EnableParallax){
 #			else
-	if (SharedData::extendedMaterialSettings.EnableTerrainParallax){
+	if (SharedData::extendedMaterialSettings.EnableTerrainParallax || Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLandHasDisplacement){
 #			endif		
 #			if defined(TERRAIN_VARIATION)
 			float weights[6];
@@ -2608,7 +2608,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(TRUE_PBR)
 	if (SharedData::extendedMaterialSettings.EnableParallax)
 #			else
-	if (SharedData::extendedMaterialSettings.EnableTerrainParallax)
+	if (SharedData::extendedMaterialSettings.EnableTerrainParallax || Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLandHasDisplacement)
 #			endif#					if defined(TERRAIN_VARIATION)
 				parallaxShadow = ExtendedMaterials::GetParallaxSoftShadowMultiplierTerrain(input, uv, mipLevels, lightDirectionTS, sh0, parallaxShadowQuality, screenNoise, displacementParams, sharedOffset, dx, dy);
 #					else

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2347,7 +2347,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	if (SharedData::extendedMaterialSettings.EnableParallax){
 #			else
 	if (SharedData::extendedMaterialSettings.EnableTerrainParallax || Permutation::ExtraFeatureDescriptor & Permutation::ExtraFeatureFlags::THLandHasDisplacement){
-#			endif		
+#			endif
 #			if defined(TERRAIN_VARIATION)
 			float weights[6];
 			// Initialize weights array

--- a/src/Features/ExtendedMaterials.cpp
+++ b/src/Features/ExtendedMaterials.cpp
@@ -44,7 +44,7 @@ void ExtendedMaterials::DrawSettings()
 			ImGui::Text("Enables parallax on standard meshes made for parallax.");
 		}
 
-		if (ImGui::Checkbox("Enable Terrain", (bool*)&settings.EnableTerrain)) {
+		if (ImGui::Checkbox("Enable Legacy Terrain", (bool*)&settings.EnableTerrain)) {
 			if (settings.EnableTerrain) {
 				DataLoaded();
 			}

--- a/src/Features/TerrainHelper.cpp
+++ b/src/Features/TerrainHelper.cpp
@@ -176,6 +176,8 @@ void TerrainHelper::BSLightingShader_SetupMaterial(RE::BSLightingShaderMaterialB
 
 	const auto state = globals::state;
 	const auto& stateData = globals::game::graphicsState->GetRuntimeData();
+	
+	state->permutationData.ExtraFeatureDescriptor &= ~(1 << 6);
 
 	// Populate extended slots
 	// Please update bits allocation in ExtraFeatureDescriptor/Permutation.hlsli and other feature code if you need to change the constant 6
@@ -183,6 +185,7 @@ void TerrainHelper::BSLightingShader_SetupMaterial(RE::BSLightingShaderMaterialB
 		if (materialBase.parallax[textureI] != nullptr && materialBase.parallax[textureI] != stateData.defaultTextureNormalMap) {
 			thExtendedRendererState.SetPSTexture(textureI, materialBase.parallax[textureI]->rendererTexture);
 			state->permutationData.ExtraFeatureDescriptor |= 1 << textureI;
+			state->permutationData.ExtraFeatureDescriptor |= (1 << 6);
 		} else {
 			thExtendedRendererState.SetPSTexture(textureI, nullptr);
 			state->permutationData.ExtraFeatureDescriptor &= ~(1 << textureI);

--- a/src/Features/TerrainHelper.cpp
+++ b/src/Features/TerrainHelper.cpp
@@ -176,7 +176,7 @@ void TerrainHelper::BSLightingShader_SetupMaterial(RE::BSLightingShaderMaterialB
 
 	const auto state = globals::state;
 	const auto& stateData = globals::game::graphicsState->GetRuntimeData();
-	
+
 	state->permutationData.ExtraFeatureDescriptor &= ~(1 << 6);
 
 	// Populate extended slots


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adaptive parallax rendering now chooses between modern and legacy parallax paths for materials, terrain and shadows, improving depth and consistency across scenes.
  * Improved shadow sampling and mip/co‑ordinate selection reduce artifacts and stabilize detail at varying distances.

* **UI**
  * Checkbox renamed to "Enable Legacy Terrain" for clearer terrain mode selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->