### PR TITLE
fix: visual artifacts small particles

### DIFF
--- a/features/Upscaling/Shaders/Upscaling/EncodeTexturesCS.hlsl
+++ b/features/Upscaling/Shaders/Upscaling/EncodeTexturesCS.hlsl
@@ -63,6 +63,8 @@ RWTexture2D<float2> MotionVectorOutput : register(u2);
 #endif
 
 	float reactiveMask = taaMask.x * 0.1 + taaMask.y;
+	reactiveMask = max(reactiveMask, NormalsWaterMask[dispatchID.xy].w);
+ 	reactiveMask = max(reactiveMask, transparencyCompositionMask); 
 	ReactiveMask[dispatchID.xy] = reactiveMask;
 
 	TransparencyCompositionMask[dispatchID.xy] = transparencyCompositionMask;


### PR DESCRIPTION

https://github.com/user-attachments/assets/a3df31de-ad5e-4ee3-8988-627b4bc3a782

 This pull request modifies the EncodeTexturesCS.hlsl compute shader to incorporate additional scene
  information into the reactiveMask output.

  The specific lines in question are:
   reactiveMask = max(reactiveMask, NormalsWaterMask[dispatchID.xy].w);
   reactiveMask = max(reactiveMask, transparencyCompositionMask);

  Details:
  The reactiveMask is an input to temporal upscaling algorithms (e.g., DLSS, FSR) used to guide temporal
  accumulation and reconstruction.
   The first line integrates the w component of NormalsWaterMask, which typically represents water surface identification, into the reactiveMask. I don't think this one is a big issue but thought to add it in anyways.
   The second line integrates the transparencyCompositionMask, which identifies transparent scene elements,
     into the reactiveMask.

  This integration provides the upscaling algorithm with additional per-pixel context regarding water and
  transparency. This data can be utilized by the upscaler to apply specific temporal filtering or
  reconstruction strategies to pixels identified as belonging to water surfaces or transparent objects. The
  objective is to enable more granular control over the upscaling process in these specific regions of the
  rendered frame.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering accuracy for upscaled textures by refining how transparency and water effects are composited, resulting in more consistent visual quality during dynamic scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->