### PR TITLE
fix(ui): load previously selected theme on startup

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -235,6 +235,16 @@ void Menu::Load(json& o_json)
 		} else {
 			logger::warn("Failed to load Default Dark theme on first launch");
 		}
+	} else if (!settings.SelectedThemePreset.empty()) {
+		// Load the previously selected theme preset (including custom themes)
+		if (LoadThemePreset(settings.SelectedThemePreset)) {
+			logger::info("Loaded saved theme preset: {}", settings.SelectedThemePreset);
+		} else {
+			logger::warn("Failed to load saved theme preset '{}', falling back to Default", settings.SelectedThemePreset);
+			if (LoadThemePreset("Default")) {
+				settings.SelectedThemePreset = "Default";
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
fixes an oversight mentioned in https://github.com/doodlum/skyrim-community-shaders/issues/1648

untested but logically should just work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced theme restoration on app launch with improved fallback support to prevent theme loading failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->