### PR TITLE
fix(eyes): disable vanilla eye normal

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2693,7 +2693,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	}
 #	endif
 
-#	if defined(EYE)
+#	if defined(EYE) && defined(VANILLA_EYE_NORMAL)
 	worldNormal.xyz = input.EyeNormal;
 #	endif  // EYE
 


### PR DESCRIPTION
vanilla eye normal has always been something that people has been complaining for years. bypassing this benefits all eye shader under modern lighting.
hide the vanilla eye normal behind define, just in case someone want it back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated eye lighting behavior conditions for improved specificity and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->