### PR TITLE
refactor(ui): add settings for shader block hotkeys

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -141,6 +141,9 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	SkipCompilationKey,
 	EffectToggleKey,
 	OverlayToggleKey,
+	ShaderBlockPrevKey,
+	ShaderBlockNextKey,
+	EnableShaderBlocking,
 	FirstTimeSetupCompleted,
 	Theme,
 	SelectedThemePreset)
@@ -487,7 +490,9 @@ void Menu::DrawGeneralSettings()
 		.settingToggleKey = settingToggleKey,
 		.settingsEffectsToggle = settingsEffectsToggle,
 		.settingSkipCompilationKey = settingSkipCompilationKey,
-		.settingOverlayToggleKey = settingOverlayToggleKey
+		.settingOverlayToggleKey = settingOverlayToggleKey,
+		.settingShaderBlockPrevKey = settingShaderBlockPrevKey,
+		.settingShaderBlockNextKey = settingShaderBlockNextKey
 	};
 
 	// Render settings using extracted component
@@ -673,12 +678,13 @@ void Menu::ProcessInputEventQueue()
 					std::function<void(uint32_t)> action;
 				};
 				auto shaderCache = globals::shaderCache;
-				auto devMode = globals::state->IsDeveloperMode();
 				HotkeyAction hotkeyActions[] = {
 					{ &settings.ToggleKey, &settingToggleKey, [this](uint32_t key) { settings.ToggleKey = key; settingToggleKey = false; } },
 					{ &settings.SkipCompilationKey, &settingSkipCompilationKey, [this](uint32_t key) { settings.SkipCompilationKey = key; settingSkipCompilationKey = false; } },
 					{ &settings.EffectToggleKey, &settingsEffectsToggle, [this](uint32_t key) { settings.EffectToggleKey = key; settingsEffectsToggle = false; } },
 					{ &settings.OverlayToggleKey, &settingOverlayToggleKey, [this](uint32_t key) { settings.OverlayToggleKey = key; settingOverlayToggleKey = false; } },
+					{ &settings.ShaderBlockPrevKey, &settingShaderBlockPrevKey, [this](uint32_t key) { settings.ShaderBlockPrevKey = key; settingShaderBlockPrevKey = false; } },
+					{ &settings.ShaderBlockNextKey, &settingShaderBlockNextKey, [this](uint32_t key) { settings.ShaderBlockNextKey = key; settingShaderBlockNextKey = false; } },
 				};
 				bool handled = false;
 				for (auto& h : hotkeyActions) {
@@ -705,8 +711,8 @@ void Menu::ProcessInputEventQueue()
 						{ settings.ToggleKey, [this]() { IsEnabled = !IsEnabled; } },
 						{ settings.SkipCompilationKey, [shaderCache]() { shaderCache->backgroundCompilation = true; } },
 						{ settings.EffectToggleKey, [shaderCache]() { shaderCache->SetEnabled(!shaderCache->IsEnabled()); } },
-						{ priorShaderKey, [shaderCache, devMode]() { if (devMode) shaderCache->IterateShaderBlock(); } },
-						{ nextShaderKey, [shaderCache, devMode]() { if (devMode) shaderCache->IterateShaderBlock(false); } },
+						{ settings.ShaderBlockPrevKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(); } },
+						{ settings.ShaderBlockNextKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(false); } },
 						{ settings.OverlayToggleKey, []() {
 							 Menu::GetSingleton()->overlayVisible = !Menu::GetSingleton()->overlayVisible;
 						 } },

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -134,8 +134,8 @@ public:
 	bool settingSkipCompilationKey = false;
 	bool settingsEffectsToggle = false;
 	bool settingOverlayToggleKey = false;
-	uint32_t priorShaderKey = VK_PRIOR;  // used for blocking shaders in debugging
-	uint32_t nextShaderKey = VK_NEXT;    // used for blocking shaders in debugging
+	bool settingShaderBlockPrevKey = false;  // Debug: capture shader block prev key
+	bool settingShaderBlockNextKey = false;  // Debug: capture shader block next key
 
 	// Font caching (made public for ThemeManager and OverlayRenderer access)
 	// Marked mutable because they're cache fields that may be updated from const methods
@@ -365,6 +365,9 @@ public:
 		uint32_t SkipCompilationKey = VK_ESCAPE;
 		uint32_t EffectToggleKey = VK_MULTIPLY;  // toggle all effects
 		uint32_t OverlayToggleKey = VK_F10;      // Global overlay toggle key for all overlays
