### PR TITLE
feat(sky-sync): add sun offset and MinElevation sliders

### DIFF
--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -34,7 +34,7 @@ void SkySync::DrawSettings()
 	}
 	ImGui::SliderInt("Moon light source", &settings.MoonLightSource, 0, static_cast<uint8_t>(MoonLightSource::Count) - 1, MoonLightSourceNames[settings.MoonLightSource], ImGuiSliderFlags_AlwaysClamp);
 	ImGui::SliderFloat("Min Shadow Elevation", &settings.MinShadowElevation, 0.0f, 45.0f, "%.01f deg");
-	ImGui::Text("The minimum angle sunlight will set to. Caps shadow length. Higher = shorter shadows at sunset/sunrise.");	
+	ImGui::Text("The minimum angle sunlight will set to. Caps shadow length. Higher = shorter shadows at sunset/sunrise.");
 }
 
 void SkySync::LoadSettings(json& o_json)

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -6,7 +6,12 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	UseAlternateSunPath,
 	MoonLightSource,
 	SunPath,
-	CustomAngle)
+	CustomAngle,
+	SunriseBeginOffset,
+	SunriseEndOffset,
+	SunsetBeginOffset,
+	SunsetEndOffset,
+	MinShadowElevation)
 
 void SkySync::DrawSettings()
 {
@@ -22,9 +27,14 @@ void SkySync::DrawSettings()
 			if (ImGui::SliderFloat("Custom angle", &settings.CustomAngle, -90.0f, 90.0f, "%.0f", ImGuiSliderFlags_AlwaysClamp))
 				SetSunAngle();
 		}
+		ImGui::SliderFloat("Sunrise Begin (Hours)", &settings.SunriseBeginOffset, -5.0f, 5.0f, "%.1f");
+		ImGui::SliderFloat("Sunrise End (Hours)", &settings.SunriseEndOffset, -5.0f, 5.0f, "%.1f");
+		ImGui::SliderFloat("Sunset Begin (Hours)", &settings.SunsetBeginOffset, -5.0f, 5.0f, "%.1f");
+		ImGui::SliderFloat("Sunset End (Hours)", &settings.SunsetEndOffset, -5.0f, 5.0f, "%.1f");
 	}
-
 	ImGui::SliderInt("Moon light source", &settings.MoonLightSource, 0, static_cast<uint8_t>(MoonLightSource::Count) - 1, MoonLightSourceNames[settings.MoonLightSource], ImGuiSliderFlags_AlwaysClamp);
+	ImGui::SliderFloat("Min Shadow Elevation", &settings.MinShadowElevation, 0.0f, 45.0f, "%.01f deg");
+	ImGui::Text("The minimum angle sunlight will set to. Caps shadow length. Higher = shorter shadows at sunset/sunrise.");	
 }
 
 void SkySync::LoadSettings(json& o_json)
