### PR TITLE
fix(tests): change success hint to compile correctly

### DIFF
--- a/tests/shaders/runtime_discovered_tests.cpp
+++ b/tests/shaders/runtime_discovered_tests.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Auto-discovered HLSL tests", "[autodiscovery]")
 				FAIL("Test failed: " << errorMsg);
 			}
 
-			INFO("✓ " << test.displayName);
+			INFO("[PASS] " << test.displayName);
 		}
 	}
 }


### PR DESCRIPTION
So that people using code pag 936 or 1252 could compile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test output formatting to improve readability of test results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->