### PR TITLE
build: add HLSL intellisense

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,27 @@ if(CLANG_FORMAT_PATH)
 endif()
 
 # #######################################################################################################################
+# # HLSL additional include directories for VS intellisense
+# #######################################################################################################################
+
+set(HLSL_INCLUDE_DIRS ${FEATURE_SHADER_DIRS} "package/Shaders")
+
+set(HLSL_INCLUDE_JSON "")
+foreach(dir IN LISTS HLSL_INCLUDE_DIRS)
+    if(HLSL_INCLUDE_JSON STREQUAL "")
+        set(HLSL_INCLUDE_JSON "    \"${dir}\"")
+    else()
+        set(HLSL_INCLUDE_JSON "${HLSL_INCLUDE_JSON},\n    \"${dir}\"")
+    endif()
+endforeach()
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/shadertoolsconfig.json.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/shadertoolsconfig.json"
+    @ONLY
+)
+
+# #######################################################################################################################
 # # Shader validation config generation
 # #######################################################################################################################
 

--- a/cmake/shadertoolsconfig.json.in
+++ b/cmake/shadertoolsconfig.json.in
@@ -1,0 +1,8 @@
+{
+  "root":  true,
+  "hlsl.preprocessorDefinitions": {
+  },
+  "hlsl.additionalIncludeDirectories": [
+@HLSL_INCLUDE_JSON@
+  ]
+}


### PR DESCRIPTION
adds CMake 'shadertoolsconfig.json' generation from feature list which in turn allows intellisense to recognize CS includes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Visual Studio IntelliSense support for shader development with improved HLSL include directory configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->