@@ -394,7 +404,9 @@ void SkySync::ShadowFader::SetLighting(const RE::Sun* sun, RE::NiPoint3 dir, flo
 
 inline void SkySync::ShadowFader::ClampDirection(RE::NiPoint3& dir)
 {
-	constexpr float minElev = DirectX::XMConvertToRadians(MinElevation);
+	float minDegrees = globals::features::skySync.settings.MinShadowElevation;
+
+	float minElev = DirectX::XMConvertToRadians(minDegrees);
 	const float elev = DirectX::XMScalarASinEst(dir.z);
 	if (elev >= minElev)
 		return;
@@ -419,10 +431,15 @@ SkySync::VolumetricLightingDescriptor* SkySync::ApplyVolumetricLighting_Volumetr
 
 void SkySync::ClimateTimings::Update(const RE::TESClimate* climate)
 {
-	sunriseBegin = climate->timing.sunrise.begin / 6.0f;
-	sunriseEnd = climate->timing.sunrise.end / 6.0f;
-	sunsetBegin = climate->timing.sunset.begin / 6.0f;
-	sunsetEnd = climate->timing.sunset.end / 6.0f;
+	float srbegin = globals::features::skySync.settings.SunriseBeginOffset;
+	float srend = globals::features::skySync.settings.SunriseEndOffset;
+	float ssbegin = globals::features::skySync.settings.SunsetBeginOffset;
+	float ssend = globals::features::skySync.settings.SunsetEndOffset;
+
+	sunriseBegin = (climate->timing.sunrise.begin / 6.0f) + srbegin;
+	sunriseEnd = (climate->timing.sunrise.end / 6.0f) + srend;
+	sunsetBegin = (climate->timing.sunset.begin / 6.0f) + ssbegin;
+	sunsetEnd = (climate->timing.sunset.end / 6.0f) + ssend;
 	sunrise = (sunriseBegin + sunriseEnd) * 0.5f - 0.25f;
 	sunset = (sunsetBegin + sunsetEnd) * 0.5f + 0.25f;
 	sunriseFadeOutMoonStart = sunriseBegin - 0.5f;

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -30,7 +30,7 @@ void SkySync::DrawSettings()
 	}
 
 	ImGui::SliderInt("Moon light source", &settings.MoonLightSource, 0, static_cast<uint8_t>(MoonLightSource::Count) - 1, MoonLightSourceNames[settings.MoonLightSource], ImGuiSliderFlags_AlwaysClamp);
-	ImGui::SliderFloat("Min Shadow Elevation", &settings.MinShadowElevation, 0.0f, 45.0f, "%.1f deg");
+	ImGui::SliderFloat("Min Shadow Elevation", &settings.MinShadowElevation, 0.0f, 45.0f, "%.1f deg", ImGuiSliderFlags_AlwaysClamp);
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text("The minimum angle sunlight will set to. Caps shadow length. Higher = shorter shadows at sunset/sunrise.");
 	}

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -419,7 +419,8 @@ void SkySync::ShadowFader::SetLighting(const RE::Sun* sun, RE::NiPoint3 dir, flo
 
 inline void SkySync::ShadowFader::ClampDirection(RE::NiPoint3& dir)
 {
-	const float minDegrees = std::clamp(globals::features::skySync.settings.MinShadowElevation, 0.0f, 45.0f);
+	const float minDegrees = globals::features::skySync.settings.MinShadowElevation;
+	const float minElev = DirectX::XMConvertToRadians(minDegrees);
 	const float minElev = DirectX::XMConvertToRadians(minDegrees);
 	const float elev = DirectX::XMScalarASinEst(dir.z);
 	if (elev >= minElev)

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -37,15 +37,15 @@ void SkySync::DrawSettings()
 	ImGui::Spacing();
 	ImGui::Spacing();
 	if (ImGui::TreeNodeEx("Sun Position Offsets", ImGuiTreeNodeFlags_DefaultOpen)) {
-			ImGui::TextWrapped("Moves sun height during sunrise/sunset. Reset weather to see changes.");
-			ImGui::SliderFloat("Sunrise Begin (Hours)", &settings.SunriseBeginOffset, -5.0f, 5.0f, "%.1f");
-			ImGui::SliderFloat("Sunrise End (Hours)", &settings.SunriseEndOffset, -5.0f, 5.0f, "%.1f");
-			ImGui::SliderFloat("Sunset Begin (Hours)", &settings.SunsetBeginOffset, -5.0f, 5.0f, "%.1f");
-			ImGui::SliderFloat("Sunset End (Hours)", &settings.SunsetEndOffset, -5.0f, 5.0f, "%.1f");
-		}
-		ImGui::Spacing();
-		ImGui::Spacing();
-		ImGui::TreePop();
+		ImGui::TextWrapped("Moves sun height during sunrise/sunset. Reset weather to see changes.");
+		ImGui::SliderFloat("Sunrise Begin (Hours)", &settings.SunriseBeginOffset, -5.0f, 5.0f, "%.1f");
+		ImGui::SliderFloat("Sunrise End (Hours)", &settings.SunriseEndOffset, -5.0f, 5.0f, "%.1f");
+		ImGui::SliderFloat("Sunset Begin (Hours)", &settings.SunsetBeginOffset, -5.0f, 5.0f, "%.1f");
+		ImGui::SliderFloat("Sunset End (Hours)", &settings.SunsetEndOffset, -5.0f, 5.0f, "%.1f");
+	}
+	ImGui::Spacing();
+	ImGui::Spacing();
+	ImGui::TreePop();
 }
 
 void SkySync::LoadSettings(json& o_json)
@@ -447,7 +447,6 @@ SkySync::VolumetricLightingDescriptor* SkySync::ApplyVolumetricLighting_Volumetr
 
 void SkySync::ClimateTimings::Update(const RE::TESClimate* climate)
 {
-
 	float srbegin = globals::features::skySync.settings.SunriseBeginOffset;
 	float srend = globals::features::skySync.settings.SunriseEndOffset;
 	float ssbegin = globals::features::skySync.settings.SunsetBeginOffset;

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -1,4 +1,4 @@
-﻿#include "SkySync.h"
+#include "SkySync.h"
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	SkySync::Settings,
@@ -27,14 +27,25 @@ void SkySync::DrawSettings()
 			if (ImGui::SliderFloat("Custom angle", &settings.CustomAngle, -90.0f, 90.0f, "%.0f", ImGuiSliderFlags_AlwaysClamp))
 				SetSunAngle();
 		}
-		ImGui::SliderFloat("Sunrise Begin (Hours)", &settings.SunriseBeginOffset, -5.0f, 5.0f, "%.1f");
-		ImGui::SliderFloat("Sunrise End (Hours)", &settings.SunriseEndOffset, -5.0f, 5.0f, "%.1f");
-		ImGui::SliderFloat("Sunset Begin (Hours)", &settings.SunsetBeginOffset, -5.0f, 5.0f, "%.1f");
-		ImGui::SliderFloat("Sunset End (Hours)", &settings.SunsetEndOffset, -5.0f, 5.0f, "%.1f");
 	}
