### PR TITLE
feat(lod): add gamma sliders

### DIFF
--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -143,6 +143,10 @@ namespace SharedData
 		float LODObjectBrightness;
 		float LODObjectSnowBrightness;
 		bool DisableTerrainVertexColors;
+		float LODTerrainGamma;
+		float LODObjectGamma;
+		float LODObjectSnowGamma;
+		float pad0;
 	};
 
 	struct HairSpecularSettings

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1829,7 +1829,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 #	if defined(LOD_BLENDING)
 #		if defined(LODOBJECTS) || defined(LODOBJECTSHD)
-	baseColor.xyz *= SharedData::lodBlendingSettings.LODObjectBrightness;
+	baseColor.xyz = pow(abs(baseColor.xyz), SharedData::lodBlendingSettings.LODObjectGamma) * SharedData::lodBlendingSettings.LODObjectBrightness;
 #		elif defined(LODLANDSCAPE)
 	// First apply terrain variation if enabled
 	#			if defined(TERRAIN_VARIATION)
@@ -1843,7 +1843,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 			baseColor.xyz = Color::Diffuse(lodStochasticColor.rgb);
 		}
 #			endif
-	baseColor.xyz *= SharedData::lodBlendingSettings.LODTerrainBrightness;
+	baseColor.xyz = pow(abs(baseColor.xyz), SharedData::lodBlendingSettings.LODTerrainGamma) * SharedData::lodBlendingSettings.LODTerrainBrightness;
 #		endif
 #	endif  // LOD_BLENDING
 
@@ -1945,7 +1945,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		endif
 
 #		if defined(LOD_BLENDING)
-	lodLandColor.xyz *= SharedData::lodBlendingSettings.LODTerrainBrightness;
+	lodLandColor.xyz = pow(abs(lodLandColor.xyz), SharedData::lodBlendingSettings.LODTerrainGamma) * SharedData::lodBlendingSettings.LODTerrainBrightness;
 #		endif  // LOD_BLENDING
 	float lodBlendParameter = GetLodLandBlendParameter(lodLandColor.xyz);
 	float lodBlendMask = TexLandLodBlend2Sampler.Sample(SampLandLodBlend2Sampler, 3.0.xx * input.TexCoord0.zw).x;
@@ -2042,7 +2042,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		}
 		glintParameters = lerp(glintParameters, projectedGlintParameters, projectedMaterialWeight);
 #			elif defined(LOD_BLENDING) && (defined(LODOBJECTS) || defined(LODOBJECTSHD))
-		projBaseColor.xyz *= SharedData::lodBlendingSettings.LODObjectSnowBrightness;
+		projBaseColor.xyz = pow(abs(projBaseColor.xyz), SharedData::lodBlendingSettings.LODObjectSnowGamma) * SharedData::lodBlendingSettings.LODObjectSnowBrightness;
 #			endif  // TRUE_PBR
 		normal.xyz = lerp(normal.xyz, finalProjNormal, projectedMaterialWeight);
 		baseColor.xyz = lerp(baseColor.xyz, projBaseColor, projectedMaterialWeight);

--- a/src/Features/LODBlending.cpp
+++ b/src/Features/LODBlending.cpp
@@ -5,13 +5,19 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	LODTerrainBrightness,
 	LODObjectBrightness,
 	LODObjectSnowBrightness,
