### PR TITLE
fix(SSGI): hang during cell transition

### DIFF
--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -667,7 +667,10 @@ void ScreenSpaceGI::DrawSSGI()
 	bool* enableSSAO = reinterpret_cast<bool*>(reinterpret_cast<uintptr_t>(BSImagespaceShaderISSAOBlurH.get()) + 0x50LL);
 	*enableSSAO = false;
 
-	if (!(settings.Enabled && ShadersOK())) {
+	// Skip during loading screens to prevent GPU stalls during cell transitions
+	bool isLoading = globals::game::ui && globals::game::ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME);
+
+	if (!(settings.Enabled && ShadersOK()) || isLoading) {
 		FLOAT clr[4] = { 0.f, 0.f, 0.f, 0.f };
 		context->ClearUnorderedAccessViewFloat(texAo[outputAoIdx]->uav.get(), clr);
 		context->ClearUnorderedAccessViewFloat(texIlY[outputIlIdx]->uav.get(), clr);


### PR DESCRIPTION
Tested by original issue creator for #1649, says it fixed it

Hopefully fixes https://github.com/doodlum/skyrim-community-shaders/issues/1649  

- Detects when the loading screen is open (cell transitions)
- Skips all SSGI compute shader dispatches during loading
- Prevents GPU command queue saturation when fg is active

This matches the pattern used by skylighting and dynamic cubemaps,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance during loading screens by preventing unnecessary graphics processing when the loading menu is active, reducing resource consumption during transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->