### PR TITLE
refactor: restructure lighting

### DIFF
--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -67,6 +67,7 @@ namespace Hair
 		const float NdotV = saturate(dot(N, V));
 		const float VNdotV = dot(VN, V);
 		const float VNdotL = dot(VN, L);
+		const float satVNdotL = saturate(VNdotL);
 		const float HdotV = saturate(dot(H, V));
 		const float HdotL = saturate(dot(H, L));
 		const float wrapped = 0.5;
@@ -74,7 +75,7 @@ namespace Hair
 		// [Yibing Jiang 2016, "The Process of Creating Volumetric-based Materials in Uncharted 4"]
 		// https://advances.realtimerendering.com/s2016
 		dirDiffuse = saturate(oNdotL + wrapped) / (1 + wrapped);
-		float3 scatterColor = lerp(float3(0.992, 0.808, 0.518), baseColor, 0.5);
+		float3 scatterColor = baseColor * baseColor;
 		dirDiffuse = saturate(scatterColor + NdotL) * dirDiffuse * lightColor * SharedData::hairSpecularSettings.DiffuseMult;
 
 		float3 TshiftPrimary;
@@ -205,74 +206,54 @@ namespace Hair
 			T = ShiftTangent(T, N, shift);
 		}
 
-		const float cosThetaV = dot(VN, V);
-
 		float backlit = SharedData::hairSpecularSettings.Transmission;
 
 		dirTransmission += D_Marschner(L, V, T, roughness, baseColor, 0, backlit) * lightColor * SharedData::hairSpecularSettings.SpecularMult;
 		dirTransmission += GetHairDiffuseAttenuationKajiyaKay(T, V, L, selfShadow, baseColor) * lightColor * SharedData::hairSpecularSettings.DiffuseMult;
 	}
 
-	void GetHairDirectLight(out float3 dirDiffuse, out float3 dirSpecular, out float3 dirTransmission, float3 T, float3 L, float3 V, float3 N, float3 VN, float3 lightColor, float shininess, float selfShadow, float2 uv, float3 baseColor)
+	void GetHairDirectLight(out DirectLightingOutput lightingOutput, DirectContext context, MaterialProperties material, float3x3 tbnTr, float2 uv)
 	{
+		const float3 T = normalize(context.worldNormal);
+		const float3 V = normalize(context.viewDir);
+		const float3 N = normalize(context.vertexNormal);
+		const float3 VN = normalize(tbnTr[2]);
+		const float3 L = normalize(context.lightDir);
+
 		if (SharedData::hairSpecularSettings.HairMode == 0) {
-			GetHairDirectLightScheuermann(dirDiffuse, dirSpecular, dirTransmission, T, L, V, N, VN, lightColor, shininess, selfShadow, uv, baseColor);
+			GetHairDirectLightScheuermann(lightingOutput.diffuse, lightingOutput.specular, lightingOutput.transmission, T, L, V, N, VN, context.lightColor, material.Shininess, context.hairShadow, uv, material.BaseColor);
 		} else {
-			GetHairDirectLightMarschner(dirDiffuse, dirSpecular, dirTransmission, T, L, V, N, VN, lightColor, shininess, selfShadow, uv, baseColor);
+			GetHairDirectLightMarschner(lightingOutput.diffuse, lightingOutput.specular, lightingOutput.transmission, T, L, V, N, VN, context.lightColor, material.Shininess, context.hairShadow, uv, material.BaseColor);
 		}
 	}
 
-	void GetHairIndirectSpecularLobeWeights(out float3 diffuseLobeWeight, out float3 specularLobeWeightPrimary, out float3 specularLobeWeightSecondary, float3 T, float3 N, float3 V, float3 VN, float shininess, float2 uv, float3 baseColor)
+	void GetHairIndirectSpecularLobeWeights(out IndirectLobeWeights lobeWeights, IndirectContext context, MaterialProperties material, float2 uv)
 	{
-		const float roughnessPrimary = pow(abs(2.0 / (shininess + 2.0)), 0.25);
-		const float roughnessSecondary = pow(abs(2.0 / (shininess * 0.5 + 2.0)), 0.25);
-		const float NdotV = saturate(dot(N, V));
+		lobeWeights = (IndirectLobeWeights)0;
+		
+		const float3 T = normalize(context.worldNormal);
+		const float3 V = normalize(context.viewDir);
+		const float3 N = normalize(context.vertexNormal);
 
 		if (SharedData::hairSpecularSettings.HairMode == 1) {
-			specularLobeWeightPrimary = 0;
-			specularLobeWeightSecondary = 0;
-
 			if (SharedData::hairSpecularSettings.EnableTangentShift) {
 				const float shift = TexTangentShift.SampleLevel(SampColorSampler, uv, 0).x - 0.5;
 				T = ShiftTangent(T, N, shift);
 			}
 			float3 L = normalize(V - T * dot(V, T));
 
-			diffuseLobeWeight = D_Marschner(L, V, T, roughnessPrimary, baseColor, 0.2, 0) * Math::PI;
-			diffuseLobeWeight += GetHairDiffuseAttenuationKajiyaKay(T, V, L, 1, baseColor) * Math::PI;
+			lobeWeights.diffuse = D_Marschner(L, V, T, 1 - saturate(shininess * 0.01), material.BaseColor, 0.2, 0) * Math::PI;
+			lobeWeights.diffuse += GetHairDiffuseAttenuationKajiyaKay(T, V, L, 1, material.BaseColor) * Math::PI;
 			return;
 		} else {
-			float NdotVshifted = NdotV;
-			float NdotVshifted2 = NdotV;
+			float3 L = normalize(V - T * dot(V, T));
+			float3 diffuseLobeWeight;
+			float3 specularLobeWeight;
+			float3 transmissionLobeWeight;
 
-			if (SharedData::hairSpecularSettings.EnableTangentShift) {
-				const float shift = TexTangentShift.SampleLevel(SampColorSampler, uv, 0).x - 0.5;
-				NdotVshifted = saturate(dot(ShiftNormal(T, N, shift + SharedData::hairSpecularSettings.PrimaryTangentShift), V));
-				NdotVshifted2 = saturate(dot(ShiftNormal(T, N, shift + SharedData::hairSpecularSettings.SecondaryTangentShift), V));
-			}
-
-			diffuseLobeWeight = baseColor;
-			specularLobeWeightPrimary = 0;
-			specularLobeWeightSecondary = 0;
-
-			const float2 specularBRDFPrimary = BRDF::EnvBRDF(roughnessPrimary, NdotVshifted);
-			const float2 specularBRDFSecondary = BRDF::EnvBRDF(roughnessSecondary, NdotVshifted2);
-
-			const float3 F0 = HairF0();
-			specularLobeWeightPrimary = F0 * specularBRDFPrimary.x + specularBRDFPrimary.y;
-			diffuseLobeWeight *= (1 - specularLobeWeightPrimary);
-			diffuseLobeWeight = saturate(diffuseLobeWeight);
-			specularLobeWeightPrimary *= 1 + F0 * (1 / (specularBRDFPrimary.x + specularBRDFPrimary.y) - 1);
-
-			specularLobeWeightSecondary = F0 * specularBRDFSecondary.x + specularBRDFSecondary.y;
-			specularLobeWeightSecondary *= 1 + F0 * (1 / (specularBRDFSecondary.x + specularBRDFSecondary.y) - 1);
-			specularLobeWeightSecondary *= baseColor;
-
-			float3 R = reflect(-V, N);
-			float horizon = min(1.0 + dot(R, VN), 1.0);
-			horizon = horizon * horizon;
-			specularLobeWeightPrimary *= horizon;
-			specularLobeWeightSecondary *= horizon;
+			GetHairDirectLightScheuermann(diffuseLobeWeight, specularLobeWeight, transmissionLobeWeight, T, L, V, N, N, 1, material.Shininess * 0.75, 1, uv, material.BaseColor)
+			lobeWeights.diffuse = material.BaseColor;
+			lobeWeights.specular = specularLobeWeight;
 		}
 	}
 
@@ -318,39 +299,5 @@ namespace Hair
 		}
 		return lerp(1.0, shadow, SharedData::hairSpecularSettings.SelfShadowStrength);
 	}
-
-#if defined(DYNAMIC_CUBEMAPS)
-#	if defined(SKYLIGHTING)
-	float3 GetHairDynamicCubemapSpecularIrradiance(float2 uv, float2 ScreenUV, float3 T, float3 N, float3 VN, float3 V, float glossiness, float3 specLobePrim, float3 specLobeSec, sh2 skylighting)
-#	else
-	float3 GetHairDynamicCubemapSpecularIrradiance(float2 uv, float2 ScreenUV, float3 T, float3 N, float3 VN, float3 V, float glossiness, float3 specLobePrim, float3 specLobeSec)
-#	endif
-	{
-		if (SharedData::hairSpecularSettings.HairMode == 1) {
-			return 0;
-		}
-		float3 SpecularIrradiance = 0;
-		float3 N1 = N;
-		float3 N2 = N;
-
-		const float roughnessPrimary = SharedData::hairSpecularSettings.HairMode == 1 ? 1.0 : pow(abs(2.0 / (glossiness + 2.0)), 0.25);
-		const float roughnessSecondary = pow(abs(2.0 / (glossiness * 0.5 + 2.0)), 0.25);
-
-		if (SharedData::hairSpecularSettings.EnableTangentShift) {
-			const float shift = TexTangentShift.SampleLevel(SampColorSampler, uv, 0).x - 0.5;
-			N1 = ShiftNormal(T, N, shift + (SharedData::hairSpecularSettings.HairMode == 1 ? 0.0 : SharedData::hairSpecularSettings.PrimaryTangentShift));
-			N2 = ShiftNormal(T, N, shift + SharedData::hairSpecularSettings.SecondaryTangentShift);
-		}
-
-#	if defined(SKYLIGHTING)
-		SpecularIrradiance += DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(ScreenUV, N1, VN, V, roughnessPrimary, skylighting) * specLobePrim;
-		SpecularIrradiance += DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(ScreenUV, N2, VN, V, roughnessSecondary, skylighting) * specLobeSec;
-#	else
-		SpecularIrradiance += DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(ScreenUV, N1, VN, V, roughnessPrimary) * specLobePrim;
-		SpecularIrradiance += DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(ScreenUV, N2, VN, V, roughnessSecondary) * specLobeSec;
-#	endif
-		return SpecularIrradiance;
-	}
-#endif
 }
 #endif  //__HAIR_DEPENDENCY_HLSL__

--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -227,11 +227,11 @@ namespace Hair
 		}
 	}
 
-	void GetHairIndirectSpecularLobeWeights(out IndirectLobeWeights lobeWeights, IndirectContext context, MaterialProperties material, float2 uv)
+	void GetHairIndirectLobeWeights(out IndirectLobeWeights lobeWeights, IndirectContext context, MaterialProperties material, float2 uv)
 	{
 		lobeWeights = (IndirectLobeWeights)0;
 		
-		const float3 T = normalize(context.worldNormal);
+		float3 T = normalize(context.worldNormal);
 		const float3 V = normalize(context.viewDir);
 		const float3 N = normalize(context.vertexNormal);
 
@@ -242,8 +242,8 @@ namespace Hair
 			}
 			float3 L = normalize(V - T * dot(V, T));
 
-			lobeWeights.diffuse = D_Marschner(L, V, T, 1 - saturate(shininess * 0.01), material.BaseColor, 0.2, 0) * Math::PI;
-			lobeWeights.diffuse += GetHairDiffuseAttenuationKajiyaKay(T, V, L, 1, material.BaseColor) * Math::PI;
+			lobeWeights.diffuse = D_Marschner(L, V, T, 1 - saturate(material.Shininess * 0.01), material.BaseColor, 0.2, 0) * Math::PI * SharedData::hairSpecularSettings.SpecularIndirectMult;
+			lobeWeights.diffuse += GetHairDiffuseAttenuationKajiyaKay(T, V, L, 1, material.BaseColor) * Math::PI * SharedData::hairSpecularSettings.DiffuseIndirectMult;
 			return;
 		} else {
 			float3 L = normalize(V - T * dot(V, T));
@@ -251,9 +251,9 @@ namespace Hair
 			float3 specularLobeWeight;
 			float3 transmissionLobeWeight;
 
-			GetHairDirectLightScheuermann(diffuseLobeWeight, specularLobeWeight, transmissionLobeWeight, T, L, V, N, N, 1, material.Shininess * 0.75, 1, uv, material.BaseColor)
-			lobeWeights.diffuse = material.BaseColor;
-			lobeWeights.specular = specularLobeWeight;
+			GetHairDirectLightScheuermann(diffuseLobeWeight, specularLobeWeight, transmissionLobeWeight, T, L, V, N, N, 1, material.Shininess * 0.75, 1, uv, material.BaseColor);
+			lobeWeights.diffuse = material.BaseColor * SharedData::hairSpecularSettings.DiffuseIndirectMult;
+			lobeWeights.diffuse += specularLobeWeight * SharedData::hairSpecularSettings.SpecularIndirectMult;
 		}
 	}
 

--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -75,7 +75,7 @@ namespace Hair
 		// [Yibing Jiang 2016, "The Process of Creating Volumetric-based Materials in Uncharted 4"]
 		// https://advances.realtimerendering.com/s2016
 		dirDiffuse = saturate(oNdotL + wrapped) / (1 + wrapped);
-		float3 scatterColor = baseColor * baseColor;
+		float3 scatterColor = pow(baseColor, 0.5);
 		dirDiffuse = saturate(scatterColor + NdotL) * dirDiffuse * lightColor * SharedData::hairSpecularSettings.DiffuseMult;
 
 		float3 TshiftPrimary;
@@ -246,14 +246,11 @@ namespace Hair
 			lobeWeights.diffuse += GetHairDiffuseAttenuationKajiyaKay(T, V, L, 1, material.BaseColor) * Math::PI * SharedData::hairSpecularSettings.DiffuseIndirectMult;
 			return;
 		} else {
-			float3 L = normalize(V - T * dot(V, T));
-			float3 diffuseLobeWeight;
-			float3 specularLobeWeight;
-			float3 transmissionLobeWeight;
-
-			GetHairDirectLightScheuermann(diffuseLobeWeight, specularLobeWeight, transmissionLobeWeight, T, L, V, N, N, 1, material.Shininess * 0.75, 1, uv, material.BaseColor);
-			lobeWeights.diffuse = material.BaseColor * SharedData::hairSpecularSettings.DiffuseIndirectMult;
-			lobeWeights.diffuse += specularLobeWeight * SharedData::hairSpecularSettings.SpecularIndirectMult;
+			lobeWeights.diffuse = saturate(material.BaseColor * SharedData::hairSpecularSettings.DiffuseIndirectMult);
+			float2 hairBRDF = BRDF::EnvBRDF(material.Roughness, saturate(dot(N, V)));
+			float3 hairSpecularLobe = material.F0 * hairBRDF.x + hairBRDF.y;
+			lobeWeights.diffuse *= (1 - hairSpecularLobe);
+			lobeWeights.specular = saturate(hairSpecularLobe * SharedData::hairSpecularSettings.SpecularIndirectMult);
 		}
 	}
 

--- a/features/Hair Specular/Shaders/Hair/Hair.hlsli
+++ b/features/Hair Specular/Shaders/Hair/Hair.hlsli
@@ -230,7 +230,7 @@ namespace Hair
 	void GetHairIndirectLobeWeights(out IndirectLobeWeights lobeWeights, IndirectContext context, MaterialProperties material, float2 uv)
 	{
 		lobeWeights = (IndirectLobeWeights)0;
-		
+
 		float3 T = normalize(context.worldNormal);
 		const float3 V = normalize(context.viewDir);
 		const float3 N = normalize(context.vertexNormal);

--- a/package/Shaders/Common/LightingCommon.hlsli
+++ b/package/Shaders/Common/LightingCommon.hlsli
@@ -3,19 +3,47 @@
 
 #include "Common/BRDF.hlsli"
 
+#if defined(TRUE_PBR)
+#	include "Common/PBR.hlsli"
+#endif
+
+#if defined(TRUE_PBR)
+struct CoatContext
+{
+	float3 coatNormal;
+	float3 coatViewDir;
+	float3 coatLightDir;
+	float3 coatHalfVector;
+};
+#endif
+
 struct Context
 {
     float3 worldNormal;
+	float NdotL;
     float3 geometryNormal;
+	float NdotV;
     float3 viewDir;
+	float NdotH;
     float3 lightDir;
+	float VdotH;
     float3 halfVector;
+	float LdotH;
     float3 lightColor;
-    float NdotL;
-    float NdotV;
-    float NdotH;
-    float VdotH;
-    float LdotH;
+
+#if defined(TRUE_PBR)
+	CoatContext coatContext;
+#endif
+};
+
+struct LightingOutput
+{
+	float3 diffuse = 0;
+	float3 specular = 0;
+	float3 transmission = 0;
+#if defined(TRUE_PBR)
+	float3 coatDiffuse = 0;
+#endif
 };
 
 struct MaterialProperties
@@ -113,24 +141,32 @@ float3 VanillaSpecular(Context context, float shininess, float2 uv)
 	return lightColorMultiplier;
 }
 
-void EvaluateLighting(Context context, MaterialProperties material, float2 uv, out float3 outDiffuse, out float3 outSpecular, out float3 outTransmission)
+#if defined(TRUE_PBR)
+void EvaluateLightingPBR(Context context, MaterialProperties material, float3x3 tbnTr, float2 uv, out LightingOutput outLighting)
 {
-#if !defined(TRUE_PBR)
-    outDiffuse = material.BaseColor * saturate(context.NdotL) * context.lightColor;
-    #		if defined(SOFT_LIGHTING)
-	outDiffuse += context.lightColor * GetSoftLightMultiplier(context.NdotL) * rimSoftLightColor.xyz;
+	// TODO: migrate PBR lighting code here
+}
+#endif
+
+void EvaluateLighting(Context context, MaterialProperties material, float3x3 tbnTr, float2 uv, out LightingOutput outLighting)
+{
+	outLighting = (LightingOutput)0;
+#if defined(TRUE_PBR)
+	EvaluateLightingPBR(context, material, tbnTr, uv, outLighting);
+#else
+    outLighting.diffuse = material.BaseColor * saturate(context.NdotL) * context.lightColor;
+#		if defined(SOFT_LIGHTING)
+	outLighting.diffuse += context.lightColor * GetSoftLightMultiplier(context.NdotL) * rimSoftLightColor.xyz;
 #		endif
 
 #		if defined(RIM_LIGHTING)
-	outDiffuse += context.lightColor * GetRimLightMultiplier(context.lightDir, context.viewDir, context.worldNormal) * rimSoftLightColor.xyz;
+	outLighting.diffuse += context.lightColor * GetRimLightMultiplier(context.lightDir, context.viewDir, context.worldNormal) * rimSoftLightColor.xyz;
 #		endif
 
 #		if defined(BACK_LIGHTING)
-	outDiffuse += context.lightColor * saturate(-context.NdotL) * backLightColor.xyz;
+	outLighting.diffuse += context.lightColor * saturate(-context.NdotL) * backLightColor.xyz;
 #		endif
-    outSpecular = VanillaSpecular(context, material.Shininess, uv) * material.SpecularColor * material.Glossiness * context.lightColor;
-#else
-    // TODO: Migrate from PBR.hlsli
+    outLighting.specular = VanillaSpecular(context, material.Shininess, uv) * material.SpecularColor * material.Glossiness * context.lightColor;
 #endif
 }
 

--- a/package/Shaders/Common/LightingCommon.hlsli
+++ b/package/Shaders/Common/LightingCommon.hlsli
@@ -106,7 +106,7 @@ float3x3 ReconstructTBN(float3 worldPos, float3 worldNormal, float2 uv)
 	float3 bitangent = normalize(dFdy * dUVdx.x - dFdx * dUVdy.x);
 	tangent = normalize(tangent - worldNormal * dot(worldNormal, tangent));
 	bitangent = normalize(bitangent - worldNormal * dot(worldNormal, bitangent));
-	
+
 	return float3x3(tangent, bitangent, normalize(worldNormal));
 }
 #endif

--- a/package/Shaders/Common/LightingCommon.hlsli
+++ b/package/Shaders/Common/LightingCommon.hlsli
@@ -62,6 +62,8 @@ struct MaterialProperties
 #	    if (defined(RIM_LIGHTING) || defined(SOFT_LIGHTING) || defined(LOAD_SOFT_LIGHTING))
     float3 rimSoftLightColor = 0;
 #       endif
+	float Roughness = 1;
+	float3 F0 = 0;
 #	else
 	float Roughness = 1;
 	float Metallic = 0;

--- a/package/Shaders/Common/LightingCommon.hlsli
+++ b/package/Shaders/Common/LightingCommon.hlsli
@@ -25,23 +25,23 @@ struct IndirectContext
 	float3 worldNormal;
 	float3 vertexNormal;
 	float3 viewDir;