+
 	ImGui::SliderInt("Moon light source", &settings.MoonLightSource, 0, static_cast<uint8_t>(MoonLightSource::Count) - 1, MoonLightSourceNames[settings.MoonLightSource], ImGuiSliderFlags_AlwaysClamp);
-	ImGui::SliderFloat("Min Shadow Elevation", &settings.MinShadowElevation, 0.0f, 45.0f, "%.01f deg");
-	ImGui::Text("The minimum angle sunlight will set to. Caps shadow length. Higher = shorter shadows at sunset/sunrise.");
+	ImGui::SliderFloat("Min Shadow Elevation", &settings.MinShadowElevation, 0.0f, 45.0f, "%.1f deg");
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text("The minimum angle sunlight will set to. Caps shadow length. Higher = shorter shadows at sunset/sunrise.");
+	}
+	ImGui::Spacing();
+	ImGui::Spacing();
+	if (ImGui::TreeNodeEx("Sun Position Offsets", ImGuiTreeNodeFlags_DefaultOpen)) {
+			ImGui::TextWrapped("Moves sun height during sunrise/sunset. Reset weather to see changes.");
+			ImGui::SliderFloat("Sunrise Begin (Hours)", &settings.SunriseBeginOffset, -5.0f, 5.0f, "%.1f");
+			ImGui::SliderFloat("Sunrise End (Hours)", &settings.SunriseEndOffset, -5.0f, 5.0f, "%.1f");
+			ImGui::SliderFloat("Sunset Begin (Hours)", &settings.SunsetBeginOffset, -5.0f, 5.0f, "%.1f");
+			ImGui::SliderFloat("Sunset End (Hours)", &settings.SunsetEndOffset, -5.0f, 5.0f, "%.1f");
+		}
+		ImGui::Spacing();
+		ImGui::Spacing();
+		ImGui::TreePop();
 }
 
 void SkySync::LoadSettings(json& o_json)
@@ -43,6 +54,11 @@ void SkySync::LoadSettings(json& o_json)
 	settings.MoonLightSource = std::clamp(settings.MoonLightSource, static_cast<int32_t>(MoonLightSource::Brightest), static_cast<int32_t>(MoonLightSource::Secunda));
 	settings.SunPath = std::clamp(settings.SunPath, static_cast<int32_t>(SunPath::Southern), static_cast<int32_t>(SunPath::Custom));
 	SetSunAngle();
+	settings.SunriseBeginOffset = std::clamp(settings.SunriseBeginOffset, -5.0f, 5.0f);
+	settings.SunriseEndOffset = std::clamp(settings.SunriseEndOffset, -5.0f, 5.0f);
+	settings.SunsetBeginOffset = std::clamp(settings.SunsetBeginOffset, -5.0f, 5.0f);
+	settings.SunsetEndOffset = std::clamp(settings.SunsetEndOffset, -5.0f, 5.0f);
+	settings.MinShadowElevation = std::clamp(settings.MinShadowElevation, 0.0f, 45.0f);
 }
 
 void SkySync::SaveSettings(json& o_json)
