### PR TITLE
feat(ui): DLSS preset selection

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -216,11 +216,8 @@ void Upscaling::DrawSettings()
 		} else if (upscaleMethod == UpscaleMethod::kDLSS) {
 			ImGui::SliderFloat("Sharpness", &settings.sharpnessDLSS, 0.0f, 1.0f, "%.1f");
 
-			// VR DLSS preset selection
-			if (globals::game::isVR) {
-				const char* presets[] = { "F (Fast)", "J (Quality)", "K (Ultra)" };
-				ImGui::SliderInt("DLSS Preset", (int*)&settings.DLSSPreset, 0, 2, presets[settings.DLSSPreset]);
-			}
+			const char* presets[] = { "F (Fast)", "J (Quality)", "K (Ultra)" };
+			ImGui::SliderInt("DLSS Preset", (int*)&settings.DLSSPreset, 0, 2, presets[settings.DLSSPreset]);
 		}
 	}
 


### PR DESCRIPTION
## Description
I enabled DLSS preset selection in the UI (previously VR-only). Using preset F (“Fast”) reduces ghosting and, in my setup, fixes the dark particle trails from this issue: https://github.com/doodlum/skyrim-community-shaders/issues/1627.

## Details
- In testing, DLSS didn’t seem to use `ReactiveMask` and `TransparencyCompositionMask` from [`EncodeTexturesCS.hlsl`](https://github.com/doodlum/skyrim-community-shaders/blob/v1.4.6/features/Upscaling/Shaders/Upscaling/EncodeTexturesCS.hlsl#L66-L68). This likely affects particles in particular, which don’t have reliable physics or motion vectors.
- Working hypothesis:
  - Preset F is more conservative and gives more weight to hint masks (`ReactiveMask`, `TransparencyCompositionMask`), helping reduce ghosting.
  - Presets J and K lean more on motion vectors, with less mask influence. This keeps more detail but can show ghosting if motion vectors or masks aren’t solid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DLSS Preset slider is now consistently visible whenever DLSS is active, regardless of VR mode. Users can now adjust the DLSS preset setting in all scenarios without restrictions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->