-}
+};
 
 struct DirectLightingOutput
 {
-	float3 diffuse = 0;
-	float3 specular = 0;
-	float3 transmission = 0;
+	float3 diffuse;
+	float3 specular;
+	float3 transmission;
 #if defined(TRUE_PBR)
-	float3 coatDiffuse = 0;
+	float3 coatDiffuse;
 #endif
 };
 
 struct IndirectLobeWeights
 {
-	float3 diffuse = 0;
-	float3 specular = 0;
-}
+	float3 diffuse;
+	float3 specular;
+};
 
 #if defined(TRUE_PBR)
 #	if defined(GLINT)
@@ -56,40 +56,57 @@ namespace Glints
 
 struct MaterialProperties
 {
-	float3 BaseColor = 0;
+	float3 BaseColor;
 #if !defined(TRUE_PBR)
-	float Shininess = 0;
-	float Glossiness = 0;
-	float3 SpecularColor = 0;
+	float Shininess;
+	float Glossiness;
+	float3 SpecularColor;
 #	if (defined(RIM_LIGHTING) || defined(SOFT_LIGHTING) || defined(LOAD_SOFT_LIGHTING))
-    float3 rimSoftLightColor = 0;
+    float3 rimSoftLightColor;
 #   endif
-	float Roughness = 1;
-	float3 F0 = 0;
+#	if defined(BACK_LIGHTING)
+	float3 backLightColor;
+#	endif
+	float Roughness;
+	float3 F0;
 #else
-	float Roughness = 1;
-	float Metallic = 0;
-	float AO = 1;
-	float3 F0 = 0;
-	float3 SubsurfaceColor = 0;
-	float Thickness = 0;
-	float3 CoatColor = 0;
-	float CoatStrength = 0;
-	float CoatRoughness = 0;
-	float3 CoatF0 = 0;
-	float3 FuzzColor = 0;
-	float FuzzWeight = 0;
-	float GlintScreenSpaceScale = 1.5;
-	float GlintLogMicrofacetDensity = 1.0;
-	float GlintMicrofacetRoughness = 0.015;
-	float GlintDensityRandomization = 2.0;
+	float Roughness;
+	float Metallic;
+	float AO;
+	float3 F0;
+	float3 SubsurfaceColor;
+	float Thickness;
+	float3 CoatColor;
+	float CoatStrength;
+	float CoatRoughness;
+	float3 CoatF0;
+	float3 FuzzColor;
+	float FuzzWeight;
+	float GlintScreenSpaceScale;
+	float GlintLogMicrofacetDensity;
+	float GlintMicrofacetRoughness;
+	float GlintDensityRandomization;
 	Glints::GlintCachedVars GlintCache;
-	float Noise = 0;
+	float Noise;
 #endif
 };
 
 float ShininessToRoughness(float shininess)
 {
 	return pow(abs(2.0 / (shininess + 2.0)), 0.25);
+}
+
+float3x3 ReconstructTBN(float3 worldPos, float3 worldNormal, float2 uv)
+{
+	float3 dFdx = ddx(worldPos);
+	float3 dFdy = ddy(worldPos);
+	float2 dUVdx = ddx(uv);
+	float2 dUVdy = ddy(uv);
+	float3 tangent = normalize(dFdx * dUVdy.y - dFdy * dUVdx.y);
+	float3 bitangent = normalize(dFdy * dUVdx.x - dFdx * dUVdy.x);
+	tangent = normalize(tangent - worldNormal * dot(worldNormal, tangent));
+	bitangent = normalize(bitangent - worldNormal * dot(worldNormal, bitangent));
+	
+	return float3x3(tangent, bitangent, normalize(worldNormal));
 }
 #endif

--- a/package/Shaders/Common/LightingCommon.hlsli
+++ b/package/Shaders/Common/LightingCommon.hlsli
@@ -1,42 +1,31 @@
 #ifndef LIGHTING_COMMON_HLSLI
 #define LIGHTING_COMMON_HLSLI
 
-#include "Common/BRDF.hlsli"
-
-#if defined(TRUE_PBR)
-#	include "Common/PBR.hlsli"
-#endif
-
-#if defined(TRUE_PBR)
-struct CoatContext
+struct DirectContext
 {
-	float3 coatNormal;
+    float3 worldNormal;
+    float3 vertexNormal;
+    float3 viewDir;
+    float3 lightDir;
+    float3 halfVector;
+    float3 lightColor;
+#if defined(TRUE_PBR)
+	float3 coatWorldNormal;
 	float3 coatViewDir;
 	float3 coatLightDir;
 	float3 coatHalfVector;
-};
+	float3 coatLightColor;
 #endif
+};
 
-struct Context
+struct IndirectContext
 {
-    float3 worldNormal;
-	float NdotL;
-    float3 geometryNormal;
-	float NdotV;
-    float3 viewDir;
-	float NdotH;
-    float3 lightDir;
-	float VdotH;
-    float3 halfVector;
-	float LdotH;
-    float3 lightColor;
+	float3 worldNormal;
+	float3 vertexNormal;
+	float3 viewDir;
+}
 
-#if defined(TRUE_PBR)
-	CoatContext coatContext;
-#endif
-};
-
-struct LightingOutput
+struct DirectLightingOutput
 {
 	float3 diffuse = 0;
 	float3 specular = 0;
@@ -45,6 +34,23 @@ struct LightingOutput
 	float3 coatDiffuse = 0;
 #endif
 };
+
+struct IndirectLobeWeights
+{
+	float3 diffuse = 0;
+	float3 specular = 0;
+}
+
+#if defined(TRUE_PBR)
+#	if defined(GLINT)
+#		include "Common/Glints/Glints2023.hlsli"
+#	else
+namespace Glints
+{
+	typedef float GlintCachedVars;
+}
+#	endif
+#endif
 
 struct MaterialProperties
 {
@@ -77,97 +83,3 @@ struct MaterialProperties
 	float Noise = 0;
 #	endif
 };
-
-Context CreateLightingContext(float3 worldNormal, float3 geometryNormal, float3 viewDir, float3 lightDir, float3 lightColor, float3 lightAttenuation, float shadowFactor)
-{
-    Context context;
-    context.worldNormal = normalize(worldNormal);
-    context.geometryNormal = normalize(geometryNormal);
-    context.viewDir = normalize(viewDir);
-    context.lightDir = normalize(lightDir);
-    context.halfVector = normalize(context.viewDir + context.lightDir);
-    context.lightColor = lightColor * lightAttenuation * shadowFactor;
-    context.NdotL = dot(context.worldNormal, context.lightDir);
-    context.NdotV = dot(context.worldNormal, context.viewDir);
-    context.NdotH = dot(context.worldNormal, context.halfVector);
-    context.VdotH = dot(context.viewDir, context.halfVector);
-    context.LdotH = dot(context.lightDir, context.halfVector);
-    return context;
-}
-
-float3 VanillaSpecular(Context context, float shininess, float2 uv)
-{
-    float3 N = context.worldNormal;
-    float3 G = context.geometryNormal;
-    float3 V = context.viewDir;
-    float3 L = context.lightDir;
-    float3 H = context.halfVector;
-    float HdotN;
-#	if defined(ANISO_LIGHTING)
-	float3 AN = normalize(N * 0.5 + G);
-	float LdotAN = dot(AN, L);
-	float HdotAN = dot(AN, H);
-	HdotN = 1 - min(1, abs(LdotAN - HdotAN));
-#	else
-	HdotN = saturate(context.NdotH);
-#	endif
-
-#	if defined(SPECULAR)
-	float lightColorMultiplier = exp2(shininess * log2(HdotN));
-
-#	elif defined(SPARKLE)
-	float lightColorMultiplier = 0;
-#	else
-	float lightColorMultiplier = HdotN;
-#	endif
-
-#	if defined(ANISO_LIGHTING)
-	lightColorMultiplier *= 0.7 * max(0, L.z);
-#	endif
-
-#	if defined(SPARKLE) && !defined(SNOW)
-	float3 sparkleUvScale = exp2(float3(1.3, 1.6, 1.9) * log2(abs(SparkleParams.x)).xxx);
-
-	float sparkleColor1 = TexProjDetail.Sample(SampProjDetailSampler, uv * sparkleUvScale.xx).z;
-	float sparkleColor2 = TexProjDetail.Sample(SampProjDetailSampler, uv * sparkleUvScale.yy).z;
-	float sparkleColor3 = TexProjDetail.Sample(SampProjDetailSampler, uv * sparkleUvScale.zz).z;
-	float sparkleColor = ProcessSparkleColor(sparkleColor1) + ProcessSparkleColor(sparkleColor2) + ProcessSparkleColor(sparkleColor3);
-	float VdotN = dot(V, N);
-	V += N * -(2 * VdotN);
-	float sparkleMultiplier = exp2(SparkleParams.w * log2(saturate(dot(V, -L)))) * (SparkleParams.z * sparkleColor);
-	sparkleMultiplier = sparkleMultiplier >= 0.5 ? 1 : 0;
-	lightColorMultiplier += sparkleMultiplier * HdotN;
-#	endif
-	return lightColorMultiplier;
-}
-
-#if defined(TRUE_PBR)
-void EvaluateLightingPBR(Context context, MaterialProperties material, float3x3 tbnTr, float2 uv, out LightingOutput outLighting)
-{
-	// TODO: migrate PBR lighting code here
-}
-#endif
-
-void EvaluateLighting(Context context, MaterialProperties material, float3x3 tbnTr, float2 uv, out LightingOutput outLighting)
-{
-	outLighting = (LightingOutput)0;
-#if defined(TRUE_PBR)
-	EvaluateLightingPBR(context, material, tbnTr, uv, outLighting);
-#else
-    outLighting.diffuse = material.BaseColor * saturate(context.NdotL) * context.lightColor;
-#		if defined(SOFT_LIGHTING)
-	outLighting.diffuse += context.lightColor * GetSoftLightMultiplier(context.NdotL) * rimSoftLightColor.xyz;
-#		endif
-
-#		if defined(RIM_LIGHTING)
-	outLighting.diffuse += context.lightColor * GetRimLightMultiplier(context.lightDir, context.viewDir, context.worldNormal) * rimSoftLightColor.xyz;
-#		endif
-
-#		if defined(BACK_LIGHTING)
-	outLighting.diffuse += context.lightColor * saturate(-context.NdotL) * backLightColor.xyz;
-#		endif
-    outLighting.specular = VanillaSpecular(context, material.Shininess, uv) * material.SpecularColor * material.Glossiness * context.lightColor;
-#endif
-}
-
-#endif

--- a/package/Shaders/Common/LightingCommon.hlsli
+++ b/package/Shaders/Common/LightingCommon.hlsli
@@ -15,6 +15,8 @@ struct DirectContext
 	float3 coatLightDir;
 	float3 coatHalfVector;
 	float3 coatLightColor;
+#elif defined(HAIR) && defined(CS_HAIR)
+	float hairShadow;
 #endif
 };
 
@@ -55,16 +57,16 @@ namespace Glints
 struct MaterialProperties
 {
 	float3 BaseColor = 0;
-#	if !defined(TRUE_PBR)
+#if !defined(TRUE_PBR)
 	float Shininess = 0;
 	float Glossiness = 0;
 	float3 SpecularColor = 0;
-#	    if (defined(RIM_LIGHTING) || defined(SOFT_LIGHTING) || defined(LOAD_SOFT_LIGHTING))
+#	if (defined(RIM_LIGHTING) || defined(SOFT_LIGHTING) || defined(LOAD_SOFT_LIGHTING))
     float3 rimSoftLightColor = 0;
-#       endif
+#   endif
 	float Roughness = 1;
 	float3 F0 = 0;
-#	else
+#else
 	float Roughness = 1;
 	float Metallic = 0;
 	float AO = 1;
@@ -83,5 +85,11 @@ struct MaterialProperties
 	float GlintDensityRandomization = 2.0;
 	Glints::GlintCachedVars GlintCache;
 	float Noise = 0;
-#	endif
+#endif
 };
+
+float ShininessToRoughness(float shininess)
+{
+	return pow(abs(2.0 / (shininess + 2.0)), 0.25);
+}
+#endif

--- a/package/Shaders/Common/LightingCommon.hlsli
+++ b/package/Shaders/Common/LightingCommon.hlsli
@@ -1,0 +1,137 @@
+#ifndef LIGHTING_COMMON_HLSLI
+#define LIGHTING_COMMON_HLSLI
+
+#include "Common/BRDF.hlsli"
+
+struct Context
+{
+    float3 worldNormal;
+    float3 geometryNormal;
+    float3 viewDir;
+    float3 lightDir;
+    float3 halfVector;
+    float3 lightColor;
+    float NdotL;
+    float NdotV;
+    float NdotH;
+    float VdotH;
+    float LdotH;
+};
+
+struct MaterialProperties
+{
+	float3 BaseColor = 0;
+#	if !defined(TRUE_PBR)
+	float Shininess = 0;
+	float Glossiness = 0;
+	float3 SpecularColor = 0;
+#	    if (defined(RIM_LIGHTING) || defined(SOFT_LIGHTING) || defined(LOAD_SOFT_LIGHTING))
+    float3 rimSoftLightColor = 0;
+#       endif
+#	else
+	float Roughness = 1;
+	float Metallic = 0;
+	float AO = 1;
+	float3 F0 = 0;
+	float3 SubsurfaceColor = 0;
+	float Thickness = 0;
+	float3 CoatColor = 0;
+	float CoatStrength = 0;
+	float CoatRoughness = 0;
+	float3 CoatF0 = 0;
+	float3 FuzzColor = 0;
+	float FuzzWeight = 0;
+	float GlintScreenSpaceScale = 1.5;
+	float GlintLogMicrofacetDensity = 1.0;
+	float GlintMicrofacetRoughness = 0.015;
+	float GlintDensityRandomization = 2.0;
+	Glints::GlintCachedVars GlintCache;
+	float Noise = 0;
+#	endif
+};
+
+Context CreateLightingContext(float3 worldNormal, float3 geometryNormal, float3 viewDir, float3 lightDir, float3 lightColor, float3 lightAttenuation, float shadowFactor)
+{
+    Context context;
+    context.worldNormal = normalize(worldNormal);
+    context.geometryNormal = normalize(geometryNormal);
+    context.viewDir = normalize(viewDir);
+    context.lightDir = normalize(lightDir);
+    context.halfVector = normalize(context.viewDir + context.lightDir);
+    context.lightColor = lightColor * lightAttenuation * shadowFactor;
+    context.NdotL = dot(context.worldNormal, context.lightDir);
+    context.NdotV = dot(context.worldNormal, context.viewDir);
+    context.NdotH = dot(context.worldNormal, context.halfVector);
+    context.VdotH = dot(context.viewDir, context.halfVector);
+    context.LdotH = dot(context.lightDir, context.halfVector);
+    return context;
+}
+
+float3 VanillaSpecular(Context context, float shininess, float2 uv)
+{
+    float3 N = context.worldNormal;
+    float3 G = context.geometryNormal;
+    float3 V = context.viewDir;
+    float3 L = context.lightDir;
+    float3 H = context.halfVector;
+    float HdotN;
+#	if defined(ANISO_LIGHTING)
+	float3 AN = normalize(N * 0.5 + G);
+	float LdotAN = dot(AN, L);
+	float HdotAN = dot(AN, H);
+	HdotN = 1 - min(1, abs(LdotAN - HdotAN));
+#	else
+	HdotN = saturate(context.NdotH);
+#	endif
+
+#	if defined(SPECULAR)
+	float lightColorMultiplier = exp2(shininess * log2(HdotN));
+
+#	elif defined(SPARKLE)
+	float lightColorMultiplier = 0;
+#	else
+	float lightColorMultiplier = HdotN;
+#	endif
+
+#	if defined(ANISO_LIGHTING)
+	lightColorMultiplier *= 0.7 * max(0, L.z);
+#	endif
+
+#	if defined(SPARKLE) && !defined(SNOW)
+	float3 sparkleUvScale = exp2(float3(1.3, 1.6, 1.9) * log2(abs(SparkleParams.x)).xxx);
+
+	float sparkleColor1 = TexProjDetail.Sample(SampProjDetailSampler, uv * sparkleUvScale.xx).z;
+	float sparkleColor2 = TexProjDetail.Sample(SampProjDetailSampler, uv * sparkleUvScale.yy).z;
+	float sparkleColor3 = TexProjDetail.Sample(SampProjDetailSampler, uv * sparkleUvScale.zz).z;
+	float sparkleColor = ProcessSparkleColor(sparkleColor1) + ProcessSparkleColor(sparkleColor2) + ProcessSparkleColor(sparkleColor3);
+	float VdotN = dot(V, N);
+	V += N * -(2 * VdotN);
+	float sparkleMultiplier = exp2(SparkleParams.w * log2(saturate(dot(V, -L)))) * (SparkleParams.z * sparkleColor);
+	sparkleMultiplier = sparkleMultiplier >= 0.5 ? 1 : 0;
+	lightColorMultiplier += sparkleMultiplier * HdotN;
+#	endif
+	return lightColorMultiplier;
+}
+
+void EvaluateLighting(Context context, MaterialProperties material, float2 uv, out float3 outDiffuse, out float3 outSpecular, out float3 outTransmission)
+{
+#if !defined(TRUE_PBR)
+    outDiffuse = material.BaseColor * saturate(context.NdotL) * context.lightColor;
+    #		if defined(SOFT_LIGHTING)
+	outDiffuse += context.lightColor * GetSoftLightMultiplier(context.NdotL) * rimSoftLightColor.xyz;
+#		endif
+
+#		if defined(RIM_LIGHTING)
+	outDiffuse += context.lightColor * GetRimLightMultiplier(context.lightDir, context.viewDir, context.worldNormal) * rimSoftLightColor.xyz;
+#		endif
+
+#		if defined(BACK_LIGHTING)
+	outDiffuse += context.lightColor * saturate(-context.NdotL) * backLightColor.xyz;
+#		endif
+    outSpecular = VanillaSpecular(context, material.Shininess, uv) * material.SpecularColor * material.Glossiness * context.lightColor;
+#else
+    // TODO: Migrate from PBR.hlsli
+#endif
+}
+
+#endif