@@ -431,6 +447,7 @@ SkySync::VolumetricLightingDescriptor* SkySync::ApplyVolumetricLighting_Volumetr
 
 void SkySync::ClimateTimings::Update(const RE::TESClimate* climate)
 {
+
 	float srbegin = globals::features::skySync.settings.SunriseBeginOffset;
 	float srend = globals::features::skySync.settings.SunriseEndOffset;
 	float ssbegin = globals::features::skySync.settings.SunsetBeginOffset;

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -37,11 +37,12 @@ void SkySync::DrawSettings()
 	ImGui::Spacing();
 	ImGui::Spacing();
 	if (ImGui::TreeNodeEx("Sun Position Offsets", ImGuiTreeNodeFlags_DefaultOpen)) {
-		ImGui::TextWrapped("Moves sun height during sunrise/sunset. Reset weather to see changes.");
-		ImGui::SliderFloat("Sunrise Begin (Hours)", &settings.SunriseBeginOffset, -5.0f, 5.0f, "%.1f");
-		ImGui::SliderFloat("Sunrise End (Hours)", &settings.SunriseEndOffset, -5.0f, 5.0f, "%.1f");
-		ImGui::SliderFloat("Sunset Begin (Hours)", &settings.SunsetBeginOffset, -5.0f, 5.0f, "%.1f");
-		ImGui::SliderFloat("Sunset End (Hours)", &settings.SunsetEndOffset, -5.0f, 5.0f, "%.1f");
+			ImGui::TextWrapped("Moves sun height during sunrise/sunset. Reset weather to see changes.");
+			ImGui::SliderFloat("Sunrise Begin (Hours)", &settings.SunriseBeginOffset, -5.0f, 5.0f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
+			ImGui::SliderFloat("Sunrise End (Hours)", &settings.SunriseEndOffset, -5.0f, 5.0f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
+			ImGui::SliderFloat("Sunset Begin (Hours)", &settings.SunsetBeginOffset, -5.0f, 5.0f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
+			ImGui::SliderFloat("Sunset End (Hours)", &settings.SunsetEndOffset, -5.0f, 5.0f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
+			ImGui::TreePop();
 	}
 }
 
@@ -50,12 +51,13 @@ void SkySync::LoadSettings(json& o_json)
 	settings = o_json;
 	settings.MoonLightSource = std::clamp(settings.MoonLightSource, static_cast<int32_t>(MoonLightSource::Brightest), static_cast<int32_t>(MoonLightSource::Secunda));
 	settings.SunPath = std::clamp(settings.SunPath, static_cast<int32_t>(SunPath::Southern), static_cast<int32_t>(SunPath::Custom));
-	SetSunAngle();
+	settings.CustomAngle = std::clamp(settings.CustomAngle, -90.0f, 90.0f);
 	settings.SunriseBeginOffset = std::clamp(settings.SunriseBeginOffset, -5.0f, 5.0f);
 	settings.SunriseEndOffset = std::clamp(settings.SunriseEndOffset, -5.0f, 5.0f);
 	settings.SunsetBeginOffset = std::clamp(settings.SunsetBeginOffset, -5.0f, 5.0f);
 	settings.SunsetEndOffset = std::clamp(settings.SunsetEndOffset, -5.0f, 5.0f);
 	settings.MinShadowElevation = std::clamp(settings.MinShadowElevation, 0.0f, 45.0f);
+	SetSunAngle();
 }
 
 void SkySync::SaveSettings(json& o_json)
@@ -417,9 +419,8 @@ void SkySync::ShadowFader::SetLighting(const RE::Sun* sun, RE::NiPoint3 dir, flo
 
 inline void SkySync::ShadowFader::ClampDirection(RE::NiPoint3& dir)
 {
-	float minDegrees = globals::features::skySync.settings.MinShadowElevation;
-
-	float minElev = DirectX::XMConvertToRadians(minDegrees);
+	const float minDegrees = std::clamp(globals::features::skySync.settings.MinShadowElevation, 0.0f, 45.0f);
+	const float minElev = DirectX::XMConvertToRadians(minDegrees);
 	const float elev = DirectX::XMScalarASinEst(dir.z);
 	if (elev >= minElev)
 		return;
@@ -444,15 +445,21 @@ SkySync::VolumetricLightingDescriptor* SkySync::ApplyVolumetricLighting_Volumetr
 
 void SkySync::ClimateTimings::Update(const RE::TESClimate* climate)
 {
-	float srbegin = globals::features::skySync.settings.SunriseBeginOffset;
-	float srend = globals::features::skySync.settings.SunriseEndOffset;
-	float ssbegin = globals::features::skySync.settings.SunsetBeginOffset;
-	float ssend = globals::features::skySync.settings.SunsetEndOffset;
+	const float SunriseBeginOffset = globals::features::skySync.settings.SunriseBeginOffset;
+	const float SunriseEndOffset = globals::features::skySync.settings.SunriseEndOffset;
+	const float SunsetBeginOffset = globals::features::skySync.settings.SunsetBeginOffset;
+	const float SunsetEndOffset = globals::features::skySync.settings.SunsetEndOffset;
 
-	sunriseBegin = (climate->timing.sunrise.begin / 6.0f) + srbegin;
-	sunriseEnd = (climate->timing.sunrise.end / 6.0f) + srend;
-	sunsetBegin = (climate->timing.sunset.begin / 6.0f) + ssbegin;
-	sunsetEnd = (climate->timing.sunset.end / 6.0f) + ssend;
+	sunriseBegin = (climate->timing.sunrise.begin / 6.0f) + SunriseBeginOffset;
+	sunriseEnd = (climate->timing.sunrise.end / 6.0f) + SunriseEndOffset;
+	sunsetBegin = (climate->timing.sunset.begin / 6.0f) + SunsetBeginOffset;
+	sunsetEnd = (climate->timing.sunset.end / 6.0f) + SunsetEndOffset;
+	// Basic ordering guarantees (prevents divide-by-zero / negative duration paths).
+	constexpr float kMinGapHours = 0.1f;
+	if (sunriseEnd <= sunriseBegin)	sunriseEnd = sunriseBegin + kMinGapHours;
+	if (sunsetEnd <= sunsetBegin)	sunsetEnd = sunsetBegin + kMinGapHours;
+	if (sunsetBegin <= sunriseEnd)	sunsetBegin = sunriseEnd + kMinGapHours;
+	if (sunsetEnd <= sunsetBegin)	sunsetEnd = sunsetBegin + kMinGapHours;
 	sunrise = (sunriseBegin + sunriseEnd) * 0.5f - 0.25f;
 	sunset = (sunsetBegin + sunsetEnd) * 0.5f + 0.25f;
 	sunriseFadeOutMoonStart = sunriseBegin - 0.5f;

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -421,7 +421,6 @@ inline void SkySync::ShadowFader::ClampDirection(RE::NiPoint3& dir)
 {
 	const float minDegrees = globals::features::skySync.settings.MinShadowElevation;
 	const float minElev = DirectX::XMConvertToRadians(minDegrees);
-	const float minElev = DirectX::XMConvertToRadians(minDegrees);
 	const float elev = DirectX::XMScalarASinEst(dir.z);
 	if (elev >= minElev)
 		return;

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -37,12 +37,12 @@ void SkySync::DrawSettings()
 	ImGui::Spacing();
 	ImGui::Spacing();
 	if (ImGui::TreeNodeEx("Sun Position Offsets", ImGuiTreeNodeFlags_DefaultOpen)) {
-			ImGui::TextWrapped("Moves sun height during sunrise/sunset. Reset weather to see changes.");
-			ImGui::SliderFloat("Sunrise Begin (Hours)", &settings.SunriseBeginOffset, -5.0f, 5.0f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::SliderFloat("Sunrise End (Hours)", &settings.SunriseEndOffset, -5.0f, 5.0f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::SliderFloat("Sunset Begin (Hours)", &settings.SunsetBeginOffset, -5.0f, 5.0f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::SliderFloat("Sunset End (Hours)", &settings.SunsetEndOffset, -5.0f, 5.0f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::TreePop();
+		ImGui::TextWrapped("Moves sun height during sunrise/sunset. Reset weather to see changes.");
+		ImGui::SliderFloat("Sunrise Begin (Hours)", &settings.SunriseBeginOffset, -5.0f, 5.0f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
+		ImGui::SliderFloat("Sunrise End (Hours)", &settings.SunriseEndOffset, -5.0f, 5.0f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
+		ImGui::SliderFloat("Sunset Begin (Hours)", &settings.SunsetBeginOffset, -5.0f, 5.0f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
+		ImGui::SliderFloat("Sunset End (Hours)", &settings.SunsetEndOffset, -5.0f, 5.0f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
+		ImGui::TreePop();
 	}
 }
 
@@ -456,10 +456,14 @@ void SkySync::ClimateTimings::Update(const RE::TESClimate* climate)
 	sunsetEnd = (climate->timing.sunset.end / 6.0f) + SunsetEndOffset;
 	// Basic ordering guarantees (prevents divide-by-zero / negative duration paths).
 	constexpr float kMinGapHours = 0.1f;
-	if (sunriseEnd <= sunriseBegin)	sunriseEnd = sunriseBegin + kMinGapHours;
-	if (sunsetEnd <= sunsetBegin)	sunsetEnd = sunsetBegin + kMinGapHours;
-	if (sunsetBegin <= sunriseEnd)	sunsetBegin = sunriseEnd + kMinGapHours;
-	if (sunsetEnd <= sunsetBegin)	sunsetEnd = sunsetBegin + kMinGapHours;
+	if (sunriseEnd <= sunriseBegin)
+		sunriseEnd = sunriseBegin + kMinGapHours;
+	if (sunsetEnd <= sunsetBegin)
+		sunsetEnd = sunsetBegin + kMinGapHours;
+	if (sunsetBegin <= sunriseEnd)
+		sunsetBegin = sunriseEnd + kMinGapHours;
+	if (sunsetEnd <= sunsetBegin)
+		sunsetEnd = sunsetBegin + kMinGapHours;
 	sunrise = (sunriseBegin + sunriseEnd) * 0.5f - 0.25f;
 	sunset = (sunsetBegin + sunsetEnd) * 0.5f + 0.25f;
 	sunriseFadeOutMoonStart = sunriseBegin - 0.5f;

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -43,9 +43,6 @@ void SkySync::DrawSettings()
 		ImGui::SliderFloat("Sunset Begin (Hours)", &settings.SunsetBeginOffset, -5.0f, 5.0f, "%.1f");
 		ImGui::SliderFloat("Sunset End (Hours)", &settings.SunsetEndOffset, -5.0f, 5.0f, "%.1f");
 	}
-	ImGui::Spacing();
-	ImGui::Spacing();
-	ImGui::TreePop();
 }
 
 void SkySync::LoadSettings(json& o_json)

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -31,6 +31,11 @@ public:
 		int32_t MoonLightSource = 0;
 		int32_t SunPath = 0;
 		float CustomAngle = -35.0f;
+		float SunriseBeginOffset = 0.0f;
+		float SunriseEndOffset = 0.0f;
+		float SunsetBeginOffset = 0.0f;
+		float SunsetEndOffset = 0.0f;
+		float MinShadowElevation = 0.25f;
 	};
 
 	Settings settings;

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -152,7 +152,6 @@ private:
 	static constexpr float SunHorizonDistance = 280.0f;
 	static constexpr float SunPeakDistance = 400.0f;
 	static constexpr float SunScaleFactor = 48.0f / 2048.0f;
-	static constexpr float MinElevation = 0.25f;
 
 	static constexpr float SouthernSunAngle = 90.0f - 35.0f;
 	static constexpr float NorthernSunAngle = 90.0f + 35.0f;


### PR DESCRIPTION
Adds new sliders that control sun position by adding climatetimings offsets, and can change the MinElevation value to limit shadow depth. Changing sun position requires a weather refresh, MinElevation works in realtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adjustable sunrise/sunset Begin/End offsets with sliders for finer control
  * Minimum shadow elevation slider to customize shadow behavior
  * Collapsible "Sun Position Offsets" UI section with tooltips

* **Improvements**
  * Timing and rendering now honor the new offsets and minimum shadow elevation
  * Inputs clamped and guarded to ensure valid sunrise/sunset ordering and stable shadow math

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->