### PR TITLE
feat(interior sun): force single shadow cascade option

### DIFF
--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -220,13 +220,9 @@ void Deferred::CopyShadowData()
 			static float* gShadowDistance = reinterpret_cast<float*>(REL::RelocationID(528314, 415263).address());
 			const float maxDistance = *gShadowDistance;
 
-			// Use a small offset for the first cascade to avoid near-plane issues
-			// Starting at exactly 0.0 can cause shadow artifacts very close to the player
-			constexpr float FIRST_CASCADE_START = 10.0f;
-
 			// Override the split distances in the buffer that shaders read from
 			shadowData->EndSplitDistances = { maxDistance, maxDistance, maxDistance, shadowData->EndSplitDistances.w };
-			shadowData->StartSplitDistances = { FIRST_CASCADE_START, maxDistance, maxDistance, shadowData->StartSplitDistances.w };
+			shadowData->StartSplitDistances = { 0.0f, maxDistance, maxDistance, shadowData->StartSplitDistances.w };
 
 			context->Unmap(perShadow->resource.get(), 0);
 		}

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -216,9 +216,8 @@ void Deferred::CopyShadowData()
 		if (SUCCEEDED(context->Map(perShadow->resource.get(), 0, D3D11_MAP_READ_WRITE, 0, &mapped))) {
 			auto* shadowData = static_cast<PerGeometry*>(mapped.pData);
 
-			// Get shadow distance from game global variable
-			static float* gShadowDistance = reinterpret_cast<float*>(REL::RelocationID(528314, 415263).address());
-			const float maxDistance = *gShadowDistance;
+			// Use the same interior shadow distance that we set in SetFrameCamera for consistency
+			const float maxDistance = *globals::features::interiorSun.gInteriorShadowDistance;
 
 			// Override the split distances in the buffer that shaders read from
 			shadowData->EndSplitDistances = { maxDistance, maxDistance, maxDistance, shadowData->EndSplitDistances.w };

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -220,9 +220,13 @@ void Deferred::CopyShadowData()
 			static float* gShadowDistance = reinterpret_cast<float*>(REL::RelocationID(528314, 415263).address());
 			const float maxDistance = *gShadowDistance;
 
+			// Use a small offset for the first cascade to avoid near-plane issues
+			// Starting at exactly 0.0 can cause shadow artifacts very close to the player
+			constexpr float FIRST_CASCADE_START = 10.0f;
+
 			// Override the split distances in the buffer that shaders read from
 			shadowData->EndSplitDistances = { maxDistance, maxDistance, maxDistance, shadowData->EndSplitDistances.w };
-			shadowData->StartSplitDistances = { 0.0f, maxDistance, maxDistance, shadowData->StartSplitDistances.w };
+			shadowData->StartSplitDistances = { FIRST_CASCADE_START, maxDistance, maxDistance, shadowData->StartSplitDistances.w };
 
 			context->Unmap(perShadow->resource.get(), 0);
 		}

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -210,21 +210,20 @@ void Deferred::CopyShadowData()
 	context->CSSetShader(nullptr, nullptr, 0);
 
 	// Apply interior sun single cascade fix by modifying the shadow buffer that shaders actually read
