### PR TITLE
fix: removed duplicate perframe buffer setup in prepass

### DIFF
--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -288,25 +288,6 @@ void Deferred::PrepassPasses()
 	auto context = globals::d3d::context;
 	context->OMSetRenderTargets(0, nullptr, nullptr);  // Unbind all bound render targets
 
-	globals::game::stateUpdateFlags->set(RE::BSGraphics::ShaderFlags::DIRTY_RENDERTARGET);  // Run OMSetRenderTargets again
-
-	{
-		ID3D11Buffer* buffers[1] = { *globals::game::perFrame.get() };
-
-		ID3D11Buffer* vrBuffer = nullptr;
-
-		if (REL::Module::IsVR()) {
-			static REL::Relocation<ID3D11Buffer**> VRValues{ REL::Offset(0x3180688) };
-			vrBuffer = *VRValues.get();
-		}
-		if (vrBuffer) {
-			context->CSSetConstantBuffers(12, 1, buffers);
-			context->CSSetConstantBuffers(13, 1, &vrBuffer);
-		} else {
-			context->CSSetConstantBuffers(12, 1, buffers);
-		}
-	}
-
 	globals::truePBR->PrePass();
 	for (auto* feature : Feature::GetFeatureList()) {
 		if (feature->loaded) {

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -2610,15 +2610,28 @@ namespace SIE
 		totalTime.QuadPart += now.QuadPart - lastCalculation.QuadPart;
 		lastCalculation = now;
 		
-		// Check if compilation is complete and set completion time if needed
+		// Check if compilation is complete and set completion time if needed (thread-safe)
+		bool shouldLogCompletion = false;
 		if (completionTime.QuadPart == 0 && completedTasks + failedTasks >= totalTasks) {
-			QueryPerformanceCounter(&completionTime);
+			std::scoped_lock lock(compilationMutex);
+			// Double-check with lock held to prevent race condition
+			if (completionTime.QuadPart == 0 && completedTasks + failedTasks >= totalTasks) {
+				QueryPerformanceCounter(&completionTime);
+				shouldLogCompletion = true;
+			}
+		}
+		
+		// Log completion outside the lock to avoid holding it during logging
+		if (shouldLogCompletion) {
 			logger::debug("Compilation completed in {} ms", GetHumanTime(static_cast<double>(completionTime.QuadPart - lastReset.QuadPart) * 1000.0 / frequency.QuadPart));
 		}
 		
-		std::scoped_lock lock(compilationMutex);
-		processedTasks.insert(task);
-		tasksInProgress.erase(task);
+		// Handle task completion tracking
+		{
+			std::scoped_lock lock(compilationMutex);
+			processedTasks.insert(task);
+			tasksInProgress.erase(task);
+		}
 		conditionVariable.notify_one();
 	}
 

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -2609,6 +2609,13 @@ namespace SIE
 		QueryPerformanceCounter(&now);
 		totalTime.QuadPart += now.QuadPart - lastCalculation.QuadPart;
 		lastCalculation = now;
+		
+		// Check if compilation is complete and set completion time if needed
+		if (completionTime.QuadPart == 0 && completedTasks + failedTasks >= totalTasks) {
+			QueryPerformanceCounter(&completionTime);
+			logger::debug("Compilation completed in {} ms", GetHumanTime(static_cast<double>(completionTime.QuadPart - lastReset.QuadPart) * 1000.0 / frequency.QuadPart));
+		}
+		
 		std::scoped_lock lock(compilationMutex);
 		processedTasks.insert(task);
 		tasksInProgress.erase(task);
@@ -2627,6 +2634,7 @@ namespace SIE
 		cacheHitTasks = 0;
 		QueryPerformanceCounter(&lastReset);
 		QueryPerformanceCounter(&lastCalculation);
+		completionTime = { 0 };  // Reset completion time
 		totalTime = { 0 };
 	}
 
@@ -2644,6 +2652,8 @@ namespace SIE
 
 	double CompilationSet::GetEta()
 	{
+		// For ETA calculation, we still use the active compilation time (totalTime)
+		// because it reflects the actual work time, not wall-clock time
 		double totalMs = static_cast<double>(totalTime.QuadPart) * 1000.0 / frequency.QuadPart;
 
 		if (totalMs == 0.0) {
@@ -2656,7 +2666,13 @@ namespace SIE
 
 	std::string CompilationSet::GetStatsString(bool a_timeOnly, bool a_elapsedOnly)
 	{
-		double totalMs = static_cast<double>(totalTime.QuadPart) * 1000.0 / frequency.QuadPart;
+		// Calculate elapsed time since compilation started
+		LARGE_INTEGER currentTime;
+		QueryPerformanceCounter(&currentTime);
+		
+		// Use completion time if compilation is finished, otherwise current time
+		LARGE_INTEGER endTime = (completionTime.QuadPart != 0) ? completionTime : currentTime;
+		double totalMs = static_cast<double>(endTime.QuadPart - lastReset.QuadPart) * 1000.0 / frequency.QuadPart;
 
 		if (a_timeOnly) {
 			if (a_elapsedOnly) {

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -2724,7 +2724,7 @@ namespace SIE
 		QueryPerformanceCounter(&now);
 		totalTime.QuadPart += now.QuadPart - lastCalculation.QuadPart;
 		lastCalculation = now;
-		
+
 		// Check if compilation is complete and set completion time if needed (thread-safe)
 		bool shouldLogCompletion = false;
 		if (completionTime.QuadPart == 0 && completedTasks + failedTasks >= totalTasks) {
@@ -2735,12 +2735,12 @@ namespace SIE
 				shouldLogCompletion = true;
 			}
 		}
-		
+
 		// Log completion outside the lock to avoid holding it during logging
 		if (shouldLogCompletion) {
 			logger::debug("Compilation completed in {} ms", GetHumanTime(static_cast<double>(completionTime.QuadPart - lastReset.QuadPart) * 1000.0 / frequency.QuadPart));
 		}
-		
+
 		// Handle task completion tracking
 		{
 			std::scoped_lock lock(compilationMutex);
@@ -2797,7 +2797,7 @@ namespace SIE
 		// Calculate elapsed time since compilation started
 		LARGE_INTEGER currentTime;
 		QueryPerformanceCounter(&currentTime);
-		
+
 		// Use completion time if compilation is finished, otherwise current time
 		LARGE_INTEGER endTime = (completionTime.QuadPart != 0) ? completionTime : currentTime;
 		double totalMs = static_cast<double>(endTime.QuadPart - lastReset.QuadPart) * 1000.0 / frequency.QuadPart;

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -244,6 +244,7 @@ namespace SIE
 	public:
 		LARGE_INTEGER lastReset;
 		LARGE_INTEGER lastCalculation;
+		LARGE_INTEGER completionTime;  // When compilation completed
 		LARGE_INTEGER frequency;
 		LARGE_INTEGER totalTime = { 0 };
 
@@ -252,6 +253,7 @@ namespace SIE
 			QueryPerformanceFrequency(&frequency);
 			QueryPerformanceCounter(&lastReset);
 			QueryPerformanceCounter(&lastCalculation);
+			completionTime = { 0 };  // Initialize to zero (not completed)
 		}
 
 		std::optional<ShaderCompilationTask> WaitTake(std::stop_token stoken);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified render initialization by removing a redundant render-target rebinding step and related per-frame buffer rebinds in the prepass path.

* **New Features / Improvements**
  * Improved shader compilation timing: record compilation completion time, reset timing on cache clear, and provide more accurate elapsed/ETA and progress reporting with safer synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->