### PR TITLE
feat: vanilla shadow bleed fix

### DIFF
--- a/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
+++ b/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
@@ -79,7 +79,7 @@ cbuffer PerTechnique : register(b0)
 		{ 0.001, 0.001, 0.001 }
 	};
 
-	float3 normalizedCoordinates = float3(dispatchID.xy + 0.5, max(dispatchID.z - 1, 0.0)) * rcp(TextureDimensions.xyz);
+	float3 normalizedCoordinates = float3(dispatchID.xy + 0.5, max(dispatchID.z - 1.0, 0.0)) * rcp(TextureDimensions.xyz);
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(normalizedCoordinates.xy);
 	float3 depthUv = Stereo::ConvertFromStereoUV(normalizedCoordinates, eyeIndex) + StepCoefficients[IterationIndex];
 	float depth = InverseRepartitionTex.SampleLevel(InverseRepartitionSampler, depthUv.z, 0);

--- a/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
+++ b/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
@@ -79,9 +79,8 @@ cbuffer PerTechnique : register(b0)
 		{ 0.001, 0.001, 0.001 }
 	};
 
-	float3 normalizedCoordinates = dispatchID.xyz * rcp(TextureDimensions.xyz);
-	float2 uv = normalizedCoordinates.xy;
-	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
+	float3 normalizedCoordinates = float3(dispatchID.xy + 0.5, max(dispatchID.z - 1, 0.0)) * rcp(TextureDimensions.xyz);
+	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(normalizedCoordinates.xy);
 	float3 depthUv = Stereo::ConvertFromStereoUV(normalizedCoordinates, eyeIndex) + StepCoefficients[IterationIndex];
 	float depth = InverseRepartitionTex.SampleLevel(InverseRepartitionSampler, depthUv.z, 0);
 	float4 positionCS = float4(2 * depthUv.x - 1, 1 - 2 * depthUv.y, depth, 1);

--- a/package/Shaders/Utility.hlsl
+++ b/package/Shaders/Utility.hlsl
@@ -648,7 +648,7 @@ PS_OUTPUT main(PS_INPUT input)
 
 		float3 positionLS = mul(transpose(lightProjectionMatrix), float4(positionMS.xyz, 1)).xyz;
 
-		// Calculate derivative based slope estimation and scale by cascade texel world space size to control self-shadowing and peter panning
+		// This is a fix for peter panning issues wrt Interior Sun
 		uint3 shadowMapResolution;
 		TexShadowMapSamplerComp.GetDimensions(shadowMapResolution.x, shadowMapResolution.y, shadowMapResolution.z);
 
@@ -656,14 +656,12 @@ PS_OUTPUT main(PS_INPUT input)
 		float cascadeSplitL0 = FrameBuffer::CameraProj[eyeIndex][2][3] / (EndSplitDistances[0] - FrameBuffer::CameraProj[eyeIndex][2][2]);
 		float cascadeSplitL1 = FrameBuffer::CameraProj[eyeIndex][2][3] / (EndSplitDistances[1] - FrameBuffer::CameraProj[eyeIndex][2][2]);
 		float cascadeCoverage = (cascadeIndex == 0) ? cascadeSplitL0 : cascadeSplitL1 - cascadeSplitL0;
-
 		float cascadeTexelSize = cascadeCoverage / shadowMapResolution.x;
 
-		//Note: higher bias reduces peter panning, lower bias leads to more self-shadowing(shadow acne)
-		float bias = (SharedData::InInterior) ? 0.00001 : 0.001; // Interiors seem to handle self shadowing better
-		float slope = min(max(abs(ddx(positionLS.z)), abs(ddy(positionLS.z))), 0.001); // Limit to avoid outline aliasing
-		float slopeBias = bias + slope * cascadeTexelSize;
-		float cascadeSurfaceZ = positionLS.z - slopeBias;
+		// With a shadowMapThreshold = 0.005 this gives a bias around 0.0025, 0.0013 @ 4k, 8000wsu max depth in interiors
+		// Note: lower bias reduces peter panning but also leads to more self-shadowing(shadow acne)
+		float receiverDepthBias = (SharedData::InInterior) ? shadowMapThreshold * rcp(cascadeTexelSize * 2.5) : shadowMapThreshold;
+		float cascadeSurfaceZ = positionLS.z - receiverDepthBias;
 
 #			if SHADOWFILTER == 0
 		float shadowMapValue = TexShadowMapSampler.Sample(SampShadowMapSampler, float3(positionLS.xy, cascadeIndex)).x;
