### PR TITLE
fix(snow): use world space vectors

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -289,7 +289,8 @@ VS_OUTPUT main(VS_INPUT input)
 	vsout.LandBlendWeights2.w = 1 - saturate(0.000375600968 * (9625.59961 - length(gridOffset)));
 	vsout.LandBlendWeights2.xyz = input.LandBlendWeights2.xyz;
 #	elif defined(PROJECTED_UV) && !defined(SKINNED)
-	vsout.TexProj = TextureProj[eyeIndex][2].xyz;
+	float3x3 texProjWorld3x3 = float3x3(World[eyeIndex][0].xyz, World[eyeIndex][1].xyz, World[eyeIndex][2].xyz);
+	vsout.TexProj = mul(texProjWorld3x3, TextureProj[eyeIndex][2].xyz);
 #	endif
 
 #	if defined(EYE)


### PR DESCRIPTION
Fix snow appearing on vertical surfaces facing certain directions

Snow projection was comparing model-space and world-space vectors directly, causing inconsistent results based on
object rotation. Some wall-mounted objects (like rugs) would incorrectly show snow depending on which compass
direction they faced.

Fixed by transforming the projection direction to world space before the comparison.
  
Easiest way I found to replicate this was to download https://www.nexusmods.com/skyrimspecialedition/mods/18223 and create a new character, speedrun into the house and look at the rug facing the east.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Rendering**
  * Improved texture projection coordinate transformation in shader processing for enhanced visual accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->