--- a/package/Shaders/Common/LightingEval.hlsli
+++ b/package/Shaders/Common/LightingEval.hlsli
@@ -138,7 +138,7 @@ void GetIndirectLobeWeights(out IndirectLobeWeights lobeWeights, IndirectContext
 #	endif
 	lobeWeights.diffuse = material.BaseColor;
 #	if defined(DYNAMIC_CUBEMAPS)
-	if (!any(material.F0 > 0)) {
+	if (any(material.F0 > 0)) {
 		const float3 N = context.worldNormal;
 		const float3 V = context.viewDir;
 		const float3 VN = context.vertexNormal;

--- a/package/Shaders/Common/LightingEval.hlsli
+++ b/package/Shaders/Common/LightingEval.hlsli
@@ -98,6 +98,13 @@ void EvaluateLighting(DirectContext context, MaterialProperties material, float3
 #if defined(TRUE_PBR)
 	PBR::GetDirectLightInput(lightingOutput, context, material, tbnTr, uv);
 #else
+#	if defined(HAIR) && defined(CS_HAIR)
+	if (SharedData::hairSpecularSettings.Enabled)
+	{
+		Hair::GetHairDirectLight(lightingOutput, context, material, tbnTr, uv);
+		return;
+	}
+#	endif
 	const float NdotL = dot(context.worldNormal, context.lightDir);
     lightingOutput.diffuse = material.BaseColor * saturate(NdotL) * context.lightColor;
 #		if defined(SOFT_LIGHTING)

--- a/package/Shaders/Common/LightingEval.hlsli
+++ b/package/Shaders/Common/LightingEval.hlsli
@@ -44,6 +44,7 @@ IndirectContext CreateIndirectLightingContext(float3 worldNormal, float3 vertexN
 	context.worldNormal = normalize(worldNormal);
 	context.vertexNormal = normalize(vertexNormal);
 	context.viewDir = normalize(viewDir);
+	return context;
 }
 
 float3 VanillaSpecular(DirectContext context, float shininess, float2 uv)
@@ -60,7 +61,7 @@ float3 VanillaSpecular(DirectContext context, float shininess, float2 uv)
 	float HdotAN = dot(AN, H);
 	HdotN = 1 - min(1, abs(LdotAN - HdotAN));
 #	else
-	HdotN = saturate(context.NdotH);
+	HdotN = saturate(dot(H, N));
 #	endif
 
 #	if defined(SPECULAR)
@@ -97,6 +98,9 @@ void EvaluateLighting(DirectContext context, MaterialProperties material, float3
 	lightingOutput = (DirectLightingOutput)0;
 #if defined(TRUE_PBR)
 	PBR::GetDirectLightInput(lightingOutput, context, material, tbnTr, uv);
+	lightingOutput.diffuse *= Color::PBRLightingScale;
+	lightingOutput.specular *= Color::PBRLightingScale;
+	lightingOutput.transmission *= Color::PBRLightingScale;
 #else
 #	if defined(HAIR) && defined(CS_HAIR)
 	if (SharedData::hairSpecularSettings.Enabled)
@@ -108,26 +112,33 @@ void EvaluateLighting(DirectContext context, MaterialProperties material, float3
 	const float NdotL = dot(context.worldNormal, context.lightDir);
     lightingOutput.diffuse = material.BaseColor * saturate(NdotL) * context.lightColor;
 #		if defined(SOFT_LIGHTING)
-	lightingOutput.diffuse += context.lightColor * GetSoftLightMultiplier(NdotL) * rimSoftLightColor.xyz;
+	lightingOutput.diffuse += context.lightColor * GetSoftLightMultiplier(NdotL) * material.rimSoftLightColor;
 #		endif
 
 #		if defined(RIM_LIGHTING)
-	lightingOutput.diffuse += context.lightColor * GetRimLightMultiplier(context.lightDir, context.viewDir, context.worldNormal) * rimSoftLightColor.xyz;
+	lightingOutput.diffuse += context.lightColor * GetRimLightMultiplier(context.lightDir, context.viewDir, context.worldNormal) * material.rimSoftLightColor;
 #		endif
 
 #		if defined(BACK_LIGHTING)
-	lightingOutput.diffuse += context.lightColor * saturate(-NdotL) * backLightColor.xyz;
+	lightingOutput.diffuse += context.lightColor * saturate(-NdotL) * material.backLightColor;
 #		endif
     lightingOutput.specular = VanillaSpecular(context, material.Shininess, uv) * material.SpecularColor * material.Glossiness * context.lightColor;
 #endif
 }
 
-void GetIndirectLobeWeights(out IndirectLobeWeights lobeWeights, IndirectContext context, MaterialProperties material)
+void GetIndirectLobeWeights(out IndirectLobeWeights lobeWeights, IndirectContext context, MaterialProperties material, float2 uv)
 {
 	lobeWeights = (IndirectLobeWeights)0;
 #if defined(TRUE_PBR)
 	PBR::GetIndirectLobeWeights(lobeWeights, context, material);
 #else
+#	if defined(HAIR) && defined(CS_HAIR)
+	if (SharedData::hairSpecularSettings.Enabled)
+	{
+		Hair::GetHairIndirectLobeWeights(lobeWeights, context, material, uv);
+		return;
+	}
+#	endif
 	lobeWeights.diffuse = material.BaseColor;
 #	if defined(DYNAMIC_CUBEMAPS)
 	if (!any(material.F0 > 0)) {
@@ -157,7 +168,7 @@ void GetIndirectLobeWeights(out IndirectLobeWeights lobeWeights, IndirectContext
 #if defined(WETNESS_EFFECTS)
 void EvaluateWetnessLighting(float3 wetnessNormal, DirectContext context, float roughness, inout DirectLightingOutput lightingOutput)
 {
-	const float wetnessStrength = 1 - roughness;
+	const float wetnessStrength = saturate(1 - roughness);
 #	if defined(TRUE_PBR)
 	const float3 lightColor = context.coatLightColor;
 #	else
@@ -178,11 +189,15 @@ void EvaluateWetnessLighting(float3 wetnessNormal, DirectContext context, float 
 
 	float D = BRDF::D_GGX(roughness, NdotH);
 	float G = BRDF::Vis_SmithJointApprox(roughness, NdotV, NdotL);
-	float3 F = BRDF::F_Schlick(specularColor, VdotH);
+	float3 F = BRDF::F_Schlick(wetnessF0, VdotH);
 
 	F *= wetnessStrength;
 
 	float3 wetnessSpecular = D * G * F * NdotL * lightColor;
+
+#if !defined(TRUE_PBR)
+	wetnessSpecular *= Math::PI * Color::PBRLightingScale;  // Compensate for GGX on traditional specular
+#endif
 
 	lightingOutput.diffuse *= 1 - F;
 	lightingOutput.specular *= 1 - F;
@@ -192,10 +207,11 @@ void EvaluateWetnessLighting(float3 wetnessNormal, DirectContext context, float 
 float3 GetWetnessIndirectLobeWeights(inout IndirectLobeWeights lobeWeights, float3 wetnessNormal, float roughness, IndirectContext context)
 {
 	const float wetnessF0 = 0.02;
-	const float wetnessStrength = 1 - roughness;
+	const float wetnessStrength = saturate(1 - roughness);
 
 	const float3 N = wetnessNormal;
 	const float3 V = context.viewDir;
+	const float3 VN = context.vertexNormal;
 
 	float NdotV = saturate(abs(dot(N, V)) + EPSILON_DOT_CLAMP);
 	float2 specularBRDF = BRDF::EnvBRDF(roughness, NdotV);

--- a/package/Shaders/Common/LightingEval.hlsli
+++ b/package/Shaders/Common/LightingEval.hlsli
@@ -3,6 +3,7 @@
 #include "Common/LightingCommon.hlsli"
 
 #include "Common/BRDF.hlsli"
+#include "Common/Math.hlsli"
 #if defined(TRUE_PBR)
 #	include "Common/PBR.hlsli"
 #endif
@@ -146,4 +147,66 @@ void GetIndirectLobeWeights(out IndirectLobeWeights lobeWeights, IndirectContext
 #endif
 }
 
+#if defined(WETNESS_EFFECTS)
+void EvaluateWetnessLighting(float3 wetnessNormal, DirectContext context, float roughness, inout DirectLightingOutput lightingOutput)
+{
+	const float wetnessStrength = 1 - roughness;
+#	if defined(TRUE_PBR)
+	const float3 lightColor = context.coatLightColor;
+#	else
+	const float3 lightColor = context.lightColor;
+#	endif
+
+	const float wetnessF0 = 0.02;
+
+	const float3 N = wetnessNormal;
+	const float3 V = context.viewDir;
+	const float3 L = context.lightDir;
+	const float3 H = context.halfVector;
+
+	float NdotL = clamp(dot(N, L), EPSILON_DOT_CLAMP, 1);
+	float NdotV = saturate(abs(dot(N, V)) + EPSILON_DOT_CLAMP);
+	float NdotH = saturate(dot(N, H));
+	float VdotH = saturate(dot(V, H));
+
+	float D = BRDF::D_GGX(roughness, NdotH);
+	float G = BRDF::Vis_SmithJointApprox(roughness, NdotV, NdotL);
+	float3 F = BRDF::F_Schlick(specularColor, VdotH);
+
+	F *= wetnessStrength;
+
+	float3 wetnessSpecular = D * G * F * NdotL * lightColor;
+
+	lightingOutput.diffuse *= 1 - F;
+	lightingOutput.specular *= 1 - F;
+	lightingOutput.specular += wetnessSpecular;
+}
+
+float3 GetWetnessIndirectLobeWeights(inout IndirectLobeWeights lobeWeights, float3 wetnessNormal, float roughness, IndirectContext context)
+{
+	const float wetnessF0 = 0.02;
+	const float wetnessStrength = 1 - roughness;
+
+	const float3 N = wetnessNormal;
+	const float3 V = context.viewDir;
+
+	float NdotV = saturate(abs(dot(N, V)) + EPSILON_DOT_CLAMP);
+	float2 specularBRDF = BRDF::EnvBRDF(roughness, NdotV);
+	float3 specularLobeWeight = wetnessF0 * specularBRDF.x + specularBRDF.y;
+
+	specularLobeWeight *= wetnessStrength;
+
+	lobeWeights.diffuse *= 1 - specularLobeWeight;
+	lobeWeights.specular *= 1 - specularLobeWeight;
+
+	// Horizon specular occlusion
+	// https://marmosetco.tumblr.com/post/81245981087
+	float3 R = reflect(-V, N);
+	float horizon = min(1.0 + dot(R, VN), 1.0);
+	horizon = horizon * horizon;
+	specularLobeWeight *= horizon;
+
+	return specularLobeWeight;
+}
+#endif
 #endif

--- a/package/Shaders/Common/LightingEval.hlsli
+++ b/package/Shaders/Common/LightingEval.hlsli
@@ -1,0 +1,128 @@
+#ifndef LIGHTING_EVAL_HLSLI
+#define LIGHTING_EVAL_HLSLI
+#include "Common/LightingCommon.hlsli"
+
+#include "Common/BRDF.hlsli"
+#if defined(TRUE_PBR)
+#	include "Common/PBR.hlsli"
+#endif
+
+#if defined(TRUE_PBR)
+DirectContext CreateDirectLightingContext(float3 worldNormal, float3 coatWorldNormal, float3 vertexNormal, float3 viewDir, float3 coatViewDir, float3 lightDir, float3 coatLightDir, float3 lightColor, float shadowFactor, float parallaxShadow)
+#else
+DirectContext CreateDirectLightingContext(float3 worldNormal, float3 vertexNormal, float3 viewDir, float3 lightDir, float3 lightColor, float shadowFactor, float parallaxShadow)
+#endif
+{
+    DirectContext context = (DirectContext)0;
+    context.worldNormal = normalize(worldNormal);
+    context.vertexNormal = normalize(vertexNormal);
+    context.viewDir = normalize(viewDir);
+    context.lightDir = normalize(lightDir);
+    context.halfVector = normalize(context.viewDir + context.lightDir);
+    context.lightColor = lightColor * shadowFactor * parallaxShadow;
+#if defined(TRUE_PBR)
+	context.coatWorldNormal = normalize(coatWorldNormal);
+	context.coatViewDir = normalize(coatViewDir);
+	context.coatLightDir = normalize(coatLightDir);
+	context.coatHalfVector = normalize(context.coatViewDir + context.coatLightDir);
+	[branch] if ((PBRFlags & PBR::Flags::InterlayerParallax) != 0)
+	{
+		context.coatLightColor = lightColor * shadowFactor;
+	}
+	else
+	{
+		context.coatLightColor = context.lightColor;
+	}
+#endif
+    return context;
+}
+
+#if defined(TRUE_PBR)
+IndirectContext CreateIndirectLightingContext(float3 worldNormal, float3 vertexNormal, float3 viewDir)
+{
+	IndirectContext context = (IndirectContext)0;
+	context.worldNormal = normalize(worldNormal);
+	context.vertexNormal = normalize(vertexNormal);
+	context.viewDir = normalize(viewDir);
+}
+
+float3 VanillaSpecular(DirectContext context, float shininess, float2 uv)
+{
+    const float3 N = context.worldNormal;
+    const float3 G = context.vertexNormal;
+    const float3 V = context.viewDir;
+    const float3 L = context.lightDir;
+    const float3 H = context.halfVector;
+    float HdotN;
+#	if defined(ANISO_LIGHTING)
+	const float3 AN = normalize(N * 0.5 + G);
+	float LdotAN = dot(AN, L);
+	float HdotAN = dot(AN, H);
+	HdotN = 1 - min(1, abs(LdotAN - HdotAN));
+#	else
+	HdotN = saturate(context.NdotH);
+#	endif
+
+#	if defined(SPECULAR)
+	float lightColorMultiplier = exp2(shininess * log2(HdotN));
+
+#	elif defined(SPARKLE)
+	float lightColorMultiplier = 0;
+#	else
+	float lightColorMultiplier = HdotN;
+#	endif
+
+#	if defined(ANISO_LIGHTING)
+	lightColorMultiplier *= 0.7 * max(0, L.z);
+#	endif
+
+#	if defined(SPARKLE) && !defined(SNOW)
+	float3 sparkleUvScale = exp2(float3(1.3, 1.6, 1.9) * log2(abs(SparkleParams.x)).xxx);
+
+	float sparkleColor1 = TexProjDetail.Sample(SampProjDetailSampler, uv * sparkleUvScale.xx).z;
+	float sparkleColor2 = TexProjDetail.Sample(SampProjDetailSampler, uv * sparkleUvScale.yy).z;
+	float sparkleColor3 = TexProjDetail.Sample(SampProjDetailSampler, uv * sparkleUvScale.zz).z;
+	float sparkleColor = ProcessSparkleColor(sparkleColor1) + ProcessSparkleColor(sparkleColor2) + ProcessSparkleColor(sparkleColor3);
+	float VdotN = dot(V, N);
+	V += N * -(2 * VdotN);
+	float sparkleMultiplier = exp2(SparkleParams.w * log2(saturate(dot(V, -L)))) * (SparkleParams.z * sparkleColor);
+	sparkleMultiplier = sparkleMultiplier >= 0.5 ? 1 : 0;
+	lightColorMultiplier += sparkleMultiplier * HdotN;
+#	endif
+	return lightColorMultiplier;
+}
+
+void EvaluateLighting(DirectContext context, MaterialProperties material, float3x3 tbnTr, float2 uv, out DirectLightingOutput lightingOutput)
+{
+	lightingOutput = (DirectLightingOutput)0;
+#if defined(TRUE_PBR)
+	PBR::GetDirectLightInput(lightingOutput, context, material, tbnTr, uv);
+#else
+	const float NdotL = dot(context.worldNormal, context.lightDir);
+    lightingOutput.diffuse = material.BaseColor * saturate(NdotL) * context.lightColor;
+#		if defined(SOFT_LIGHTING)
+	lightingOutput.diffuse += context.lightColor * GetSoftLightMultiplier(NdotL) * rimSoftLightColor.xyz;
+#		endif
+
+#		if defined(RIM_LIGHTING)
+	lightingOutput.diffuse += context.lightColor * GetRimLightMultiplier(context.lightDir, context.viewDir, context.worldNormal) * rimSoftLightColor.xyz;
+#		endif
+
+#		if defined(BACK_LIGHTING)
+	lightingOutput.diffuse += context.lightColor * saturate(-NdotL) * backLightColor.xyz;
+#		endif
+    lightingOutput.specular = VanillaSpecular(context, material.Shininess, uv) * material.SpecularColor * material.Glossiness * context.lightColor;
+#endif
+}
+
+void GetIndirectLobeWeights(out IndirectLobeWeights lobeWeights, IndirectContext context, MaterialProperties material)
+{
+	lobeWeights = (IndirectLobeWeights)0;
+#if defined(TRUE_PBR)
+	PBR::GetIndirectLobeWeights(lobeWeights, context, material);
+#else
+	lobeWeights.diffuse = material.BaseColor;
+#endif
+}
+
+#endif

--- a/package/Shaders/Common/LightingEval.hlsli
+++ b/package/Shaders/Common/LightingEval.hlsli
@@ -107,7 +107,7 @@ void EvaluateLighting(DirectContext context, MaterialProperties material, float3
 	}
 #	endif
 	const float NdotL = dot(context.worldNormal, context.lightDir);
-    lightingOutput.diffuse = material.BaseColor * saturate(NdotL) * context.lightColor;
+    lightingOutput.diffuse = saturate(NdotL) * context.lightColor;
 #		if defined(SOFT_LIGHTING)
 	lightingOutput.diffuse += context.lightColor * GetSoftLightMultiplier(NdotL) * material.rimSoftLightColor;
 #		endif

--- a/package/Shaders/Common/LightingEval.hlsli
+++ b/package/Shaders/Common/LightingEval.hlsli
@@ -98,9 +98,6 @@ void EvaluateLighting(DirectContext context, MaterialProperties material, float3
 	lightingOutput = (DirectLightingOutput)0;
 #if defined(TRUE_PBR)
 	PBR::GetDirectLightInput(lightingOutput, context, material, tbnTr, uv);
-	lightingOutput.diffuse *= Color::PBRLightingScale;
-	lightingOutput.specular *= Color::PBRLightingScale;
-	lightingOutput.transmission *= Color::PBRLightingScale;
 #else
 #	if defined(HAIR) && defined(CS_HAIR)
 	if (SharedData::hairSpecularSettings.Enabled)

--- a/package/Shaders/Common/LightingEval.hlsli
+++ b/package/Shaders/Common/LightingEval.hlsli
@@ -51,7 +51,7 @@ float3 VanillaSpecular(DirectContext context, float shininess, float2 uv)
 {
     const float3 N = context.worldNormal;
     const float3 G = context.vertexNormal;
-    const float3 V = context.viewDir;
+    float3 V = context.viewDir;
     const float3 L = context.lightDir;
     const float3 H = context.halfVector;
     float HdotN;

--- a/package/Shaders/Common/LightingEval.hlsli
+++ b/package/Shaders/Common/LightingEval.hlsli
@@ -147,8 +147,6 @@ void GetIndirectLobeWeights(out IndirectLobeWeights lobeWeights, IndirectContext
 
 		float2 specularBRDF = BRDF::EnvBRDF(material.Roughness, NdotV);
 		lobeWeights.specular = material.F0 * specularBRDF.x + specularBRDF.y;
-
-		lobeWeights.diffuse *= (1 - lobeWeights.specular);
 		lobeWeights.specular *= 1 + material.F0 * (1 / (specularBRDF.x + specularBRDF.y) - 1);
 
 		// Horizon specular occlusion

--- a/package/Shaders/Common/LightingEval.hlsli
+++ b/package/Shaders/Common/LightingEval.hlsli
@@ -37,7 +37,6 @@ DirectContext CreateDirectLightingContext(float3 worldNormal, float3 vertexNorma
     return context;
 }
 
-#if defined(TRUE_PBR)
 IndirectContext CreateIndirectLightingContext(float3 worldNormal, float3 vertexNormal, float3 viewDir)
 {
 	IndirectContext context = (IndirectContext)0;
@@ -122,6 +121,28 @@ void GetIndirectLobeWeights(out IndirectLobeWeights lobeWeights, IndirectContext
 	PBR::GetIndirectLobeWeights(lobeWeights, context, material);
 #else
 	lobeWeights.diffuse = material.BaseColor;
+#	if defined(DYNAMIC_CUBEMAPS)
+	if (!any(material.F0 > 0)) {
+		const float3 N = context.worldNormal;
+		const float3 V = context.viewDir;
+		const float3 VN = context.vertexNormal;
+
+		float NdotV = saturate(dot(N, V));
+
+		float2 specularBRDF = BRDF::EnvBRDF(material.Roughness, NdotV);
+		lobeWeights.specular = material.F0 * specularBRDF.x + specularBRDF.y;
+
+		lobeWeights.diffuse *= (1 - lobeWeights.specular);
+		lobeWeights.specular *= 1 + material.F0 * (1 / (specularBRDF.x + specularBRDF.y) - 1);
+
+		// Horizon specular occlusion
+		// https://marmosetco.tumblr.com/post/81245981087
+		float3 R = reflect(-V, N);
+		float horizon = min(1.0 + dot(R, VN), 1.0);
+		horizon = horizon * horizon;
+		lobeWeights.specular *= horizon;
+	}
+#	endif
 #endif
 }
 

--- a/package/Shaders/Common/PBR.hlsli
+++ b/package/Shaders/Common/PBR.hlsli
@@ -1,5 +1,6 @@
 #ifndef __PBR_DEPENDENCY_HLSL__
 #define __PBR_DEPENDENCY_HLSL__
+#include "Common/LightingCommon.hlsli"
 
 #include "Common/BRDF.hlsli"
 #include "Common/Color.hlsli"
@@ -60,94 +61,6 @@ namespace PBR
 	}
 
 #if defined(GLINT)
-#	include "Common/Glints/Glints2023.hlsli"
-#else
-	namespace Glints
-	{
-		typedef float GlintCachedVars;
-	}
-#endif
-
-	struct SurfaceProperties
-	{
-		float3 BaseColor;
-		float Roughness;
-		float Metallic;
-		float AO;
-		float3 F0;
-		float3 SubsurfaceColor;
-		float Thickness;
-		float3 CoatColor;
-		float CoatStrength;
-		float CoatRoughness;
-		float3 CoatF0;
-		float3 FuzzColor;
-		float FuzzWeight;
-		float GlintScreenSpaceScale;
-		float GlintLogMicrofacetDensity;
-		float GlintMicrofacetRoughness;
-		float GlintDensityRandomization;
-		Glints::GlintCachedVars GlintCache;
-		float Noise;
-	};
-
-	SurfaceProperties InitSurfaceProperties()
-	{
-		SurfaceProperties surfaceProperties;
-
-		surfaceProperties.Roughness = 1;
-		surfaceProperties.Metallic = 0;
-		surfaceProperties.AO = 1;
-		surfaceProperties.F0 = 0;
-
-		surfaceProperties.SubsurfaceColor = 0;
-		surfaceProperties.Thickness = 0;
-
-		surfaceProperties.CoatColor = 0;
-		surfaceProperties.CoatStrength = 0;
-		surfaceProperties.CoatRoughness = 0;
-		surfaceProperties.CoatF0 = 0;
-
-		surfaceProperties.FuzzColor = 0;
-		surfaceProperties.FuzzWeight = 0;
-
-		surfaceProperties.GlintScreenSpaceScale = 1.5;
-		surfaceProperties.GlintLogMicrofacetDensity = 1.0;
-		surfaceProperties.GlintMicrofacetRoughness = 0.015;
-		surfaceProperties.GlintDensityRandomization = 2.0;
-
-#ifdef GLINT
-		surfaceProperties.GlintCache.uv = 0;
-		surfaceProperties.GlintCache.gridSeed = 0;
-		surfaceProperties.GlintCache.footprintArea = 0;
-		surfaceProperties.Noise = 0;
-#endif
-
-		return surfaceProperties;
-	}
-
-	struct LightProperties
-	{
-		float3 LightColor;
-		float3 CoatLightColor;
-	};
-
-	LightProperties InitLightProperties(float3 lightColor, float3 nonParallaxShadow, float3 parallaxShadow)
-	{
-		LightProperties result;
-		result.LightColor = lightColor * nonParallaxShadow * parallaxShadow;
-		[branch] if ((PBRFlags & Flags::InterlayerParallax) != 0)
-		{
-			result.CoatLightColor = lightColor * nonParallaxShadow;
-		}
-		else
-		{
-			result.CoatLightColor = result.LightColor;
-		}
-		return result;
-	}
-
-#if defined(GLINT)
 	float3 GetSpecularDirectLightMultiplierMicrofacetWithGlint(float noise, float roughness, float3 specularColor, float NdotL, float NdotV, float NdotH, float VdotH, float glintH,
 		float logDensity, float microfacetRoughness, float densityRandomization, Glints::GlintCachedVars glintCache,
 		out float3 F)
@@ -203,7 +116,7 @@ namespace PBR
 		return exp(-0.5 * Theta * Theta / (B * B)) / (sqrt(Math::TAU) * B);
 	}
 
-	float3 GetHairDiffuseColorMarschner(float3 N, float3 V, float3 L, float NdotL, float NdotV, float VdotL, float backlit, float area, SurfaceProperties surfaceProperties)
+	float3 GetHairDiffuseColorMarschner(float3 N, float3 V, float3 L, float NdotL, float NdotV, float VdotL, float backlit, float area, MaterialProperties material)
 	{
 		float3 S = 0;
 
@@ -225,9 +138,9 @@ namespace PBR
 			Shift * 4
 		};
 		float B[] = {
-			area + surfaceProperties.Roughness,
-			area + surfaceProperties.Roughness / 2,
-			area + surfaceProperties.Roughness * 2
+			area + material.Roughness,
+			area + material.Roughness / 2,
+			area + material.Roughness * 2
 		};
 
 		float hairIOR = HairIOR();
@@ -248,7 +161,7 @@ namespace PBR
 		h = cosHalfPhi * (1 + a * (0.6 - 0.8 * cosPhi));
 		f = BRDF::F_Schlick(specularColor, cosThetaD * sqrt(saturate(1 - h * h))).x;
 		Fp = (1 - f) * (1 - f);
-		Tp = pow(abs(surfaceProperties.BaseColor), 0.5 * sqrt(1 - (h * a) * (h * a)) / cosThetaD);
+		Tp = pow(abs(material.BaseColor), 0.5 * sqrt(1 - (h * a) * (h * a)) / cosThetaD);
 		Np = exp(-3.65 * cosPhi - 3.98);
 		S += (Mp * Np) * (Fp * Tp) * backlit;
 
@@ -256,14 +169,14 @@ namespace PBR
 		Mp = HairGaussian(B[2], ThetaH - Alpha[2]);
 		f = BRDF::F_Schlick(specularColor, cosThetaD * 0.5f).x;
 		Fp = (1 - f) * (1 - f) * f;
-		Tp = pow(abs(surfaceProperties.BaseColor), 0.8 / cosThetaD);
+		Tp = pow(abs(material.BaseColor), 0.8 / cosThetaD);
 		Np = exp(17 * cosPhi - 16.78);
 		S += (Mp * Np) * (Fp * Tp);
 
 		return S;
 	}
 
-	float3 GetHairDiffuseAttenuationKajiyaKay(float3 N, float3 V, float3 L, float NdotL, float NdotV, float shadow, SurfaceProperties surfaceProperties)
+	float3 GetHairDiffuseAttenuationKajiyaKay(float3 N, float3 V, float3 L, float NdotL, float NdotV, float shadow, MaterialProperties material)
 	{
 		float3 S = 0;
 
@@ -273,32 +186,36 @@ namespace PBR
 		const float wrap = 1;
 		float wrappedNdotL = saturate((dot(fakeN, L) + wrap) / ((1 + wrap) * (1 + wrap)));
 		float diffuseScatter = (1 / Math::PI) * lerp(wrappedNdotL, diffuseKajiya, 0.33);
-		float luma = Color::RGBToLuminance(surfaceProperties.BaseColor);
-		float3 scatterTint = pow(surfaceProperties.BaseColor / luma, 1 - shadow);
-		S += sqrt(surfaceProperties.BaseColor) * diffuseScatter * scatterTint;
+		float luma = Color::RGBToLuminance(material.BaseColor);
+		float3 scatterTint = pow(material.BaseColor / luma, 1 - shadow);
+		S += sqrt(material.BaseColor) * diffuseScatter * scatterTint;
 
 		return S;
 	}
 
-	float3 GetHairColorMarschner(float3 N, float3 V, float3 L, float NdotL, float NdotV, float VdotL, float shadow, float backlit, float area, SurfaceProperties surfaceProperties)
+	float3 GetHairColorMarschner(float3 N, float3 V, float3 L, float NdotL, float NdotV, float VdotL, float shadow, float backlit, float area, MaterialProperties material)
 	{
 		float3 color = 0;
 
-		color += GetHairDiffuseColorMarschner(N, V, L, NdotL, NdotV, VdotL, backlit, area, surfaceProperties);
-		color += GetHairDiffuseAttenuationKajiyaKay(N, V, L, NdotL, NdotV, shadow, surfaceProperties);
+		color += GetHairDiffuseColorMarschner(N, V, L, NdotL, NdotV, VdotL, backlit, area, material);
+		color += GetHairDiffuseAttenuationKajiyaKay(N, V, L, NdotL, NdotV, shadow, material);
 
 		return color;
 	}
 
-	void GetDirectLightInput(out float3 diffuse, out float3 coatDiffuse, out float3 transmission, out float3 specular, float3 N, float3 coatN, float3 V, float3 coatV, float3 L, float3 coatL, LightProperties lightProperties, SurfaceProperties surfaceProperties,
-		float3x3 tbnTr, float2 uv)
+	void GetDirectLightInput(out DirectLightingOutput lightingOutput, DirectContext context, MaterialProperties material, float3x3 tbnTr, float2 uv)
 	{
-		diffuse = 0;
-		coatDiffuse = 0;
-		transmission = 0;
-		specular = 0;
+		lightingOutput = (DirectLightingOutput)0;
 
-		float3 H = normalize(V + L);
+		const float3 N = context.worldNormal;
+		const float3 V = context.viewDir;
+		const float3 L = context.lightDir;
+		const float3 H = context.halfVector;
+
+		const float3 coatN = context.coatWorldNormal;
+		const float3 coatV = context.coatViewDir;
+		const float3 coatL = context.coatLightDir;
+		const float3 coatH = context.coatHalfVector;
 
 		float NdotL = dot(N, L);
 		float NdotV = dot(N, V);
@@ -315,46 +232,44 @@ namespace PBR
 #if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 		[branch] if ((PBRFlags & Flags::HairMarschner) != 0)
 		{
-			transmission += lightProperties.LightColor * GetHairColorMarschner(N, V, L, NdotL, NdotV, VdotL, 0, 1, 0, surfaceProperties);
+			lightingOutput.transmission += lightProperties.LightColor * GetHairColorMarschner(N, V, L, NdotL, NdotV, VdotL, 0, 1, 0, material);
 		}
 		else
 #endif
 		{
-			diffuse += lightProperties.LightColor * satNdotL * BRDF::Diffuse_Lambert();
+			lightingOutput.diffuse += lightProperties.LightColor * satNdotL * BRDF::Diffuse_Lambert();
 
 			float3 F;
 #if defined(GLINT)
-			specular += GetSpecularDirectLightMultiplierMicrofacetWithGlint(surfaceProperties.Noise, surfaceProperties.Roughness, surfaceProperties.F0, satNdotL, satNdotV, satNdotH, satVdotH, mul(tbnTr, H).x,
-							surfaceProperties.GlintLogMicrofacetDensity, surfaceProperties.GlintMicrofacetRoughness, surfaceProperties.GlintDensityRandomization, surfaceProperties.GlintCache, F) *
+			lightingOutput.specular += GetSpecularDirectLightMultiplierMicrofacetWithGlint(material.Noise, material.Roughness, material.F0, satNdotL, satNdotV, satNdotH, satVdotH, mul(tbnTr, H).x,
+							material.GlintLogMicrofacetDensity, material.GlintMicrofacetRoughness, material.GlintDensityRandomization, material.GlintCache, F) *
 			            lightProperties.LightColor * satNdotL;
 #else
-			specular += GetSpecularDirectLightMultiplierMicrofacet(surfaceProperties.Roughness, surfaceProperties.F0, satNdotL, satNdotV, satNdotH, satVdotH, F) * lightProperties.LightColor * satNdotL;
+			lightingOutput.specular += GetSpecularDirectLightMultiplierMicrofacet(material.Roughness, material.F0, satNdotL, satNdotV, satNdotH, satVdotH, F) * lightProperties.LightColor * satNdotL;
 #endif
 
-			float2 specularBRDF = BRDF::EnvBRDF(surfaceProperties.Roughness, satNdotV);
-			specular *= 1 + surfaceProperties.F0 * (1 / (specularBRDF.x + specularBRDF.y) - 1);
+			float2 specularBRDF = BRDF::EnvBRDF(material.Roughness, satNdotV);
+			lightingOutput.specular *= 1 + material.F0 * (1 / (specularBRDF.x + specularBRDF.y) - 1);
 
 #if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 			[branch] if ((PBRFlags & Flags::Fuzz) != 0)
 			{
-				float3 fuzzSpecular = GetSpecularDirectLightMultiplierMicroflakes(surfaceProperties.Roughness, surfaceProperties.FuzzColor, satNdotL, satNdotV, satNdotH, satVdotH) * lightProperties.LightColor * satNdotL;
-				fuzzSpecular *= 1 + surfaceProperties.FuzzColor * (1 / (specularBRDF.x + specularBRDF.y) - 1);
+				float3 fuzzSpecular = GetSpecularDirectLightMultiplierMicroflakes(material.Roughness, material.FuzzColor, satNdotL, satNdotV, satNdotH, satVdotH) * lightProperties.LightColor * satNdotL;
+				fuzzSpecular *= 1 + material.FuzzColor * (1 / (specularBRDF.x + specularBRDF.y) - 1);
 
-				specular = lerp(specular, fuzzSpecular, surfaceProperties.FuzzWeight);
+				lightingOutput.specular = lerp(lightingOutput.specular, fuzzSpecular, material.FuzzWeight);
 			}
 
 			[branch] if ((PBRFlags & Flags::Subsurface) != 0)
 			{
 				const float subsurfacePower = 12.234;
 				float forwardScatter = exp2(saturate(-VdotL) * subsurfacePower - subsurfacePower);
-				float backScatter = saturate(satNdotL * surfaceProperties.Thickness + (1.0 - surfaceProperties.Thickness)) * 0.5;
-				float subsurface = lerp(backScatter, 1, forwardScatter) * (1.0 - surfaceProperties.Thickness);
-				transmission += surfaceProperties.SubsurfaceColor * subsurface * lightProperties.LightColor * BRDF::Diffuse_Lambert();
+				float backScatter = saturate(satNdotL * material.Thickness + (1.0 - material.Thickness)) * 0.5;
+				float subsurface = lerp(backScatter, 1, forwardScatter) * (1.0 - material.Thickness);
+				lightingOutput.transmission += material.SubsurfaceColor * subsurface * lightProperties.LightColor * BRDF::Diffuse_Lambert();
 			}
 			else if ((PBRFlags & Flags::TwoLayer) != 0)
 			{
-				float3 coatH = normalize(coatV + coatL);
-
 				float coatNdotL = satNdotL;
 				float coatNdotV = satNdotV;
 				float coatNdotH = satNdotH;
@@ -368,14 +283,14 @@ namespace PBR
 				}
 
 				float3 coatF;
-				float3 coatSpecular = GetSpecularDirectLightMultiplierMicrofacet(surfaceProperties.CoatRoughness, surfaceProperties.CoatF0, coatNdotL, coatNdotV, coatNdotH, coatVdotH, coatF) * lightProperties.CoatLightColor * coatNdotL;
+				float3 coatSpecular = GetSpecularDirectLightMultiplierMicrofacet(material.CoatRoughness, material.CoatF0, coatNdotL, coatNdotV, coatNdotH, coatVdotH, coatF) * lightProperties.CoatLightColor * coatNdotL;
 
-				float3 layerAttenuation = 1 - coatF * surfaceProperties.CoatStrength;
-				diffuse *= layerAttenuation;
-				specular *= layerAttenuation;
+				float3 layerAttenuation = 1 - coatF * material.CoatStrength;
+				lightingOutput.diffuse *= layerAttenuation;
+				lightingOutput.specular *= layerAttenuation;
 
-				coatDiffuse += lightProperties.CoatLightColor * coatNdotL * BRDF::Diffuse_Lambert();
-				specular += coatSpecular * surfaceProperties.CoatStrength;
+				lightingOutput.coatDiffuse += lightProperties.CoatLightColor * coatNdotL * BRDF::Diffuse_Lambert();
+				lightingOutput.specular += coatSpecular * material.CoatStrength;
 			}
 #endif
 		}
@@ -398,10 +313,13 @@ namespace PBR
 		return wetnessSpecular * wetnessStrength;
 	}
 
-	void GetIndirectLobeWeights(out float3 diffuseLobeWeight, out float3 specularLobeWeight, float3 N, float3 V, float3 VN, float3 diffuseColor, SurfaceProperties surfaceProperties)
+	void GetIndirectLobeWeights(out IndirectLobeWeights lobeWeights, IndirectContext context, MaterialProperties material)
 	{
-		diffuseLobeWeight = 0;
-		specularLobeWeight = 0;
+		lobeWeights = (IndirectLobeWeights)0;
+
+		const float3 N = context.worldNormal;
+		const float3 V = context.viewDir;
+		const float3 VN = context.vertexNormal;
 
 		float NdotV = saturate(dot(N, V));
 
@@ -411,49 +329,49 @@ namespace PBR
 			float3 L = normalize(V - N * dot(V, N));
 			float NdotL = dot(N, L);
 			float VdotL = dot(V, L);
-			diffuseLobeWeight = GetHairColorMarschner(N, V, L, NdotL, NdotV, VdotL, 1, 0, 0.2, surfaceProperties);
+			lobeWeights.diffuse = GetHairColorMarschner(N, V, L, NdotL, NdotV, VdotL, 1, 0, 0.2, material);
 		}
 		else
 #endif
 		{
-			diffuseLobeWeight = diffuseColor;
+			lobeWeights.diffuse = diffuseColor;
 
 #if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 			[branch] if ((PBRFlags & Flags::Subsurface) != 0)
 			{
-				diffuseLobeWeight += surfaceProperties.SubsurfaceColor * (1 - surfaceProperties.Thickness) / Math::PI;
+				lobeWeights.diffuse += material.SubsurfaceColor * (1 - material.Thickness) / Math::PI;
 			}
 			[branch] if ((PBRFlags & Flags::Fuzz) != 0)
 			{
-				diffuseLobeWeight += surfaceProperties.FuzzColor * surfaceProperties.FuzzWeight;
+				lobeWeights.diffuse += material.FuzzColor * material.FuzzWeight;
 			}
 #endif
 
-			float2 specularBRDF = BRDF::EnvBRDF(surfaceProperties.Roughness, NdotV);
-			specularLobeWeight = surfaceProperties.F0 * specularBRDF.x + specularBRDF.y;
+			float2 specularBRDF = BRDF::EnvBRDF(material.Roughness, NdotV);
+			lobeWeights.specular = material.F0 * specularBRDF.x + specularBRDF.y;
 
-			diffuseLobeWeight *= (1 - specularLobeWeight);
-			specularLobeWeight *= 1 + surfaceProperties.F0 * (1 / (specularBRDF.x + specularBRDF.y) - 1);
+			lobeWeights.diffuse *= (1 - lobeWeights.specular);
+			lobeWeights.specular *= 1 + material.F0 * (1 / (specularBRDF.x + specularBRDF.y) - 1);
 
 #if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 			[branch] if ((PBRFlags & Flags::TwoLayer) != 0)
 			{
-				float2 coatSpecularBRDF = BRDF::EnvBRDF(surfaceProperties.CoatRoughness, NdotV);
-				float3 coatSpecularLobeWeight = surfaceProperties.CoatF0 * coatSpecularBRDF.x + coatSpecularBRDF.y;
-				coatSpecularLobeWeight *= 1 + surfaceProperties.CoatF0 * (1 / (coatSpecularBRDF.x + coatSpecularBRDF.y) - 1);
+				float2 coatSpecularBRDF = BRDF::EnvBRDF(material.CoatRoughness, NdotV);
+				float3 coatSpecularLobeWeight = material.CoatF0 * coatSpecularBRDF.x + coatSpecularBRDF.y;
+				coatSpecularLobeWeight *= 1 + material.CoatF0 * (1 / (coatSpecularBRDF.x + coatSpecularBRDF.y) - 1);
 
-				float3 coatF = BRDF::F_Schlick(surfaceProperties.CoatF0, NdotV);
+				float3 coatF = BRDF::F_Schlick(material.CoatF0, NdotV);
 
-				float3 layerAttenuation = 1 - coatF * surfaceProperties.CoatStrength;
-				diffuseLobeWeight *= layerAttenuation;
-				specularLobeWeight *= layerAttenuation;
+				float3 layerAttenuation = 1 - coatF * material.CoatStrength;
+				lobeWeights.diffuse *= layerAttenuation;
+				lobeWeights.specular *= layerAttenuation;
 
 				[branch] if ((PBRFlags & Flags::ColoredCoat) != 0)
 				{
-					float3 coatDiffuseLobeWeight = surfaceProperties.CoatColor * (1 - coatSpecularLobeWeight);
-					diffuseLobeWeight += coatDiffuseLobeWeight * surfaceProperties.CoatStrength;
+					float3 coatDiffuseLobeWeight = material.CoatColor * (1 - coatSpecularLobeWeight);
+					lobeWeights.diffuse += coatDiffuseLobeWeight * material.CoatStrength;
 				}
-				specularLobeWeight += coatSpecularLobeWeight * surfaceProperties.CoatStrength;
+				lobeWeights.specular += coatSpecularLobeWeight * material.CoatStrength;
 			}
 #endif
 		}
@@ -463,16 +381,16 @@ namespace PBR
 		float3 R = reflect(-V, N);
 		float horizon = min(1.0 + dot(R, VN), 1.0);
 		horizon = horizon * horizon;
-		specularLobeWeight *= horizon;
+		lobeWeights.specular *= horizon;
 
-		float3 diffuseAO = surfaceProperties.AO;
-		float3 specularAO = Color::SpecularAOLagarde(NdotV, surfaceProperties.AO, surfaceProperties.Roughness);
+		float3 diffuseAO = material.AO;
+		float3 specularAO = Color::SpecularAOLagarde(NdotV, material.AO, material.Roughness);
 
 		diffuseAO = Color::MultiBounceAO(diffuseColor, diffuseAO.x).y;
-		specularAO = Color::MultiBounceAO(surfaceProperties.F0, specularAO.x).y;
+		specularAO = Color::MultiBounceAO(material.F0, specularAO.x).y;
 
-		diffuseLobeWeight *= diffuseAO;
-		specularLobeWeight *= specularAO;
+		lobeWeights.diffuse *= diffuseAO;
+		lobeWeights.specular *= specularAO;
 	}
 
 	float3 GetWetnessIndirectSpecularLobeWeight(float3 N, float3 V, float3 VN, float roughness)

--- a/package/Shaders/Common/PBR.hlsli
+++ b/package/Shaders/Common/PBR.hlsli
@@ -232,20 +232,20 @@ namespace PBR
 #if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 		[branch] if ((PBRFlags & Flags::HairMarschner) != 0)
 		{
-			lightingOutput.transmission += lightProperties.LightColor * GetHairColorMarschner(N, V, L, NdotL, NdotV, VdotL, 0, 1, 0, material);
+			lightingOutput.transmission += context.lightColor * GetHairColorMarschner(N, V, L, NdotL, NdotV, VdotL, 0, 1, 0, material);
 		}
 		else
 #endif
 		{
-			lightingOutput.diffuse += lightProperties.LightColor * satNdotL * BRDF::Diffuse_Lambert();
+			lightingOutput.diffuse += context.lightColor * satNdotL * BRDF::Diffuse_Lambert();
 
 			float3 F;
 #if defined(GLINT)
 			lightingOutput.specular += GetSpecularDirectLightMultiplierMicrofacetWithGlint(material.Noise, material.Roughness, material.F0, satNdotL, satNdotV, satNdotH, satVdotH, mul(tbnTr, H).x,
 							material.GlintLogMicrofacetDensity, material.GlintMicrofacetRoughness, material.GlintDensityRandomization, material.GlintCache, F) *
-			            lightProperties.LightColor * satNdotL;
+			            context.lightColor * satNdotL;
 #else
-			lightingOutput.specular += GetSpecularDirectLightMultiplierMicrofacet(material.Roughness, material.F0, satNdotL, satNdotV, satNdotH, satVdotH, F) * lightProperties.LightColor * satNdotL;
+			lightingOutput.specular += GetSpecularDirectLightMultiplierMicrofacet(material.Roughness, material.F0, satNdotL, satNdotV, satNdotH, satVdotH, F) * context.lightColor * satNdotL;
 #endif
 
 			float2 specularBRDF = BRDF::EnvBRDF(material.Roughness, satNdotV);
@@ -254,7 +254,7 @@ namespace PBR
 #if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 			[branch] if ((PBRFlags & Flags::Fuzz) != 0)
 			{
-				float3 fuzzSpecular = GetSpecularDirectLightMultiplierMicroflakes(material.Roughness, material.FuzzColor, satNdotL, satNdotV, satNdotH, satVdotH) * lightProperties.LightColor * satNdotL;
+				float3 fuzzSpecular = GetSpecularDirectLightMultiplierMicroflakes(material.Roughness, material.FuzzColor, satNdotL, satNdotV, satNdotH, satVdotH) * context.lightColor * satNdotL;
 				fuzzSpecular *= 1 + material.FuzzColor * (1 / (specularBRDF.x + specularBRDF.y) - 1);
 
 				lightingOutput.specular = lerp(lightingOutput.specular, fuzzSpecular, material.FuzzWeight);
@@ -266,7 +266,7 @@ namespace PBR
 				float forwardScatter = exp2(saturate(-VdotL) * subsurfacePower - subsurfacePower);
 				float backScatter = saturate(satNdotL * material.Thickness + (1.0 - material.Thickness)) * 0.5;
 				float subsurface = lerp(backScatter, 1, forwardScatter) * (1.0 - material.Thickness);
-				lightingOutput.transmission += material.SubsurfaceColor * subsurface * lightProperties.LightColor * BRDF::Diffuse_Lambert();
+				lightingOutput.transmission += material.SubsurfaceColor * subsurface * context.lightColor * BRDF::Diffuse_Lambert();
 			}
 			else if ((PBRFlags & Flags::TwoLayer) != 0)
 			{
@@ -283,13 +283,13 @@ namespace PBR
 				}
 
 				float3 coatF;
-				float3 coatSpecular = GetSpecularDirectLightMultiplierMicrofacet(material.CoatRoughness, material.CoatF0, coatNdotL, coatNdotV, coatNdotH, coatVdotH, coatF) * lightProperties.CoatLightColor * coatNdotL;
+				float3 coatSpecular = GetSpecularDirectLightMultiplierMicrofacet(material.CoatRoughness, material.CoatF0, coatNdotL, coatNdotV, coatNdotH, coatVdotH, coatF) * context.coatLightColor * coatNdotL;
 
 				float3 layerAttenuation = 1 - coatF * material.CoatStrength;
 				lightingOutput.diffuse *= layerAttenuation;
 				lightingOutput.specular *= layerAttenuation;
 
-				lightingOutput.coatDiffuse += lightProperties.CoatLightColor * coatNdotL * BRDF::Diffuse_Lambert();
+				lightingOutput.coatDiffuse += context.coatLightColor * coatNdotL * BRDF::Diffuse_Lambert();
 				lightingOutput.specular += coatSpecular * material.CoatStrength;
 			}
 #endif
@@ -334,7 +334,7 @@ namespace PBR
 		else
 #endif
 		{
-			lobeWeights.diffuse = diffuseColor;
+			lobeWeights.diffuse = material.BaseColor;
 
 #if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 			[branch] if ((PBRFlags & Flags::Subsurface) != 0)
@@ -386,7 +386,7 @@ namespace PBR
 		float3 diffuseAO = material.AO;
 		float3 specularAO = Color::SpecularAOLagarde(NdotV, material.AO, material.Roughness);
 
-		diffuseAO = Color::MultiBounceAO(diffuseColor, diffuseAO.x).y;
+		diffuseAO = Color::MultiBounceAO(material.BaseColor, diffuseAO.x).y;
 		specularAO = Color::MultiBounceAO(material.F0, specularAO.x).y;
 
 		lobeWeights.diffuse *= diffuseAO;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -662,48 +662,6 @@ float ProcessSparkleColor(float color)
 }
 #	endif
 
-float3 GetLightSpecularInput(PS_INPUT input, float3 L, float3 V, float3 N, float3 lightColor, float shininess, float2 uv)
-{
-	float3 H = normalize(V + L);
-	float HdotN = 1.0;
-#	if defined(ANISO_LIGHTING)
-	float3 AN = normalize(N * 0.5 + float3(input.TBN0.z, input.TBN1.z, input.TBN2.z));
-	float LdotAN = dot(AN, L);
-	float HdotAN = dot(AN, H);
-	HdotN = 1 - min(1, abs(LdotAN - HdotAN));
-#	else
-	HdotN = saturate(dot(H, N));
-#	endif
-
-#	if defined(SPECULAR)
-	float lightColorMultiplier = exp2(shininess * log2(HdotN));
-
-#	elif defined(SPARKLE)
-	float lightColorMultiplier = 0;
-#	else
-	float lightColorMultiplier = HdotN;
-#	endif
-
-#	if defined(ANISO_LIGHTING)
-	lightColorMultiplier *= 0.7 * max(0, L.z);
-#	endif
-
-#	if defined(SPARKLE) && !defined(SNOW)
-	float3 sparkleUvScale = exp2(float3(1.3, 1.6, 1.9) * log2(abs(SparkleParams.x)).xxx);
-
-	float sparkleColor1 = TexProjDetail.Sample(SampProjDetailSampler, uv * sparkleUvScale.xx).z;
-	float sparkleColor2 = TexProjDetail.Sample(SampProjDetailSampler, uv * sparkleUvScale.yy).z;
-	float sparkleColor3 = TexProjDetail.Sample(SampProjDetailSampler, uv * sparkleUvScale.zz).z;
-	float sparkleColor = ProcessSparkleColor(sparkleColor1) + ProcessSparkleColor(sparkleColor2) + ProcessSparkleColor(sparkleColor3);
-	float VdotN = dot(V, N);
-	V += N * -(2 * VdotN);
-	float sparkleMultiplier = exp2(SparkleParams.w * log2(saturate(dot(V, -L)))) * (SparkleParams.z * sparkleColor);
-	sparkleMultiplier = sparkleMultiplier >= 0.5 ? 1 : 0;
-	lightColorMultiplier += sparkleMultiplier * HdotN;
-#	endif
-	return lightColor * lightColorMultiplier;
-}
-
 float3 TransformNormal(float3 normal)
 {
 	return normal * 2 + -1.0.xxx;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1021,8 +1021,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #	if !defined(TRUE_PBR)
 #		if defined(LANDSCAPE)
 	float shininess = dot(input.LandBlendWeights1, LandscapeTexture1to4IsSpecPower) + input.LandBlendWeights2.x * LandscapeTexture5to6IsSpecPower.x + input.LandBlendWeights2.y * LandscapeTexture5to6IsSpecPower.y;
-#		else
+#		elif defined(SPECULAR)
 	float shininess = SpecularColor.w;
+#		else
+	float shininess = 0.0;
 #		endif  // defined (LANDSCAPE)
 #	endif
 
@@ -2201,6 +2203,87 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #       endif
 #	endif  // TRUE_PBR
 
+	bool dynamicCubemap = false;
+
+#	if defined(ENVMAP) || defined(MULTI_LAYER_PARALLAX) || defined(EYE)
+	float envMask = EnvmapData.x * MaterialData.x;
+
+	float viewNormalAngle = dot(worldNormal.xyz, viewDirection);
+	float3 envSamplingPoint = (viewNormalAngle * 2) * worldNormal.xyz - viewDirection;
+
+	if (envMask > 0.0) {
+		if (EnvmapData.y) {
+			envMask *= TexEnvMaskSampler.Sample(SampEnvMaskSampler, uv).x;
+		} else {
+			envMask *= glossiness;
+		}
+	}
+
+	float3 envColor = 0.0;
+
+	if (envMask > 0.0) {
+#		if defined(DYNAMIC_CUBEMAPS)
+		uint2 envSize;
+		TexEnvSampler.GetDimensions(envSize.x, envSize.y);
+
+#			if defined(EMAT)
+		if (envSize.x == 1 && envSize.y == 1 || complexMaterial) {
+#			else
+		if (envSize.x == 1 && envSize.y == 1) {
+#			endif
+
+			dynamicCubemap = true;
+
+#			if defined(EMAT)
+			if (!complexMaterial)
+#			endif
+			{
+				// Dynamic Cubemap Creator sets this value to black, if it is anything but black it is wrong
+				float3 envColorTest = TexEnvSampler.SampleLevel(SampEnvSampler, float3(0.0, 1.0, 0.0), 15).xyz;
+				dynamicCubemap = all(envColorTest == 0.0);
+			}
+
+#			if defined(CREATOR)
+			if (SharedData::cubemapCreatorSettings.Enabled) {
+				dynamicCubemap = true;
+			}
+#			endif
+
+			if (dynamicCubemap) {
+				float4 envColorBase = TexEnvSampler.SampleLevel(SampEnvSampler, float3(1.0, 0.0, 0.0), 15);
+
+				if (envColorBase.a < 1.0) {
+					material.F0 = Color::GammaToLinear(envColorBase.rgb);
+					material.Roughness = envColorBase.a;
+				} else {
+					material.F0 = 1.0;
+					material.Roughness = 1.0 / 7.0;
+				}
+
+#			if defined(CREATOR)
+				if (SharedData::cubemapCreatorSettings.Enabled) {
+					material.F0 = SharedData::cubemapCreatorSettings.CubemapColor.rgb;
+					material.Roughness = SharedData::cubemapCreatorSettings.CubemapColor.a;
+				}
+#			endif
+
+#			if defined(EMAT)
+				float complexMaterialRoughness = 1.0 - complexMaterialColor.y;
+				material.Roughness = lerp(material.Roughness, complexMaterialRoughness, complexMaterial);
+				material.F0 = lerp(material.F0, complexSpecular, complexMaterial);
+#			endif
+			}
+		}
+#		endif
+
+		if (!dynamicCubemap) {
+			float3 envColorBase = Color::GammaToLinear(TexEnvSampler.Sample(SampEnvSampler, envSamplingPoint).xyz);
+			envColor = envColorBase.xyz * envMask;
+		}
+	}
+
+#	endif  // defined (ENVMAP) || defined (MULTI_LAYER_PARALLAX) || defined(EYE)
+
 	float porosity = 1.0;
 
 #	if defined(SKYLIGHTING)
@@ -2614,6 +2697,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	diffuseColor += emitColor.xyz;
 #	endif
 
+	IndirectContext indirectContext;
+	IndirectLobeWeights indirectLobeWeights;
+
 	float3 ambientNormal = worldNormal;
 #	if defined(HAIR) && defined(CS_HAIR)
 	if (SharedData::hairSpecularSettings.Enabled && SharedData::hairSpecularSettings.HairMode == 1)
@@ -2666,109 +2752,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #	if defined(TRUE_PBR) && defined(LOD_LAND_BLEND) && !defined(DEFERRED)
 	lodLandDiffuseColor += directionalAmbientColor;
 #	endif
-
-#	if !defined(TRUE_PBR)
-#		if defined(HAIR) && defined(CS_HAIR)
-	if (!SharedData::hairSpecularSettings.Enabled)
-		diffuseColor += directionalAmbientColor;
-#		else
-	diffuseColor += directionalAmbientColor;
-#		endif
-#	endif
-
-#	if defined(ENVMAP) || defined(MULTI_LAYER_PARALLAX) || defined(EYE)
-	float envMask = EnvmapData.x * MaterialData.x;
-
-	float viewNormalAngle = dot(worldNormal.xyz, viewDirection);
-	float3 envSamplingPoint = (viewNormalAngle * 2) * worldNormal.xyz - viewDirection;
-
-	if (envMask > 0.0) {
-		if (EnvmapData.y) {
-			envMask *= TexEnvMaskSampler.Sample(SampEnvMaskSampler, uv).x;
-		} else {
-			envMask *= glossiness;
-		}
-	}
-
-	float3 envColor = 0.0;
-	bool dynamicCubemap = false;
-
-#		if defined(DYNAMIC_CUBEMAPS)
-	float3 F0 = 0.0;
-	float envRoughness = 1.0;
-#		endif
-
-	if (envMask > 0.0) {
-#		if defined(DYNAMIC_CUBEMAPS)
-		uint2 envSize;
-		TexEnvSampler.GetDimensions(envSize.x, envSize.y);
-
-#			if defined(EMAT)
-		if (envSize.x == 1 && envSize.y == 1 || complexMaterial) {
-#			else
-		if (envSize.x == 1 && envSize.y == 1) {
-#			endif
-
-			dynamicCubemap = true;
-
-#			if defined(EMAT)
-			if (!complexMaterial)
-#			endif
-			{
-				// Dynamic Cubemap Creator sets this value to black, if it is anything but black it is wrong
-				float3 envColorTest = TexEnvSampler.SampleLevel(SampEnvSampler, float3(0.0, 1.0, 0.0), 15).xyz;
-				dynamicCubemap = all(envColorTest == 0.0);
-			}
-
-#			if defined(CREATOR)
-			if (SharedData::cubemapCreatorSettings.Enabled) {
-				dynamicCubemap = true;
-			}
-#			endif
-
-			if (dynamicCubemap) {
-				float4 envColorBase = TexEnvSampler.SampleLevel(SampEnvSampler, float3(1.0, 0.0, 0.0), 15);
-
-				if (envColorBase.a < 1.0) {
-					F0 = Color::GammaToLinear(envColorBase.rgb);
-					envRoughness = envColorBase.a;
-				} else {
-					F0 = 1.0;
-					envRoughness = 1.0 / 7.0;
-				}
-
-#			if defined(CREATOR)
-				if (SharedData::cubemapCreatorSettings.Enabled) {
-					F0 = SharedData::cubemapCreatorSettings.CubemapColor.rgb;
-					envRoughness = SharedData::cubemapCreatorSettings.CubemapColor.a;
-				}
-#			endif
-
-#			if defined(EMAT)
-				float complexMaterialRoughness = 1.0 - complexMaterialColor.y;
-				envRoughness = lerp(envRoughness, complexMaterialRoughness, complexMaterial);
-				F0 = lerp(F0, complexSpecular, complexMaterial);
-#			endif
-
-				if (any(F0 > 0.0))
-#			if defined(SKYLIGHTING)
-					envColor = DynamicCubemaps::GetDynamicCubemap(worldNormal, vertexNormal, viewDirection, envRoughness, F0, skylightingSH) * envMask;
-#			else
-					envColor = DynamicCubemaps::GetDynamicCubemap(worldNormal, vertexNormal, viewDirection, envRoughness, F0) * envMask;
-#			endif
-				else
-					envColor = 0.0;
-			}
-		}
-#		endif
-
-		if (!dynamicCubemap) {
-			float3 envColorBase = Color::GammaToLinear(TexEnvSampler.Sample(SampEnvSampler, envSamplingPoint).xyz);
-			envColor = envColorBase.xyz * envMask;
-		}
-	}
-
-#	endif  // defined (ENVMAP) || defined (MULTI_LAYER_PARALLAX) || defined(EYE)
 
 	float2 screenMotionVector = MotionBlur::GetSSMotionVector(input.WorldPosition, input.PreviousWorldPosition, eyeIndex);
 
@@ -2859,6 +2842,18 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	float4 color = 0;
 
+	indirectContext = CreateIndirectLightingContext(ambientNormal, vertexNormal.xyz, viewDirection);
+
+	GetIndirectLobeWeights(indirectLobeWeights, indirectContext, material);
+#	if defined(ENVMAP) || defined(MULTI_LAYER_PARALLAX) || defined(EYE)
+	indirectLobeWeights.specular *= envMask;
+#	endif
+
+#	if defined(SPECULAR) && !defined(TRUE_PBR)
+	indirectLobeWeights.specular *= MaterialData.yyy;
+	specularColor *= MaterialData.yyy;
+#	endif
+
 #	if defined(TRUE_PBR)
 	{
 		float3 directLightsDiffuseInput = diffuseColor * baseColor.xyz;
@@ -2870,61 +2865,28 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		color.xyz += directLightsDiffuseInput;
 	}
 
-	float3 indirectDiffuseLobeWeight, indirectSpecularLobeWeight;
-	PBR::GetIndirectLobeWeights(indirectDiffuseLobeWeight, indirectSpecularLobeWeight, worldNormal.xyz, viewDirection, vertexNormal, baseColor.xyz, material);
-#		if defined(WETNESS_EFFECTS)
-	if (waterRoughnessSpecular < 1.0)
-		indirectSpecularLobeWeight = max(indirectSpecularLobeWeight, PBR::GetWetnessIndirectSpecularLobeWeight(wetnessNormal, viewDirection, vertexNormal, waterRoughnessSpecular));
-#		endif
-
-	color.xyz += indirectDiffuseLobeWeight * directionalAmbientColor;
-
-#		if !defined(DEFERRED)
-#			if defined(DYNAMIC_CUBEMAPS)
-#				if defined(SKYLIGHTING)
-	specularColorPBR += indirectSpecularLobeWeight * DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(screenUV, worldNormal, vertexNormal, viewDirection, material.Roughness, skylightingSH);
-#				else
-	specularColorPBR += indirectSpecularLobeWeight * DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(screenUV, worldNormal, vertexNormal, viewDirection, material.Roughness);
-#				endif
-#			else
-	specularColorPBR += indirectSpecularLobeWeight * directionalAmbientColor;
-#			endif
-#		else
-	indirectDiffuseLobeWeight *= vertexColor;
-#		endif
-
 	// Fixes white items in UI for VR
 	[branch] if ((PBRFlags & PBR::Flags::HasEmissive) != 0)
 	{
 		color.xyz += emitColor.xyz;
 	}
-	color.xyz += transmissionColor;
-#	elif defined(HAIR) && defined(CS_HAIR)
-	color.xyz += diffuseColor * baseColor.xyz;
-	if (SharedData::hairSpecularSettings.Enabled) {
-		color.xyz += indirectDiffuseLobeWeight * directionalAmbientColor;
-		color.xyz += transmissionColor;
-	}
 #	else
-	color.xyz += diffuseColor * baseColor.xyz;
+	color.xyz += diffuseColor * material.BaseColor;
 #	endif
 
-#	if defined(HAIR) && defined(CS_HAIR)
-#		if !defined(DEFERRED)
-#			if defined(DYNAMIC_CUBEMAPS)
-	if (SharedData::hairSpecularSettings.Enabled && SharedData::hairSpecularSettings.HairMode != 1)
-#				if defined(SKYLIGHTING)
-	{
-		float3 indirectSpecular = Hair::GetHairDynamicCubemapSpecularIrradiance(uv, screenUV, hairT, worldNormal, vertexNormal, viewDirection, SharedData::hairSpecularSettings.HairGlossiness, indirectSpecularLobeWeightPrim, indirectSpecularLobeWeightSec, skylightingSH);
-		color.xyz += indirectSpecular;
-	}
-#				else
-	{
-		float3 indirectSpecular = Hair::GetHairDynamicCubemapSpecularIrradiance(uv, screenUV, hairT, worldNormal, vertexNormal, viewDirection, SharedData::hairSpecularSettings.HairGlossiness, indirectSpecularLobeWeightPrim, indirectSpecularLobeWeightSec);
-		color.xyz += indirectSpecular;
-	}
-#				endif
+	color.xyz += indirectLobeWeights.diffuse * directionalAmbientColor;
+	color.xyz += transmissionColor;
+
+#	if !defined(DEFERRED)
+	if (any(indirectLobeWeights.specular > 0))
+#		if defined(DYNAMIC_CUBEMAPS)
+#			if defined(SKYLIGHTING)
+		color.xyz += indirectLobeWeights.specular * DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(screenUV, worldNormal, vertexNormal, viewDirection, material.Roughness, skylightingSH);
+#			else
+		color.xyz += indirectLobeWeights.specular * DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(screenUV, worldNormal, vertexNormal, viewDirection, material.Roughness);
 #			endif
+#		else
+		color.xyz += indirectLobeWeights.specular * directionalAmbientColor;
 #		endif
 #	endif
 
@@ -2949,15 +2911,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		endif
 #	endif  // MULTI_LAYER_PARALLAX
 
-#	if defined(SPECULAR)
-# 		if defined(HAIR) && defined(CS_HAIR)
-	if (!SharedData::hairSpecularSettings.Enabled)
-#		endif
-		specularColor = (specularColor * glossiness * MaterialData.yyy) * SpecularColor.xyz;
-#	elif defined(SPARKLE)
-	specularColor *= glossiness;
-#	endif  // SPECULAR
-
 #	if defined(SNOW)
 	if (useSnowSpecular)
 		specularColor = 0;
@@ -2977,11 +2930,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #	if defined(EMAT_ENVMAP)
 	specularColor *= complexSpecular;
 #	endif  // defined (EMAT) && defined(ENVMAP)
-
-#	if !defined(DEFERRED) && defined(DYNAMIC_CUBEMAPS) && (defined(ENVMAP) || defined(MULTI_LAYER_PARALLAX) || defined(EYE))
-	if (dynamicCubemap)
-		specularColor += envColor;
-#	endif
 
 #	if defined(WETNESS_EFFECTS) && !defined(TRUE_PBR)
 	specularColor += wetnessSpecular * wetnessGlossinessSpecular;
@@ -3049,7 +2997,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	diffuseColor = 0.0;
 	dynamicCubemap = true;
 	envColor = 1.0;
-	envRoughness = 0.0;
+	material.Roughness = 0.0;
 	color.xyz = 0;
 #	endif
 
@@ -3192,50 +3140,12 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	psout.Specular = float4(specularColor, psout.Diffuse.w);
 	psout.Albedo = float4(outputAlbedo, psout.Diffuse.w);
 
-	float outGlossiness = saturate(glossiness * SSRParams.w);
-
-#		if defined(HAIR) && defined(CS_HAIR)
-	if (SharedData::hairSpecularSettings.Enabled) {
-		outGlossiness = 1.0 - (SharedData::hairSpecularSettings.HairMode == 1 ? 1.0 : pow(abs(2.0 / (glossiness * 0.5 + 2.0)), 0.25));
-	}
-#		endif
-
 #		if defined(WETNESS_EFFECTS)
 	screenSpaceNormal = normalize(FrameBuffer::WorldToView(wetnessNormal, false, eyeIndex));
 #		endif
 
-#		if defined(TRUE_PBR)
-	psout.Reflectance = float4(indirectSpecularLobeWeight, psout.Diffuse.w);
-#			if defined(WETNESS_EFFECTS)
-	psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), lerp(pbrGlossiness, max(pbrGlossiness, wetnessGlossinessSpecular), wetnessGlossinessSpecular), psout.Diffuse.w);
-#			else
-	psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), pbrGlossiness, psout.Diffuse.w);
-#			endif
-#		elif defined(HAIR) && defined(CS_HAIR)
-	if (SharedData::hairSpecularSettings.Enabled) {
-#			if defined(WETNESS_EFFECTS)
-		psout.Reflectance = float4(indirectSpecularLobeWeightPrim + indirectSpecularLobeWeightSec + wetnessReflectance, psout.Diffuse.w);
-		psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), lerp(outGlossiness, max(outGlossiness, wetnessGlossinessSpecular), wetnessGlossinessSpecular), psout.Diffuse.w);
-#			else
-		psout.Reflectance = float4(indirectSpecularLobeWeightPrim + indirectSpecularLobeWeightSec, psout.Diffuse.w);
-		psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), outGlossiness, psout.Diffuse.w);
-#			endif
-	} else {
-#			if defined(WETNESS_EFFECTS)
-		psout.Reflectance = float4(wetnessReflectance, psout.Diffuse.w);
-		psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), lerp(outGlossiness, max(outGlossiness, wetnessGlossinessSpecular), wetnessGlossinessSpecular), psout.Diffuse.w);
-#			else
-		psout.Reflectance = float4(0.0.xxx, psout.Diffuse.w);
-		psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), outGlossiness, psout.Diffuse.w);
-#			endif
-	}
-#		elif defined(WETNESS_EFFECTS)
-	psout.Reflectance = float4(wetnessReflectance, psout.Diffuse.w);
-	psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), lerp(outGlossiness, max(outGlossiness, wetnessGlossinessSpecular), wetnessGlossinessSpecular), psout.Diffuse.w);
-#		else
-	psout.Reflectance = float4(0.0.xxx, psout.Diffuse.w);
-	psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), outGlossiness, psout.Diffuse.w);
-#		endif
+	psout.Reflectance = float4(indirectLobeWeights.specular, psout.Diffuse.w);
+	psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), saturate(1.0 - material.Roughness), psout.Diffuse.w);
 
 #		if defined(SNOW)
 #			if defined(TRUE_PBR)
