### PR TITLE
build: bump eastl to 3.27.01

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,16 @@
+{
+    "default-registry": {
+        "kind": "git",
+        "repository": "https://github.com/microsoft/vcpkg",
+        "baseline": "a62ce77d56ee07513b4b67de1ec2daeaebfae51a"
+    },
+    "registries": [
+        {
+            "kind": "git",
+            "repository": "https://github.com/alandtse/vcpkg",
+            "baseline": "a62ce77d56ee07513b4b67de1ec2daeaebfae51a",
+            "reference": "eastl-3.27.01",
+            "packages": ["eastl"]
+        }
+    ]
+}

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -5,7 +5,7 @@
             "repository": "https://github.com/alandtse/vcpkg",
             "baseline": "0793c0ffb30cccd574f7804ac367d028c39b72ec",
             "reference": "eastl-3.27.01",
-            "packages": ["eastl"]
+            "packages": ["eastl", "eabase"]
         }
     ]
 }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,9 +1,4 @@
 {
-    "default-registry": {
-        "kind": "git",
-        "repository": "https://github.com/microsoft/vcpkg",
-        "baseline": "a62ce77d56ee07513b4b67de1ec2daeaebfae51a"
-    },
     "registries": [
         {
             "kind": "git",

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -3,7 +3,7 @@
         {
             "kind": "git",
             "repository": "https://github.com/alandtse/vcpkg",
-            "baseline": "a62ce77d56ee07513b4b67de1ec2daeaebfae51a",
+            "baseline": "0793c0ffb30cccd574f7804ac367d028c39b72ec",
             "reference": "eastl-3.27.01",
             "packages": ["eastl"]
         }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -38,7 +38,7 @@
         },
         {
             "name": "eastl",
-            "version": "3.27.01"
+            "version": "3.27.1"
         },
         {
             "name": "imgui",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -53,5 +53,5 @@
             "version": "1.606.4"
         }
     ],
-    "builtin-baseline": "a62ce77d56ee07513b4b67de1ec2daeaebfae51a"
+    "builtin-baseline": "656bccc57bf4599a038f93b86f80584042170fcd"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -37,6 +37,10 @@
             "version": "3.5.0"
         },
         {
+            "name": "eabase",
+            "version": "2025-08-03"
+        },
+        {
             "name": "eastl",
             "version": "3.27.01"
         },
@@ -53,5 +57,5 @@
             "version": "1.606.4"
         }
     ],
-    "builtin-baseline": "656bccc57bf4599a038f93b86f80584042170fcd"
+    "builtin-baseline": "a62ce77d56ee07513b4b67de1ec2daeaebfae51a"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -37,6 +37,10 @@
             "version": "3.5.0"
         },
         {
+            "name": "eastl",
+            "version": "3.27.01"
+        },
+        {
             "name": "imgui",
             "version": "1.90"
         },

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -38,7 +38,7 @@
         },
         {
             "name": "eastl",
-            "version": "3.27.1"
+            "version": "3.27.01"
         },
         {
             "name": "imgui",


### PR DESCRIPTION
DO NOT MERGE
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated to a single git package registry for vcpkg.
  * Pinned eastl to version 3.27.01 to stabilize dependency resolution and builds.
  * Added an override for eabase (2025-08-03).
  * Updated the registry baseline reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->