### PR TITLE
fix: remove duplicate buffer setup

### DIFF
--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -288,25 +288,6 @@ void Deferred::PrepassPasses()
 	auto context = globals::d3d::context;
 	context->OMSetRenderTargets(0, nullptr, nullptr);  // Unbind all bound render targets
 
-	globals::game::stateUpdateFlags->set(RE::BSGraphics::ShaderFlags::DIRTY_RENDERTARGET);  // Run OMSetRenderTargets again
-
-	{
-		ID3D11Buffer* buffers[1] = { *globals::game::perFrame.get() };
-
-		ID3D11Buffer* vrBuffer = nullptr;
-
-		if (REL::Module::IsVR()) {
-			static REL::Relocation<ID3D11Buffer**> VRValues{ REL::Offset(0x3180688) };
-			vrBuffer = *VRValues.get();
-		}
-		if (vrBuffer) {
-			context->CSSetConstantBuffers(12, 1, buffers);
-			context->CSSetConstantBuffers(13, 1, &vrBuffer);
-		} else {
-			context->CSSetConstantBuffers(12, 1, buffers);
-		}
-	}
-
 	globals::truePBR->PrePass();
 	for (auto* feature : Feature::GetFeatureList()) {
 		if (feature->loaded) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal rendering pipeline implementation by removing redundant code paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->