@@ -3245,20 +3155,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	psout.Parameters.x = Color::RGBToLuminanceAlternative(lightsSpecularColor);
 #			endif
 	psout.Parameters.w = psout.Diffuse.w;
-#		endif
-
-#		if (defined(ENVMAP) || defined(MULTI_LAYER_PARALLAX) || defined(EYE))
-#			if defined(DYNAMIC_CUBEMAPS)
-	if (dynamicCubemap) {
-#				if defined(WETNESS_EFFECTS)
-		psout.Reflectance.xyz = max(envColor, wetnessReflectance);
-		psout.NormalGlossiness.z = lerp(1.0 - envRoughness, max(1.0 - envRoughness, wetnessGlossinessSpecular), wetnessGlossinessSpecular);
-#				else
-		psout.Reflectance.xyz = envColor;
-		psout.NormalGlossiness.z = 1.0 - envRoughness;
-#				endif
-	}
-#			endif
 #		endif
 
 #		if defined(SSS) && defined(SKIN)

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1989,6 +1989,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 #	if defined(MODELSPACENORMALS) && !defined(SKINNED)
 	float3 worldNormal = normal.xyz;
+	float3x3 tbnTr = ReconstructTBN(input.WorldPosition.xyz, worldNormal, screenUV);
 #	else
 	float3 worldNormal = normalize(mul(tbn, normal.xyz));
 
