### PR TITLE
fix(build): fix Package-AIO-Manual for fresh pulls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -846,9 +846,9 @@ set(AIO_PACKAGE "${DIST_PATH}/${PROJECT_NAME}_AIO-${UTC_NOW}.7z")
 add_custom_command(
     OUTPUT ${AIO_PACKAGE}
     DEPENDS ${CORE_SOURCES}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${AIO_DIR}
     COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --prefix ${AIO_DIR}
-    COMMAND ${CMAKE_COMMAND} -E tar cfv ${AIO_PACKAGE} --format=7zip -- .
-    WORKING_DIRECTORY ${AIO_DIR}
+    COMMAND ${CMAKE_COMMAND} -E chdir ${AIO_DIR} ${CMAKE_COMMAND} -E tar cfv ${AIO_PACKAGE} --format=7zip -- .
     COMMENT "Creating AIO zip package (manual)"
 )
 add_custom_target("Package-AIO-Manual" DEPENDS ${AIO_PACKAGE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -848,7 +848,9 @@ add_custom_command(
     DEPENDS ${CORE_SOURCES}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${AIO_DIR}
     COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --prefix ${AIO_DIR}
-    COMMAND ${CMAKE_COMMAND} -E chdir ${AIO_DIR} ${CMAKE_COMMAND} -E tar cfv ${AIO_PACKAGE} --format=7zip -- .
+    COMMAND
+        ${CMAKE_COMMAND} -E chdir ${AIO_DIR} ${CMAKE_COMMAND} -E tar cfv
+        ${AIO_PACKAGE} --format=7zip -- .
     COMMENT "Creating AIO zip package (manual)"
 )
 add_custom_target("Package-AIO-Manual" DEPENDS ${AIO_PACKAGE})


### PR DESCRIPTION
  The Package-AIO-Manual custom command used WORKING_DIRECTORY ${AIO_DIR}, but MSBuild validates that the
  working directory exists before running any commands. On fresh builds where build/ALL/aio doesn't
  exist, the entire command fails immediately.
  
  To repro remove ``build/ALL/aio`` then run ``cmake --build build/ALL --target Package-AIO-Manual``

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system reliability by ensuring proper directory creation during package assembly operations.
  * Optimized package creation workflow for enhanced consistency and stability across build environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->