### PR TITLE
feat(LLF): add debug overlay in llf visualiser

### DIFF
--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -53,6 +53,16 @@ void LightLimitFix::DrawSettings()
 	}
 }
 
+void LightLimitFix::DrawOverlay()
+{
+	if (!settings.EnableLightsVisualisation)
+		return;
+	ImGui::SetNextWindowPos(ImVec2(10, 10), ImGuiCond_Always);
+	ImGui::Begin("##LLFDebug", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings);
+	ImGui::TextColored(ImVec4(1.0f, 0.3f, 0.3f, 1.0f), "DEBUG FEATURE - LIGHT LIMIT VISUALISATION ENABLED");
+	ImGui::End();
+}
+
 LightLimitFix::PerFrame LightLimitFix::GetCommonBufferData()
 {
 	PerFrame perFrame{};

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "Buffer.h"
+#include "OverlayFeature.h"
 
-struct LightLimitFix : Feature
+struct LightLimitFix : OverlayFeature
 {
 private:
 	static constexpr std::string_view MOD_ID = "99548";
@@ -155,6 +156,8 @@ public:
 	virtual void RestoreDefaultSettings() override;
 
 	virtual void DrawSettings() override;
+	virtual void DrawOverlay() override;
+	virtual bool IsOverlayVisible() const override { return settings.EnableLightsVisualisation; }
 
 	virtual void PostPostLoad() override;
 	virtual void DataLoaded() override;


### PR DESCRIPTION
just should add a text to the top left stating debug mode on to stop new users accidentally toggling it and thinking their game broke.

![202601~2](https://github.com/user-attachments/assets/5635708b-30f4-4def-b2c1-eb4158a06994)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual overlay for displaying light debugging information.
  * Light visualization mode is now configurable through settings and can be toggled on/off.
  * Cluster size data is now propagated through the per-frame data system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->