-	if (globals::features::interiorSun.loaded && globals::features::interiorSun.isInteriorWithSun && 
+	if (globals::features::interiorSun.loaded && globals::features::interiorSun.isInteriorWithSun &&
 		globals::features::interiorSun.settings.ForceSingleShadowCascade) {
-		
 		D3D11_MAPPED_SUBRESOURCE mapped;
 		if (SUCCEEDED(context->Map(perShadow->resource.get(), 0, D3D11_MAP_READ_WRITE, 0, &mapped))) {
 			auto* shadowData = static_cast<PerGeometry*>(mapped.pData);
-			
+
 			// Get shadow distance from game global variable
 			static float* gShadowDistance = reinterpret_cast<float*>(REL::RelocationID(528314, 415263).address());
 			const float maxDistance = *gShadowDistance;
-			
+
 			// Override the split distances in the buffer that shaders read from
 			shadowData->EndSplitDistances = { maxDistance, maxDistance, maxDistance, shadowData->EndSplitDistances.w };
 			shadowData->StartSplitDistances = { 0.0f, maxDistance, maxDistance, shadowData->StartSplitDistances.w };
-			
+
 			context->Unmap(perShadow->resource.get(), 0);
 		}
 	}

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -8,6 +8,7 @@
 
 #include "Features/DynamicCubemaps.h"
 #include "Features/IBL.h"
+#include "Features/InteriorSun.h"
 #include "Features/ScreenSpaceGI.h"
 #include "Features/Skylighting.h"
 #include "Features/SubsurfaceScattering.h"
@@ -207,6 +208,26 @@ void Deferred::CopyShadowData()
 	context->CSSetConstantBuffers(0, 3, buffers);
 
 	context->CSSetShader(nullptr, nullptr, 0);
+
+	// Apply interior sun single cascade fix by modifying the shadow buffer that shaders actually read
+	if (globals::features::interiorSun.loaded && globals::features::interiorSun.isInteriorWithSun && 
+		globals::features::interiorSun.settings.ForceSingleShadowCascade) {
+		
+		D3D11_MAPPED_SUBRESOURCE mapped;
+		if (SUCCEEDED(context->Map(perShadow->resource.get(), 0, D3D11_MAP_READ_WRITE, 0, &mapped))) {
+			auto* shadowData = static_cast<PerGeometry*>(mapped.pData);
+			
+			// Get shadow distance from game global variable
+			static float* gShadowDistance = reinterpret_cast<float*>(REL::RelocationID(528314, 415263).address());
+			const float maxDistance = *gShadowDistance;
+			
+			// Override the split distances in the buffer that shaders read from
+			shadowData->EndSplitDistances = { maxDistance, maxDistance, maxDistance, shadowData->EndSplitDistances.w };
+			shadowData->StartSplitDistances = { 0.0f, maxDistance, maxDistance, shadowData->StartSplitDistances.w };
+			
+			context->Unmap(perShadow->resource.get(), 0);
+		}
+	}
 
 	{
 		context->PSGetShaderResources(4, 1, &shadowView);

--- a/src/EngineFixes/ShadowmapCascadeCullingFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeCullingFix.cpp
@@ -1,4 +1,6 @@
 ﻿#include "ShadowmapCascadeCullingFix.h"
+#include "Features/InteriorSun.h"
+#include "Globals.h"
 
 void ShadowmapCascadeCullingFix::Install()
 {
@@ -11,19 +13,31 @@ void ShadowmapCascadeCullingFix::BSShadowDirectionalLight_SetFrameCamera_BuildCa
 {
 	func(dirLight, outPlanes, frustumSplit, splitCornerIndices, numSplitCornerIndices, lightDir, cameraPos, cornerOffsetIndex);
 
-	// This fix pulls the far face corners back towards the near face corners by double fSplitOverlap to provide an effective overlap of 1 * fSplitOverlap in each direction.
-	// This corrects the vanilla behaviour which sets nearFace = farFace for the next cascade camera, where nearFace already includes +fSplitOverlap
-	// which incorrectly pushes out the culling for the next cascade camera causing shadow gaps even at the default fSplitOverlap of 100.
-	// This newly calculated farFace is not immediately used but will be copied into the nearFace for the next cascade camera and provide effective overlap.
+	auto& interiorSun = globals::features::interiorSun;
+	const bool isInteriorSun = interiorSun.loaded && interiorSun.isInteriorWithSun;
+	const bool singleCascadeMode = isInteriorSun && interiorSun.settings.ForceSingleShadowCascade;
 
-	const float splitOverlap = *gfSplitOverlap * 2.0f;
+	if (isInteriorSun) {
+		// DISABLE frustum culling entirely for ALL interior sun scenarios
+		// This allows geometry outside the view (like windows above/behind the camera)
+		// to still cast shadows and produce volumetric lighting effects
+		// The room/portal system already handles coarse culling via DirShadowLightCulling
+		outPlanes.activePlanes = static_cast<RE::NiFrustumPlanes::ActivePlane>(0);
+	} else if (!singleCascadeMode) {
+		// This fix pulls the far face corners back towards the near face corners by double fSplitOverlap to provide an effective overlap of 1 * fSplitOverlap in each direction.
+		// This corrects the vanilla behaviour which sets nearFace = farFace for the next cascade camera, where nearFace already includes +fSplitOverlap
+		// which incorrectly pushes out the culling for the next cascade camera causing shadow gaps even at the default fSplitOverlap of 100.
+		// This newly calculated farFace is not immediately used but will be copied into the nearFace for the next cascade camera and provide effective overlap.
 
-	for (uint32_t i = 0; i < 4; ++i) {
-		auto& nearCorner = frustumSplit.nearFace[i];
-		auto& farCorner = frustumSplit.farFace[i];
-		auto dir = farCorner - nearCorner;
-		dir.Unitize();
+		const float splitOverlap = *gfSplitOverlap * 2.0f;
 
-		farCorner -= dir * splitOverlap;
+		for (uint32_t i = 0; i < 4; ++i) {
+			auto& nearCorner = frustumSplit.nearFace[i];
+			auto& farCorner = frustumSplit.farFace[i];
+			auto dir = farCorner - nearCorner;
+			dir.Unitize();
+
+			farCorner -= dir * splitOverlap;
+		}
 	}
 }

--- a/src/EngineFixes/ShadowmapCascadeCullingFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeCullingFix.cpp
@@ -1,6 +1,4 @@
 ﻿#include "ShadowmapCascadeCullingFix.h"
-#include "Features/InteriorSun.h"
-#include "Globals.h"
 
 void ShadowmapCascadeCullingFix::Install()
 {
@@ -13,31 +11,19 @@ void ShadowmapCascadeCullingFix::BSShadowDirectionalLight_SetFrameCamera_BuildCa
 {
 	func(dirLight, outPlanes, frustumSplit, splitCornerIndices, numSplitCornerIndices, lightDir, cameraPos, cornerOffsetIndex);
 
-	auto& interiorSun = globals::features::interiorSun;
-	const bool isInteriorSun = interiorSun.loaded && interiorSun.isInteriorWithSun;
-	const bool singleCascadeMode = isInteriorSun && interiorSun.settings.ForceSingleShadowCascade;
+	// This fix pulls the far face corners back towards the near face corners by double fSplitOverlap to provide an effective overlap of 1 * fSplitOverlap in each direction.
+	// This corrects the vanilla behaviour which sets nearFace = farFace for the next cascade camera, where nearFace already includes +fSplitOverlap
+	// which incorrectly pushes out the culling for the next cascade camera causing shadow gaps even at the default fSplitOverlap of 100.
+	// This newly calculated farFace is not immediately used but will be copied into the nearFace for the next cascade camera and provide effective overlap.
 
-	if (isInteriorSun) {
-		// DISABLE frustum culling entirely for ALL interior sun scenarios
-		// This allows geometry outside the view (like windows above/behind the camera)
-		// to still cast shadows and produce volumetric lighting effects
-		// The room/portal system already handles coarse culling via DirShadowLightCulling
-		outPlanes.activePlanes = static_cast<RE::NiFrustumPlanes::ActivePlane>(0);
-	} else if (!singleCascadeMode) {
-		// This fix pulls the far face corners back towards the near face corners by double fSplitOverlap to provide an effective overlap of 1 * fSplitOverlap in each direction.
-		// This corrects the vanilla behaviour which sets nearFace = farFace for the next cascade camera, where nearFace already includes +fSplitOverlap
-		// which incorrectly pushes out the culling for the next cascade camera causing shadow gaps even at the default fSplitOverlap of 100.
-		// This newly calculated farFace is not immediately used but will be copied into the nearFace for the next cascade camera and provide effective overlap.
+	const float splitOverlap = *gfSplitOverlap * 2.0f;
 
-		const float splitOverlap = *gfSplitOverlap * 2.0f;
+	for (uint32_t i = 0; i < 4; ++i) {
+		auto& nearCorner = frustumSplit.nearFace[i];
+		auto& farCorner = frustumSplit.farFace[i];
+		auto dir = farCorner - nearCorner;
+		dir.Unitize();
 
-		for (uint32_t i = 0; i < 4; ++i) {
-			auto& nearCorner = frustumSplit.nearFace[i];
-			auto& farCorner = frustumSplit.farFace[i];
-			auto dir = farCorner - nearCorner;
-			dir.Unitize();
-
-			farCorner -= dir * splitOverlap;
-		}
+		farCorner -= dir * splitOverlap;
 	}
 }

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -81,7 +81,7 @@ void InteriorSun::PostPostLoad()
 void InteriorSun::EarlyPrepass()
 {
 	isInteriorWithSun = IsInteriorWithSun(RE::TES::GetSingleton()->interiorCell);
-	
+
 	// Force interior shadow distance to 8000 if it doesn't match (overrides INI value)
 	if (gInteriorShadowDistance && *gInteriorShadowDistance != INTERIOR_SHADOW_DISTANCE) {
 		*gInteriorShadowDistance = INTERIOR_SHADOW_DISTANCE;

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -120,6 +120,7 @@ void InteriorSun::EarlyPrepass()
 	isInteriorWithSun = IsInteriorWithSun(RE::TES::GetSingleton()->interiorCell);
 
 	// Continuously force interior shadow distance to override INI value
+	// Force interior shadow distance to 8000 if it doesn't match (overrides INI value)
 	if (gInteriorShadowDistance && *gInteriorShadowDistance != INTERIOR_SHADOW_DISTANCE) {
 		logger::info("[Interior Sun] EarlyPrepass detected wrong shadow distance: {}, forcing to {}", 
 			*gInteriorShadowDistance, INTERIOR_SHADOW_DISTANCE);

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -34,6 +34,8 @@ void InteriorSun::DrawSettings()
 			"Sets the distance shadows are rendered at in interiors. "
 			"Lower values improve performance but may cause shadow popping and other visual issues.");
 	}
+	ImGui::TextWrapped("Note: Match this value to fInteriorShadowDistance in your SkyrimPrefs.ini. Minimum recommended: 5000 (lower values may cause visual bugs in large interiors).");
+	ImGui::Spacing();
 }
 
 void InteriorSun::LoadSettings(json& o_json)

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -24,7 +24,7 @@ void InteriorSun::DrawSettings()
 			"Prevents shadow quality degradation at distance, allowing smaller light-blocking masks. "
 			"Recommended for properly prepared interior spaces.");
 	}
-	if (ImGui::SliderFloat("Interior Shadow Distance", &settings.InteriorShadowDistance, 1000.0f, 8000.0f)) {
+	if (ImGui::SliderFloat("Interior Shadow Distance", &settings.InteriorShadowDistance, 3000.0f, 8000.0f)) { // min 3000, any less creates visual issues in most interiors.
 		*gInteriorShadowDistance = settings.InteriorShadowDistance;
 		auto tes = RE::TES::GetSingleton();
 		SetShadowDistance(tes && tes->interiorCell);
@@ -32,7 +32,7 @@ void InteriorSun::DrawSettings()
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text(
 			"Sets the distance shadows are rendered at in interiors. "
-			"Lower values provide higher quality shadows and improved performance but may cause distant interior spaces to light up incorrectly. ");
+			"Lower values improve performance but may cause shadow popping and other visual issues.");
 	}
 }
 

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -41,7 +41,7 @@ void InteriorSun::DrawSettings()
 	ImGui::Spacing();
 	ImGui::Separator();
 	ImGui::Text("Shadow Quality Settings (Advanced)");
-	
+
 	if (iShadowMapResolution) {
 		int shadowMapRes = iShadowMapResolution->GetSInt();
 		if (ImGui::SliderInt("Shadow Map Resolution", &shadowMapRes, 512, 8192, "%d")) {
@@ -353,32 +353,32 @@ bool InteriorSun::BSShadowDirectionalLight_SetFrameCamera::thunk(RE::BSShadowDir
 				cascadeCamera = shadowData.shadowmapDescriptors[0].camera;
 			}
 		}
-		
+
 		if (cascadeCamera) {
 			auto& frustum = cascadeCamera->GetRuntimeData2().viewFrustum;
-			
+
 			if (frustum.bOrtho) {
 				// Calculate current frustum dimensions
 				const float currentWidth = frustum.fRight - frustum.fLeft;
 				const float currentHeight = frustum.fTop - frustum.fBottom;
-				
+
 				// Scale factor to tighten frustum - smaller = higher texel density
 				// Use a percentage of the shadow distance for dynamic scaling
 				const float targetScale = 0.4f;  // 40% of original size = 2.5x texel density boost
-				
+
 				// Calculate center point
 				const float centerX = (frustum.fLeft + frustum.fRight) * 0.5f;
 				const float centerY = (frustum.fTop + frustum.fBottom) * 0.5f;
-				
+
 				// Apply scaling around center point
 				const float newHalfWidth = (currentWidth * targetScale) * 0.5f;
 				const float newHalfHeight = (currentHeight * targetScale) * 0.5f;
-				
+
 				frustum.fLeft = centerX - newHalfWidth;
 				frustum.fRight = centerX + newHalfWidth;
 				frustum.fTop = centerY + newHalfHeight;
 				frustum.fBottom = centerY - newHalfHeight;
-				
+
 				// Update the camera with modified frustum
 				RE::NiUpdateData updateData;
 				cascadeCamera->Update(updateData);

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -41,6 +41,40 @@ void InteriorSun::RestoreDefaultSettings()
 	settings = {};
 }
 
+void InteriorSun::Load()
+{
+	// Get BOTH shadow distance pointers
+	gShadowDistance = reinterpret_cast<float*>(REL::RelocationID(528314, 415263).address());
+	gInteriorShadowDistance = reinterpret_cast<float*>(REL::RelocationID(513755, 391724).address());
+	
+	logger::info("[Interior Sun] gShadowDistance: {:X} = {}", 
+		reinterpret_cast<uintptr_t>(gShadowDistance), *gShadowDistance);
+	logger::info("[Interior Sun] gInteriorShadowDistance: {:X} = {}", 
+		reinterpret_cast<uintptr_t>(gInteriorShadowDistance), *gInteriorShadowDistance);
+	
+	// Force BOTH to 8000 - the game might be reading from either one
+	*gShadowDistance = INTERIOR_SHADOW_DISTANCE;
+	*gInteriorShadowDistance = INTERIOR_SHADOW_DISTANCE;
+	
+	logger::info("[Interior Sun] Forced both shadow distances to {}", INTERIOR_SHADOW_DISTANCE);
+}
+
+void InteriorSun::DataLoaded()
+{
+	// This is called AFTER kDataLoaded, which is when the game loads INI values
+	// Force shadow distances again to override the INI values
+	if (gShadowDistance && gInteriorShadowDistance) {
+		logger::info("[Interior Sun] DataLoaded - Before: gShadowDistance={}, gInteriorShadowDistance={}", 
+			*gShadowDistance, *gInteriorShadowDistance);
+		
+		*gShadowDistance = INTERIOR_SHADOW_DISTANCE;
+		*gInteriorShadowDistance = INTERIOR_SHADOW_DISTANCE;
+		
+		logger::info("[Interior Sun] DataLoaded - After: gShadowDistance={}, gInteriorShadowDistance={}", 
+			*gShadowDistance, *gInteriorShadowDistance);
+	}
+}
+
 void InteriorSun::PostPostLoad()
 {
 	stl::write_thunk_call<BSBatchRenderer_RenderPassImmediately>(REL::RelocationID(100852, 107642).address() + REL::Relocate(0x29E, 0x28F));
@@ -59,10 +93,7 @@ void InteriorSun::PostPostLoad()
 	REL::safe_fill(REL::RelocationID(38900, 39946).address() + REL::Relocate(0x2CA, 0x22B), REL::NOP, REL::Module::IsAE() ? 6 : 2);
 
 	gShadowDistance = reinterpret_cast<float*>(REL::RelocationID(528314, 415263).address());
-	gInteriorShadowDistance = reinterpret_cast<float*>(REL::RelocationID(513755, 391724).address());
 
-	// Force interior shadow distance to 8000 to ensure consistency
-	*gInteriorShadowDistance = INTERIOR_SHADOW_DISTANCE;
 
 	// Patches BSShadowDirectionalLight::SetFrameCamera to read the correct shadow distance value in interior cells
 	// This redirects the vanilla code to use gInteriorShadowDistance instead of gShadowDistance for interiors
@@ -75,15 +106,23 @@ void InteriorSun::PostPostLoad()
 
 	rasterStateCullMode = globals::game::isVR ? &globals::game::shadowState->GetVRRuntimeData().rasterStateCullMode : &globals::game::shadowState->GetRuntimeData().rasterStateCullMode;
 
+	// Force both shadow distances again in case game loaded INI after Load()
+	*gShadowDistance = INTERIOR_SHADOW_DISTANCE;
+	*gInteriorShadowDistance = INTERIOR_SHADOW_DISTANCE;
+	logger::info("[Interior Sun] Re-forced shadow distances in PostPostLoad: gShadowDistance={}, gInteriorShadowDistance={}", 
+		*gShadowDistance, *gInteriorShadowDistance);
+
 	logger::info("[Interior Sun] Installed hooks");
 }
 
 void InteriorSun::EarlyPrepass()
 {
 	isInteriorWithSun = IsInteriorWithSun(RE::TES::GetSingleton()->interiorCell);
-	
-	// Force interior shadow distance to 8000 if it doesn't match (overrides INI value)
+
+	// Continuously force interior shadow distance to override INI value
 	if (gInteriorShadowDistance && *gInteriorShadowDistance != INTERIOR_SHADOW_DISTANCE) {
+		logger::info("[Interior Sun] EarlyPrepass detected wrong shadow distance: {}, forcing to {}", 
+			*gInteriorShadowDistance, INTERIOR_SHADOW_DISTANCE);
 		*gInteriorShadowDistance = INTERIOR_SHADOW_DISTANCE;
 	}
 }

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -244,7 +244,7 @@ void InteriorSun::SetShadowDistance(bool inInterior)
 bool InteriorSun::BSShadowDirectionalLight_SetFrameCamera::thunk(RE::BSShadowDirectionalLight* a_light, const RE::NiCamera& a_camera)
 {
 	auto& singleton = globals::features::interiorSun;
-	
+
 	// Save and disable frustum culling for interior sun to prevent view-dependent geometry culling
 	bool savedCullingStates = false;
 	if (singleton.loaded && singleton.isInteriorWithSun && a_light) {
@@ -264,10 +264,10 @@ bool InteriorSun::BSShadowDirectionalLight_SetFrameCamera::thunk(RE::BSShadowDir
 			savedCullingStates = true;
 		}
 	}
-	
+
 	// Call original function
 	bool result = func(a_light, a_camera);
-	
+
 	// Restore original culling process states
 	if (savedCullingStates && a_light) {
 		auto& runtimeData = a_light->GetShadowDirectionalLightRuntimeData();

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -191,11 +191,22 @@ void InteriorSun::PopulateReplacementJobArrays(RE::TESObjectCELL* cell, const RE
 
 	// Add extra rooms and portals that are in the direction of the sun
 	for (const auto& object : currentCellRoomsAndPortals) {
-		if (addedSet.find(object.get()) != addedSet.end() || !IsInSunDirectionAndWithinShadowDistance(object, lightDir, playerPos))
+		if (addedSet.find(object.get()) != addedSet.end())
 			continue;
 
-		addedSet.insert(object.get());
-		replacementJobArrays[count++ % jobArraySize].push_back(object);
+		// For single cascade mode, include ALL rooms/portals within shadow distance
+		// regardless of sun direction to prevent view-dependent culling issues
+		if (settings.ForceSingleShadowCascade) {
+			// Include EVERYTHING - no distance checks at all for maximum coverage
+			addedSet.insert(object.get());
+			replacementJobArrays[count++ % jobArraySize].push_back(object);
+		} else {
+			// Normal multi-cascade mode: only add if in sun direction
+			if (IsInSunDirectionAndWithinShadowDistance(object, lightDir, playerPos)) {
+				addedSet.insert(object.get());
+				replacementJobArrays[count++ % jobArraySize].push_back(object);
+			}
+		}
 	}
 
 	arraysCleared = false;

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -197,11 +197,9 @@ void InteriorSun::PopulateReplacementJobArrays(RE::TESObjectCELL* cell, const RE
 		// For single cascade mode, include ALL rooms/portals within shadow distance
 		// regardless of sun direction to prevent view-dependent culling issues
 		if (settings.ForceSingleShadowCascade) {
-			// Include EVERYTHING - no distance checks at all for maximum coverage
 			addedSet.insert(object.get());
 			replacementJobArrays[count++ % jobArraySize].push_back(object);
 		} else {
-			// Normal multi-cascade mode: only add if in sun direction
 			if (IsInSunDirectionAndWithinShadowDistance(object, lightDir, playerPos)) {
 				addedSet.insert(object.get());
 				replacementJobArrays[count++ % jobArraySize].push_back(object);

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -6,7 +6,8 @@
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	InteriorSun::Settings,
 	ForceDoubleSidedRendering,
-	InteriorShadowDistance)
+	InteriorShadowDistance,
+	ForceSingleShadowCascade)
 
 void InteriorSun::DrawSettings()
 {
@@ -15,6 +16,13 @@ void InteriorSun::DrawSettings()
 		ImGui::Text(
 			"Disables backface culling during sun shadowmap rendering in interiors. "
 			"Will prevent most light leaking through unmasked/unprepared interiors at a small performance cost. ");
+	}
+	ImGui::Checkbox("Force Single Shadow Cascade", &settings.ForceSingleShadowCascade);
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text(
+			"Forces the use of a single high-quality shadow cascade for interiors instead of multiple cascades. "
+			"Prevents shadow quality degradation at distance, allowing smaller light-blocking masks. "
+			"Recommended for properly prepared interior spaces.");
 	}
 	if (ImGui::SliderFloat("Interior Shadow Distance", &settings.InteriorShadowDistance, 1000.0f, 8000.0f)) {
 		*gInteriorShadowDistance = settings.InteriorShadowDistance;
@@ -67,6 +75,9 @@ void InteriorSun::PostPostLoad()
 	const std::uintptr_t address = REL::RelocationID(101499, 108496).address() + REL::Relocate(0xD62, 0xE6C, 0xE72);
 	const std::int32_t displacement = static_cast<std::int32_t>(reinterpret_cast<std::uintptr_t>(gShadowDistance) - (address + 8));
 	REL::safe_write(address + 4, &displacement, sizeof(displacement));
+
+	// Hook SetFrameCamera to modify shadow split distances for interior sun
+	stl::write_vfunc<0x10, BSShadowDirectionalLight_SetFrameCamera>(RE::VTABLE_BSShadowDirectionalLight[0]);
 
 	rasterStateCullMode = globals::game::isVR ? &globals::game::shadowState->GetVRRuntimeData().rasterStateCullMode : &globals::game::shadowState->GetRuntimeData().rasterStateCullMode;
 
@@ -217,4 +228,34 @@ void InteriorSun::SetShadowDistance(bool inInterior)
 	using func_t = decltype(SetShadowDistance);
 	static REL::Relocation<func_t> func{ REL::RelocationID(98978, 105631).address() };
 	func(inInterior);
+}
+
+bool InteriorSun::BSShadowDirectionalLight_SetFrameCamera::thunk(RE::BSShadowDirectionalLight* a_light, const RE::NiCamera& a_camera)
+{
+	// Call original function - it calculates the split distances
+	bool result = func(a_light, a_camera);
+
+	auto& singleton = globals::features::interiorSun;
+
+	// AFTER SetFrameCamera calculates splits, override them for interior sun if enabled
+	// These modified values will persist and be used when constant buffers are set up
+	if (result && singleton.loaded && singleton.isInteriorWithSun && singleton.settings.ForceSingleShadowCascade) {
+		auto& runtimeData = a_light->GetShadowDirectionalLightRuntimeData();
+		
+		// Force all cascades to use the maximum distance (effectively using only one cascade)
+		// This prevents shadow quality degradation at distance in interiors
+		const float maxDistance = *singleton.gShadowDistance;
+		
+		// Set all split distances to force a single high-quality cascade
+		// Cascade 0 covers the full range, cascades 1 and 2 are effectively disabled
+		runtimeData.endSplitDistances[0] = maxDistance;
+		runtimeData.endSplitDistances[1] = maxDistance;
+		runtimeData.endSplitDistances[2] = maxDistance;
+		
+		runtimeData.startSplitDistances[0] = 0.0f;
+		runtimeData.startSplitDistances[1] = maxDistance;  // Start beyond max, effectively disabled
+		runtimeData.startSplitDistances[2] = maxDistance;  // Start beyond max, effectively disabled
+	}
+
+	return result;
 }

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -37,6 +37,37 @@ void InteriorSun::DrawSettings()
 			"Higher values cover larger areas but reduce shadow quality. "
 			"Lower values improve quality but may not cover entire interior.");
 	}
+
+	ImGui::Spacing();
+	ImGui::Separator();
+	ImGui::Text("Shadow Quality Settings (Advanced)");
+	
+	if (iShadowMapResolution) {
+		int shadowMapRes = iShadowMapResolution->GetSInt();
+		if (ImGui::SliderInt("Shadow Map Resolution", &shadowMapRes, 512, 8192, "%d")) {
+			iShadowMapResolution->data.i = shadowMapRes;
+		}
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text(
+				"Resolution of the shadow map texture. "
+				"Higher values = sharper shadows but lower performance. "
+				"Affects ALL shadows in the game, not just interiors. "
+				"Requires game restart to take full effect.");
+		}
+	}
+
+	if (fFirstSliceDistance) {
+		float firstSlice = fFirstSliceDistance->GetFloat();
+		if (ImGui::SliderFloat("First Slice Distance", &firstSlice, 100.0f, 10000.0f, "%.0f")) {
+			fFirstSliceDistance->data.f = firstSlice;
+		}
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text(
+				"Distance of the first shadow cascade slice. "
+				"Lower values = better close-range shadow quality. "
+				"Only applies when not using Force Single Shadow Cascade.");
+		}
+	}
 }
 
 void InteriorSun::LoadSettings(json& o_json)
@@ -60,10 +91,21 @@ void InteriorSun::Load()
 	gShadowDistance = reinterpret_cast<float*>(REL::RelocationID(528314, 415263).address());
 	gInteriorShadowDistance = reinterpret_cast<float*>(REL::RelocationID(513755, 391724).address());
 
+	// Get INI settings
+	iShadowMapResolution = RE::GetINISetting("iShadowMapResolution:Display");
+	fFirstSliceDistance = RE::GetINISetting("fFirstSliceDistance:Display");
+
 	logger::info("[Interior Sun] gShadowDistance: {:X} = {}",
 		reinterpret_cast<uintptr_t>(gShadowDistance), *gShadowDistance);
 	logger::info("[Interior Sun] gInteriorShadowDistance: {:X} = {}",
 		reinterpret_cast<uintptr_t>(gInteriorShadowDistance), *gInteriorShadowDistance);
+
+	if (iShadowMapResolution) {
+		logger::info("[Interior Sun] iShadowMapResolution = {}", iShadowMapResolution->GetSInt());
+	}
+	if (fFirstSliceDistance) {
+		logger::info("[Interior Sun] fFirstSliceDistance = {}", fFirstSliceDistance->GetFloat());
+	}
 
 	// Force BOTH to user setting - the game might be reading from either one
 	*gShadowDistance = settings.InteriorShadowDistance;
@@ -311,6 +353,53 @@ bool InteriorSun::BSShadowDirectionalLight_SetFrameCamera::thunk(RE::BSShadowDir
 
 		runtimeData.startSplitDistances[2] = maxDistance;
 		runtimeData.endSplitDistances[2] = maxDistance;
+
+		// Adjust frustum bounds based on shadow distance for better quality
+		RE::NiPointer<RE::NiCamera> camera;
+		if (globals::game::isVR) {
+			auto& shadowData = a_light->GetVRRuntimeData();
+			if (!shadowData.shadowmapDescriptors.empty()) {
+				camera = shadowData.shadowmapDescriptors[0].camera;
+			}
+		} else {
+			auto& shadowData = a_light->GetRuntimeData();
+			if (!shadowData.shadowmapDescriptors.empty()) {
+				camera = shadowData.shadowmapDescriptors[0].camera;
+			}
+		}
+		
+		if (camera) {
+			auto& frustum = camera->GetRuntimeData2().viewFrustum;
+			
+			if (frustum.bOrtho) {
+				const float currentWidth = frustum.fRight - frustum.fLeft;
+				const float currentHeight = frustum.fTop - frustum.fBottom;
+				
+				// Tighten frustum for higher shadow resolution
+				// Scale with shadow distance but keep good quality at lower distances
+				const float targetFrustumSize = std::max(2500.0f, maxDistance * 0.6f);
+				
+				// Only tighten if current frustum is larger than target
+				if (currentWidth > targetFrustumSize || currentHeight > targetFrustumSize) {
+					const float maxDim = (currentWidth > currentHeight) ? currentWidth : currentHeight;
+					const float scale = targetFrustumSize / maxDim;
+					const float centerX = (frustum.fLeft + frustum.fRight) * 0.5f;
+					const float centerY = (frustum.fTop + frustum.fBottom) * 0.5f;
+					const float halfWidth = (currentWidth * scale) * 0.5f;
+					const float halfHeight = (currentHeight * scale) * 0.5f;
+					
+					frustum.fLeft = centerX - halfWidth;
+					frustum.fRight = centerX + halfWidth;
+					frustum.fTop = centerY + halfHeight;
+					frustum.fBottom = centerY - halfHeight;
+					frustum.fNear = 1.0f;
+					frustum.fFar = maxDistance;
+					
+					RE::NiUpdateData updateData;
+					camera->Update(updateData);
+				}
+			}
+		}
 	}
 
 	return result;

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -6,7 +6,6 @@
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	InteriorSun::Settings,
 	ForceDoubleSidedRendering,
-	InteriorShadowDistance,
 	ForceSingleShadowCascade)
 
 void InteriorSun::DrawSettings()
@@ -24,18 +23,7 @@ void InteriorSun::DrawSettings()
 			"Prevents shadow quality degradation at distance, allowing smaller light-blocking masks. "
 			"Recommended for properly prepared interior spaces.");
 	}
