### PR TITLE
build: fix zipping aio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -662,11 +662,12 @@ if(AIO_ZIP_TO_DIST)
 
     set(TARGET_AIO_ZIP "${PROJECT_NAME}_AIO-${UTC_NOW}.7z")
     message("Zipping ${AIO_DIR} to ${CMAKE_SOURCE_DIR}/dist/${TARGET_AIO_ZIP}")
-	add_custom_target(
+    add_custom_target(
         AIO_ZIP_PACKAGE
-		ALL
-        COMMAND ${CMAKE_COMMAND} -E tar cf
-                ${CMAKE_SOURCE_DIR}/dist/${TARGET_AIO_ZIP} --format=7zip -- .
+        ALL
+        COMMAND
+            ${CMAKE_COMMAND} -E tar cf
+            ${CMAKE_SOURCE_DIR}/dist/${TARGET_AIO_ZIP} --format=7zip -- .
         WORKING_DIRECTORY ${AIO_DIR}
         DEPENDS PREPARE_AIO
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -662,12 +662,12 @@ if(AIO_ZIP_TO_DIST)
 
     set(TARGET_AIO_ZIP "${PROJECT_NAME}_AIO-${UTC_NOW}.7z")
     message("Zipping ${AIO_DIR} to ${CMAKE_SOURCE_DIR}/dist/${TARGET_AIO_ZIP}")
-    add_custom_command(
-        TARGET ${PROJECT_NAME}
-        POST_BUILD
-        COMMAND
-            ${CMAKE_COMMAND} -E tar cf
-            ${CMAKE_SOURCE_DIR}/dist/${TARGET_AIO_ZIP} --format=7zip -- .
+	add_custom_target(
+        AIO_ZIP_PACKAGE
+		ALL
+        COMMAND ${CMAKE_COMMAND} -E tar cf
+                ${CMAKE_SOURCE_DIR}/dist/${TARGET_AIO_ZIP} --format=7zip -- .
         WORKING_DIRECTORY ${AIO_DIR}
+        DEPENDS PREPARE_AIO
     )
 endif()


### PR DESCRIPTION
This pull request updates the packaging logic in the `CMakeLists.txt` file to improve how the AIO (All-In-One) ZIP package is generated. The main change is replacing the post-build command with a dedicated custom target, which enhances build control and dependency management.

**Build system improvements:**

* Replaced the `add_custom_command` (post-build) with an `add_custom_target` named `AIO_ZIP_PACKAGE`, making the ZIP packaging a distinct build target. This allows for better integration with build workflows and easier invocation of packaging independently.
* Added `DEPENDS PREPARE_AIO` to ensure the packaging step only runs after the preparation step completes, improving build reliability and correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured the build process to ensure package creation runs reliably as an independent operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->