### PR TITLE
fix(grass): use correct light direction

### DIFF
--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -642,7 +642,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float3 sss = dirLightColor * saturate(-dirLightAngle);
 
 	if (complex)
-		lightsSpecularColor += GrassLighting::GetLightSpecularInput(DirLightDirection, viewDirection, normal, dirLightColor, SharedData::grassLightingSettings.Glossiness);
+		lightsSpecularColor += GrassLighting::GetLightSpecularInput(SharedData::DirLightDirection.xyz, viewDirection, normal, dirLightColor, SharedData::grassLightingSettings.Glossiness);
 #			endif
 
 #			if defined(LIGHT_LIMIT_FIX)


### PR DESCRIPTION
This pull request makes a minor update to the `RunGrass.hlsl` shader to ensure the correct directional light vector is used in specular lighting calculations. The change clarifies which value is passed to the `GrassLighting::GetLightSpecularInput` function, improving code correctness and maintainability.

- Lighting calculation fix:
  * Updated the call to `GrassLighting::GetLightSpecularInput` to use `SharedData::DirLightDirection.xyz` instead of `DirLightDirection`, ensuring the correct directional light vector is provided for specular lighting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed directional lighting for grass so specular highlights and shading match the scene light direction, improving visual consistency and realism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->