### PR TITLE
feat(perf-overlay): add size controls

### DIFF
--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -300,7 +300,8 @@ void PerformanceOverlay::DrawOverlay()
 		windowFlags |= ImGuiWindowFlags_NoBackground;
 	} else {
 		windowFlags &= ~ImGuiWindowFlags_NoDecoration;
-		windowFlags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize;
+		windowFlags &= ~ImGuiWindowFlags_AlwaysAutoResize;
+		windowFlags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse;
 	}
 
 	// Set background opacity


### PR DESCRIPTION
readds perf overlay size controls to be in line with every other menu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Performance Overlay window resizing behavior when borders are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->