### PR TITLE
fix(hair): use indirect normal for deferred marschner hair

### DIFF
--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -326,6 +326,9 @@ namespace Hair
 	float3 GetHairDynamicCubemapSpecularIrradiance(float2 uv, float2 ScreenUV, float3 T, float3 N, float3 VN, float3 V, float glossiness, float3 specLobePrim, float3 specLobeSec)
 #	endif
 	{
+		if (SharedData::hairSpecularSettings.HairMode == 1) {
+			return 0;
+		}
 		float3 SpecularIrradiance = 0;
 		float3 N1 = N;
 		float3 N2 = N;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2098,9 +2098,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		endif
 	hairT = Hair::ReorientTangent(hairT, worldNormal);
 
-	if (SharedData::hairSpecularSettings.Enabled && SharedData::hairSpecularSettings.EnableTangentShift) {
-		float3 shiftedNormal = Hair::ShiftWorldNormal(hairT, worldNormal, 0, uv);
-		screenSpaceNormal = normalize(FrameBuffer::WorldToView(shiftedNormal, false, eyeIndex));
+	if (SharedData::hairSpecularSettings.Enabled) {
+		if (SharedData::hairSpecularSettings.EnableTangentShift && SharedData::hairSpecularSettings.HairMode != 1) {
+			float3 shiftedNormal = Hair::ShiftWorldNormal(hairT, worldNormal, 0, uv);
+			screenSpaceNormal = normalize(FrameBuffer::WorldToView(shiftedNormal, false, eyeIndex));
+		}
 	}
 
 	float3 transmissionColor = 0;
@@ -2721,6 +2723,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #	if defined(HAIR) && defined(CS_HAIR)
 	if (SharedData::hairSpecularSettings.Enabled && SharedData::hairSpecularSettings.HairMode == 1)
 		ambientNormal = normalize(viewDirection - hairT * dot(viewDirection, hairT));
+		screenSpaceNormal = normalize(FrameBuffer::WorldToView(ambientNormal, false, eyeIndex));
 #	endif
 
 	float3 directionalAmbientColor = max(0, mul(DirectionalAmbient, float4(ambientNormal, 1.0)));


### PR DESCRIPTION
now uses normalize(V- T * dot(V, T)) as screenSpaceNormal for marschner to make indirect diffuse look better

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized hair specular lighting calculations to skip unnecessary computations in certain rendering modes.

* **Bug Fixes**
  * Improved hair tangent shift and screen-space normal calculations for more consistent hair appearance across different rendering conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->