### PR TITLE
fix(ui): enter key now behaves properly when first time popup is open

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -683,6 +683,13 @@ void Menu::ProcessInputEventQueue()
 				bool handled = false;
 				for (auto& h : hotkeyActions) {
 					if (*(h.settingFlag)) {
+						// During first-time setup, don't capture Enter or Escape as hotkeys
+						// These keys are reserved for closing the dialog
+						if (HomePageRenderer::ShouldShowFirstTimeSetup() && (key == VK_RETURN || key == VK_ESCAPE)) {
+							*(h.settingFlag) = false;  // Cancel hotkey capture mode
+							handled = true;
+							break;
+						}
 						h.action(key);
 						handled = true;
 						break;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where pressing Enter or Escape during first-time setup could unintentionally be registered as hotkey assignments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->