### PR TITLE
fix: replace eastl vector with std

### DIFF
--- a/src/Features/GrassCollision.cpp
+++ b/src/Features/GrassCollision.cpp
@@ -22,7 +22,7 @@ void GrassCollision::DrawSettings()
 
 void GrassCollision::UpdateCollisions(PerFrame& perFrameData)
 {
-	eastl::vector<RE::Actor*> actorList{};
+	std::vector<RE::Actor*> actorList{};
 
 	// Actor query code from po3 under MIT
 	// https://github.com/powerof3/PapyrusExtenderSSE/blob/7a73b47bc87331bec4e16f5f42f2dbc98b66c3a7/include/Papyrus/Functions/Faction.h#L24C7-L46
@@ -51,10 +51,10 @@ void GrassCollision::UpdateCollisions(PerFrame& perFrameData)
 		return distA < distB;
 	});
 
-	eastl::vector<BoundingBoxPacked> boundingBoxData{};
+	std::vector<BoundingBoxPacked> boundingBoxData{};
 	boundingBoxData.reserve(MAX_BOUNDING_BOXES);
 
-	eastl::vector<float4> collisionsData{};
+	std::vector<float4> collisionsData{};
 	collisionsData.reserve(MAX_COLLISIONS);
 
 	uint collisionIndexExtent = 0;
@@ -69,7 +69,7 @@ void GrassCollision::UpdateCollisions(PerFrame& perFrameData)
 			if (distance > 2048.0f)
 				continue;
 
-			eastl::vector<float4> collisionShapes{};
+			std::vector<float4> collisionShapes{};
 
 			RE::BSVisit::TraverseScenegraphCollision(root, [&](RE::bhkNiCollisionObject* a_object) -> RE::BSVisit::BSVisitControl {
 				RE::NiPoint3 centerPos;

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -384,7 +384,7 @@ void LightLimitFix::UpdateLights()
 		eyePositionCached[eyeIndex] = { eyePosition.x, eyePosition.y, eyePosition.z };
 	}
 
-	eastl::vector<LightData> lightsData{};
+	std::vector<LightData> lightsData{};
 	lightsData.reserve(MAX_LIGHTS);
 
 	// Process point lights


### PR DESCRIPTION
This fixes potential crashes with grass collision and lighting. Unfortunately, newer EASTL versions use a version scheme which is incompatible with vcpkg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Upgraded internal container implementations in grass collision detection and lighting systems. These code improvements enhance codebase consistency and long-term maintainability through modernized library usage and practices. The changes strengthen code quality and developer efficiency without altering gameplay mechanics, visual quality, performance characteristics, or any user-facing features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->