@@ -2113,7 +2114,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	}
 #	endif
 
-	MaterialProperties material;
+	MaterialProperties material = (MaterialProperties)0;
+
+	material.F0 = 0;
+	material.Roughness = 1;
 
 #	if defined(TRUE_PBR)
 	material.Noise = screenNoise;
@@ -2130,7 +2134,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 #		if defined(GLINT)
 	float glintNoise = Random::R1Modified(float(SharedData::FrameCount), (Random::pcg2d(uint2(input.Position.xy)) / 4294967296.0).x);
-	PBR::Glints::PrecomputeGlints(glintNoise, uvOriginal, ddx(uvOriginal), ddy(uvOriginal), material.GlintScreenSpaceScale, material.GlintCache);
+	Glints::PrecomputeGlints(glintNoise, uvOriginal, ddx(uvOriginal), ddy(uvOriginal), material.GlintScreenSpaceScale, material.GlintCache);
 #		endif
 
 	baseColor.xyz *= 1 - material.Metallic;
@@ -2191,19 +2195,28 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		endif
 #	else
 	material.BaseColor = baseColor.xyz;
+#		if defined(SPECULAR)
 	material.Shininess = shininess;
 	material.Glossiness = glossiness;
 	material.SpecularColor = SpecularColor.xyz;