-	if (ImGui::SliderFloat("Interior Shadow Distance", &settings.InteriorShadowDistance, 3000.0f, 8000.0f)) {  // min 3000, any less creates visual issues in most interiors.
-		*gInteriorShadowDistance = settings.InteriorShadowDistance;
-		auto tes = RE::TES::GetSingleton();
-		SetShadowDistance(tes && tes->interiorCell);
-	}
-	if (auto _tt = Util::HoverTooltipWrapper()) {
-		ImGui::Text(
-			"Sets the distance shadows are rendered at in interiors. "
-			"Lower values improve performance but may cause shadow popping and other visual issues.");
-	}
-	ImGui::TextWrapped("Note: Match this value to fInteriorShadowDistance in your SkyrimPrefs.ini. Minimum recommended: 5000 (lower values may cause visual bugs in large interiors).");
-	ImGui::Spacing();
+	ImGui::TextDisabled("Interior Shadow Distance: %.0f (fixed)", INTERIOR_SHADOW_DISTANCE);
 }
 
 void InteriorSun::LoadSettings(json& o_json)
@@ -73,9 +61,13 @@ void InteriorSun::PostPostLoad()
 	gShadowDistance = reinterpret_cast<float*>(REL::RelocationID(528314, 415263).address());
 	gInteriorShadowDistance = reinterpret_cast<float*>(REL::RelocationID(513755, 391724).address());
 
