### PR TITLE
fix: fix sky flickering from junk IBL data; skysync fixes

### DIFF
--- a/features/IBL/Shaders/IBL/DiffuseIBLCS.hlsl
+++ b/features/IBL/Shaders/IBL/DiffuseIBLCS.hlsl
@@ -36,7 +36,7 @@ void main(uint3 dispatchID : SV_DispatchThreadID, uint groupIndex : SV_GroupInde
 
 	// ENB compat
 	rayDir.z = -abs(rayDir.z);
-	
+
 	// Sample cubemap with optimized direction
 	float3 color = EnvTexture.SampleLevel(LinearSampler, -rayDir, 0).xyz;
 

--- a/features/IBL/Shaders/IBL/DiffuseIBLCS.hlsl
+++ b/features/IBL/Shaders/IBL/DiffuseIBLCS.hlsl
@@ -36,7 +36,7 @@ void main(uint3 dispatchID : SV_DispatchThreadID, uint groupIndex : SV_GroupInde
 
 	// ENB compat
 	rayDir.z = -abs(rayDir.z);
-
+	
 	// Sample cubemap with optimized direction
 	float3 color = EnvTexture.SampleLevel(LinearSampler, -rayDir, 0).xyz;
 

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -202,7 +202,7 @@ namespace SharedData
 	{
 		bool Enable;
 		float3 pad;
-		
+
 		float GradientIntensity;
 		float GradientDesaturation;
 		float GradientTopIntensity;
@@ -229,7 +229,7 @@ namespace SharedData
 		float CloudsCurve;
 		float CloudsDesaturation;
 		float CloudsOpacity;
-		
+
 		float3 CloudsColorFilter;
 		float CloudsVertexAlphaBoost;
 

--- a/package/Shaders/DeferredCompositeCS.hlsl
+++ b/package/Shaders/DeferredCompositeCS.hlsl
@@ -125,6 +125,7 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, out float ao, out float3 il, i
 
 #if defined(SSGI)
 
+	if (depth < 1.0f) {
 	float ssgiAo;
 	float3 ssgiIl;
 	SampleSSGI(dispatchID.xy, normalWS, ssgiAo, ssgiIl);

--- a/package/Shaders/DeferredCompositeCS.hlsl
+++ b/package/Shaders/DeferredCompositeCS.hlsl
@@ -119,7 +119,7 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, out float ao, out float3 il, i
 #		endif
 
 	sh2 skylighting = Skylighting::sample(SharedData::skylightingSettings, SkylightingProbeArray, stbn_vec3_2Dx1D_128x128x64, dispatchID.xy, positionMS.xyz, normalWS);
-	
+
 	float3 V = normalize(positionWS.xyz);
 	float3 R = reflect(V, normalWS);
 
@@ -131,12 +131,12 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, out float ao, out float3 il, i
 	SampleSSGI(dispatchID.xy, normalWS, ssgiAo, ssgiIl);
 
 	float3 directionalAmbientColor = max(0, mul(SharedData::DirectionalAmbient, float4(normalWS, 1.0)));
-	
-	if (SharedData::enbSettings.Enable){		
+
+	if (SharedData::enbSettings.Enable){
 		sh2 shR = ImageBasedLighting::DiffuseSkyIBLTexture.Load(int3(0, 0, 0));
 		sh2 shG = ImageBasedLighting::DiffuseSkyIBLTexture.Load(int3(1, 0, 0));
 		sh2 shB = ImageBasedLighting::DiffuseSkyIBLTexture.Load(int3(2, 0, 0));
-  
+
 		float colorR = SphericalHarmonics::SHHallucinateZH3Irradiance(shR, -normalWS);
 		float colorG = SphericalHarmonics::SHHallucinateZH3Irradiance(shG, -normalWS);
 		float colorB = SphericalHarmonics::SHHallucinateZH3Irradiance(shB, -normalWS);

--- a/package/Shaders/DistantTree.hlsl
+++ b/package/Shaders/DistantTree.hlsl
@@ -242,7 +242,7 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 directionalAmbientColor = max(0, mul(SharedData::DirectionalAmbient, float4(normal, 1.0)));
 #			if defined(IBL)
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
-		directionalAmbientColor += ImageBasedLighting::GetIBLColor(-normal) * SharedData::enbSettings.IBLMultiplicativeAmount;	
+		directionalAmbientColor += ImageBasedLighting::GetIBLColor(-normal) * SharedData::enbSettings.IBLMultiplicativeAmount;
 	}
 #			endif
 	diffuseColor += directionalAmbientColor;
@@ -269,7 +269,7 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 directionalAmbientColor = mul(SharedData::DirectionalAmbient, float4(normal, 1.0));
 #			if defined(IBL)
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
-		directionalAmbientColor += ImageBasedLighting::GetIBLColor(-normal) * SharedData::enbSettings.IBLMultiplicativeAmount;	
+		directionalAmbientColor += ImageBasedLighting::GetIBLColor(-normal) * SharedData::enbSettings.IBLMultiplicativeAmount;
 	}
 #			endif
 	diffuseColor += directionalAmbientColor;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2744,7 +2744,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #	if defined(IBL)
 	if (SharedData::iblSettings.EnableDiffuseIBL && inWorld) {
 		float3 iblColor = ImageBasedLighting::GetIBLColor(-ambientNormal);
-		directionalAmbientColor += iblColor * SharedData::enbSettings.IBLMultiplicativeAmount;		
+		directionalAmbientColor += iblColor * SharedData::enbSettings.IBLMultiplicativeAmount;
 		directionalAmbientColorAdditive += iblColor * SharedData::enbSettings.IBLAdditiveAmount;
 	}
 #	endif

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -747,10 +747,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #				endif  // SKYLIGHTING
 
 #				if defined(IBL)
-	if (SharedData::iblSettings.EnableDiffuseIBL) {	
+	if (SharedData::iblSettings.EnableDiffuseIBL) {
 		float3 iblColor = ImageBasedLighting::GetIBLColor(-normal);
-		directionalAmbientColor += iblColor * SharedData::enbSettings.IBLMultiplicativeAmount;		
-		directionalAmbientColorAdditive += iblColor * SharedData::enbSettings.IBLAdditiveAmount;		
+		directionalAmbientColor += iblColor * SharedData::enbSettings.IBLMultiplicativeAmount;
+		directionalAmbientColorAdditive += iblColor * SharedData::enbSettings.IBLAdditiveAmount;
 	}
 #				endif
 
@@ -938,8 +938,8 @@ PS_OUTPUT main(PS_INPUT input)
 #			if defined(IBL)
 	if (SharedData::iblSettings.EnableDiffuseIBL) {
 		float3 iblColor = ImageBasedLighting::GetIBLColor(-normal);
-		directionalAmbientColor += iblColor * SharedData::enbSettings.IBLMultiplicativeAmount;				
-		directionalAmbientColorAdditive += iblColor * SharedData::enbSettings.IBLAdditiveAmount;				
+		directionalAmbientColor += iblColor * SharedData::enbSettings.IBLMultiplicativeAmount;
+		directionalAmbientColorAdditive += iblColor * SharedData::enbSettings.IBLAdditiveAmount;
 	}
 #			endif
 

--- a/package/Shaders/Sky.hlsl
+++ b/package/Shaders/Sky.hlsl
@@ -255,12 +255,12 @@ PS_OUTPUT main(PS_INPUT input)
 #		endif
 
 	if ((Permutation::ExtraShaderDescriptor & Permutation::ExtraFlags::IsSun)) {
-		float distanceFromCenter = length(input.TexCoord0.xy * 2.0 - 1.0); 
+		float distanceFromCenter = length(input.TexCoord0.xy * 2.0 - 1.0);
 
-		float sun = smoothstep(SharedData::enbSettings.ProceduralSunSize, 
-                               SharedData::enbSettings.ProceduralSunSize - SharedData::enbSettings.ProceduralSunEdgeSoftness * SharedData::enbSettings.ProceduralSunSize * 0.5, 
+		float sun = smoothstep(SharedData::enbSettings.ProceduralSunSize,
+                               SharedData::enbSettings.ProceduralSunSize - SharedData::enbSettings.ProceduralSunEdgeSoftness * SharedData::enbSettings.ProceduralSunSize * 0.5,
                                distanceFromCenter * 25.0);
-		
+
 		float sunGlow = SharedData::enbSettings.ProceduralSunGlowCurve > 0.0 ? pow(pow(saturate(1.0 - distanceFromCenter), rcp(SharedData::enbSettings.ProceduralSunGlowCurve)), 3.0) * SharedData::enbSettings.ProceduralSunGlowIntensity : 0.0;
 
 		baseColor = sun + sunGlow;

--- a/src/Features/ENBPostProcessing.cpp
+++ b/src/Features/ENBPostProcessing.cpp
@@ -70,7 +70,7 @@ ENBPostProcessing::PerFrame ENBPostProcessing::GetCommonBufferData()
 	data.VolumetricRaysColorFilter = settingManager.GetInterpolatedColorTimeOfDayValue("ColorFilter", "GAMEVOLUMETRICRAYS");
 
 	data.ProceduralSunSize = settingManager.GetValue<float>("Size", "PROCEDURALSUN");
-	data.ProceduralSunEdgeSoftness =settingManager.GetValue<float>("EdgeSoftness", "PROCEDURALSUN");
+	data.ProceduralSunEdgeSoftness = settingManager.GetValue<float>("EdgeSoftness", "PROCEDURALSUN");
 	data.ProceduralSunGlowIntensity = settingManager.GetInterpolatedTimeOfDayValue("GlowIntensity", "PROCEDURALSUN");
 	data.ProceduralSunGlowCurve = settingManager.GetInterpolatedTimeOfDayValue("GlowCurve", "PROCEDURALSUN");
 
@@ -110,7 +110,7 @@ float3 Curve(float3 color, float power)
 
 	return color;
 }
-	
+
 float3 Desaturation(float3 color, float desaturation)
 {
 	float luminance = color.Dot({ 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f });
@@ -164,7 +164,7 @@ void ENBPostProcessing::OverrideWeather(RE::Sky* a_sky)
 		dirLightColorF3 = Desaturation(dirLightColorF3, settingManager.GetInterpolatedTimeOfDayValue("DirectLightingDesaturation", "ENVIRONMENT"));
 		dirLightColorF3 = ColorFilter(dirLightColorF3, settingManager.GetInterpolatedColorTimeOfDayValue("DirectLightingColorFilter", "ENVIRONMENT"), settingManager.GetInterpolatedTimeOfDayValue("DirectLightingColorFilterAmount", "ENVIRONMENT"));
 		dirLightColorF3 = Intensity(dirLightColorF3, settingManager.GetInterpolatedTimeOfDayValue("DirectLightingIntensity", "ENVIRONMENT"));
-		
+
 		dirLightColorF3 /= !globals::game::isVR ? imageSpaceManager->GetRuntimeData().data.baseData.hdr.sunlightScale : imageSpaceManager->GetVRRuntimeData().data.baseData.hdr.sunlightScale;
 
 		dirLightColor = F3ToNi(dirLightColorF3);
@@ -204,7 +204,7 @@ void ENBPostProcessing::OverrideWeather(RE::Sky* a_sky)
 
 	{
 		auto fogAmountMultiplier = settingManager.GetInterpolatedTimeOfDayValue("FogAmountMultiplier", "ENVIRONMENT");
-		
+
 		a_sky->fogNear /= fogAmountMultiplier;
 		a_sky->fogFar /= fogAmountMultiplier;
 	}
@@ -237,7 +237,7 @@ void ENBPostProcessing::OverrideWeather(RE::Sky* a_sky)
 		auto& starsColor = colors[(uint)RE::TESWeather::ColorTypes::kStars];
 
 		float3 starsColorF3 = NiToF3(starsColor);
-		
+
 		starsColorF3 = Curve(starsColorF3, settingManager.GetInterpolatedTimeOfDayValue("StarsCurve", "SKY"));
 		starsColorF3 = Intensity(starsColorF3, settingManager.GetInterpolatedTimeOfDayValue("StarsIntensity", "SKY"));
 
@@ -312,7 +312,7 @@ struct Sky_UpdateColors
 {
 	static void thunk(RE::Sky* This, float a_delta)
 	{
-		func(This, a_delta);	
+		func(This, a_delta);
 		globals::features::enbPostProcessing.CheckCommonData();
 		if (globals::features::enbPostProcessing.enableEffect)
 			globals::features::enbPostProcessing.OverrideWeather(This);

--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -86,7 +86,7 @@ void IBL::Prepass()
 	std::array<ID3D11ShaderResourceView*, 1> srvs = { (dynamicCubemaps.loaded && envTexture) ? envTexture->srv.get() : nullptr };
 	std::array<ID3D11UnorderedAccessView*, 1> uavs = { diffuseIBLTexture->uav.get() };
 	std::array<ID3D11SamplerState*, 1> samplers = { Deferred::GetSingleton()->linearSampler };
-	
+
 	auto renderer = globals::game::renderer;
 	auto& cubemap = renderer->GetRendererData().cubemapRenderTargets[RE::RENDER_TARGETS_CUBEMAP::kREFLECTIONS];
 

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -463,21 +463,21 @@ void SkySync::Moon_Update::thunk(RE::Moon* moon, RE::Sky* sky)
 	if (auto& singleton = globals::features::skySync; singleton.settings.Enabled) {
 		float* target = moon == sky->masser ? &singleton.masserPhaseIntensityFactor : &singleton.secundaPhaseIntensityFactor;
 		if (updateMoonTexture != moon->updateMoonTexture || *target <= 0.0f) {
-		// Gets the texture name of the current moon phase when it changes rather than reading direct global variables
-		// Allows for compatibility with other mods that don't directly update the in-game phase values
-		const auto moonShaderProperty = skyrim_cast<RE::BSSkyShaderProperty*>(moon->moonMesh->GetGeometryRuntimeData().properties[1].get());
-		if (!moonShaderProperty)
-			return;
+			// Gets the texture name of the current moon phase when it changes rather than reading direct global variables
+			// Allows for compatibility with other mods that don't directly update the in-game phase values
+			const auto moonShaderProperty = skyrim_cast<RE::BSSkyShaderProperty*>(moon->moonMesh->GetGeometryRuntimeData().properties[1].get());
+			if (!moonShaderProperty)
+				return;
 
-		const auto texture = moonShaderProperty->GetBaseTexture();
-		if (!texture)
-			return;
+			const auto texture = moonShaderProperty->GetBaseTexture();
+			if (!texture)
+				return;
 
-		const auto phase = Util::Moon::GetPhaseFromTexture(texture->name.c_str());
-		const float intensityFactor = Util::Moon::GetPhaseIntensityFactor(phase);
+			const auto phase = Util::Moon::GetPhaseFromTexture(texture->name.c_str());
+			const float intensityFactor = Util::Moon::GetPhaseIntensityFactor(phase);
 
-		*target = intensityFactor;
-	}
+			*target = intensityFactor;
+		}
 	}
 }
 

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -12,7 +12,23 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 
 void SkySync::DrawSettings()
 {
-	ImGui::Checkbox("Enabled", &settings.Enabled);
+	if (ImGui::Checkbox("Enabled", &settings.Enabled)) {
+		shadowFader.Reset();
+
+		if (!settings.Enabled) {
+			auto sky = RE::Sky::GetSingleton();
+			if (sky && sky->sun && sky->sun->light) {
+				auto dir = sky->sun->light->local.rotate.GetVectorX();
+				if (dir.Unitize() < FLT_EPSILON)
+					dir = { 0.0f, 0.0f, 1.0f };
+
+				ShadowFader::SetLighting(sky->sun, dir, 1.0f);
+				SetSunBaseVisibility(sky->sun, 1.0f);
+			}
+
+			volumetricLightingIntensityFactor = 1.0f;
+		}
+	}
 
 	ImGui::Checkbox("Use alternate sun path", &settings.UseAlternateSunPath);
 
@@ -209,10 +225,13 @@ void SkySync::ProcessMoon(const RE::Moon* moon, const float time, const Caster t
 	const float moonRadius = type == Caster::Masser ? static_cast<float>(*gMasserSize) : static_cast<float>(*gSecundaSize);
 	float intensity = CalculateVisibility(dir, moon->moonMesh->local.translate.y, moonRadius);
 
-	if (type == Caster::Masser)
-		intensity *= masserPhaseIntensityFactor;
-	else if (type == Caster::Secunda)
-		intensity *= secundaPhaseIntensityFactor * Util::Moon::SecundaIntensityFactor;
+	if (type == Caster::Masser) {
+		const float factor = masserPhaseIntensityFactor > 0.0f ? masserPhaseIntensityFactor : 1.0f;
+		intensity *= factor;
+	} else if (type == Caster::Secunda) {
+		const float factor = secundaPhaseIntensityFactor > 0.0f ? secundaPhaseIntensityFactor : 1.0f;
+		intensity *= factor * Util::Moon::SecundaIntensityFactor;
+	}
 
 	if (time >= timings.sunriseFadeOutMoonStart && time <= timings.sunriseFadeOutMoonEnd)
 		intensity *= SmoothStep(timings.sunriseFadeOutMoonEnd, timings.sunriseFadeOutMoonStart, time);
@@ -441,7 +460,9 @@ void SkySync::Moon_Update::thunk(RE::Moon* moon, RE::Sky* sky)
 
 	func(moon, sky);
 
-	if (auto& singleton = globals::features::skySync; singleton.settings.Enabled && updateMoonTexture != moon->updateMoonTexture) {
+	if (auto& singleton = globals::features::skySync; singleton.settings.Enabled) {
+		float* target = moon == sky->masser ? &singleton.masserPhaseIntensityFactor : &singleton.secundaPhaseIntensityFactor;
+		if (updateMoonTexture != moon->updateMoonTexture || *target <= 0.0f) {
 		// Gets the texture name of the current moon phase when it changes rather than reading direct global variables
 		// Allows for compatibility with other mods that don't directly update the in-game phase values
 		const auto moonShaderProperty = skyrim_cast<RE::BSSkyShaderProperty*>(moon->moonMesh->GetGeometryRuntimeData().properties[1].get());
@@ -455,8 +476,8 @@ void SkySync::Moon_Update::thunk(RE::Moon* moon, RE::Sky* sky)
 		const auto phase = Util::Moon::GetPhaseFromTexture(texture->name.c_str());
 		const float intensityFactor = Util::Moon::GetPhaseIntensityFactor(phase);
 
-		float* target = moon == sky->masser ? &singleton.masserPhaseIntensityFactor : &singleton.secundaPhaseIntensityFactor;
 		*target = intensityFactor;
+	}
 	}
 }
 

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -804,7 +804,7 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 				data.SecundaColor = color;
 			}
 		}
-		
+
 		sharedDataCB->Update(data);
 	}
 


### PR DESCRIPTION
compositecs.hlsl changes fix the sky colour explosions from video in discord.

turning off SkySync now snaps the sun’s light and glare back to Skyrim’s default values, so shadows shouldn't stay broken. Moon brightness calculations pick reasonable defaults until the game provides phase data, giving Masser and Secunda usable light immediately.

I couldn't reaalllyyy see what issue you were having with skysync but this should make the moons behave better now and the sun shadows should fix themselves when toggling. if this doesn't work just incorporate the deferredcompositecs fixes.

i don't know why the bot changed formatting on files i didn't even touch. i hate the auto formatter.