### PR TITLE
fix(ui): welcome popup size issues

### DIFF
--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -277,9 +277,8 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 		return;
 	}
 
-	// Set font scale to 27 pixels for this window only
-	// Assuming default font is approximately 13 pixels, scale to ~27
-	ImGui::SetWindowFontScale(27.0f / 13.0f);
+	// Set font scale for better readability in this welcome dialog
+	ImGui::SetWindowFontScale(SETUP_DIALOG_FONT_SCALE);
 
 	auto menu = Menu::GetSingleton();
 
@@ -425,8 +424,8 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 
 	ImGui::Spacing();
 
-	// Check for Enter or Escape key to close
-	bool shouldClose = ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_Escape);
+	// Check for Enter or Escape key to close, but only if not capturing a hotkey
+	bool shouldClose = (ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_Escape)) && !menu->settingToggleKey;
 
 	if (shouldClose) {
 		MarkFirstTimeSetupComplete();

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -259,7 +259,8 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	// Center the window properly with rounded corners and thin border
 	ImVec2 center = ImVec2(io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f);
 	ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-	ImGui::SetNextWindowSize(ImVec2(500, 400), ImGuiCond_Always);
+	// Set a minimum width for better layout, but allow auto-sizing for height
+	ImGui::SetNextWindowSizeConstraints(ImVec2(500, 0), ImVec2(600, FLT_MAX));
 
 	// Style for rounded window with thin border
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 8.0f);
@@ -267,13 +268,18 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 
 	ImGuiWindowFlags flags = ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
 	                         ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings |
-	                         ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoTitleBar;  // Prevent scrolling and remove title
+	                         ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoTitleBar | 
+	                         ImGuiWindowFlags_AlwaysAutoResize;  // Prevent scrolling, remove title, auto-resize
 
 	if (!ImGui::Begin("##FirstTimeSetup", nullptr, flags)) {
 		ImGui::PopStyleVar(2);
 		ImGui::End();
 		return;
 	}
+
+	// Set font scale to 27 pixels for this window only
+	// Assuming default font is approximately 13 pixels, scale to ~27
+	ImGui::SetWindowFontScale(27.0f / 13.0f);
 
 	auto menu = Menu::GetSingleton();
 
@@ -419,24 +425,21 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 
 	ImGui::Spacing();
 
-	// Center the continue button
-	float continueButtonWidth = 140.0f;
-	ImGui::SetCursorPosX((windowWidth - continueButtonWidth) * 0.5f);
-
-	// Check for Enter or Escape key first
+	// Check for Enter or Escape key to close
 	bool shouldClose = ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_Escape);
 
-	if (ImGui::Button("Continue", ImVec2(continueButtonWidth, 30)) || shouldClose) {
+	if (shouldClose) {
 		MarkFirstTimeSetupComplete();
 		// Note: Settings are automatically saved to ensure welcome screen won't show again
 	}
 
 	// Center the help text
-	const char* helpText = "(Press Enter or Escape to continue)";
+	const char* helpText = "Press Escape or Enter to continue";
 	float helpWidth = ImGui::CalcTextSize(helpText).x;
 	ImGui::SetCursorPosX((windowWidth - helpWidth) * 0.5f);
 	ImGui::TextDisabled("%s", helpText);
 
+	ImGui::SetWindowFontScale(1.0f);  // Reset font scale
 	ImGui::PopStyleVar(2);  // Pop WindowRounding and WindowBorderSize
 	ImGui::End();
 }

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -268,7 +268,7 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 
 	ImGuiWindowFlags flags = ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
 	                         ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings |
-	                         ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoTitleBar | 
+	                         ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoTitleBar |
 	                         ImGuiWindowFlags_AlwaysAutoResize;  // Prevent scrolling, remove title, auto-resize
 
 	if (!ImGui::Begin("##FirstTimeSetup", nullptr, flags)) {
@@ -440,7 +440,7 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	ImGui::TextDisabled("%s", helpText);
 
 	ImGui::SetWindowFontScale(1.0f);  // Reset font scale
-	ImGui::PopStyleVar(2);  // Pop WindowRounding and WindowBorderSize
+	ImGui::PopStyleVar(2);            // Pop WindowRounding and WindowBorderSize
 	ImGui::End();
 }
 

--- a/src/Menu/HomePageRenderer.h
+++ b/src/Menu/HomePageRenderer.h
@@ -8,6 +8,7 @@ public:
 	// Constants
 	static constexpr const char* DISCORD_URL = "https://discord.com/invite/nkrQybAsyy";
 	static constexpr float TITLE_FONT_SCALE = 2.0f;
+	static constexpr float SETUP_DIALOG_FONT_SCALE = 0.75f;
 	static constexpr float QUICK_LINKS_BUTTON_WIDTH = 180.0f;
 	static constexpr float LOGO_WATERMARK_HEIGHT = 260.0f;
 


### PR DESCRIPTION
forces font size and removes some repeated text to clean up welcome screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - First-time setup dialog now auto-resizes (min width 500, max width 600) with no scrollbar/title bar for a cleaner layout.
  - Dialog uses an adjusted, more compact font scale for consistent presentation.
  - Keyboard support: press Enter or Escape to complete and close the setup (unless you're actively configuring a hotkey).
  - Removed the fixed-width Continue button and updated help text for clearer guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->