### PR TITLE
fix(perf-overlay): fix infinite draw calls table height

### DIFF
--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -375,6 +375,7 @@ namespace Util
 	 *        Each function should compare two rows and return true if the first should come before the second.
 	 * @param cellRender Function to render a cell: (rowIdx, colIdx, const T& row).
 	 * @param footerRows Optional static footer rows (not sorted, rendered after main rows).
+	 * @param outerSize Optional outer size for the table (0,0 = auto-size).
 	 */
 	template <typename T>
 	void ShowSortedStringTableCustom(
@@ -385,10 +386,16 @@ namespace Util
 		bool ascending,
 		const std::vector<std::function<bool(const T&, const T&, bool)>>& customSorts,
 		std::function<void(int, int, const T&)> cellRender,
-		const std::vector<T>& footerRows = {})
+		const std::vector<T>& footerRows = {},
+		const ImVec2& outerSize = ImVec2(0, 0))
 	{
 		ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable | ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingStretchProp;
-		if (ImGui::BeginTable(table_id, static_cast<int>(headers.size()), flags)) {
+		ImVec2 tableSize = outerSize;
+		if (outerSize.y == 0.0f) {
+			size_t totalRows = rows.size() + footerRows.size();
+			tableSize.y = ImGui::GetTextLineHeightWithSpacing() * (static_cast<float>((totalRows < 15) ? totalRows : 15) + 1.2f);
+		}
+		if (ImGui::BeginTable(table_id, static_cast<int>(headers.size()), flags, tableSize)) {
 			// Set up columns with content-based sizing
 			for (size_t i = 0; i < headers.size(); ++i) {
 				ImGui::TableSetupColumn(headers[i].c_str());


### PR DESCRIPTION
fixes issue introduced in f9ab73825 that added ImGuiTableFlags_ScrollY without an outer size parameter, meaning the table goes too tall.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/6999137b-320d-4555-a9a7-ddd337ee9da3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced table display with improved sizing controls, including automatic height adjustment to fit content when not explicitly specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->