### PR TITLE
fix(Dynamic Cubemap): Added a check for timeskip

### DIFF
--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -477,7 +477,7 @@ void DynamicCubemaps::UpdateCubemap()
 	// Reset capture when game time jumps (wait menu, timescale changes, console commands)
 	if (auto calendar = RE::Calendar::GetSingleton()) {
 		float currentHoursPassed = calendar->GetHoursPassed();
-		float hoursPassedDiff = abs(currentHoursPassed - previousHoursPassed);
+		float hoursPassedDiff = std::abs(currentHoursPassed - previousHoursPassed);
 		previousHoursPassed = currentHoursPassed;
 
 		if (hoursPassedDiff >= 0.01f) {  // ~36 seconds game time

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -473,6 +473,19 @@ void DynamicCubemaps::Irradiance(bool a_reflections)
 void DynamicCubemaps::UpdateCubemap()
 {
 	TracyD3D11Zone(globals::state->tracyCtx, "Cubemap Update");
+
+	// Reset capture when game time jumps (wait menu, timescale changes, console commands)
+	if (auto calendar = RE::Calendar::GetSingleton()) {
+		float currentHoursPassed = calendar->GetHoursPassed();
+		float hoursPassedDiff = abs(currentHoursPassed - previousHoursPassed);
+		previousHoursPassed = currentHoursPassed;
+
+		if (hoursPassedDiff >= 0.01f) {  // ~36 seconds game time
+			resetCapture[0] = true;
+			resetCapture[1] = true;
+		}
+	}
+
 	if (recompileFlag) {
 		logger::debug("Recompiling for Dynamic Cubemaps");
 		auto shaderCache = globals::shaderCache;

--- a/src/Features/DynamicCubemaps.h
+++ b/src/Features/DynamicCubemaps.h
@@ -68,6 +68,7 @@ public:
 
 	bool resetCapture[2] = { true, true };
 	bool recompileFlag = false;
+	float previousHoursPassed = 0.0f;
 
 	enum class NextTask
 	{


### PR DESCRIPTION
When a user skips time the dynamic cubemap remains stale, this checks if a large timeskip has occurred and then resets the cubemap. Fixes #1622. This starts happening when in real time when the timescale is around 2080ish. Use visual studio debugger to test this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cubemap capture now resets when in-game time advances abruptly, preventing stale or incorrect reflections.
  * Improves visual continuity of dynamic reflections after time jumps so environments and lighting remain accurate.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->