### PR TITLE
chore(featureissues): default collapse testing menu

### DIFF
--- a/src/FeatureIssues.cpp
+++ b/src/FeatureIssues.cpp
@@ -1436,7 +1436,7 @@ namespace FeatureIssues
 			auto* menu = Menu::GetSingleton();
 			const auto& themeSettings = menu->GetTheme();
 
-			if (ImGui::CollapsingHeader("Testing", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick)) {
+			if (ImGui::CollapsingHeader("Testing", ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick)) {
 				{
 					auto sectionWrapper = Util::SectionWrapper("Feature Issue Testing",
 						"These tools create test INI files to trigger all known feature issue types for testing purposes.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The “Testing” section in Developer Mode and in the Feature Issues UI now starts collapsed instead of expanded, reducing initial visual clutter.
  * Initial visibility only is affected; functionality, data, and interactions remain unchanged. Users can expand these sections as needed for the same content and controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->