### PR TITLE
fix(ui): anchor reset settings button position 

### DIFF
--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -446,10 +446,18 @@ void FeatureListRenderer::DrawMenuVisitor::RenderFeatureSettingsTab(Feature* fea
 		}
 
 		if (!isDisabled && isLoaded) {
-			ImVec2 childSize = ImGui::GetWindowSize();
+			// Position button in screen coordinates so it stays fixed in viewport when scrolling
+			ImVec2 windowPos = ImGui::GetWindowPos();
+			ImVec2 windowSize = ImGui::GetWindowSize();
+			float scrollbarWidth = ImGui::GetScrollMaxY() > 0 ? ImGui::GetStyle().ScrollbarSize : 0.0f;
+
 			float iconDimension = ImGui::GetFrameHeight() * 1.2f;
 			ImVec2 iconSize = ImVec2(iconDimension, iconDimension);
-			ImGui::SetCursorPos(ImVec2(childSize.x - iconSize.x - 10.0f, childSize.y - iconSize.y - 10.0f));
+			float padding = 10.0f;
+			ImVec2 buttonPos = ImVec2(
+				windowPos.x + windowSize.x - iconSize.x - padding - scrollbarWidth,
+				windowPos.y + windowSize.y - iconSize.y - padding);
+			ImGui::SetCursorScreenPos(buttonPos);
 			auto& theme = globals::menu->GetTheme().Palette;
 			ImVec4 iconColor = theme.Text;
 			iconColor.w *= 0.7f;


### PR DESCRIPTION
Changes the settings button to anchor it regardless of how you scroll. Should fix #1609, I think davo would be an excellent reviewer for this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed feature settings button positioning to remain anchored at a fixed screen location when enabled, properly accounting for scrollbar width and viewport changes during scrolling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->