+		uint32_t ShaderBlockPrevKey = VK_PRIOR;  // Debug: cycle backward through shaders (PageUp)
+		uint32_t ShaderBlockNextKey = VK_NEXT;   // Debug: cycle forward through shaders (PageDown)
+		bool EnableShaderBlocking = false;       // Enable shader blocking hotkeys for debugging
 		bool FirstTimeSetupCompleted = false;    // Track if first-time setup has been completed
 		ThemeSettings Theme;
 		std::string SelectedThemePreset = "";  // Currently selected theme preset (empty = custom/user theme)

--- a/src/Menu/AdvancedSettingsRenderer.cpp
+++ b/src/Menu/AdvancedSettingsRenderer.cpp
@@ -277,13 +277,63 @@ void AdvancedSettingsRenderer::RenderShaderDebugSection()
 		ImGui::PopStyleColor();  // ChildBg
 	}
 
+	// Shader Debug section
+	if (ImGui::CollapsingHeader("Shader Debug")) {
+		auto menu = globals::menu;
+		auto& menuSettings = menu->GetSettings();
+		auto& themeSettings = menuSettings.Theme;
+
+		if (ImGui::Checkbox("Enable Shader Blocking", &menuSettings.EnableShaderBlocking)) {
+			// Setting saved automatically on next save
+		}
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Enables hotkeys to cycle through and block individual shaders for debugging purposes.");
+		}
+
+		if (menuSettings.EnableShaderBlocking) {
+			ImGui::Indent();
+
+			// Shader Block Previous Key
+			if (menu->settingShaderBlockPrevKey) {
+				ImGui::Text("Press any key for Shader Block Previous...");
+			} else {
+				ImGui::AlignTextToFramePadding();
+				ImGui::Text("Block Previous:");
+				ImGui::SameLine();
+				ImGui::AlignTextToFramePadding();
+				ImGui::TextColored(themeSettings.StatusPalette.CurrentHotkey, "%s", Util::Input::KeyIdToString(menuSettings.ShaderBlockPrevKey));
+				ImGui::SameLine();
+				if (ImGui::Button("Change##ShaderBlockPrev")) {
+					menu->settingShaderBlockPrevKey = true;
+				}
+			}
+
+			// Shader Block Next Key
+			if (menu->settingShaderBlockNextKey) {
+				ImGui::Text("Press any key for Shader Block Next...");
+			} else {
+				ImGui::AlignTextToFramePadding();
+				ImGui::Text("Block Next:");
+				ImGui::SameLine();
+				ImGui::AlignTextToFramePadding();
+				ImGui::TextColored(themeSettings.StatusPalette.CurrentHotkey, "%s", Util::Input::KeyIdToString(menuSettings.ShaderBlockNextKey));
+				ImGui::SameLine();
+				if (ImGui::Button("Change##ShaderBlockNext")) {
+					menu->settingShaderBlockNextKey = true;
+				}
+			}
+
+			ImGui::Unindent();
+		}
+	}
+
 	// Active shaders list
 	if (ImGui::CollapsingHeader("Active Shaders", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Text("Active Shaders (Used Recently)");
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"List of shaders that have been used in recent frames. "
-				"Use PAGEUP/PAGEDOWN to cycle through and block shaders for debugging. "
+				"Enable Shader Blocking above to use hotkeys to cycle through and block shaders for debugging. "
 				"Shaders not used for ~1 second are removed from this list.");
 		}
 

--- a/src/Menu/SettingsTabRenderer.h
+++ b/src/Menu/SettingsTabRenderer.h
@@ -15,6 +15,8 @@ public:
 		bool& settingsEffectsToggle;
 		bool& settingSkipCompilationKey;
 		bool& settingOverlayToggleKey;
+		bool& settingShaderBlockPrevKey;  // Debug: shader block previous key
+		bool& settingShaderBlockNextKey;  // Debug: shader block next key
 	};
 
 	static void RenderGeneralSettings(


### PR DESCRIPTION
This change is intended to stop users from accidentally trying to hit shader block hotkeys. Instead this feature will only work when it is enabled under Advanced -> Shader Debugging, where there you need to enable it. You also have the option of rebinding the buttons for how to navigate the blocked shader.

Should resolve #1617 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added customizable shader blocking feature with dedicated hotkeys for navigating shader blocks
  - New "Shader Debug" section in Advanced Settings provides:
    - Toggle to enable/disable shader blocking functionality
    - Configurable hotkeys for navigating to previous and next shader blocks
  - Shader block navigation transitioned from developer-only mode to standard user-accessible settings with full customization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->