### PR TITLE
fix(grass collision): ignore hkpListShape

### DIFF
--- a/src/Utils/ActorUtils.cpp
+++ b/src/Utils/ActorUtils.cpp
@@ -11,7 +11,7 @@ namespace Util
 
 		RE::bhkRigidBody* bhkRigid = collisionObj->body.get() ? collisionObj->body.get()->AsBhkRigidBody() : nullptr;
 		RE::hkpRigidBody* hkpRigid = bhkRigid ? skyrim_cast<RE::hkpRigidBody*>(bhkRigid->referencedObject.get()) : nullptr;
-		if (bhkRigid && hkpRigid && !skyrim_cast<RE::hkpListShape*>(hkpRigid)) { // Ignore hkpListShape, unsupported
+		if (bhkRigid && hkpRigid && !skyrim_cast<RE::hkpListShape*>(hkpRigid)) {  // Ignore hkpListShape, unsupported
 			RE::hkVector4 massCenter;
 			bhkRigid->GetCenterOfMassWorld(massCenter);
 			float massTrans[4];

--- a/src/Utils/ActorUtils.cpp
+++ b/src/Utils/ActorUtils.cpp
@@ -11,7 +11,7 @@ namespace Util
 
 		RE::bhkRigidBody* bhkRigid = collisionObj->body.get() ? collisionObj->body.get()->AsBhkRigidBody() : nullptr;
 		RE::hkpRigidBody* hkpRigid = bhkRigid ? skyrim_cast<RE::hkpRigidBody*>(bhkRigid->referencedObject.get()) : nullptr;
-		if (bhkRigid && hkpRigid) {
+		if (bhkRigid && hkpRigid && !skyrim_cast<RE::hkpListShape*>(hkpRigid)) { // Ignore hkpListShape, unsupported
 			RE::hkVector4 massCenter;
 			bhkRigid->GetCenterOfMassWorld(massCenter);
 			float massTrans[4];


### PR DESCRIPTION
Ignore hkpListShape like found in https://www.nexusmods.com/skyrimspecialedition/mods/69701 to fix bad collisions.

It would be better for someone to add support for parsing this type of list, this is a quick fix.

Untested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by preventing processing of unsupported shape configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->