### PR TITLE
fix(terrain shadows): fix brightened lods

### DIFF
--- a/package/Shaders/Common/ShadowSampling.hlsli
+++ b/package/Shaders/Common/ShadowSampling.hlsli
@@ -149,7 +149,7 @@ namespace ShadowSampling
 
 		float worldShadow = 1.0;
 #if defined(TERRAIN_SHADOWS)
-		worldShadow = lerp(TerrainShadows::GetTerrainShadow(positionWS + offset, LinearSampler), 1.0, 0.1);
+		worldShadow = TerrainShadows::GetTerrainShadow(positionWS + offset, LinearSampler);
 #endif
 
 #if defined(CLOUD_SHADOWS)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Adjusted terrain shadow calculation to use the raw terrain shadow value instead of a fixed blend, improving consistency and perceived depth.
  - Users may notice more accurate shading on terrain surfaces, with better contrast and fewer washed-out areas in complex lighting.
  - Change applies only when terrain shadows are enabled; other lighting and shadow systems are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->