### PR TITLE
fix(terrain): vanilla diffuse in pbr terrain cell too bright due to wrong color space

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1346,7 +1346,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		if defined(TRUE_PBR)
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile0PBR) == 0)
 		{
-			landColorRGB1 = landColorRGB1 / Color::PBRLightingScale;
+			landColorRGB1 = Color::GammaToTrueLinear(landColorRGB1 / Color::PBRLightingScale);
 		}
 #		endif
 		float landAlpha1 = landColor1.a;
@@ -1427,7 +1427,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		if defined(TRUE_PBR)
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile1PBR) == 0)
 		{
-			landColorRGB2 = landColorRGB2 / Color::PBRLightingScale;
+			landColorRGB2 = Color::GammaToTrueLinear(landColorRGB2 / Color::PBRLightingScale);
 		}
 #		endif
 		float landAlpha2 = landColor2.a;
@@ -1507,7 +1507,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		if defined(TRUE_PBR)
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile2PBR) == 0)
 		{
-			landColorRGB3 = landColorRGB3 / Color::PBRLightingScale;
+			landColorRGB3 = Color::GammaToTrueLinear(landColorRGB3 / Color::PBRLightingScale);
 		}
 #		endif
 		float landAlpha3 = landColor3.a;
@@ -1587,7 +1587,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		if defined(TRUE_PBR)
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile3PBR) == 0)
 		{
-			landColorRGB4 = landColorRGB4 / Color::PBRLightingScale;
+			landColorRGB4 = Color::GammaToTrueLinear(landColorRGB4 / Color::PBRLightingScale);
 		}
 #		endif
 		float landAlpha4 = landColor4.a;
@@ -1667,7 +1667,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		if defined(TRUE_PBR)
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile4PBR) == 0)
 		{
-			landColorRGB5 = landColorRGB5 / Color::PBRLightingScale;
+			landColorRGB5 = Color::GammaToTrueLinear(landColorRGB5 / Color::PBRLightingScale);
 		}
 #		endif
 		float landAlpha5 = landColor5.a;
@@ -1748,7 +1748,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		if defined(TRUE_PBR)
 		[branch] if ((PBRFlags & PBR::TerrainFlags::LandTile5PBR) == 0)
 		{
-			landColorRGB6 = landColorRGB6 / Color::PBRLightingScale;
+			landColorRGB6 = Color::GammaToTrueLinear(landColorRGB6 / Color::PBRLightingScale);
 		}
 #		endif
 		float landAlpha6 = landColor6.a;


### PR DESCRIPTION
Simple fix to align the color space of the pbr and vanilla diffuse when a vanilla material is used in pbr shaded terrain.

<img width="1920" height="1080" alt="The Elder Scrolls V  Skyrim Special Edition Screenshot 2025 10 09 - 16 09 19 65" src="https://github.com/user-attachments/assets/336e7ec1-876c-455f-9f52-d3e4f062fbf4" />

->

<img width="1920" height="1080" alt="The Elder Scrolls V  Skyrim Special Edition Screenshot 2025 10 09 - 17 36 52 80" src="https://github.com/user-attachments/assets/7ee88244-721c-49a0-9921-d9829362ee01" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected terrain color processing for land tiles to use gamma-correct rendering with PBR lighting.
  * Results in more accurate and consistent land colors across layers, especially under varying lighting conditions.
  * Reduces washed-out or overly dark tones, improving visual fidelity and natural appearance of terrain shading.
  * No changes to controls or settings; improvement is automatic and backward-compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->