### PR TITLE
refactor(UI): move light limit visualization into debug

### DIFF
--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -17,7 +17,16 @@ void LightLimitFix::DrawSettings()
 {
 	auto shaderCache = globals::shaderCache;
 
-	if (ImGui::TreeNodeEx("Light Limit Visualization", ImGuiTreeNodeFlags_DefaultOpen)) {
+	if (ImGui::TreeNodeEx("Statistics", ImGuiTreeNodeFlags_DefaultOpen)) {
+		ImGui::Text(std::format("Clustered Light Count : {}", lightCount).c_str());
+
+		ImGui::TreePop();
+	}
+
+	///////////////////////////////
+	ImGui::SeparatorText("Debug");
+
+	if (ImGui::TreeNode("Light Limit Visualization")) {
 		ImGui::Checkbox("Enable Lights Visualisation", &settings.EnableLightsVisualisation);
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Enables visualization of the light limit\n");
@@ -40,12 +49,6 @@ void LightLimitFix::DrawSettings()
 			shaderCache->Clear(RE::BSShader::Type::Lighting);
 			previousEnableLightsVisualisation = currentEnableLightsVisualisation;
 		}
-
-		ImGui::TreePop();
-	}
-
-	if (ImGui::TreeNodeEx("Statistics", ImGuiTreeNodeFlags_DefaultOpen)) {
-		ImGui::Text(std::format("Clustered Light Count : {}", lightCount).c_str());
 
 		ImGui::TreePop();
 	}

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -10,7 +10,6 @@ static constexpr uint MAX_LIGHTS = 1024;
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	LightLimitFix::Settings,
 	EnableContactShadows,
-	EnableLightsVisualisation,
 	LightsVisualisationMode)
 
 void LightLimitFix::DrawSettings()


### PR DESCRIPTION
A frequent support inquiry is about this toggle. As it exists right now, users may confuse the `Enable Lights Visualization` toggle with a toggle for the LLF feature. Some reading might clear that up, but reading is a big ask for regular users.

Changes:
- Moved `Light Limit Visualization` into a new debug section at the bottom of the page. Collapsed by default
- Made `Enable Lights Visualization` ephemeral, no longer saves to JSON. Kept other settings unchanged, including `Lights Visualization Mode`

While looking into this, I noticed that there's no standard way to implement a debug section for each feature. There appears to be various implementations (e.g., Screen Space GI, Terrain Shadows, Wetness Effects). I don't have a source of truth so I just went with the SSGI implementation. If a different design is preferred, I can make that change.

<img width="748" height="264" alt="image" src="https://github.com/user-attachments/assets/2df24376-8df6-4d12-87da-026ec305b88b" />
<img width="754" height="346" alt="image" src="https://github.com/user-attachments/assets/f3fc079b-f4e1-4bd2-97d4-c71843ef68ae" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Statistics section displaying clustered light count information in visualization settings.

* **Improvements**
  * Reorganized debug visualization UI structure for improved clarity and organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->