### PR TITLE
build: fix race condition for pdb generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,6 +440,7 @@ if(AUTO_PLUGIN_DEPLOYMENT OR AIO_ZIP_TO_DIST)
     add_custom_command(
         TARGET ${PROJECT_NAME}
         POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${AIO_DIR}/SKSE/Plugins"
         COMMAND
             ${CMAKE_COMMAND} -E copy_if_different
             "$<TARGET_FILE:${PROJECT_NAME}>"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,7 +332,8 @@ if(AUTO_PLUGIN_DEPLOYMENT OR AIO_ZIP_TO_DIST)
     # deploys from copying everything every build.
     set(_prepare_aio_cmds)
 
-    # Ensure SKSE/Plugins dir exists and copy built plugin files
+    # Ensure SKSE/Plugins dir exists
+    # Note: DLL and PDB are copied via POST_BUILD command to avoid race conditions
     list(
         APPEND
         _prepare_aio_cmds
@@ -341,26 +342,6 @@ if(AUTO_PLUGIN_DEPLOYMENT OR AIO_ZIP_TO_DIST)
         -E
         make_directory
         "${AIO_DIR}/SKSE/Plugins"
-    )
-    list(
-        APPEND
-        _prepare_aio_cmds
-        COMMAND
-        ${CMAKE_COMMAND}
-        -E
-        copy_if_different
-        $<TARGET_FILE:${PROJECT_NAME}>
-        "${AIO_DIR}/SKSE/Plugins/$<TARGET_FILE_NAME:${PROJECT_NAME}>"
-    )
-    list(
-        APPEND
-        _prepare_aio_cmds
-        COMMAND
-        ${CMAKE_COMMAND}
-        -E
-        copy_if_different
-        $<TARGET_PDB_FILE:${PROJECT_NAME}>
-        "${AIO_DIR}/SKSE/Plugins/$<TARGET_PDB_FILE_NAME:${PROJECT_NAME}>"
     )
 
     # Copy package files
@@ -452,6 +433,23 @@ if(AUTO_PLUGIN_DEPLOYMENT OR AIO_ZIP_TO_DIST)
         PREPARE_AIO
         ALL
         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/prepare_aio.stamp
+    )
+
+    # Copy DLL and PDB using POST_BUILD to avoid race conditions with file locking
+    # This ensures the linker has fully released the files before we attempt to copy them
+    add_custom_command(
+        TARGET ${PROJECT_NAME}
+        POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_FILE:${PROJECT_NAME}>"
+            "${AIO_DIR}/SKSE/Plugins/$<TARGET_FILE_NAME:${PROJECT_NAME}>"
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_PDB_FILE:${PROJECT_NAME}>"
+            "${AIO_DIR}/SKSE/Plugins/$<TARGET_PDB_FILE_NAME:${PROJECT_NAME}>"
+        COMMENT "Copying built DLL and PDB to AIO package"
+        VERBATIM
     )
 
     # Only copy shaders when HLSL files change; copy individually so unchanged


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability by changing plugin deployment to occur after linking, preventing race conditions when copying build artifacts.
* **Documentation**
  * Added explanatory comments clarifying the post-build deployment approach and rationale.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->