### PR TITLE
docs(UI): remove duplicate GPL license statement

### DIFF
--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -243,7 +243,6 @@ void HomePageRenderer::RenderFAQSection()
 			"Yes! Community Shaders is completely open source and available on GitHub. You can view "
 			"the source code, report issues, suggest features, and contribute to the project. "
 			"The project is licensed under GPL, ensuring it remains free and open for everyone."
-			"The project is licensed under GPL, ensuring it remains free and open for everyone."
 			" Branding materials and assets (icons, nexus branding, typography, etc) are not covered by the GPL Licence."
 			" Any included assets may not be used without explicit permission.");
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate text in the FAQ where the licensing sentence appeared twice; the repeated line has been removed to ensure a single, accurate entry and a cleaner FAQ layout. No changes to functionality.

* **Documentation**
  * Polished FAQ copy so licensing information appears once, improving readability and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->