### PR TITLE
fix(PBR): memory heap corruption with pbr resources setup

### DIFF
--- a/src/TruePBR/BSLightingShaderMaterialPBR.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBR.cpp
@@ -9,7 +9,14 @@ BSLightingShaderMaterialPBR::~BSLightingShaderMaterialPBR()
 
 BSLightingShaderMaterialPBR* BSLightingShaderMaterialPBR::Make()
 {
-	return new BSLightingShaderMaterialPBR;
+	// Use Skyrim's memory manager to allocate the material, matching how vanilla
+	// materials are created. This ensures proper deallocation through RE::free()
+	// when the material's reference count reaches zero.
+	auto* material = RE::malloc<BSLightingShaderMaterialPBR>();
+	if (material) {
+		new (material) BSLightingShaderMaterialPBR();
+	}
+	return material;
 }
 
 RE::BSShaderMaterial* BSLightingShaderMaterialPBR::Create()

--- a/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
@@ -15,7 +15,14 @@ BSLightingShaderMaterialPBRLandscape::~BSLightingShaderMaterialPBRLandscape()
 
 BSLightingShaderMaterialPBRLandscape* BSLightingShaderMaterialPBRLandscape::Make()
 {
-	return new BSLightingShaderMaterialPBRLandscape;
+	// Use Skyrim's memory manager to allocate the material, matching how vanilla
+	// materials are created. This ensures proper deallocation through RE::free()
+	// when the material's reference count reaches zero.
+	auto* material = RE::malloc<BSLightingShaderMaterialPBRLandscape>();
+	if (material) {
+		new (material) BSLightingShaderMaterialPBRLandscape();
+	}
+	return material;
 }
 
 RE::BSShaderMaterial* BSLightingShaderMaterialPBRLandscape::Create()


### PR DESCRIPTION
untested, but appears to be root cause.
fixes https://github.com/doodlum/skyrim-community-shaders/issues/1654

vanilla game manages resources via RE::malloc, but PBR BSLightingShaderMaterialPBR::Make() / Landscape were using C++ new instead, causing a heap mismatch when the game tried to destroy materials using the internal memory manager.