+#		else
+	material.Shininess = 0;
+	material.Glossiness = 0;
+	material.SpecularColor = 0;
+#		endif
 #	    if (defined(RIM_LIGHTING) || defined(SOFT_LIGHTING) || defined(LOAD_SOFT_LIGHTING))
     material.rimSoftLightColor = rimSoftLightColor.xyz;
 #       endif
+#		if defined(BACK_LIGHTING)
+	material.backLightColor = backLightColor.xyz;
+#		endif
 #	endif  // TRUE_PBR
 
 #	if defined(CS_HAIR) && defined(HAIR)
 	if (SharedData::hairSpecularSettings.Enabled) {
 		material.Shininess = SharedData::hairSpecularSettings.HairGlossiness;
 		material.F0 = Hair::HairF0();
-		material.Roughness = SharedData::hairSpecularSettings.HairMode == 1 ? 1 : ShininessToRoughness(SharedData::hairSpecularSettings.HairGlossiness);
+		material.Roughness = 1;
 	}
 #	endif
 
@@ -2389,7 +2402,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float3 rippleNormal = normalize(lerp(float3(0, 0, 1), raindropInfo.xyz, lerp(flatnessAmount, 1.0, 0.5)));
 	wetnessNormal = WetnessEffects::ReorientNormal(rippleNormal, wetnessNormal);
 
-	waterRoughnessSpecular = 1.0 - wetnessGlossinessSpecular;
+	waterRoughnessSpecular = saturate(1.0 - wetnessGlossinessSpecular);
 #	endif
 
 	float3 dirLightColor = Color::Light(DirLightColor.xyz);
@@ -2498,9 +2511,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	DirectContext dirLightContext;
 	DirectLightingOutput dirLightOutput;
 #	if defined(TRUE_PBR)
-	dirLightContext = CreateDirectLightingContext(worldNormal.xyz, coatWorldNormal, vertexNormal.xyz, refractedViewDirection, viewDirection, refractedDirLightDirection, DirLightDirection, dirLightColor, dirLightColorMultiplier, dirDetailShadow, parallaxShadow);
+	dirLightContext = CreateDirectLightingContext(worldNormal.xyz, coatWorldNormal, vertexNormal.xyz, refractedViewDirection, viewDirection, refractedDirLightDirection, DirLightDirection, dirLightColor * dirLightColorMultiplier, dirDetailShadow, parallaxShadow);
 #	else
-	dirLightContext = CreateDirectLightingContext(worldNormal.xyz, vertexNormal.xyz, viewDirection, DirLightDirection, dirLightColor, dirLightColorMultiplier, dirDetailShadow, parallaxShadow);
+	dirLightContext = CreateDirectLightingContext(worldNormal.xyz, vertexNormal.xyz, viewDirection, DirLightDirection, dirLightColor * dirLightColorMultiplier, dirDetailShadow, parallaxShadow);
 #		if defined(HAIR) && defined(CS_HAIR)
 	if (SharedData::hairSpecularSettings.Enabled) {
 		float hairShadow = Hair::HairSelfShadow(input.WorldPosition.xyz, DirLightDirection, screenNoise, eyeIndex);
@@ -2739,7 +2752,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	diffuseColor += emitColor.xyz;
 #	endif
 
-	IndirectContext indirectContext;
+	IndirectContext indirectContext = (IndirectContext)0;
 	IndirectLobeWeights indirectLobeWeights;
 
 	float3 ambientNormal = worldNormal;
@@ -2814,13 +2827,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	porosity = lerp(porosity, 0.0, saturate(sqrt(envMask)));
 #			endif
 	float wetnessDarkeningAmount = porosity * wetnessGlossinessAlbedo;
-	baseColor.xyz = lerp(baseColor.xyz, pow(abs(baseColor.xyz), 1.0 + wetnessDarkeningAmount), 0.5);
-#		endif
-
-#		if defined(DYNAMIC_CUBEMAPS)
-	float3 wetnessReflectance = GetWetnessIndirectLobeWeights(indirectLobeWeights, wetnessNormal, waterRoughnessSpecular, indirectContext);
-#		else
-	float3 wetnessReflectance = 0.0;
+	material.BaseColor = lerp(material.BaseColor, pow(abs(material.BaseColor), 1.0 + wetnessDarkeningAmount), 0.5);
 #		endif
 #	endif
 
@@ -2869,7 +2876,15 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	indirectContext = CreateIndirectLightingContext(ambientNormal, vertexNormal.xyz, viewDirection);
 
-	GetIndirectLobeWeights(indirectLobeWeights, indirectContext, material);
+	GetIndirectLobeWeights(indirectLobeWeights, indirectContext, material, uvOriginal);
+
+#	if defined(WETNESS_EFFECTS)
+#		if defined(DYNAMIC_CUBEMAPS)
+	float3 wetnessReflectance = GetWetnessIndirectLobeWeights(indirectLobeWeights, wetnessNormal, waterRoughnessSpecular, indirectContext);
+#		else
+	float3 wetnessReflectance = 0.0;
+#		endif
+#	endif
 #	if defined(ENVMAP) || defined(MULTI_LAYER_PARALLAX) || defined(EYE)
 	indirectLobeWeights.specular *= envMask;
 #	endif
@@ -2961,7 +2976,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #	endif
 
 #	if !defined(DEFERRED)
-	if (any(indirectLobeWeights.specular > 0))
+	if (any(indirectLobeWeights.specular > 0)
+#		if defined(WETNESS_EFFECTS)
+		|| any(wetnessReflectance > 0)
+#		endif
+	)
 #		if defined(DYNAMIC_CUBEMAPS)
 #			if defined(SKYLIGHTING)
 		color.xyz += indirectLobeWeights.specular * DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(screenUV, worldNormal, vertexNormal, viewDirection, material.Roughness, skylightingSH);
@@ -3162,7 +3181,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	screenSpaceNormal = normalize(FrameBuffer::WorldToView(wetnessNormal, false, eyeIndex));
 	indirectLobeWeights.specular += wetnessReflectance;
 	if (waterRoughnessSpecular < 1)
-		material.Roughness = lerp(material.Roughness, waterRoughnessSpecular, wetnessGlossinessSpecular);
+		material.Roughness = lerp(material.Roughness, waterRoughnessSpecular, wetnessReflectance);
 #		endif
 
 	psout.Reflectance = float4(indirectLobeWeights.specular, psout.Diffuse.w);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -3148,10 +3148,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	psout.Albedo = float4(outputAlbedo, psout.Diffuse.w);
 
 #		if defined(WETNESS_EFFECTS)
-	screenSpaceNormal = normalize(FrameBuffer::WorldToView(wetnessNormal, false, eyeIndex));
 	indirectLobeWeights.specular += wetnessReflectance;
-	if (waterRoughnessSpecular < 1)
+	if (waterRoughnessSpecular < 1) {
+		screenSpaceNormal = lerp(screenSpaceNormal, normalize(FrameBuffer::WorldToView(wetnessNormal, false, eyeIndex)), saturate(wetnessGlossinessSpecular));
 		material.Roughness = lerp(material.Roughness, waterRoughnessSpecular, wetnessReflectance);
+	}
 #		endif
 
 	psout.Reflectance = float4(indirectLobeWeights.specular, psout.Diffuse.w);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2189,10 +2189,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		material.FuzzWeight = lerp(material.FuzzWeight, 0, projectedMaterialWeight);
 	}
 #		endif
-
-	float3 specularColorPBR = 0;
-
-	float pbrGlossiness = 1 - material.Roughness;
 #	else
 	material.BaseColor = baseColor.xyz;
 	material.Shininess = shininess;
@@ -2308,7 +2304,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #	if defined(WETNESS_EFFECTS)
 	// Initialize wetness parameters
 	float wetness = 0.0;
-	float3 wetnessSpecular = 0.0;
 	float3 wetnessNormal = worldNormal;
 
 	// Calculate shore wetness factors
@@ -2494,6 +2489,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #	endif
 
 	EvaluateLighting(dirLightContext, material, tbnTr, uvOriginal, dirLightOutput);
+#	if defined(WETNESS_EFFECTS)
+	if (waterRoughnessSpecular < 1)
+		EvaluateWetnessLighting(wetnessNormal, dirLightContext, waterRoughnessSpecular, dirLightOutput);
+#	endif
+
 	lightsDiffuseColor += dirLightOutput.diffuse;
 	lightsSpecularColor += dirLightOutput.specular;
 #	if defined(TRUE_PBR)
@@ -2543,6 +2543,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		pointLightContext = CreateDirectLightingContext(worldNormal.xyz, vertexNormal.xyz, viewDirection, normalizedLightDirection, lightColor, lightShadow, 1);
 #			endif
 		EvaluateLighting(pointLightContext, material, tbnTr, uvOriginal, pointLightOutput);
+#			if defined(WETNESS_EFFECTS)
+		if (waterRoughnessSpecular < 1)
+			EvaluateWetnessLighting(wetnessNormal, pointLightContext, waterRoughnessSpecular, pointLightOutput);
+#			endif
 		lightsDiffuseColor += pointLightOutput.diffuse;
 		lightsSpecularColor += pointLightOutput.specular;
 #			if defined(TRUE_PBR)
@@ -2655,6 +2659,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		pointLightContext = CreateDirectLightingContext(worldNormal.xyz, vertexNormal.xyz, viewDirection, normalizedLightDirection, lightColor, lightShadow, parallaxShadow);
 #			endif
 		EvaluateLighting(pointLightContext, material, tbnTr, uvOriginal, pointLightOutput);
+#			if defined(WETNESS_EFFECTS)
+		if (waterRoughnessSpecular < 1)
+			EvaluateWetnessLighting(wetnessNormal, pointLightContext, waterRoughnessSpecular, pointLightOutput);
+#			endif
+
 		lightsDiffuseColor += pointLightOutput.diffuse;
 		lightsSpecularColor += pointLightOutput.specular;
 #			if defined(TRUE_PBR)
@@ -2776,31 +2785,14 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		endif
 
 #		if defined(DYNAMIC_CUBEMAPS)
-#			if defined(SKYLIGHTING)
-	float3 wetnessReflectance = DynamicCubemaps::GetDynamicCubemap(wetnessNormal, vertexNormal, viewDirection, waterRoughnessSpecular, 0.02 * wetnessGlossinessSpecular, skylightingSH);
-#			else
-	float3 wetnessReflectance = DynamicCubemaps::GetDynamicCubemap(wetnessNormal, vertexNormal, viewDirection, waterRoughnessSpecular, 0.02 * wetnessGlossinessSpecular);
-#			endif
+	float3 wetnessReflectance = GetWetnessIndirectLobeWeights(indirectLobeWeights, wetnessNormal, waterRoughnessSpecular, indirectContext);
 #		else
 	float3 wetnessReflectance = 0.0;
-#		endif
-
-#		if !defined(DEFERRED)
-	wetnessSpecular += wetnessReflectance;
 #		endif
 #	endif
 
 #	if defined(HAIR)
 	float3 vertexColor = lerp(1, TintColor.xyz, input.Color.y);
-#		if defined(CS_HAIR)
-	float3 indirectDiffuseLobeWeight, indirectSpecularLobeWeightPrim, indirectSpecularLobeWeightSec;
-	if (SharedData::hairSpecularSettings.Enabled)
-		vertexColor = 1;
-	Hair::GetHairIndirectSpecularLobeWeights(indirectDiffuseLobeWeight, indirectSpecularLobeWeightPrim, indirectSpecularLobeWeightSec, hairT, worldNormal.xyz, viewDirection, vertexNormal, SharedData::hairSpecularSettings.HairGlossiness, uv, baseColor.xyz);
-	indirectDiffuseLobeWeight *= SharedData::hairSpecularSettings.DiffuseIndirectMult;
-	indirectSpecularLobeWeightPrim *= SharedData::hairSpecularSettings.SpecularIndirectMult;
-	indirectSpecularLobeWeightSec *= SharedData::hairSpecularSettings.SpecularIndirectMult;
-#		endif  // CS_HAIR
 #	elif defined(SKYLIGHTING)
 	float3 vertexColor = input.Color.xyz;
 	float vertexAO = max(max(vertexColor.r, vertexColor.g), vertexColor.b);
@@ -2877,19 +2869,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	color.xyz += indirectLobeWeights.diffuse * directionalAmbientColor;
 	color.xyz += transmissionColor;
 
-#	if !defined(DEFERRED)
-	if (any(indirectLobeWeights.specular > 0))
-#		if defined(DYNAMIC_CUBEMAPS)
-#			if defined(SKYLIGHTING)
-		color.xyz += indirectLobeWeights.specular * DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(screenUV, worldNormal, vertexNormal, viewDirection, material.Roughness, skylightingSH);
-#			else
-		color.xyz += indirectLobeWeights.specular * DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(screenUV, worldNormal, vertexNormal, viewDirection, material.Roughness);
-#			endif
-#		else
-		color.xyz += indirectLobeWeights.specular * directionalAmbientColor;
-#		endif
-#	endif
-
 	color.xyz *= vertexColor;
 
 #	if defined(MULTI_LAYER_PARALLAX)
@@ -2931,39 +2910,45 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	specularColor *= complexSpecular;
 #	endif  // defined (EMAT) && defined(ENVMAP)
 
-#	if defined(WETNESS_EFFECTS) && !defined(TRUE_PBR)
-	specularColor += wetnessSpecular * wetnessGlossinessSpecular;
-#	endif
-
 #	if defined(LOD_LAND_BLEND) && defined(TRUE_PBR)
 	{
 		lodLandDiffuseColor += directionalAmbientColor;
 		float3 litLodLandColor = vertexColor * lodLandColor.xyz * lodLandFadeFactor * lodLandDiffuseColor;
 		color.xyz = lerp(color.xyz * Color::PBRLightingScale, litLodLandColor, lodLandBlendFactor);
 
-		specularColor = lerp(specularColorPBR * Color::PBRLightingScale, 0, lodLandBlendFactor);
-		indirectDiffuseLobeWeight = lerp(indirectDiffuseLobeWeight * Color::PBRLightingScale, vertexColor * lodLandColor.xyz * lodLandFadeFactor, lodLandBlendFactor);
-		indirectSpecularLobeWeight = lerp(indirectSpecularLobeWeight, 0, lodLandBlendFactor);
-		pbrGlossiness = lerp(pbrGlossiness, 0, lodLandBlendFactor);
+		specularColor = lerp(specularColor * Color::PBRLightingScale, 0, lodLandBlendFactor);
+		indirectLobeWeights.diffuse = lerp(indirectLobeWeights.diffuse * Color::PBRLightingScale, vertexColor * lodLandColor.xyz * lodLandFadeFactor, lodLandBlendFactor);
+		indirectLobeWeights.specular = lerp(indirectLobeWeights.specular, 0, lodLandBlendFactor);
+		material.Roughness = lerp(material.Roughness, 1, lodLandBlendFactor);
 	}
 #	elif defined(TRUE_PBR)
 	color.xyz *= Color::PBRLightingScale;