-	DisableTerrainVertexColors)
+	DisableTerrainVertexColors,
+	LODTerrainGamma,
+	LODObjectGamma,
+	LODObjectSnowGamma)
 
 void LODBlending::DrawSettings()
 {
-	ImGui::SliderFloat("LOD Terrain Brightness", &settings.LODTerrainBrightness, 0.01f, 2.f, "%.2f");
-	ImGui::SliderFloat("LOD Object Brightness", &settings.LODObjectBrightness, 0.01f, 2.f, "%.2f");
-	ImGui::SliderFloat("LOD Object Snow Brightness", &settings.LODObjectSnowBrightness, 0.01f, 2.f, "%.2f");
+	ImGui::SliderFloat("LOD Terrain Brightness", &settings.LODTerrainBrightness, 0.01f, 5.f, "%.2f");
+	ImGui::SliderFloat("LOD Object Brightness", &settings.LODObjectBrightness, 0.01f, 5.f, "%.2f");
+	ImGui::SliderFloat("LOD Object Snow Brightness", &settings.LODObjectSnowBrightness, 0.01f, 5.f, "%.2f");
+	ImGui::SliderFloat("LOD Terrain Gamma", &settings.LODTerrainGamma, 0.1f, 3.f, "%.2f");
+	ImGui::SliderFloat("LOD Object Gamma", &settings.LODObjectGamma, 0.1f, 3.f, "%.2f");
+	ImGui::SliderFloat("LOD Object Snow Gamma", &settings.LODObjectSnowGamma, 0.1f, 3.f, "%.2f");
 	ImGui::Checkbox("Disable Terrain Vertex Colors", (bool*)&settings.DisableTerrainVertexColors);
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text(

--- a/src/Features/LODBlending.h
+++ b/src/Features/LODBlending.h
@@ -25,6 +25,10 @@ struct LODBlending : Feature
 		float LODObjectBrightness = 1;
 		float LODObjectSnowBrightness = 1;
 		uint DisableTerrainVertexColors = false;
+		float LODTerrainGamma = 1;
+		float LODObjectGamma = 1;
+		float LODObjectSnowGamma = 1;
+		float pad;
 	};
 
 	Settings settings;


### PR DESCRIPTION
This pull request adds gamma correction controls to the Level of Detail (LOD) blending system, allowing fine-tuning of gamma for terrain, objects, and object snow in addition to brightness. The changes include new shader parameters, UI controls, and serialization support for these gamma values, as well as updates to the shader logic to apply gamma correction during color blending.

**Gamma correction support for LOD blending:**

* Added new gamma parameters (`LODTerrainGamma`, `LODObjectGamma`, `LODObjectSnowGamma`) to the LOD blending settings struct in both the shader shared data (`SharedData.hlsli`) and C++ feature definition (`LODBlending.h`), with appropriate default values. [[1]](diffhunk://#diff-812c99694216d6c71752b796f8804075cf5652d1f32787207a1ff33e0f173c1eR146-R149) [[2]](diffhunk://#diff-ffdb3ee4f831a137d47e40077d6a6c9dcff23e432e877fb6fe37322f9cfca30cR28-R31)
* Updated the serialization macro and ImGui UI in `LODBlending.cpp` to support the new gamma parameters, including new sliders for gamma adjustment and expanded brightness slider ranges.

**Shader logic updates:**

* Modified LOD blending code in `Lighting.hlsl` to apply gamma correction using the new parameters before brightness scaling for terrain, objects, and object snow. This ensures colors are adjusted for gamma as well as brightness during blending. [[1]](diffhunk://#diff-fee9ea921e49c9a517b9ba5e6d3ff9bae2bd4dbbe5a91bfef21d64c4bb06b2a3L1832-R1832) [[2]](diffhunk://#diff-fee9ea921e49c9a517b9ba5e6d3ff9bae2bd4dbbe5a91bfef21d64c4bb06b2a3L1846-R1846) [[3]](diffhunk://#diff-fee9ea921e49c9a517b9ba5e6d3ff9bae2bd4dbbe5a91bfef21d64c4bb06b2a3L1948-R1948) [[4]](diffhunk://#diff-fee9ea921e49c9a517b9ba5e6d3ff9bae2bd4dbbe5a91bfef21d64c4bb06b2a3L2045-R2045)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gamma correction controls for LOD blending: separate gamma sliders for terrain, objects, and snow-affected objects (0.1–3.0), working alongside existing brightness controls for finer visual tuning.
* **Chores**
  * Settings for the new gamma controls are integrated so adjustments persist with other LOD blending options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->