### PR TITLE
fix(perf-overlay): removed ImGuiTableFlags_ScrollX/Y for scroll bar issues

### DIFF
--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -389,7 +389,7 @@ namespace Util
 		const std::vector<T>& footerRows = {},
 		const ImVec2& outerSize = ImVec2(0, 0))
 	{
-		ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable | ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingStretchProp;
+		ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable | ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingStretchProp;
 		ImVec2 tableSize = outerSize;
 		if (outerSize.y == 0.0f) {
 			size_t totalRows = rows.size() + footerRows.size();
@@ -974,7 +974,7 @@ namespace Util
 		ImGui::BeginChild(containerId.c_str(), ImVec2(0, tableHeight), true, ImGuiWindowFlags_HorizontalScrollbar);
 		ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, ImVec2(4, 2));
 
-		ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable | ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingStretchProp;
+		ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable | ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingStretchProp;
 		if (ImGui::BeginTable(table_id, static_cast<int>(columns.size()), flags)) {
 			// Set up columns
 			for (size_t i = 0; i < columns.size(); ++i) {


### PR DESCRIPTION
Removed ImGuiTableFlags_ScrollX/Y from UI.h to correct the behaviour of ImGuiWindowFlags_NoInputs and stop scroll bars hiding elements of the performance overlay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified table display behavior to adjust default scrolling functionality. Tables will no longer enforce explicit horizontal and vertical scrolling flags, allowing sizing to be determined by container layout instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->