@@ -682,9 +680,8 @@ PS_OUTPUT main(PS_INPUT input)
 			float3 cascade1PositionLS = mul(transpose(ShadowMapProj[eyeIndex][1]), float4(positionMS.xyz, 1)).xyz;
 
 			cascadeTexelSize = (cascadeSplitL1 - cascadeSplitL0) / shadowMapResolution.x;
-			slope = min(max(abs(ddx(cascade1PositionLS.z)), abs(ddy(cascade1PositionLS.z))), 0.001);
-			slopeBias = bias + slope * cascadeTexelSize;
-			cascadeSurfaceZ = cascade1PositionLS.z - slopeBias;
+			receiverDepthBias = (SharedData::InInterior) ? AlphaTestRef.z * rcp(cascadeTexelSize * 2.5) : AlphaTestRef.z;
+			cascadeSurfaceZ = cascade1PositionLS.z - receiverDepthBias;
 
 #			if SHADOWFILTER == 0
 			float cascade1ShadowMapValue = TexShadowMapSampler.Sample(SampShadowMapSampler, float3(cascade1PositionLS.xy, 1)).x;

--- a/package/Shaders/Utility.hlsl
+++ b/package/Shaders/Utility.hlsl
@@ -648,17 +648,20 @@ PS_OUTPUT main(PS_INPUT input)
 
 		float3 positionLS = mul(transpose(lightProjectionMatrix), float4(positionMS.xyz, 1)).xyz;
 
+		// Calculate derivative based slope estimation and scale by cascade texel world space size to control self-shadowing and peter panning
 		uint3 shadowMapResolution;
 		TexShadowMapSamplerComp.GetDimensions(shadowMapResolution.x, shadowMapResolution.y, shadowMapResolution.z);
 
+		// Convert split distance from NDC to VS
 		float cascadeSplitL0 = FrameBuffer::CameraProj[eyeIndex][2][3] / (EndSplitDistances[0] - FrameBuffer::CameraProj[eyeIndex][2][2]);
 		float cascadeSplitL1 = FrameBuffer::CameraProj[eyeIndex][2][3] / (EndSplitDistances[1] - FrameBuffer::CameraProj[eyeIndex][2][2]);
 		float cascadeCoverage = (cascadeIndex == 0) ? cascadeSplitL0 : cascadeSplitL1 - cascadeSplitL0;
 
 		float cascadeTexelSize = cascadeCoverage / shadowMapResolution.x;
 
+		//Note: higher bias reduces peter panning, lower bias leads to more self-shadowing(shadow acne)
 		float bias = (SharedData::InInterior) ? 0.00001 : 0.001; // Interiors seem to handle self shadowing better
-		float slope = min(max(abs(ddx(positionLS.z)), abs(ddy(positionLS.z))), 0.001);
+		float slope = min(max(abs(ddx(positionLS.z)), abs(ddy(positionLS.z))), 0.001); // Limit to avoid outline aliasing
 		float slopeBias = bias + slope * cascadeTexelSize;
 		float cascadeSurfaceZ = positionLS.z - slopeBias;
 

--- a/package/Shaders/Utility.hlsl
+++ b/package/Shaders/Utility.hlsl
@@ -627,6 +627,9 @@ PS_OUTPUT main(PS_INPUT input)
 	uint3 seed = Random::pcg3d(uint3(input.PositionCS.xy, input.PositionCS.x * Math::PI));
 
 #		if defined(RENDER_SHADOWMASK)
