### PR TITLE
fix(interior sun): outdated state after cell change

### DIFF
--- a/src/Features/InteriorSun.cpp
+++ b/src/Features/InteriorSun.cpp
@@ -131,6 +131,16 @@ void InteriorSun::BSBatchRenderer_RenderPassImmediately::thunk(RE::BSRenderPass*
 	func(a_pass, a_technique, a_alphaTest, a_renderFlags);
 }
 
+RE::BSEventNotifyControl InteriorSun::MenuOpenCloseEventHandler::ProcessEvent(const RE::MenuOpenCloseEvent* a_event, RE::BSTEventSource<RE::MenuOpenCloseEvent>*)
+{
+	if (a_event->menuName == RE::MainMenu::MENU_NAME) {
+		if (a_event->opening)
+			globals::features::interiorSun.isInteriorWithSun = false;
+	}
+
+	return RE::BSEventNotifyControl::kContinue;
+}
+
 void InteriorSun::ClearArrays()
 {
 	currentCellRoomsAndPortals.clear();

--- a/src/Features/InteriorSun.h
+++ b/src/Features/InteriorSun.h
@@ -28,6 +28,11 @@ public:
 	virtual void PostPostLoad() override;
 	virtual void EarlyPrepass() override;
 
+	virtual void DataLoaded() override
+	{
+		MenuOpenCloseEventHandler::Register();
+	}
+
 	struct Settings
 	{
 		bool ForceDoubleSidedRendering = true;
@@ -70,6 +75,26 @@ public:
 			}
 		}
 	}
+
+	class MenuOpenCloseEventHandler : public RE::BSTEventSink<RE::MenuOpenCloseEvent>
+	{
+	public:
+		virtual RE::BSEventNotifyControl ProcessEvent(const RE::MenuOpenCloseEvent* a_event, RE::BSTEventSource<RE::MenuOpenCloseEvent>*);
+
+		static bool Register()
+		{
+			static MenuOpenCloseEventHandler singleton;
+			auto ui = globals::game::ui;
+			if (!ui) {
+				logger::error("UI event source not found");
+				return false;
+			}
+			ui->GetEventSource<RE::MenuOpenCloseEvent>()->AddEventSink(&singleton);
+
+			logger::info("Registered {}", typeid(singleton).name());
+			return true;
+		}
+	};
 
 	static bool IsInteriorWithSun(const RE::TESObjectCELL* cell);
 

--- a/src/Features/InteriorSun.h
+++ b/src/Features/InteriorSun.h
@@ -41,7 +41,7 @@ public:
 
 	Settings settings;
 
-	bool isInteriorWithSun = false;
+	std::atomic<bool> isInteriorWithSun = false;
 
 	struct GetWorldSpace
 	{


### PR DESCRIPTION
Issue:
When transitioning from cells that use interior sun to the main menu, interior sun can't update state before early prepass is voided. This causes the 'isInteriorWithSun' flag to become stale which leads to PBR setting the incorrect lighting flags when updating render pass arrays.

Fix:
Currently this is fixed using ENC to update state. Another way to fix it would be to hook a different section of the main rendering chain that isn't voided and use that instead of early prepass. 

symptoms:
<img width="2560" height="1440" alt="ScreenShot81" src="https://github.com/user-attachments/assets/5b4cc8f8-92bf-4fc1-8432-ab9f0e22e260" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved interior lighting state management during menu open/close so interior sun exposure is reset consistently.
* **Bug Fixes**
  * More reliable behavior when opening and closing menus to prevent stale interior environment effects and visual inconsistencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->