### PR TITLE
fix(grass collision): fix non-standard timescales

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 project(
 	CommunityShaders
-	VERSION 1.4.4
+	VERSION 1.4.5
 	LANGUAGES CXX
 )
 

--- a/src/Features/GrassCollision.cpp
+++ b/src/Features/GrassCollision.cpp
@@ -187,14 +187,7 @@ void GrassCollision::Update()
 
 		perFrameData.ValidMargin = { (int)cellIDDiff.x, (int)cellIDDiff.y };
 
-		auto calendar = RE::Calendar::GetSingleton();
-
-		float currentGameTime = calendar->GetCurrentGameTime();
-		static float lastGameTime = currentGameTime;
-
-		perFrameData.TimeDelta = float((100000.0 / 1.16) * abs(double(currentGameTime) - double(lastGameTime)) / double(calendar->GetTimescale()));
-
-		lastGameTime = currentGameTime;
+		perFrameData.TimeDelta = *globals::game::deltaTime * !globals::game::ui->GameIsPaused();
 
 		perFrameData.CameraHeightDelta = prevEyePosNI.z - eyePosNI.z;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Grass collision effects now correctly pause with the game/UI, preventing motion during pauses.
- Performance
  - Improved consistency of grass collision timing by using frame-based timing, reducing jitter across varying frame rates.
- Chores
  - Bumped version to 1.4.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->