### PR TITLE
fix(tests): change display character to compile correctly

### DIFF
--- a/tests/shaders/runtime_discovered_tests.cpp
+++ b/tests/shaders/runtime_discovered_tests.cpp
@@ -1,4 +1,4 @@
-// Runtime-discovered HLSL tests
+﻿// Runtime-discovered HLSL tests
 // This file discovers and runs all HLSL tests at runtime - no code generation needed!
 
 #include "runtime_test_discovery.h"
@@ -34,7 +34,7 @@ TEST_CASE("Auto-discovered HLSL tests", "[autodiscovery]")
 				FAIL("Test failed: " << errorMsg);
 			}
 
-			INFO("✓ " << test.displayName);
+			INFO("√ " << test.displayName);
 		}
 	}
 }


### PR DESCRIPTION
change the character so that compiler using code page 1252 or 936 could compile without warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test output formatting for runtime-discovered shader tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->