### PR TITLE
fix(LL): pbr specular brightness with dalc

### DIFF
--- a/package/Shaders/Common/Color.hlsli
+++ b/package/Shaders/Common/Color.hlsli
@@ -111,7 +111,7 @@ namespace Color
 	const static float PBRLightingScale = ENABLE_LL ? 1.0 : 0.65;
 
 	// Attempt to normalise reflection brightness against DALC
-	const static float ReflectionNormalisationScale = ENABLE_LL ? 1.0 : 0.65;
+	const static float ReflectionNormalisationScale = 0.65;
 
 	const static float PBRLightingCompensation = ENABLE_LL ? 1.0 : Math::PI;
 

--- a/package/Shaders/DeferredCompositeCS.hlsl
+++ b/package/Shaders/DeferredCompositeCS.hlsl
@@ -171,7 +171,7 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, out float ao, out float3 il, i
 
 		float3 finalIrradiance = 0;
 
-        float directionalAmbientColorSpecular = Color::RGBToLuminance(max(0, mul(SharedData::DirectionalAmbient, float4(R, 1.0)))) * Color::ReflectionNormalisationScale;
+        float directionalAmbientColorSpecular = Color::RGBToLuminance(Color::Ambient(max(0, mul(SharedData::DirectionalAmbient, float4(R, 1.0))))) * Color::ReflectionNormalisationScale;
 
 #	if defined(INTERIOR)
 		float3 specularIrradiance = EnvTexture.SampleLevel(LinearSampler, R, level);


### PR DESCRIPTION
The Problem:
When using Linear Lighting with PBR materials and DALC instead of IBL, surfaces appeared too shiny/glossy - especially metals. Everything had an excessive "wet look" or mirror-like sheen.

Solution:
1) ReflectionNormalisationScale is now always 0.65 instead of switching between 1.0 (with Linear Lighting) and 0.65 (without).

Turns down the overall reflection brightness from 100% to 65% with DALC.

2) Added Color::Ambient() around the DALC (Directional Ambient Lighting Color) calculation.

Made sure the ambient light feeding into reflections goes through the same "dimming filter" that other parts of the lighting system use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified reflection normalization constant handling across rendering configurations
  * Updated ambient color calculation method in the rendering pipeline for improved consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->