-	specularColorPBR *= Color::PBRLightingScale;
-	indirectDiffuseLobeWeight *= Color::PBRLightingScale;
-	specularColor = specularColorPBR;
+	specularColor *= Color::PBRLightingScale;
+	indirectLobeWeights.diffuse *= Color::PBRLightingScale;
 #	endif
 
-	float3 outputAlbedo = baseColor.xyz * vertexColor;
-
-#		if defined(TRUE_PBR)
-	outputAlbedo = indirectDiffuseLobeWeight;
+#	if !defined(DEFERRED)
+	if (any(indirectLobeWeights.specular > 0))
+#		if defined(DYNAMIC_CUBEMAPS)
+#			if defined(SKYLIGHTING)
+		color.xyz += indirectLobeWeights.specular * DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(screenUV, worldNormal, vertexNormal, viewDirection, material.Roughness, skylightingSH);
+#				if defined(WETNESS_EFFECTS)
+		if (waterRoughnessSpecular < 1)
+			color.xyz += wetnessReflectance * DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(screenUV, wetnessNormal, vertexNormal, viewDirection, waterRoughnessSpecular, skylightingSH);
+#				endif
+#			else
+		color.xyz += indirectLobeWeights.specular * DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(screenUV, worldNormal, vertexNormal, viewDirection, material.Roughness);
+#				if defined(WETNESS_EFFECTS)
+		if (waterRoughnessSpecular < 1)
+			color.xyz += wetnessReflectance * DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(screenUV, wetnessNormal, vertexNormal, viewDirection, waterRoughnessSpecular);
+#				endif
+#			endif
+#		else
+		color.xyz += indirectLobeWeights.specular * directionalAmbientColor;
 #		endif
+#	endif
 
-#		if defined(HAIR) && defined(CS_HAIR)
-	if (SharedData::hairSpecularSettings.Enabled) {
-		outputAlbedo = indirectDiffuseLobeWeight;
-	}
-#		endif
+	float3 outputAlbedo = indirectLobeWeights.diffuse;
 
 #	if defined(IBL) && defined(SKYLIGHTING)
 	directionalAmbientColor -= iblColor;
@@ -3142,6 +3127,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 #		if defined(WETNESS_EFFECTS)
 	screenSpaceNormal = normalize(FrameBuffer::WorldToView(wetnessNormal, false, eyeIndex));
+	indirectLobeWeights.specular += wetnessReflectance;
+	if (waterRoughnessSpecular < 1)
+		material.Roughness = lerp(material.Roughness, waterRoughnessSpecular, wetnessGlossinessSpecular);
 #		endif
 
 	psout.Reflectance = float4(indirectLobeWeights.specular, psout.Diffuse.w);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2199,6 +2199,14 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #       endif
 #	endif  // TRUE_PBR
 
+#	if defined(CS_HAIR) && defined(HAIR)
+	if (SharedData::hairSpecularSettings.Enabled) {
+		material.Shininess = SharedData::hairSpecularSettings.HairGlossiness;
+		material.F0 = Hair::HairF0();
+		material.Roughness = SharedData::hairSpecularSettings.HairMode == 1 ? 1 : ShininessToRoughness(SharedData::hairSpecularSettings.HairGlossiness);
+	}
+#	endif
+
 	bool dynamicCubemap = false;
 
 #	if defined(ENVMAP) || defined(MULTI_LAYER_PARALLAX) || defined(EYE)
@@ -2211,7 +2219,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		if (EnvmapData.y) {
 			envMask *= TexEnvMaskSampler.Sample(SampEnvMaskSampler, uv).x;
 		} else {
-			envMask *= glossiness;
+			envMask *= material.Glossiness;
 		}
 	}
 
@@ -2469,6 +2477,13 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	dirLightColorMultiplier *= dirShadow;
 
+#	if defined(CS_HAIR) && defined(HAIR)
+	if (SharedData::hairSpecularSettings.Enabled) {
+		vertexNormal.xyz = worldNormal.xyz;
+		worldNormal.xyz = hairT;
+	}
+#	endif
+
 	float3 diffuseColor = 0.0.xxx;
 	float3 specularColor = 0.0.xxx;
 	float3 transmissionColor = 0.0.xxx;
@@ -2486,6 +2501,12 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	dirLightContext = CreateDirectLightingContext(worldNormal.xyz, coatWorldNormal, vertexNormal.xyz, refractedViewDirection, viewDirection, refractedDirLightDirection, DirLightDirection, dirLightColor, dirLightColorMultiplier, dirDetailShadow, parallaxShadow);
 #	else
 	dirLightContext = CreateDirectLightingContext(worldNormal.xyz, vertexNormal.xyz, viewDirection, DirLightDirection, dirLightColor, dirLightColorMultiplier, dirDetailShadow, parallaxShadow);
+#		if defined(HAIR) && defined(CS_HAIR)
+	if (SharedData::hairSpecularSettings.Enabled) {
+		float hairShadow = Hair::HairSelfShadow(input.WorldPosition.xyz, DirLightDirection, screenNoise, eyeIndex);
+		dirLightContext.hairShadow = hairShadow;
+	}
+#		endif
 #	endif
 
 	EvaluateLighting(dirLightContext, material, tbnTr, uvOriginal, dirLightOutput);
@@ -2541,6 +2562,12 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		}
 #			else
 		pointLightContext = CreateDirectLightingContext(worldNormal.xyz, vertexNormal.xyz, viewDirection, normalizedLightDirection, lightColor, lightShadow, 1);
+#				if defined(HAIR) && defined(CS_HAIR)
+		if (SharedData::hairSpecularSettings.Enabled) {
+			float hairShadow = Hair::HairSelfShadow(input.WorldPosition.xyz, normalizedLightDirection, screenNoise, eyeIndex);
+			pointLightContext.hairShadow = hairShadow;
+		}
+#				endif
 #			endif
 		EvaluateLighting(pointLightContext, material, tbnTr, uvOriginal, pointLightOutput);
 #			if defined(WETNESS_EFFECTS)
@@ -2657,6 +2684,12 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		pointLightContext = CreateDirectLightingContext(worldNormal.xyz, coatWorldNormal, vertexNormal.xyz, refractedViewDirection, viewDirection, refractedLightDirection, normalizedLightDirection, lightColor, lightShadow, parallaxShadow);
 #			else
 		pointLightContext = CreateDirectLightingContext(worldNormal.xyz, vertexNormal.xyz, viewDirection, normalizedLightDirection, lightColor, lightShadow, parallaxShadow);
+#				if defined(HAIR) && defined(CS_HAIR)
+		if (SharedData::hairSpecularSettings.Enabled) {
+			float hairShadow = Hair::HairSelfShadow(input.WorldPosition.xyz, normalizedLightDirection, screenNoise, eyeIndex);
+			pointLightContext.hairShadow = hairShadow;
+		}
+#				endif
 #			endif
 		EvaluateLighting(pointLightContext, material, tbnTr, uvOriginal, pointLightOutput);
 #			if defined(WETNESS_EFFECTS)

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -3151,7 +3151,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	indirectLobeWeights.specular += wetnessReflectance;
 	if (waterRoughnessSpecular < 1) {
 		screenSpaceNormal = lerp(screenSpaceNormal, normalize(FrameBuffer::WorldToView(wetnessNormal, false, eyeIndex)), saturate(wetnessGlossinessSpecular));
-		material.Roughness = lerp(material.Roughness, waterRoughnessSpecular, wetnessReflectance);
+		material.Roughness = lerp(material.Roughness, waterRoughnessSpecular, wetnessReflectance.x);
 	}
 #		endif
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2866,7 +2866,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 #	if defined(TRUE_PBR)
 	{
-		float3 directLightsDiffuseInput = diffuseColor * baseColor.xyz;
+		float3 directLightsDiffuseInput = diffuseColor * material.BaseColor;
 		[branch] if ((PBRFlags & PBR::Flags::ColoredCoat) != 0)
 		{
 			directLightsDiffuseInput = lerp(directLightsDiffuseInput, material.CoatColor * coatLightsDiffuseColor, material.CoatStrength);
@@ -2904,7 +2904,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	color.xyz = lerp(color.xyz, diffuseColor * vertexColor * layerColor, mlpBlendFactor);
 
 #		if defined(DEFERRED)
-	baseColor.xyz *= 1.0 - mlpBlendFactor;
+	indirectLobeWeights.diffuse *= 1.0 - mlpBlendFactor;
 #		endif
 #	endif  // MULTI_LAYER_PARALLAX
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2970,7 +2970,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		endif
 #	endif
 
-	float3 outputAlbedo = indirectLobeWeights.diffuse;
+	float3 outputAlbedo = indirectLobeWeights.diffuse * vertexColor.xyz;
 
 #	if defined(IBL) && defined(SKYLIGHTING)
 	directionalAmbientColor -= iblColor;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -976,34 +976,7 @@ float GetSnowParameterY(float texProjTmp, float alpha)
 #		include "IBL/IBL.hlsli"
 #	endif
 
-struct MaterialProperties
-{
-	float3 BaseColor = 0;
-#	if !defined(TRUE_PBR)
-	float Shininess = 0;
-	float Glossiness = 0;
-	float3 SpecularColor = 0;
-#	else
-	float Roughness = 1;
-	float Metallic = 0;
-	float AO = 1;
-	float3 F0 = 0;
-	float3 SubsurfaceColor = 0;
-	float Thickness = 0;
-	float3 CoatColor = 0;
-	float CoatStrength = 0;
-	float CoatRoughness = 0;
-	float3 CoatF0 = 0;
-	float3 FuzzColor = 0;
-	float FuzzWeight = 0;
-	float GlintScreenSpaceScale = 1.5;
-	float GlintLogMicrofacetDensity = 1.0;
-	float GlintMicrofacetRoughness = 0.015;
-	float GlintDensityRandomization = 2.0;
-	Glints::GlintCachedVars GlintCache;
-	float Noise = 0;
-#	endif
-};
+#include "Common/LightingCommon.hlsli"
 
 PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 {

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -976,6 +976,35 @@ float GetSnowParameterY(float texProjTmp, float alpha)
 #		include "IBL/IBL.hlsli"
 #	endif
 
+struct MaterialProperties
+{
+	float3 BaseColor = 0;
+#	if !defined(TRUE_PBR)
+	float Shininess = 0;
+	float Glossiness = 0;
+	float3 SpecularColor = 0;
+#	else
+	float Roughness = 1;
+	float Metallic = 0;
+	float AO = 1;
+	float3 F0 = 0;
+	float3 SubsurfaceColor = 0;
+	float Thickness = 0;
+	float3 CoatColor = 0;
+	float CoatStrength = 0;
+	float CoatRoughness = 0;
+	float3 CoatF0 = 0;
+	float3 FuzzColor = 0;
+	float FuzzWeight = 0;
+	float GlintScreenSpaceScale = 1.5;
+	float GlintLogMicrofacetDensity = 1.0;
+	float GlintMicrofacetRoughness = 0.015;
+	float GlintDensityRandomization = 2.0;
+	Glints::GlintCachedVars GlintCache;
+	float Noise = 0;
+#	endif
+};
+
 PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 {
 	PS_OUTPUT psout;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2174,7 +2174,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	if (SharedData::hairSpecularSettings.Enabled) {
 		material.Shininess = SharedData::hairSpecularSettings.HairGlossiness;
 		material.F0 = Hair::HairF0();
-		material.Roughness = 1;
+		if (SharedData::hairSpecularSettings.HairMode == 1) {
+			material.Roughness = 1;
+		} else {
+			material.Roughness = ShininessToRoughness(material.Shininess * 0.75);
+		}
 	}
 #	endif
 
@@ -2713,11 +2717,15 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	IndirectContext indirectContext = (IndirectContext)0;
 	IndirectLobeWeights indirectLobeWeights;
 
-	float3 ambientNormal = worldNormal;
+	float3 ambientNormal = worldNormal.xyz;
 #	if defined(HAIR) && defined(CS_HAIR)
-	if (SharedData::hairSpecularSettings.Enabled && SharedData::hairSpecularSettings.HairMode == 1)
-		ambientNormal = normalize(viewDirection - hairT * dot(viewDirection, hairT));
+	if (SharedData::hairSpecularSettings.Enabled) {
+		if (SharedData::hairSpecularSettings.HairMode == 1)
+			ambientNormal = normalize(viewDirection - hairT * dot(viewDirection, hairT));
+		else
+			ambientNormal = vertexNormal.xyz;
 		screenSpaceNormal = normalize(FrameBuffer::WorldToView(ambientNormal, false, eyeIndex));
+	}
 #	endif
 
 	float3 directionalAmbientColor = max(0, mul(DirectionalAmbient, float4(ambientNormal, 1.0)));
@@ -2791,6 +2799,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 #	if defined(HAIR)
 	float3 vertexColor = lerp(1, TintColor.xyz, input.Color.y);
+#		if defined(CS_HAIR)
+	if (SharedData::hairSpecularSettings.Enabled)
+		vertexColor = 1;
+#		endif
 #	elif defined(SKYLIGHTING)
 	float3 vertexColor = input.Color.xyz;
 	float vertexAO = max(max(vertexColor.r, vertexColor.g), vertexColor.b);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -887,6 +887,8 @@ float GetSnowParameterY(float texProjTmp, float alpha)
 #		undef SKYLIGHTING
 #	endif
 
+#	include "Common/LightingCommon.hlsli"
+
 #	if defined(WATER_EFFECTS)
 #		include "WaterEffects/WaterCaustics.hlsli"
 #	endif
@@ -976,7 +978,7 @@ float GetSnowParameterY(float texProjTmp, float alpha)
 #		include "IBL/IBL.hlsli"
 #	endif
 
-#include "Common/LightingCommon.hlsli"
+#	include "Common/LightingEval.hlsli"
 
 PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 {
@@ -2107,55 +2109,53 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 			screenSpaceNormal = normalize(FrameBuffer::WorldToView(shiftedNormal, false, eyeIndex));
 		}
 	}
-
-	float3 transmissionColor = 0;
 #	endif
 
+	MaterialProperties material;
+
 #	if defined(TRUE_PBR)
-	PBR::SurfaceProperties pbrSurfaceProperties = PBR::InitSurfaceProperties();
+	material.Noise = screenNoise;
 
-	pbrSurfaceProperties.Noise = screenNoise;
+	material.Roughness = clamp(rawRMAOS.x, PBR::Constants::MinRoughness, PBR::Constants::MaxRoughness);
+	material.Metallic = saturate(rawRMAOS.y);
+	material.AO = rawRMAOS.z;
+	material.F0 = lerp(saturate(rawRMAOS.w), Color::GammaToTrueLinear(baseColor.xyz), material.Metallic);
 
-	pbrSurfaceProperties.Roughness = clamp(rawRMAOS.x, PBR::Constants::MinRoughness, PBR::Constants::MaxRoughness);
-	pbrSurfaceProperties.Metallic = saturate(rawRMAOS.y);
-	pbrSurfaceProperties.AO = rawRMAOS.z;
-	pbrSurfaceProperties.F0 = lerp(saturate(rawRMAOS.w), Color::GammaToTrueLinear(baseColor.xyz), pbrSurfaceProperties.Metallic);
-
-	pbrSurfaceProperties.GlintScreenSpaceScale = max(1, glintParameters.x);
-	pbrSurfaceProperties.GlintLogMicrofacetDensity = clamp(PBR::Constants::MaxGlintDensity - glintParameters.y, PBR::Constants::MinGlintDensity, PBR::Constants::MaxGlintDensity);
-	pbrSurfaceProperties.GlintMicrofacetRoughness = clamp(glintParameters.z, PBR::Constants::MinGlintRoughness, PBR::Constants::MaxGlintRoughness);
-	pbrSurfaceProperties.GlintDensityRandomization = clamp(glintParameters.w, PBR::Constants::MinGlintDensityRandomization, PBR::Constants::MaxGlintDensityRandomization);
+	material.GlintScreenSpaceScale = max(1, glintParameters.x);
+	material.GlintLogMicrofacetDensity = clamp(PBR::Constants::MaxGlintDensity - glintParameters.y, PBR::Constants::MinGlintDensity, PBR::Constants::MaxGlintDensity);
+	material.GlintMicrofacetRoughness = clamp(glintParameters.z, PBR::Constants::MinGlintRoughness, PBR::Constants::MaxGlintRoughness);
+	material.GlintDensityRandomization = clamp(glintParameters.w, PBR::Constants::MinGlintDensityRandomization, PBR::Constants::MaxGlintDensityRandomization);
 
 #		if defined(GLINT)
 	float glintNoise = Random::R1Modified(float(SharedData::FrameCount), (Random::pcg2d(uint2(input.Position.xy)) / 4294967296.0).x);
-	PBR::Glints::PrecomputeGlints(glintNoise, uvOriginal, ddx(uvOriginal), ddy(uvOriginal), pbrSurfaceProperties.GlintScreenSpaceScale, pbrSurfaceProperties.GlintCache);
+	PBR::Glints::PrecomputeGlints(glintNoise, uvOriginal, ddx(uvOriginal), ddy(uvOriginal), material.GlintScreenSpaceScale, material.GlintCache);
 #		endif
 
-	baseColor.xyz *= 1 - pbrSurfaceProperties.Metallic;
+	baseColor.xyz *= 1 - material.Metallic;
 
-	pbrSurfaceProperties.BaseColor = baseColor.xyz;
+	material.BaseColor = baseColor.xyz;
 
 	float3 coatWorldNormal = worldNormal;
 
 #		if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 	[branch] if ((PBRFlags & PBR::Flags::Subsurface) != 0)
 	{
-		pbrSurfaceProperties.SubsurfaceColor = PBRParams2.xyz;
-		pbrSurfaceProperties.Thickness = PBRParams2.w;
+		material.SubsurfaceColor = PBRParams2.xyz;
+		material.Thickness = PBRParams2.w;
 		[branch] if ((PBRFlags & PBR::Flags::HasFeatureTexture0) != 0)
 		{
 			float4 sampledSubsurfaceProperties = TexRimSoftLightWorldMapOverlaySampler.Sample(SampRimSoftLightWorldMapOverlaySampler, uv);
-			pbrSurfaceProperties.SubsurfaceColor *= Color::Diffuse(sampledSubsurfaceProperties.xyz);
-			pbrSurfaceProperties.Thickness *= sampledSubsurfaceProperties.w;
+			material.SubsurfaceColor *= Color::Diffuse(sampledSubsurfaceProperties.xyz);
+			material.Thickness *= sampledSubsurfaceProperties.w;
 		}
-		pbrSurfaceProperties.Thickness = lerp(pbrSurfaceProperties.Thickness, 1, projectedMaterialWeight);
+		material.Thickness = lerp(material.Thickness, 1, projectedMaterialWeight);
 	}
 	else if ((PBRFlags & PBR::Flags::TwoLayer) != 0)
 	{
-		pbrSurfaceProperties.CoatColor = sampledCoatColor.xyz;
-		pbrSurfaceProperties.CoatStrength = sampledCoatColor.w;
-		pbrSurfaceProperties.CoatRoughness = MultiLayerParallaxData.x;
-		pbrSurfaceProperties.CoatF0 = MultiLayerParallaxData.y;
+		material.CoatColor = sampledCoatColor.xyz;
+		material.CoatStrength = sampledCoatColor.w;
+		material.CoatRoughness = MultiLayerParallaxData.x;
+		material.CoatF0 = MultiLayerParallaxData.y;
 
 		float2 coatUv = uv;
 		[branch] if ((PBRFlags & PBR::Flags::InterlayerParallax) != 0)
@@ -2165,33 +2165,40 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		[branch] if ((PBRFlags & PBR::Flags::HasFeatureTexture1) != 0)
 		{
 			float4 sampledCoatProperties = TexBackLightSampler.Sample(SampBackLightSampler, coatUv);
-			pbrSurfaceProperties.CoatRoughness *= sampledCoatProperties.w;
+			material.CoatRoughness *= sampledCoatProperties.w;
 			[branch] if ((PBRFlags & PBR::Flags::CoatNormal) != 0)
 			{
 				coatWorldNormal = normalize(mul(tbn, TransformNormal(sampledCoatProperties.xyz)));
 			}
 		}
-		pbrSurfaceProperties.CoatStrength = lerp(pbrSurfaceProperties.CoatStrength, 0, projectedMaterialWeight);
+		material.CoatStrength = lerp(material.CoatStrength, 0, projectedMaterialWeight);
 	}
 
 	[branch] if ((PBRFlags & PBR::Flags::Fuzz) != 0)
 	{
-		pbrSurfaceProperties.FuzzColor = MultiLayerParallaxData.xyz;
-		pbrSurfaceProperties.FuzzWeight = MultiLayerParallaxData.w;
+		material.FuzzColor = MultiLayerParallaxData.xyz;
+		material.FuzzWeight = MultiLayerParallaxData.w;
 		[branch] if ((PBRFlags & PBR::Flags::HasFeatureTexture1) != 0)
 		{
 			float4 sampledFuzzProperties = TexBackLightSampler.Sample(SampBackLightSampler, uv);
-			pbrSurfaceProperties.FuzzColor *= Color::Diffuse(sampledFuzzProperties.xyz);
-			pbrSurfaceProperties.FuzzWeight *= sampledFuzzProperties.w;
+			material.FuzzColor *= Color::Diffuse(sampledFuzzProperties.xyz);
+			material.FuzzWeight *= sampledFuzzProperties.w;
 		}
-		pbrSurfaceProperties.FuzzWeight = lerp(pbrSurfaceProperties.FuzzWeight, 0, projectedMaterialWeight);
+		material.FuzzWeight = lerp(material.FuzzWeight, 0, projectedMaterialWeight);
 	}
 #		endif
 
 	float3 specularColorPBR = 0;
-	float3 transmissionColor = 0;
 
-	float pbrGlossiness = 1 - pbrSurfaceProperties.Roughness;
+	float pbrGlossiness = 1 - material.Roughness;
+#	else
+	material.BaseColor = baseColor.xyz;
+	material.Shininess = shininess;
+	material.Glossiness = glossiness;
+	material.SpecularColor = SpecularColor.xyz;
+#	    if (defined(RIM_LIGHTING) || defined(SOFT_LIGHTING) || defined(LOAD_SOFT_LIGHTING))
+    material.rimSoftLightColor = rimSoftLightColor.xyz;
+#       endif
 #	endif  // TRUE_PBR
 
 	float porosity = 1.0;
@@ -2386,6 +2393,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	float3 diffuseColor = 0.0.xxx;
 	float3 specularColor = 0.0.xxx;
+	float3 transmissionColor = 0.0.xxx;
 
 	float3 lightsDiffuseColor = 0.0.xxx;
 	float3 coatLightsDiffuseColor = 0.0.xxx;
@@ -2393,70 +2401,25 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	float3 lodLandDiffuseColor = 0;
 
+	// Directiontal Lighting
+	DirectContext dirLightContext;
+	DirectLightingOutput dirLightOutput;
 #	if defined(TRUE_PBR)
-	{
-		PBR::LightProperties lightProperties = PBR::InitLightProperties(dirLightColor, dirLightColorMultiplier * dirDetailShadow, parallaxShadow);
-		float3 dirDiffuseColor, coatDirDiffuseColor, dirTransmissionColor, dirSpecularColor;
-		PBR::GetDirectLightInput(dirDiffuseColor, coatDirDiffuseColor, dirTransmissionColor, dirSpecularColor, worldNormal.xyz, coatWorldNormal, refractedViewDirection, viewDirection, refractedDirLightDirection, DirLightDirection, lightProperties, pbrSurfaceProperties, tbnTr, uvOriginal);
-		lightsDiffuseColor += dirDiffuseColor;
-		coatLightsDiffuseColor += coatDirDiffuseColor;
-		transmissionColor += dirTransmissionColor;
-		specularColorPBR += dirSpecularColor * !SharedData::InInterior;
-#		if defined(LOD_LAND_BLEND)
-		lodLandDiffuseColor += dirLightColor / Math::PI * saturate(dirLightAngle) * dirLightColorMultiplier * dirDetailShadow * parallaxShadow;
-#		endif
-#		if defined(WETNESS_EFFECTS)
-		if (waterRoughnessSpecular < 1.0)
-			specularColorPBR += PBR::GetWetnessDirectLightSpecularInput(wetnessNormal, viewDirection, DirLightDirection, lightProperties.CoatLightColor, waterRoughnessSpecular) * wetnessGlossinessSpecular;
-#		endif
-	}
+	dirLightContext = CreateDirectLightingContext(worldNormal.xyz, coatWorldNormal, vertexNormal.xyz, refractedViewDirection, viewDirection, refractedDirLightDirection, DirLightDirection, dirLightColor, dirLightColorMultiplier, dirDetailShadow, parallaxShadow);
 #	else
-	dirDetailShadow *= parallaxShadow;
-	dirLightColor *= dirLightColorMultiplier;
+	dirLightContext = CreateDirectLightingContext(worldNormal.xyz, vertexNormal.xyz, viewDirection, DirLightDirection, dirLightColor, dirLightColorMultiplier, dirDetailShadow, parallaxShadow);
+#	endif
 
-	float3 dirDiffuseColor = dirLightColor * saturate(dirLightAngle) * dirDetailShadow;
-
-#		if defined(SOFT_LIGHTING)
-	lightsDiffuseColor += dirLightColor * GetSoftLightMultiplier(dirLightAngle) * rimSoftLightColor.xyz;
-#		endif
-
-#		if defined(RIM_LIGHTING)
-	lightsDiffuseColor += dirLightColor * GetRimLightMultiplier(DirLightDirection, viewDirection, worldNormal.xyz) * rimSoftLightColor.xyz;
-#		endif
-
-#		if defined(BACK_LIGHTING)
-	lightsDiffuseColor += dirLightColor * saturate(-dirLightAngle) * backLightColor.xyz;
-#		endif
-
-	if (useSnowSpecular && useSnowDecalSpecular) {
-#		if defined(SNOW)
-		lightsSpecularColor += GetSnowSpecularColor(input, worldNormal.xyz, viewDirection);
-#		endif
-	} else {
-#		if defined(HAIR) && defined(CS_HAIR)
-		if (SharedData::hairSpecularSettings.Enabled) {
-			float3 dirTransmissionColor = 0.0;
-			float hairShadow = Hair::HairSelfShadow(input.WorldPosition.xyz, DirLightDirection, screenNoise, eyeIndex);
-			Hair::GetHairDirectLight(dirDiffuseColor, lightsSpecularColor, dirTransmissionColor, hairT, DirLightDirection, viewDirection, worldNormal.xyz, vertexNormal.xyz, dirLightColor.xyz * dirDetailShadow, SharedData::hairSpecularSettings.HairGlossiness, hairShadow, uv, baseColor.xyz);
-			transmissionColor += dirTransmissionColor;
-		}
-		else {
-#			if defined(SPECULAR)
-			lightsSpecularColor = GetLightSpecularInput(input, DirLightDirection, viewDirection, worldNormal.xyz, dirLightColor.xyz * dirDetailShadow, shininess, uv);
-#			endif
-		}
-#		elif defined(SPECULAR) || defined(SPARKLE)
-		lightsSpecularColor = GetLightSpecularInput(input, DirLightDirection, viewDirection, worldNormal.xyz, dirLightColor.xyz * dirDetailShadow, shininess, uv);
-#		endif
-	}
-
-	lightsDiffuseColor += dirDiffuseColor;
-
-#		if defined(WETNESS_EFFECTS)
-	if (waterRoughnessSpecular < 1.0)
-		wetnessSpecular += WetnessEffects::GetWetnessSpecular(wetnessNormal, DirLightDirection, viewDirection, dirLightColor * dirDetailShadow, waterRoughnessSpecular);
+	EvaluateLighting(dirLightContext, material, tbnTr, uvOriginal, dirLightOutput);
+	lightsDiffuseColor += dirLightOutput.diffuse;
+	lightsSpecularColor += dirLightOutput.specular;
+#	if defined(TRUE_PBR)
+	coatLightsDiffuseColor += dirLightOutput.coatDiffuse;
+#		if defined(LOD_LAND_BLEND)
+	lodLandDiffuseColor += dirLightColor / Math::PI * saturate(dirLightAngle) * dirLightColorMultiplier * dirDetailShadow * parallaxShadow;
 #		endif
 #	endif
+	transmissionColor += dirLightOutput.transmission;
 
 #	if !defined(LOD)
 #		if !defined(LIGHT_LIMIT_FIX)
@@ -2479,9 +2442,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 		float3 normalizedLightDirection = normalize(lightDirection);
 
+		DirectContext pointLightContext;
+		DirectLightingOutput pointLightOutput;
 #			if defined(TRUE_PBR)
 		{
-			float3 pointDiffuseColor, coatPointDiffuseColor, pointTransmissionColor, pointSpecularColor;
 			float3 refractedLightDirection = normalizedLightDirection;
 #				if !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 			[branch] if ((PBRFlags & PBR::Flags::InterlayerParallax) != 0)
@@ -2490,48 +2454,18 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 					refractedLightDirection = -refract(-normalizedLightDirection, coatWorldNormal, eta);
 			}
 #				endif
-			PBR::LightProperties lightProperties = PBR::InitLightProperties(lightColor, lightShadow, 1);
-			PBR::GetDirectLightInput(pointDiffuseColor, coatPointDiffuseColor, pointTransmissionColor, pointSpecularColor, worldNormal.xyz, coatWorldNormal, refractedViewDirection, viewDirection, refractedLightDirection, normalizedLightDirection, lightProperties, pbrSurfaceProperties, tbnTr, uvOriginal);
-			lightsDiffuseColor += pointDiffuseColor;
-			coatLightsDiffuseColor += coatPointDiffuseColor;
-			transmissionColor += pointTransmissionColor;
-			specularColorPBR += pointSpecularColor;
+			pointLightContext = CreateDirectLightingContext(worldNormal.xyz, coatWorldNormal, vertexNormal.xyz, refractedViewDirection, viewDirection, refractedLightDirection, normalizedLightDirection, lightColor, lightShadow, 1);
 		}
 #			else
-		lightColor *= lightShadow;
-		float lightAngle = dot(worldNormal.xyz, normalizedLightDirection.xyz);
-		float3 lightDiffuseColor = lightColor * saturate(lightAngle.xxx);
-
-#				if defined(SOFT_LIGHTING)
-		lightDiffuseColor += lightColor * GetSoftLightMultiplier(lightAngle) * rimSoftLightColor.xyz;
-#				endif  // SOFT_LIGHTING
-
-#				if defined(RIM_LIGHTING)
-		lightDiffuseColor += lightColor * GetRimLightMultiplier(normalizedLightDirection, viewDirection, worldNormal.xyz) * rimSoftLightColor.xyz;
-#				endif  // RIM_LIGHTING
-
-#				if defined(BACK_LIGHTING)
-		lightDiffuseColor += lightColor * saturate(-lightAngle) * backLightColor.xyz;
-#				endif  // BACK_LIGHTING
-#				if defined(HAIR) && defined(CS_HAIR)
-		if (SharedData::hairSpecularSettings.Enabled) {
-			float3 lightSpecularColor = 0;
-			float3 lightTransmissionColor = 0;
-			float hairShadow = Hair::HairSelfShadow(input.WorldPosition.xyz, normalizedLightDirection, screenNoise, eyeIndex);
-			Hair::GetHairDirectLight(lightDiffuseColor, lightSpecularColor, lightTransmissionColor, hairT, normalizedLightDirection, viewDirection, worldNormal.xyz, vertexNormal.xyz, lightColor, SharedData::hairSpecularSettings.HairGlossiness, hairShadow, uv, baseColor.xyz);
-			lightsSpecularColor += lightSpecularColor;
-			transmissionColor += lightTransmissionColor;
-		} else {
-#					if defined(SPECULAR)
-			lightsSpecularColor += GetLightSpecularInput(input, normalizedLightDirection, viewDirection, worldNormal.xyz, lightColor, shininess, uv);
-#					endif
-		}
-#				elif defined(SPECULAR) || (defined(SPARKLE) && !defined(SNOW))
-		lightsSpecularColor += GetLightSpecularInput(input, normalizedLightDirection, viewDirection, worldNormal.xyz, lightColor, shininess, uv);
-#				endif  // defined (SPECULAR) || (defined (SPARKLE) && !defined(SNOW))
-
-		lightsDiffuseColor += lightDiffuseColor;
+		pointLightContext = CreateDirectLightingContext(worldNormal.xyz, vertexNormal.xyz, viewDirection, normalizedLightDirection, lightColor, lightShadow, 1);
 #			endif
+		EvaluateLighting(pointLightContext, material, tbnTr, uvOriginal, pointLightOutput);
+		lightsDiffuseColor += pointLightOutput.diffuse;
+		lightsSpecularColor += pointLightOutput.specular;
+#			if defined(TRUE_PBR)
+		coatLightsDiffuseColor += pointLightOutput.coatDiffuse;
+#			endif
+		transmissionColor += pointLightOutput.transmission;
 	}
 
 #		else
@@ -2630,62 +2564,20 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		}
 #			endif
 
