### PR TITLE
fix(welcome-popup): adjust font size & window spacing

### DIFF
--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -267,8 +267,7 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 
 	ImGuiWindowFlags flags = ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
 	                         ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings |
-	                         ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoTitleBar |
-	                         ImGuiWindowFlags_AlwaysAutoResize;  // Prevent scrolling, remove title, auto-resize
+	                         ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize;
 
 	if (!ImGui::Begin("##FirstTimeSetup", nullptr, flags)) {
 		ImGui::PopStyleVar(2);
@@ -437,9 +436,8 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	ImGui::SetCursorPosX((windowWidth - helpWidth) * 0.5f);
 	ImGui::TextDisabled("%s", helpText);
 
-	ImGui::SetWindowFontScale(1.0f);  // Reset font scale
-	ImGui::PopStyleVar(2);            // Pop WindowRounding and WindowBorderSize
 	ImGui::End();
+	ImGui::PopStyleVar(2);
 }
 
 bool HomePageRenderer::ShouldShowFirstTimeSetup()

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -275,8 +275,12 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 		return;
 	}
 
-	// Set font scale for better readability in this welcome dialog
-	ImGui::SetWindowFontScale(SETUP_DIALOG_FONT_SCALE);
+	// Set absolute font size for better readability in this welcome dialog
+	ImGuiIO& io = ImGui::GetIO();
+	float targetFontSize = 27.0f;
+	float currentFontSize = io.FontDefault ? io.FontDefault->FontSize : io.FontGlobalScale * 13.0f;
+	float fontScale = targetFontSize / currentFontSize;
+	ImGui::SetWindowFontScale(fontScale);
 
 	auto menu = Menu::GetSingleton();
 

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -350,6 +350,9 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	auto& themeSettings = menu->GetTheme();
 	const char* currentKeyName = Util::Input::KeyIdToString(menu->GetSettings().ToggleKey);
 
+	// Increase font size for hotkey text
+	ImGui::SetWindowFontScale(fontScale * HOTKEY_TEXT_SCALE_MULTIPLIER);
+
 	// Calculate text dimensions for centering and button area
 	float hotkeyWidth = ImGui::CalcTextSize(currentKeyName).x;
 	float centerX = (windowWidth - hotkeyWidth) * 0.5f;

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -276,7 +276,6 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	}
 
 	// Set absolute font size for better readability in this welcome dialog
-	ImGuiIO& io = ImGui::GetIO();
 	float targetFontSize = 27.0f;
 	float currentFontSize = io.FontDefault ? io.FontDefault->FontSize : io.FontGlobalScale * 13.0f;
 	float fontScale = targetFontSize / currentFontSize;

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -381,6 +381,9 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 
 	ImGui::TextColored(hotkeyColor, "%s", currentKeyName);
 
+	// Reset font scale
+	ImGui::SetWindowFontScale(fontScale);
+
 	// Handle click to start hotkey capture
 	if (clicked) {
 		menu->settingToggleKey = true;

--- a/src/Menu/HomePageRenderer.h
+++ b/src/Menu/HomePageRenderer.h
@@ -8,9 +8,8 @@ public:
 	// Constants
 	static constexpr const char* DISCORD_URL = "https://discord.com/invite/nkrQybAsyy";
 	static constexpr float TITLE_FONT_SCALE = 2.0f;
-	static constexpr float SETUP_DIALOG_FONT_SCALE = 0.75f;
 	static constexpr float QUICK_LINKS_BUTTON_WIDTH = 180.0f;
-	static constexpr float LOGO_WATERMARK_HEIGHT = 260.0f;
+	static constexpr float LOGO_WATERMARK_HEIGHT = 200.0f;
 
 	// Discord banner scaling constants
 	static constexpr float DISCORD_BANNER_TARGET_WIDTH_RATIO = 0.85f;  // 25% of window width

--- a/src/Menu/HomePageRenderer.h
+++ b/src/Menu/HomePageRenderer.h
@@ -8,6 +8,7 @@ public:
 	// Constants
 	static constexpr const char* DISCORD_URL = "https://discord.com/invite/nkrQybAsyy";
 	static constexpr float TITLE_FONT_SCALE = 2.0f;
+	static constexpr float HOTKEY_TEXT_SCALE_MULTIPLIER = 1.25f;
 	static constexpr float QUICK_LINKS_BUTTON_WIDTH = 180.0f;
 	static constexpr float LOGO_WATERMARK_HEIGHT = 200.0f;
 


### PR DESCRIPTION
- fixes font size to be forced @ 27 instead of a scale applied to existing font size.
- fix height by removing noscrollbar, autosize works right now.
- hotkey choosing text larger, draws attention faster. (yellow "End" text).
- resized background logo to fit better

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved first-time setup dialog with dynamic font scaling adjustments for enhanced text hierarchy and readability.
  * Optimized hotkey text rendering with separate scaling controls for better visual distinction.
  * Reduced logo watermark size for improved proportional balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->