+	// Force interior shadow distance to 8000 to ensure consistency
+	*gInteriorShadowDistance = INTERIOR_SHADOW_DISTANCE;
+
 	// Patches BSShadowDirectionalLight::SetFrameCamera to read the correct shadow distance value in interior cells
+	// This redirects the vanilla code to use gInteriorShadowDistance instead of gShadowDistance for interiors
 	const std::uintptr_t address = REL::RelocationID(101499, 108496).address() + REL::Relocate(0xD62, 0xE6C, 0xE72);
-	const std::int32_t displacement = static_cast<std::int32_t>(reinterpret_cast<std::uintptr_t>(gShadowDistance) - (address + 8));
+	const std::int32_t displacement = static_cast<std::int32_t>(reinterpret_cast<std::uintptr_t>(gInteriorShadowDistance) - (address + 8));
 	REL::safe_write(address + 4, &displacement, sizeof(displacement));
 
 	// Hook SetFrameCamera to modify shadow split distances for interior sun
@@ -89,6 +81,11 @@ void InteriorSun::PostPostLoad()
 void InteriorSun::EarlyPrepass()
 {
 	isInteriorWithSun = IsInteriorWithSun(RE::TES::GetSingleton()->interiorCell);
+	
+	// Force interior shadow distance to 8000 if it doesn't match (overrides INI value)
+	if (gInteriorShadowDistance && *gInteriorShadowDistance != INTERIOR_SHADOW_DISTANCE) {
+		*gInteriorShadowDistance = INTERIOR_SHADOW_DISTANCE;
+	}
 }
 
 inline bool InteriorSun::IsInteriorWithSun(const RE::TESObjectCELL* cell)