+		DirectContext pointLightContext;
+		DirectLightingOutput pointLightOutput;
 #			if defined(TRUE_PBR)
-		{
-			PBR::LightProperties lightProperties = PBR::InitLightProperties(lightColor, lightShadow, parallaxShadow);
-			float3 pointDiffuseColor, coatPointDiffuseColor, pointTransmissionColor, pointSpecularColor;
-			PBR::GetDirectLightInput(pointDiffuseColor, coatPointDiffuseColor, pointTransmissionColor, pointSpecularColor, worldNormal.xyz, coatWorldNormal, refractedViewDirection, viewDirection, refractedLightDirection, normalizedLightDirection, lightProperties, pbrSurfaceProperties, tbnTr, uvOriginal);
-			lightsDiffuseColor += pointDiffuseColor;
-			coatLightsDiffuseColor += coatPointDiffuseColor;
-			transmissionColor += pointTransmissionColor;
-			specularColorPBR += pointSpecularColor;
-#				if defined(WETNESS_EFFECTS)
-			if (waterRoughnessSpecular < 1.0)
-				specularColorPBR += PBR::GetWetnessDirectLightSpecularInput(wetnessNormal, viewDirection, normalizedLightDirection, lightProperties.CoatLightColor, waterRoughnessSpecular) * wetnessGlossinessSpecular;
-#				endif
-		}
+		pointLightContext = CreateDirectLightingContext(worldNormal.xyz, coatWorldNormal, vertexNormal.xyz, refractedViewDirection, viewDirection, refractedLightDirection, normalizedLightDirection, lightColor, lightShadow, parallaxShadow);
 #			else
-		lightColor *= lightShadow;
-
-		float3 lightDiffuseColor = lightColor * parallaxShadow * saturate(lightAngle.xxx);
-		float lightBacklighting = 1.0 + saturate(dot(normalizedLightDirection.xyz, viewDirection));
-
-#				if defined(SOFT_LIGHTING)
-		lightDiffuseColor += lightBacklighting * lightColor * GetSoftLightMultiplier(lightAngle) * rimSoftLightColor.xyz;
-#				endif
-
-#				if defined(RIM_LIGHTING)
-		lightDiffuseColor += lightBacklighting * lightColor * GetRimLightMultiplier(normalizedLightDirection, viewDirection, worldNormal.xyz) * rimSoftLightColor.xyz;
-#				endif
-
-#				if defined(BACK_LIGHTING)
-		lightDiffuseColor += lightBacklighting * lightColor * saturate(-lightAngle) * backLightColor.xyz;
-#				endif
-
-#				if defined(HAIR) && defined(CS_HAIR) && (defined(SKINNED) || !defined(MODELSPACENORMALS))
-		if (SharedData::hairSpecularSettings.Enabled) {
-			float hairShadow = Hair::HairSelfShadow(input.WorldPosition.xyz, normalizedLightDirection, screenNoise, eyeIndex);
-			float3 lightSpecularColor = 0;
-			float3 lightTransmissionColor = 0;
-			Hair::GetHairDirectLight(lightDiffuseColor, lightSpecularColor, lightTransmissionColor, hairT, normalizedLightDirection, viewDirection, worldNormal.xyz, vertexNormal.xyz, lightColor, SharedData::hairSpecularSettings.HairGlossiness, hairShadow, uv, baseColor.xyz);
-			lightsSpecularColor += lightSpecularColor;
-			transmissionColor += lightTransmissionColor;
-		} else {
-#					if defined(SPECULAR)
-			lightsSpecularColor += GetLightSpecularInput(input, normalizedLightDirection, viewDirection, worldNormal.xyz, lightColor, shininess, uv);
-#					endif
-		}
-#				elif defined(SPECULAR) || (defined(SPARKLE) && !defined(SNOW))
-		lightsSpecularColor += GetLightSpecularInput(input, normalizedLightDirection, viewDirection, worldNormal.xyz, lightColor, shininess, uv);
-#				endif
-
-		lightsDiffuseColor += lightDiffuseColor;
+		pointLightContext = CreateDirectLightingContext(worldNormal.xyz, vertexNormal.xyz, viewDirection, normalizedLightDirection, lightColor, lightShadow, parallaxShadow);
 #			endif
-
-#			if defined(WETNESS_EFFECTS)
-		if (waterRoughnessSpecular < 1.0)
-			wetnessSpecular += WetnessEffects::GetWetnessSpecular(wetnessNormal, normalizedLightDirection, viewDirection, lightColor, waterRoughnessSpecular);
+		EvaluateLighting(pointLightContext, material, tbnTr, uvOriginal, pointLightOutput);
+		lightsDiffuseColor += pointLightOutput.diffuse;
+		lightsSpecularColor += pointLightOutput.specular;
+#			if defined(TRUE_PBR)
+		coatLightsDiffuseColor += pointLightOutput.coatDiffuse;
 #			endif
+		transmissionColor += pointLightOutput.transmission;
 	}
 #		endif
 #	endif
@@ -2891,7 +2783,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	else
 #				endif
 	{
-		porosity = lerp(porosity, 0.0, saturate(sqrt(pbrSurfaceProperties.Metallic)));
+		porosity = lerp(porosity, 0.0, saturate(sqrt(material.Metallic)));
 	}
 #			elif defined(ENVMAP) || defined(MULTI_LAYER_PARALLAX)
 	porosity = lerp(porosity, 0.0, saturate(sqrt(envMask)));
@@ -2972,14 +2864,14 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float3 directLightsDiffuseInput = diffuseColor * baseColor.xyz;
 		[branch] if ((PBRFlags & PBR::Flags::ColoredCoat) != 0)
 		{
-			directLightsDiffuseInput = lerp(directLightsDiffuseInput, pbrSurfaceProperties.CoatColor * coatLightsDiffuseColor, pbrSurfaceProperties.CoatStrength);
+			directLightsDiffuseInput = lerp(directLightsDiffuseInput, material.CoatColor * coatLightsDiffuseColor, material.CoatStrength);
 		}
 
 		color.xyz += directLightsDiffuseInput;
 	}
 
 	float3 indirectDiffuseLobeWeight, indirectSpecularLobeWeight;
-	PBR::GetIndirectLobeWeights(indirectDiffuseLobeWeight, indirectSpecularLobeWeight, worldNormal.xyz, viewDirection, vertexNormal, baseColor.xyz, pbrSurfaceProperties);
+	PBR::GetIndirectLobeWeights(indirectDiffuseLobeWeight, indirectSpecularLobeWeight, worldNormal.xyz, viewDirection, vertexNormal, baseColor.xyz, material);
 #		if defined(WETNESS_EFFECTS)
 	if (waterRoughnessSpecular < 1.0)
 		indirectSpecularLobeWeight = max(indirectSpecularLobeWeight, PBR::GetWetnessIndirectSpecularLobeWeight(wetnessNormal, viewDirection, vertexNormal, waterRoughnessSpecular));
@@ -2990,9 +2882,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		if !defined(DEFERRED)
 #			if defined(DYNAMIC_CUBEMAPS)
 #				if defined(SKYLIGHTING)
-	specularColorPBR += indirectSpecularLobeWeight * DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(screenUV, worldNormal, vertexNormal, viewDirection, pbrSurfaceProperties.Roughness, skylightingSH);
+	specularColorPBR += indirectSpecularLobeWeight * DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(screenUV, worldNormal, vertexNormal, viewDirection, material.Roughness, skylightingSH);
 #				else
-	specularColorPBR += indirectSpecularLobeWeight * DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(screenUV, worldNormal, vertexNormal, viewDirection, pbrSurfaceProperties.Roughness);
+	specularColorPBR += indirectSpecularLobeWeight * DynamicCubemaps::GetDynamicCubemapSpecularIrradiance(screenUV, worldNormal, vertexNormal, viewDirection, material.Roughness);
 #				endif
 #			else
 	specularColorPBR += indirectSpecularLobeWeight * directionalAmbientColor;


### PR DESCRIPTION
Huge rewrite for lighting.hlsl:
1. Unified direct and indirect lighting eval functions
2. Well formed structures (material and context) for passing parameters
3. Consistent wetness behavior
4. Better readability and maintainability

Added header files: LightingCommon.hlsli and LightingEval.hlsli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated lighting into structured context/output and material objects, replacing scattered per-light/material parameters across PBR and hair shading.
  * Restructured hair shading branches, simplified scattering and indirect weight logic, and removed the legacy dynamic cubemap specular path.

* **New Features**
  * Centralized lighting evaluation pipeline for direct, indirect, and optional wetness effects enabling consistent, extensible material-driven shading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->