### PR TITLE
build: fix shader copying to relative paths

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -387,6 +387,37 @@ jobs:
               with:
                   vcpkgJsonGlob: vcpkg.json
 
+            - name: Locate fxc.exe
+              if: steps.check-hlsl.outputs.skip != 'true'
+              id: find_fxc
+              shell: pwsh
+              run: |
+                  # Try to find fxc.exe on PATH first
+                  $fxcCmd = Get-Command -Name fxc.exe -ErrorAction SilentlyContinue
+                  if ($fxcCmd) {
+                    $fxcPath = $fxcCmd.Source
+                    Write-Host "Found fxc.exe at $fxcPath"
+                    Add-Content -Path $env:GITHUB_OUTPUT -Value "fxc_path=$fxcPath"
+                  } else {
+                    # Try known Windows SDK locations (x64)
+                    $fxcPath = ''
+                    $sdkRoot = 'C:\Program Files (x86)\Windows Kits\10\bin'
+                    if (Test-Path $sdkRoot) {
+                      $versions = Get-ChildItem -Path $sdkRoot -Directory | Sort-Object -Descending
+                      foreach ($v in $versions) {
+                        $candidate = Join-Path $v.FullName 'x64\fxc.exe'
+                        if (Test-Path $candidate) { $fxcPath = $candidate; break }
+                      }
+                    }
+                    if ($fxcPath -ne '') {
+                      Write-Host "Found fxc.exe at $fxcPath"
+                      Add-Content -Path $env:GITHUB_OUTPUT -Value "fxc_path=$fxcPath"
+                    } else {
+                      Write-Warning "fxc.exe not found in PATH or common SDK locations"
+                      Add-Content -Path $env:GITHUB_OUTPUT -Value "fxc_path="
+                    }
+                  }
+
             - name: Cache CMake build output
               if: steps.check-hlsl.outputs.skip != 'true'
               uses: actions/cache@v4
@@ -437,7 +468,12 @@ jobs:
 
             - name: Validate shader compilation (${{ matrix.config.name }})
               if: steps.check-hlsl.outputs.skip != 'true'
-              run: hlslkit-compile --shader-dir build/ALL/aio/Shaders --output-dir build/ShaderCache --config ${{ matrix.config.file }} --max-warnings 0 --suppress-warnings X1519
+              run: |
+                  if [ -z "${{ steps.find_fxc.outputs.fxc_path }}" ]; then
+                    echo "fxc.exe not found - shader validation requires fxc.exe. Set --fxc to a valid path or ensure fxc.exe is in PATH." >&2
+                    exit 1
+                  fi
+                  hlslkit-compile --fxc "${{ steps.find_fxc.outputs.fxc_path }}" --shader-dir build/ALL/aio/Shaders --output-dir build/ShaderCache --config ${{ matrix.config.file }} --max-warnings 0 --suppress-warnings X1519
               shell: bash
 
             - name: Upload shader validation logs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,7 +473,9 @@ if(AUTO_PLUGIN_DEPLOYMENT OR AIO_ZIP_TO_DIST)
             get_filename_component(_feat_name "${_fpath}" NAME)
             foreach(_src IN LISTS _feat_shaders)
                 file(RELATIVE_PATH _rel "${_fpath}/Shaders" "${_src}")
-                set(_dst "${AIO_DIR}/Shaders/${_feat_name}/${_rel}")
+                # Place feature shader files directly under AIO_DIR/Shaders to preserve expected include paths
+                # This matches the package shader layout and ensures includes like "TerrainShadows/..." resolve correctly
+                set(_dst "${AIO_DIR}/Shaders/${_rel}")
                 get_filename_component(_dst_dir "${_dst}" DIRECTORY)
                 list(
                     APPEND


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced shader validation in the build workflow for Windows environments.
  * Streamlined shader file organization in the build output structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->