@@ -231,7 +228,7 @@ bool InteriorSun::IsInSunDirectionAndWithinShadowDistance(const RE::NiPointer<RE
 	const auto diff = object->worldBound.center - playerPos;
 	const float distance = diff.Length();
 	const float projection = lightDir.Dot(diff);
-	return projection >= -radius && (distance - radius) <= *gShadowDistance;
+	return projection >= -radius && (distance - radius) <= *gInteriorShadowDistance;
 }
 
 void InteriorSun::SetShadowDistance(bool inInterior)
@@ -246,16 +243,17 @@ bool InteriorSun::BSShadowDirectionalLight_SetFrameCamera::thunk(RE::BSShadowDir
 	auto& singleton = globals::features::interiorSun;
 
 	// Save and disable frustum culling for interior sun to prevent view-dependent geometry culling
+	// This allows geometry behind the camera to cast shadows, preventing light leaks
+	// Only do this when ForceSingleShadowCascade is enabled to avoid the straight-line light leak issue
 	bool savedCullingStates = false;
-	if (singleton.loaded && singleton.isInteriorWithSun && a_light) {
+	if (singleton.loaded && singleton.isInteriorWithSun && singleton.settings.ForceSingleShadowCascade && a_light) {
 		auto& runtimeData = a_light->GetShadowDirectionalLightRuntimeData();
 		if (runtimeData.cullingProcesses.data()) {
 			singleton.savedActivePlanes.clear();
 			for (auto& cullingProcessPtr : runtimeData.cullingProcesses) {
 				if (cullingProcessPtr) {
-					// Save original state
 					singleton.savedActivePlanes.push_back(cullingProcessPtr->planes.activePlanes);
-					// Disable all frustum planes
+					// Disable frustum culling to allow all geometry to cast shadows
 					cullingProcessPtr->planes.activePlanes = static_cast<RE::NiFrustumPlanes::ActivePlane>(0);
 				} else {
 					singleton.savedActivePlanes.push_back(static_cast<RE::NiFrustumPlanes::ActivePlane>(0));
@@ -265,7 +263,7 @@ bool InteriorSun::BSShadowDirectionalLight_SetFrameCamera::thunk(RE::BSShadowDir
 		}
 	}
 
-	// Call original function
+	// Call original function - it calculates the split distances
 	bool result = func(a_light, a_camera);
 
 	// Restore original culling process states
@@ -281,17 +279,20 @@ bool InteriorSun::BSShadowDirectionalLight_SetFrameCamera::thunk(RE::BSShadowDir
 		singleton.savedActivePlanes.clear();
 	}
 
-	// Override split distances for single cascade mode
+	// AFTER SetFrameCamera calculates splits, override them for interior sun if enabled
 	if (result && singleton.loaded && singleton.isInteriorWithSun && singleton.settings.ForceSingleShadowCascade) {
 		auto& runtimeData = a_light->GetShadowDirectionalLightRuntimeData();
-		const float maxDistance = *singleton.gShadowDistance;
+		const float maxDistance = *singleton.gInteriorShadowDistance;
 
+		// Cascade 0 covers the full range
 		runtimeData.endSplitDistances[0] = maxDistance;
-		runtimeData.endSplitDistances[1] = maxDistance;
-		runtimeData.endSplitDistances[2] = maxDistance;
-
 		runtimeData.startSplitDistances[0] = 0.0f;
+
+		// Cascades 1 and 2 start at maxDistance, effectively disabling them
+		runtimeData.endSplitDistances[1] = maxDistance;
 		runtimeData.startSplitDistances[1] = maxDistance;
+
+		runtimeData.endSplitDistances[2] = maxDistance;
 		runtimeData.startSplitDistances[2] = maxDistance;
 	}
 

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -245,67 +245,54 @@ bool InteriorSun::BSShadowDirectionalLight_SetFrameCamera::thunk(RE::BSShadowDir
 {
 	auto& singleton = globals::features::interiorSun;
 	
-	// Disable frustum culling for interior sun to prevent view-dependent geometry culling
-	// This ensures windows and other shadow-casting geometry remain visible to shadow rendering
+	// Save and disable frustum culling for interior sun to prevent view-dependent geometry culling
+	bool savedCullingStates = false;
 	if (singleton.loaded && singleton.isInteriorWithSun && a_light) {
 		auto& runtimeData = a_light->GetShadowDirectionalLightRuntimeData();
 		if (runtimeData.cullingProcesses.data()) {
+			singleton.savedActivePlanes.clear();
 			for (auto& cullingProcessPtr : runtimeData.cullingProcesses) {
 				if (cullingProcessPtr) {
+					// Save original state
+					singleton.savedActivePlanes.push_back(cullingProcessPtr->planes.activePlanes);
+					// Disable all frustum planes
 					cullingProcessPtr->planes.activePlanes = static_cast<RE::NiFrustumPlanes::ActivePlane>(0);
+				} else {
+					singleton.savedActivePlanes.push_back(static_cast<RE::NiFrustumPlanes::ActivePlane>(0));
 				}
 			}
+			savedCullingStates = true;
 		}
 	}
 	
-	// For interior sun, we need to modify the camera BEFORE the original function processes it
-	// The const_cast is necessary because we need to widen the frustum to prevent view-dependent culling
-	RE::NiFrustum originalFrustum{};
-	bool modifiedCamera = false;
-	
-	if (singleton.loaded && singleton.isInteriorWithSun) {
-		// Save original frustum and expand it massively for shadow rendering
-		auto* camera = const_cast<RE::NiCamera*>(&a_camera);
-		auto& frustum = camera->GetRuntimeData2().viewFrustum;
-		
-		originalFrustum = frustum;  // Save original
-		modifiedCamera = true;
-		
-		// Expand to near-omnidirectional to capture all geometry regardless of player view direction
-		frustum.fLeft = -10.0f;
-		frustum.fRight = 10.0f;
-		frustum.fTop = 10.0f;
-		frustum.fBottom = -10.0f;
-		// Keep near/far unchanged
-	}
-	
-	// Call original function with the (possibly modified) camera
+	// Call original function
 	bool result = func(a_light, a_camera);
 	
-	// Restore original camera frustum
-	if (modifiedCamera) {
-		auto* camera = const_cast<RE::NiCamera*>(&a_camera);
-		camera->GetRuntimeData2().viewFrustum = originalFrustum;
+	// Restore original culling process states
+	if (savedCullingStates && a_light) {
+		auto& runtimeData = a_light->GetShadowDirectionalLightRuntimeData();
+		if (runtimeData.cullingProcesses.data() && static_cast<size_t>(runtimeData.cullingProcesses.size()) == singleton.savedActivePlanes.size()) {
+			for (std::uint32_t i = 0; i < runtimeData.cullingProcesses.size(); ++i) {
+				if (runtimeData.cullingProcesses[i]) {
+					runtimeData.cullingProcesses[i]->planes.activePlanes = singleton.savedActivePlanes[i];
+				}
+			}
+		}
+		singleton.savedActivePlanes.clear();
 	}
 
-	// AFTER SetFrameCamera calculates splits, override them for interior sun if enabled
-	// These modified values will persist and be used when constant buffers are set up
+	// Override split distances for single cascade mode
 	if (result && singleton.loaded && singleton.isInteriorWithSun && singleton.settings.ForceSingleShadowCascade) {
 		auto& runtimeData = a_light->GetShadowDirectionalLightRuntimeData();
-
-		// Force all cascades to use the maximum distance (effectively using only one cascade)
-		// This prevents shadow quality degradation at distance in interiors
 		const float maxDistance = *singleton.gShadowDistance;
 
-		// Set all split distances to force a single high-quality cascade
-		// Cascade 0 covers the full range, cascades 1 and 2 are effectively disabled
 		runtimeData.endSplitDistances[0] = maxDistance;
 		runtimeData.endSplitDistances[1] = maxDistance;
 		runtimeData.endSplitDistances[2] = maxDistance;
 
 		runtimeData.startSplitDistances[0] = 0.0f;
-		runtimeData.startSplitDistances[1] = maxDistance;  // Start beyond max, effectively disabled
-		runtimeData.startSplitDistances[2] = maxDistance;  // Start beyond max, effectively disabled
+		runtimeData.startSplitDistances[1] = maxDistance;
+		runtimeData.startSplitDistances[2] = maxDistance;
 	}
 
 	return result;

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -24,7 +24,7 @@ void InteriorSun::DrawSettings()
 			"Prevents shadow quality degradation at distance, allowing smaller light-blocking masks. "
 			"Recommended for properly prepared interior spaces.");
 	}
-	if (ImGui::SliderFloat("Interior Shadow Distance", &settings.InteriorShadowDistance, 3000.0f, 8000.0f)) { // min 3000, any less creates visual issues in most interiors.
+	if (ImGui::SliderFloat("Interior Shadow Distance", &settings.InteriorShadowDistance, 3000.0f, 8000.0f)) {  // min 3000, any less creates visual issues in most interiors.
 		*gInteriorShadowDistance = settings.InteriorShadowDistance;
 		auto tes = RE::TES::GetSingleton();
 		SetShadowDistance(tes && tes->interiorCell);
@@ -241,17 +241,17 @@ bool InteriorSun::BSShadowDirectionalLight_SetFrameCamera::thunk(RE::BSShadowDir
 	// These modified values will persist and be used when constant buffers are set up
 	if (result && singleton.loaded && singleton.isInteriorWithSun && singleton.settings.ForceSingleShadowCascade) {
 		auto& runtimeData = a_light->GetShadowDirectionalLightRuntimeData();
-		
+
 		// Force all cascades to use the maximum distance (effectively using only one cascade)
 		// This prevents shadow quality degradation at distance in interiors
 		const float maxDistance = *singleton.gShadowDistance;
-		
+
 		// Set all split distances to force a single high-quality cascade
 		// Cascade 0 covers the full range, cascades 1 and 2 are effectively disabled
 		runtimeData.endSplitDistances[0] = maxDistance;
 		runtimeData.endSplitDistances[1] = maxDistance;
 		runtimeData.endSplitDistances[2] = maxDistance;
-		
+
 		runtimeData.startSplitDistances[0] = 0.0f;
 		runtimeData.startSplitDistances[1] = maxDistance;  // Start beyond max, effectively disabled
 		runtimeData.startSplitDistances[2] = maxDistance;  // Start beyond max, effectively disabled

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -46,16 +46,16 @@ void InteriorSun::Load()
 	// Get BOTH shadow distance pointers
 	gShadowDistance = reinterpret_cast<float*>(REL::RelocationID(528314, 415263).address());
 	gInteriorShadowDistance = reinterpret_cast<float*>(REL::RelocationID(513755, 391724).address());
-	
-	logger::info("[Interior Sun] gShadowDistance: {:X} = {}", 
+
+	logger::info("[Interior Sun] gShadowDistance: {:X} = {}",
 		reinterpret_cast<uintptr_t>(gShadowDistance), *gShadowDistance);
-	logger::info("[Interior Sun] gInteriorShadowDistance: {:X} = {}", 
+	logger::info("[Interior Sun] gInteriorShadowDistance: {:X} = {}",
 		reinterpret_cast<uintptr_t>(gInteriorShadowDistance), *gInteriorShadowDistance);
-	
+
 	// Force BOTH to 8000 - the game might be reading from either one
 	*gShadowDistance = INTERIOR_SHADOW_DISTANCE;
 	*gInteriorShadowDistance = INTERIOR_SHADOW_DISTANCE;
-	
+
 	logger::info("[Interior Sun] Forced both shadow distances to {}", INTERIOR_SHADOW_DISTANCE);
 }
 
@@ -64,13 +64,13 @@ void InteriorSun::DataLoaded()
 	// This is called AFTER kDataLoaded, which is when the game loads INI values
 	// Force shadow distances again to override the INI values
 	if (gShadowDistance && gInteriorShadowDistance) {
-		logger::info("[Interior Sun] DataLoaded - Before: gShadowDistance={}, gInteriorShadowDistance={}", 
+		logger::info("[Interior Sun] DataLoaded - Before: gShadowDistance={}, gInteriorShadowDistance={}",
 			*gShadowDistance, *gInteriorShadowDistance);
-		
+
 		*gShadowDistance = INTERIOR_SHADOW_DISTANCE;
 		*gInteriorShadowDistance = INTERIOR_SHADOW_DISTANCE;
-		
-		logger::info("[Interior Sun] DataLoaded - After: gShadowDistance={}, gInteriorShadowDistance={}", 
+
+		logger::info("[Interior Sun] DataLoaded - After: gShadowDistance={}, gInteriorShadowDistance={}",
 			*gShadowDistance, *gInteriorShadowDistance);
 	}
 }
@@ -94,7 +94,6 @@ void InteriorSun::PostPostLoad()
 
 	gShadowDistance = reinterpret_cast<float*>(REL::RelocationID(528314, 415263).address());
 
-
 	// Patches BSShadowDirectionalLight::SetFrameCamera to read the correct shadow distance value in interior cells
 	// This redirects the vanilla code to use gInteriorShadowDistance instead of gShadowDistance for interiors
 	const std::uintptr_t address = REL::RelocationID(101499, 108496).address() + REL::Relocate(0xD62, 0xE6C, 0xE72);
@@ -109,7 +108,7 @@ void InteriorSun::PostPostLoad()
 	// Force both shadow distances again in case game loaded INI after Load()
 	*gShadowDistance = INTERIOR_SHADOW_DISTANCE;
 	*gInteriorShadowDistance = INTERIOR_SHADOW_DISTANCE;
-	logger::info("[Interior Sun] Re-forced shadow distances in PostPostLoad: gShadowDistance={}, gInteriorShadowDistance={}", 
+	logger::info("[Interior Sun] Re-forced shadow distances in PostPostLoad: gShadowDistance={}, gInteriorShadowDistance={}",
 		*gShadowDistance, *gInteriorShadowDistance);
 
 	logger::info("[Interior Sun] Installed hooks");
@@ -122,7 +121,7 @@ void InteriorSun::EarlyPrepass()
 	// Continuously force interior shadow distance to override INI value
 	// Force interior shadow distance to 8000 if it doesn't match (overrides INI value)
 	if (gInteriorShadowDistance && *gInteriorShadowDistance != INTERIOR_SHADOW_DISTANCE) {
-		logger::info("[Interior Sun] EarlyPrepass detected wrong shadow distance: {}, forcing to {}", 
+		logger::info("[Interior Sun] EarlyPrepass detected wrong shadow distance: {}, forcing to {}",
 			*gInteriorShadowDistance, INTERIOR_SHADOW_DISTANCE);
 		*gInteriorShadowDistance = INTERIOR_SHADOW_DISTANCE;
 	}

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -6,7 +6,8 @@
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	InteriorSun::Settings,
 	ForceDoubleSidedRendering,
-	ForceSingleShadowCascade)
+	ForceSingleShadowCascade,
+	InteriorShadowDistance)
 
 void InteriorSun::DrawSettings()
 {
@@ -23,7 +24,19 @@ void InteriorSun::DrawSettings()
 			"Prevents shadow quality degradation at distance, allowing smaller light-blocking masks. "
 			"Recommended for properly prepared interior spaces.");
 	}
-	ImGui::TextDisabled("Interior Shadow Distance: %.0f (fixed)", INTERIOR_SHADOW_DISTANCE);
+	if (ImGui::SliderFloat("Interior Shadow Distance", &settings.InteriorShadowDistance, MIN_SHADOW_DISTANCE, MAX_SHADOW_DISTANCE, "%.0f")) {
+		// Update both shadow distance pointers when slider changes
+		if (gShadowDistance && gInteriorShadowDistance) {
+			*gShadowDistance = settings.InteriorShadowDistance;
+			*gInteriorShadowDistance = settings.InteriorShadowDistance;
+		}
+	}
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text(
+			"Maximum distance for interior sun shadows. "
+			"Higher values cover larger areas but reduce shadow quality. "
+			"Lower values improve quality but may not cover entire interior.");
+	}
 }
 
 void InteriorSun::LoadSettings(json& o_json)
@@ -52,11 +65,11 @@ void InteriorSun::Load()
 	logger::info("[Interior Sun] gInteriorShadowDistance: {:X} = {}",
 		reinterpret_cast<uintptr_t>(gInteriorShadowDistance), *gInteriorShadowDistance);
 
-	// Force BOTH to 8000 - the game might be reading from either one
-	*gShadowDistance = INTERIOR_SHADOW_DISTANCE;
-	*gInteriorShadowDistance = INTERIOR_SHADOW_DISTANCE;
+	// Force BOTH to user setting - the game might be reading from either one
+	*gShadowDistance = settings.InteriorShadowDistance;
+	*gInteriorShadowDistance = settings.InteriorShadowDistance;
 
-	logger::info("[Interior Sun] Forced both shadow distances to {}", INTERIOR_SHADOW_DISTANCE);
+	logger::info("[Interior Sun] Forced both shadow distances to {}", settings.InteriorShadowDistance);
 }
 
 void InteriorSun::DataLoaded()
@@ -67,8 +80,8 @@ void InteriorSun::DataLoaded()
 		logger::info("[Interior Sun] DataLoaded - Before: gShadowDistance={}, gInteriorShadowDistance={}",
 			*gShadowDistance, *gInteriorShadowDistance);
 
-		*gShadowDistance = INTERIOR_SHADOW_DISTANCE;
-		*gInteriorShadowDistance = INTERIOR_SHADOW_DISTANCE;
+		*gShadowDistance = settings.InteriorShadowDistance;
+		*gInteriorShadowDistance = settings.InteriorShadowDistance;
 
 		logger::info("[Interior Sun] DataLoaded - After: gShadowDistance={}, gInteriorShadowDistance={}",
 			*gShadowDistance, *gInteriorShadowDistance);
@@ -106,8 +119,8 @@ void InteriorSun::PostPostLoad()
 	rasterStateCullMode = globals::game::isVR ? &globals::game::shadowState->GetVRRuntimeData().rasterStateCullMode : &globals::game::shadowState->GetRuntimeData().rasterStateCullMode;
 
 	// Force both shadow distances again in case game loaded INI after Load()
-	*gShadowDistance = INTERIOR_SHADOW_DISTANCE;
-	*gInteriorShadowDistance = INTERIOR_SHADOW_DISTANCE;
+	*gShadowDistance = settings.InteriorShadowDistance;
+	*gInteriorShadowDistance = settings.InteriorShadowDistance;
 	logger::info("[Interior Sun] Re-forced shadow distances in PostPostLoad: gShadowDistance={}, gInteriorShadowDistance={}",
 		*gShadowDistance, *gInteriorShadowDistance);
 
@@ -119,11 +132,10 @@ void InteriorSun::EarlyPrepass()
 	isInteriorWithSun = IsInteriorWithSun(RE::TES::GetSingleton()->interiorCell);
 
 	// Continuously force interior shadow distance to override INI value
-	// Force interior shadow distance to 8000 if it doesn't match (overrides INI value)
-	if (gInteriorShadowDistance && *gInteriorShadowDistance != INTERIOR_SHADOW_DISTANCE) {
+	if (gInteriorShadowDistance && *gInteriorShadowDistance != settings.InteriorShadowDistance) {
 		logger::info("[Interior Sun] EarlyPrepass detected wrong shadow distance: {}, forcing to {}",
-			*gInteriorShadowDistance, INTERIOR_SHADOW_DISTANCE);
-		*gInteriorShadowDistance = INTERIOR_SHADOW_DISTANCE;
+			*gInteriorShadowDistance, settings.InteriorShadowDistance);
+		*gInteriorShadowDistance = settings.InteriorShadowDistance;
 	}
 }
 
@@ -281,58 +293,24 @@ bool InteriorSun::BSShadowDirectionalLight_SetFrameCamera::thunk(RE::BSShadowDir
 {
 	auto& singleton = globals::features::interiorSun;
 
-	// Save and disable frustum culling for interior sun to prevent view-dependent geometry culling
-	// This allows geometry behind the camera to cast shadows, preventing light leaks
-	// Only do this when ForceSingleShadowCascade is enabled to avoid the straight-line light leak issue
-	bool savedCullingStates = false;
-	if (singleton.loaded && singleton.isInteriorWithSun && singleton.settings.ForceSingleShadowCascade && a_light) {
-		auto& runtimeData = a_light->GetShadowDirectionalLightRuntimeData();
-		if (runtimeData.cullingProcesses.data()) {
-			singleton.savedActivePlanes.clear();
-			for (auto& cullingProcessPtr : runtimeData.cullingProcesses) {
-				if (cullingProcessPtr) {
-					singleton.savedActivePlanes.push_back(cullingProcessPtr->planes.activePlanes);
-					// Disable frustum culling to allow all geometry to cast shadows
-					cullingProcessPtr->planes.activePlanes = static_cast<RE::NiFrustumPlanes::ActivePlane>(0);
-				} else {
-					singleton.savedActivePlanes.push_back(static_cast<RE::NiFrustumPlanes::ActivePlane>(0));
-				}
-			}
-			savedCullingStates = true;
-		}
-	}
-
 	// Call original function - it calculates the split distances
 	bool result = func(a_light, a_camera);
-
-	// Restore original culling process states
-	if (savedCullingStates && a_light) {
-		auto& runtimeData = a_light->GetShadowDirectionalLightRuntimeData();
-		if (runtimeData.cullingProcesses.data() && static_cast<size_t>(runtimeData.cullingProcesses.size()) == singleton.savedActivePlanes.size()) {
-			for (std::uint32_t i = 0; i < runtimeData.cullingProcesses.size(); ++i) {
-				if (runtimeData.cullingProcesses[i]) {
-					runtimeData.cullingProcesses[i]->planes.activePlanes = singleton.savedActivePlanes[i];
-				}
-			}
-		}
-		singleton.savedActivePlanes.clear();
-	}
 
 	// AFTER SetFrameCamera calculates splits, override them for interior sun if enabled
 	if (result && singleton.loaded && singleton.isInteriorWithSun && singleton.settings.ForceSingleShadowCascade) {
 		auto& runtimeData = a_light->GetShadowDirectionalLightRuntimeData();
 		const float maxDistance = *singleton.gInteriorShadowDistance;
 
-		// Cascade 0 covers the full range
-		runtimeData.endSplitDistances[0] = maxDistance;
+		// Single cascade mode: cascade 0 covers the full range from 0 to maxDistance
 		runtimeData.startSplitDistances[0] = 0.0f;
+		runtimeData.endSplitDistances[0] = maxDistance;
 
-		// Cascades 1 and 2 start at maxDistance, effectively disabling them
-		runtimeData.endSplitDistances[1] = maxDistance;
+		// Disable cascades 1 and 2 by setting their ranges to maxDistance
 		runtimeData.startSplitDistances[1] = maxDistance;
+		runtimeData.endSplitDistances[1] = maxDistance;
 
-		runtimeData.endSplitDistances[2] = maxDistance;
 		runtimeData.startSplitDistances[2] = maxDistance;
+		runtimeData.endSplitDistances[2] = maxDistance;
 	}
 
 	return result;

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -335,8 +335,56 @@ bool InteriorSun::BSShadowDirectionalLight_SetFrameCamera::thunk(RE::BSShadowDir
 {
 	auto& singleton = globals::features::interiorSun;
 
-	// Call original function - it calculates the split distances
+	// Call original function first - it calculates everything
 	bool result = func(a_light, a_camera);
+
+	// AFTER SetFrameCamera completes, tighten the frustum bounds for cascade 0 in interior sun mode
+	if (result && singleton.loaded && singleton.isInteriorWithSun && singleton.settings.ForceSingleShadowCascade) {
+		// Access the first cascade camera
+		RE::NiPointer<RE::NiCamera> cascadeCamera;
+		if (globals::game::isVR) {
+			auto& shadowData = a_light->GetVRRuntimeData();
+			if (!shadowData.shadowmapDescriptors.empty()) {
+				cascadeCamera = shadowData.shadowmapDescriptors[0].camera;
+			}
+		} else {
+			auto& shadowData = a_light->GetRuntimeData();
+			if (!shadowData.shadowmapDescriptors.empty()) {
+				cascadeCamera = shadowData.shadowmapDescriptors[0].camera;
+			}
+		}
+		
+		if (cascadeCamera) {
+			auto& frustum = cascadeCamera->GetRuntimeData2().viewFrustum;
+			
+			if (frustum.bOrtho) {
+				// Calculate current frustum dimensions
+				const float currentWidth = frustum.fRight - frustum.fLeft;
+				const float currentHeight = frustum.fTop - frustum.fBottom;
+				
+				// Scale factor to tighten frustum - smaller = higher texel density
+				// Use a percentage of the shadow distance for dynamic scaling
+				const float targetScale = 0.4f;  // 40% of original size = 2.5x texel density boost
+				
+				// Calculate center point
+				const float centerX = (frustum.fLeft + frustum.fRight) * 0.5f;
+				const float centerY = (frustum.fTop + frustum.fBottom) * 0.5f;
+				
+				// Apply scaling around center point
+				const float newHalfWidth = (currentWidth * targetScale) * 0.5f;
+				const float newHalfHeight = (currentHeight * targetScale) * 0.5f;
+				
+				frustum.fLeft = centerX - newHalfWidth;
+				frustum.fRight = centerX + newHalfWidth;
+				frustum.fTop = centerY + newHalfHeight;
+				frustum.fBottom = centerY - newHalfHeight;
+				
+				// Update the camera with modified frustum
+				RE::NiUpdateData updateData;
+				cascadeCamera->Update(updateData);
+			}
+		}
+	}
 
 	// AFTER SetFrameCamera calculates splits, override them for interior sun if enabled
 	if (result && singleton.loaded && singleton.isInteriorWithSun && singleton.settings.ForceSingleShadowCascade) {
@@ -353,53 +401,6 @@ bool InteriorSun::BSShadowDirectionalLight_SetFrameCamera::thunk(RE::BSShadowDir
 
 		runtimeData.startSplitDistances[2] = maxDistance;
 		runtimeData.endSplitDistances[2] = maxDistance;
-
-		// Adjust frustum bounds based on shadow distance for better quality
-		RE::NiPointer<RE::NiCamera> camera;
-		if (globals::game::isVR) {
-			auto& shadowData = a_light->GetVRRuntimeData();
-			if (!shadowData.shadowmapDescriptors.empty()) {
-				camera = shadowData.shadowmapDescriptors[0].camera;
-			}
-		} else {
-			auto& shadowData = a_light->GetRuntimeData();
-			if (!shadowData.shadowmapDescriptors.empty()) {
-				camera = shadowData.shadowmapDescriptors[0].camera;
-			}
-		}
-		
-		if (camera) {
-			auto& frustum = camera->GetRuntimeData2().viewFrustum;
-			
-			if (frustum.bOrtho) {
-				const float currentWidth = frustum.fRight - frustum.fLeft;
-				const float currentHeight = frustum.fTop - frustum.fBottom;
-				
-				// Tighten frustum for higher shadow resolution
-				// Scale with shadow distance but keep good quality at lower distances
-				const float targetFrustumSize = std::max(2500.0f, maxDistance * 0.6f);
-				
-				// Only tighten if current frustum is larger than target
-				if (currentWidth > targetFrustumSize || currentHeight > targetFrustumSize) {
-					const float maxDim = (currentWidth > currentHeight) ? currentWidth : currentHeight;
-					const float scale = targetFrustumSize / maxDim;
-					const float centerX = (frustum.fLeft + frustum.fRight) * 0.5f;
-					const float centerY = (frustum.fTop + frustum.fBottom) * 0.5f;
-					const float halfWidth = (currentWidth * scale) * 0.5f;
-					const float halfHeight = (currentHeight * scale) * 0.5f;
-					
-					frustum.fLeft = centerX - halfWidth;
-					frustum.fRight = centerX + halfWidth;
-					frustum.fTop = centerY + halfHeight;
-					frustum.fBottom = centerY - halfHeight;
-					frustum.fNear = 1.0f;
-					frustum.fFar = maxDistance;
-					
-					RE::NiUpdateData updateData;
-					camera->Update(updateData);
-				}
-			}
-		}
 	}
 
 	return result;

--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -243,10 +243,50 @@ void InteriorSun::SetShadowDistance(bool inInterior)
 
 bool InteriorSun::BSShadowDirectionalLight_SetFrameCamera::thunk(RE::BSShadowDirectionalLight* a_light, const RE::NiCamera& a_camera)
 {
-	// Call original function - it calculates the split distances
-	bool result = func(a_light, a_camera);
-
 	auto& singleton = globals::features::interiorSun;
+	
+	// Disable frustum culling for interior sun to prevent view-dependent geometry culling
+	// This ensures windows and other shadow-casting geometry remain visible to shadow rendering
+	if (singleton.loaded && singleton.isInteriorWithSun && a_light) {
+		auto& runtimeData = a_light->GetShadowDirectionalLightRuntimeData();
+		if (runtimeData.cullingProcesses.data()) {
+			for (auto& cullingProcessPtr : runtimeData.cullingProcesses) {
+				if (cullingProcessPtr) {
+					cullingProcessPtr->planes.activePlanes = static_cast<RE::NiFrustumPlanes::ActivePlane>(0);
+				}
+			}
+		}
+	}
+	
+	// For interior sun, we need to modify the camera BEFORE the original function processes it
+	// The const_cast is necessary because we need to widen the frustum to prevent view-dependent culling
+	RE::NiFrustum originalFrustum{};
+	bool modifiedCamera = false;
+	
+	if (singleton.loaded && singleton.isInteriorWithSun) {
+		// Save original frustum and expand it massively for shadow rendering
+		auto* camera = const_cast<RE::NiCamera*>(&a_camera);
+		auto& frustum = camera->GetRuntimeData2().viewFrustum;
+		
+		originalFrustum = frustum;  // Save original
+		modifiedCamera = true;
+		
+		// Expand to near-omnidirectional to capture all geometry regardless of player view direction
+		frustum.fLeft = -10.0f;
+		frustum.fRight = 10.0f;
+		frustum.fTop = 10.0f;
+		frustum.fBottom = -10.0f;
+		// Keep near/far unchanged
+	}
+	
+	// Call original function with the (possibly modified) camera
+	bool result = func(a_light, a_camera);
+	
+	// Restore original camera frustum
+	if (modifiedCamera) {
+		auto* camera = const_cast<RE::NiCamera*>(&a_camera);
+		camera->GetRuntimeData2().viewFrustum = originalFrustum;
+	}
 
 	// AFTER SetFrameCamera calculates splits, override them for interior sun if enabled
 	// These modified values will persist and be used when constant buffers are set up

--- a/src/Features/InteriorSun.h
+++ b/src/Features/InteriorSun.h
@@ -34,12 +34,15 @@ public:
 	{
 		bool ForceDoubleSidedRendering = true;
 		bool ForceSingleShadowCascade = true;
+		float InteriorShadowDistance = 8000.0f;
 	};
 
 	Settings settings;
 
 	bool isInteriorWithSun = false;
-	static constexpr float INTERIOR_SHADOW_DISTANCE = 8000.0f;
+	static constexpr float MIN_SHADOW_DISTANCE = 3000.0f;
+	static constexpr float MAX_SHADOW_DISTANCE = 15000.0f;
+	static constexpr float DEFAULT_SHADOW_DISTANCE = 8000.0f;
 
 	struct GetWorldSpace
 	{
@@ -98,9 +101,6 @@ private:
 	RE::BSTArray<RE::NiPointer<RE::NiAVObject>> currentCellRoomsAndPortals = {};
 	RE::BSTArray<RE::BSTArray<RE::NiPointer<RE::NiAVObject>>> replacementJobArrays = {};
 	eastl::hash_set<RE::NiAVObject*> addedSet = {};
-
-	// Storage for saved culling process states
-	std::vector<REX::EnumSet<RE::NiFrustumPlanes::ActivePlane, std::uint32_t>> savedActivePlanes = {};
 
 	static RE::TESWorldSpace* enableInteriorSun;
 	static RE::TESWorldSpace* disableInteriorSun;

--- a/src/Features/InteriorSun.h
+++ b/src/Features/InteriorSun.h
@@ -93,6 +93,8 @@ private:
 
 	float* gShadowDistance = nullptr;
 	float* gInteriorShadowDistance = nullptr;
+	RE::Setting* iShadowMapResolution = nullptr;
+	RE::Setting* fFirstSliceDistance = nullptr;
 	uint32_t* rasterStateCullMode = nullptr;
 
 	RE::TESObjectCELL* currentCell = nullptr;

--- a/src/Features/InteriorSun.h
+++ b/src/Features/InteriorSun.h
@@ -39,7 +39,6 @@ public:
 	bool isInteriorWithSun = false;
 	static constexpr float INTERIOR_SHADOW_DISTANCE = 8000.0f;
 
-
 	struct GetWorldSpace
 	{
 		static RE::TESWorldSpace* thunk(RE::TES* tes);

--- a/src/Features/InteriorSun.h
+++ b/src/Features/InteriorSun.h
@@ -32,6 +32,7 @@ public:
 	{
 		bool ForceDoubleSidedRendering = true;
 		float InteriorShadowDistance = 5000;
+		bool ForceSingleShadowCascade = true;
 	};
 
 	Settings settings;
@@ -53,6 +54,12 @@ public:
 	struct BSBatchRenderer_RenderPassImmediately
 	{
 		static void thunk(RE::BSRenderPass* a_pass, uint32_t a_technique, bool a_alphaTest, uint32_t a_renderFlags);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	struct BSShadowDirectionalLight_SetFrameCamera
+	{
+		static bool thunk(RE::BSShadowDirectionalLight* a_light, const RE::NiCamera& a_camera);
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 

--- a/src/Features/InteriorSun.h
+++ b/src/Features/InteriorSun.h
@@ -25,6 +25,8 @@ public:
 	virtual void SaveSettings(json& o_json) override;
 	virtual void RestoreDefaultSettings() override;
 	virtual bool SupportsVR() override { return true; }
+	virtual void Load() override;
+	virtual void DataLoaded() override;
 	virtual void PostPostLoad() override;
 	virtual void EarlyPrepass() override;
 

--- a/src/Features/InteriorSun.h
+++ b/src/Features/InteriorSun.h
@@ -97,6 +97,9 @@ private:
 	RE::BSTArray<RE::BSTArray<RE::NiPointer<RE::NiAVObject>>> replacementJobArrays = {};
 	eastl::hash_set<RE::NiAVObject*> addedSet = {};
 
+	// Storage for saved culling process states
+	std::vector<REX::EnumSet<RE::NiFrustumPlanes::ActivePlane, std::uint32_t>> savedActivePlanes = {};
+
 	static RE::TESWorldSpace* enableInteriorSun;
 	static RE::TESWorldSpace* disableInteriorSun;
 

--- a/src/Features/InteriorSun.h
+++ b/src/Features/InteriorSun.h
@@ -31,13 +31,14 @@ public:
 	struct Settings
 	{
 		bool ForceDoubleSidedRendering = true;
-		float InteriorShadowDistance = 5000;
 		bool ForceSingleShadowCascade = true;
 	};
 
 	Settings settings;
 
 	bool isInteriorWithSun = false;
+	static constexpr float INTERIOR_SHADOW_DISTANCE = 8000.0f;
+
 
 	struct GetWorldSpace
 	{


### PR DESCRIPTION
1. Adds an optional "ForceSingleShadowCascade" button to Interior Sun Shadows that sets the first cascade for the shadow maps to be the max distance and disables the additional cascades, essentially making the resolution for the interior shadows maximum for the entire distance. This removes previous issues of bleed, light leaking, etc, and also increases the quality of the shadows dramatically with minimal performance degradation. Also makes VL actually visible where it should be, whereas previously the cascades hid this. 

2. Removes fulstrum culling when ForceSingleShadowCascade=true which caused dramatic light leaks and missing lights in certain viewing angles.

3. Streamlines gInteriorShadowDistance and gShadowDistance usage to stop bad ini values breaking the effect. Also means the slider in the UI actually controls everything it is meant to.

Logic behind keeping as toggle is for backward compatibility, some mods may be designed around shadow cascades, or users can opt to disable it for performance.

Increase to minimum shadow distance interior to 3000 units, as 1000 was awful in any room bigger than a shop would cause dramatic visual artifacts, VL bleed/explosions, etc. Fixed description for this, the quality is NOT better with lower distance (due to cascade fix now).

Disabled/Enabled.

![205D7B~1](https://github.com/user-attachments/assets/62cdda7b-8e87-4fab-929e-7ff977bccf88)
![201A17~1](https://github.com/user-attachments/assets/3213c87c-770c-402b-a41d-ce4dc7b1e2ab)

![2076DF~1](https://github.com/user-attachments/assets/bed7963b-9e72-4f86-8c27-fd5beadcdb9a)
![204E93~1](https://github.com/user-attachments/assets/1be6a3b0-b140-47ce-83ce-70ed2e0393c0)

<img width="1499" height="943" alt="image" src="https://github.com/user-attachments/assets/cb11e376-a188-4ab9-8cb7-dc3606eb6771" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Force Single Shadow Cascade" toggle for interior sun to enforce a single high-quality shadow cascade.

* **Improvements**
  * Increased interior shadow distance range (min raised to 3000 units) and clarified tooltips.
  * Shadow processing now preserves/restores culling state to avoid visual artifacts.

* **Bug Fixes**
  * Fixed shadow data handling so shadow splits are correctly applied when single-cascade mode is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->