+	if(SharedData::InInterior)
+		shadowColor = float4(0,0,0,0);
+
 	if (EndSplitDistances.z >= shadowMapDepth) {
 		float4x3 lightProjectionMatrix = ShadowMapProj[eyeIndex][0];
 		float shadowMapThreshold = AlphaTestRef.y;
@@ -645,15 +648,29 @@ PS_OUTPUT main(PS_INPUT input)
 
 		float3 positionLS = mul(transpose(lightProjectionMatrix), float4(positionMS.xyz, 1)).xyz;
 
+		uint3 shadowMapResolution;
+		TexShadowMapSamplerComp.GetDimensions(shadowMapResolution.x, shadowMapResolution.y, shadowMapResolution.z);
+
+		float cascadeSplitL0 = FrameBuffer::CameraProj[eyeIndex][2][3] / (EndSplitDistances[0] - FrameBuffer::CameraProj[eyeIndex][2][2]);
+		float cascadeSplitL1 = FrameBuffer::CameraProj[eyeIndex][2][3] / (EndSplitDistances[1] - FrameBuffer::CameraProj[eyeIndex][2][2]);
+		float cascadeCoverage = (cascadeIndex == 0) ? cascadeSplitL0 : cascadeSplitL1 - cascadeSplitL0;
+
+		float cascadeTexelSize = cascadeCoverage / shadowMapResolution.x;
+
+		float bias = (SharedData::InInterior) ? 0.00001 : 0.001; // Interiors seem to handle self shadowing better
+		float slope = min(max(abs(ddx(positionLS.z)), abs(ddy(positionLS.z))), 0.001);
+		float slopeBias = bias + slope * cascadeTexelSize;
+		float cascadeSurfaceZ = positionLS.z - slopeBias;
+
 #			if SHADOWFILTER == 0
 		float shadowMapValue = TexShadowMapSampler.Sample(SampShadowMapSampler, float3(positionLS.xy, cascadeIndex)).x;
-		if (shadowMapValue >= positionLS.z - shadowMapThreshold) {
+		if (shadowMapValue >= cascadeSurfaceZ) {
 			shadowVisibility = 1;
 		}
 #			elif SHADOWFILTER == 1
-		shadowVisibility = TexShadowMapSamplerComp.SampleCmpLevelZero(SampShadowMapSamplerComp, float3(positionLS.xy, cascadeIndex), positionLS.z - shadowMapThreshold).x;
+		shadowVisibility = TexShadowMapSamplerComp.SampleCmpLevelZero(SampShadowMapSamplerComp, float3(positionLS.xy, cascadeIndex), cascadeSurfaceZ).x;
 #			elif SHADOWFILTER == 3
-		shadowVisibility = GetPoissonDiskFilteredShadowVisibility(noise, rotationMatrix, TexShadowMapSamplerComp, SampShadowMapSamplerComp, positionLS.xy, cascadeIndex, positionLS.z - shadowMapThreshold, false);
+		shadowVisibility = GetPoissonDiskFilteredShadowVisibility(noise, rotationMatrix, TexShadowMapSamplerComp, SampShadowMapSamplerComp, positionLS.xy, cascadeIndex, cascadeSurfaceZ, false);
 #			endif
 
 		if (cascadeIndex < 1 && StartSplitDistances.y < shadowMapDepth) {
@@ -661,15 +678,20 @@ PS_OUTPUT main(PS_INPUT input)
 
 			float3 cascade1PositionLS = mul(transpose(ShadowMapProj[eyeIndex][1]), float4(positionMS.xyz, 1)).xyz;
 
+			cascadeTexelSize = (cascadeSplitL1 - cascadeSplitL0) / shadowMapResolution.x;
+			slope = min(max(abs(ddx(cascade1PositionLS.z)), abs(ddy(cascade1PositionLS.z))), 0.001);
+			slopeBias = bias + slope * cascadeTexelSize;
+			cascadeSurfaceZ = cascade1PositionLS.z - slopeBias;
+
 #			if SHADOWFILTER == 0
 			float cascade1ShadowMapValue = TexShadowMapSampler.Sample(SampShadowMapSampler, float3(cascade1PositionLS.xy, 1)).x;
-			if (cascade1ShadowMapValue >= cascade1PositionLS.z - AlphaTestRef.z) {
+			if (cascade1ShadowMapValue >= cascadeSurfaceZ) {
 				cascade1ShadowVisibility = 1;
 			}
 #			elif SHADOWFILTER == 1
-			cascade1ShadowVisibility = TexShadowMapSamplerComp.SampleCmpLevelZero(SampShadowMapSamplerComp, float3(cascade1PositionLS.xy, 1), cascade1PositionLS.z - AlphaTestRef.z).x;
+			cascade1ShadowVisibility = TexShadowMapSamplerComp.SampleCmpLevelZero(SampShadowMapSamplerComp, float3(cascade1PositionLS.xy, 1), cascadeSurfaceZ).x;
 #			elif SHADOWFILTER == 3
-			cascade1ShadowVisibility = GetPoissonDiskFilteredShadowVisibility(noise, rotationMatrix, TexShadowMapSamplerComp, SampShadowMapSamplerComp, cascade1PositionLS.xy, 1, cascade1PositionLS.z - AlphaTestRef.z, false);
+			cascade1ShadowVisibility = GetPoissonDiskFilteredShadowVisibility(noise, rotationMatrix, TexShadowMapSamplerComp, SampShadowMapSamplerComp, cascade1PositionLS.xy, 1, cascadeSurfaceZ, false);
 #			endif
 
 			float cascade1BlendFactor = smoothstep(0, 1, (shadowMapDepth - StartSplitDistances.y) / (EndSplitDistances.x - StartSplitDistances.y));
@@ -692,7 +714,7 @@ PS_OUTPUT main(PS_INPUT input)
 			shadowVisibility = min(shadowVisibility, lerp(1, focusShadowVisibility, focusShadowFade));
 		}
 
-		shadowColor.xyzw = fadeFactor * (shadowVisibility - 1) + 1;
+		shadowColor.xyzw = lerp(1.0 * !SharedData::InInterior, shadowVisibility, fadeFactor);
 	}
 #		elif defined(RENDER_SHADOWMASKSPOT)
 	float4 positionLS = mul(transpose(ShadowMapProj[eyeIndex][0]), float4(positionMS.xyz, 1));

--- a/package/Shaders/Utility.hlsl
+++ b/package/Shaders/Utility.hlsl
@@ -660,7 +660,7 @@ PS_OUTPUT main(PS_INPUT input)
 
 		// With a shadowMapThreshold = 0.005 this gives a bias around 0.0025, 0.0013 @ 4k, 8000wsu max depth in interiors
 		// Note: lower bias reduces peter panning but also leads to more self-shadowing(shadow acne)
-		float receiverDepthBias = (SharedData::InInterior) ? shadowMapThreshold * rcp(cascadeTexelSize * 2.5) : shadowMapThreshold;
+		float receiverDepthBias = (SharedData::InInterior) ? shadowMapThreshold * rcp(max(cascadeTexelSize, 0.6) * 2.5) : shadowMapThreshold;
 		float cascadeSurfaceZ = positionLS.z - receiverDepthBias;
 
 #			if SHADOWFILTER == 0
@@ -680,7 +680,7 @@ PS_OUTPUT main(PS_INPUT input)
 			float3 cascade1PositionLS = mul(transpose(ShadowMapProj[eyeIndex][1]), float4(positionMS.xyz, 1)).xyz;
 
 			cascadeTexelSize = (cascadeSplitL1 - cascadeSplitL0) / shadowMapResolution.x;
-			receiverDepthBias = (SharedData::InInterior) ? AlphaTestRef.z * rcp(cascadeTexelSize * 2.5) : AlphaTestRef.z;
+			receiverDepthBias = (SharedData::InInterior) ? AlphaTestRef.z * rcp(max(cascadeTexelSize, 0.6) * 2.5) : AlphaTestRef.z;
 			cascadeSurfaceZ = cascade1PositionLS.z - receiverDepthBias;
 
 #			if SHADOWFILTER == 0


### PR DESCRIPTION
This fixes 3 issues relating to light bleed in the shadow mask and addresses issue #1575 

Changes:
1. Add adaptive slope bias to cascade lookup depth.
2. Init shadow color to 0 in interior cells.
3. Fade end of range shadow values to 0 instead 1 in interior cells.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Interior-aware shadow handling: shadows suppressed or blended inside interiors for consistent shading.
  * Cascade depth biasing and texel-size awareness for improved shadow accuracy and smoother transitions.
  * Cascade blending/visibility updated to reduce edge artifacts and provide more stable results.
  * Spot/area shadow mask adjusted for consistent interior shading.
  * Volumetric lighting sampling aligned to centered texture coordinates for more stable eye selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->