### PR TITLE
build: pin eastl to stable commit

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,10 +1,11 @@
 {
+    "$comment": "Using temporary stable branch for eastl 3.27.1 until upstream PR is merged: https://github.com/microsoft/vcpkg/pull/49228",
     "registries": [
         {
             "kind": "git",
             "repository": "https://github.com/alandtse/vcpkg",
-            "baseline": "0793c0ffb30cccd574f7804ac367d028c39b72ec",
-            "reference": "eastl-3.27.01",
+            "baseline": "2e1caaee2dd0d06b100ae751b6bf309ea95a13b1",
+            "reference": "eastl-3.27.1-stable",
             "packages": ["eastl", "eabase"]
         }
     ]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -57,5 +57,5 @@
             "version": "1.606.4"
         }
     ],
-    "builtin-baseline": "2e1caaee2dd0d06b100ae751b6bf309ea95a13b1"
+    "builtin-baseline": "fafcc0e93bfba303e5e48790def745d27e6d449b"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -38,11 +38,11 @@
         },
         {
             "name": "eabase",
-            "version": "2025-08-03"
+            "version": "2025-08-01"
         },
         {
             "name": "eastl",
-            "version": "3.27.01"
+            "version": "3.27.1"
         },
         {
             "name": "imgui",
@@ -57,5 +57,5 @@
             "version": "1.606.4"
         }
     ],
-    "builtin-baseline": "a62ce77d56ee07513b4b67de1ec2daeaebfae51a"
+    "builtin-baseline": "2e1caaee2dd0d06b100ae751b6bf309ea95a13b1"
 }


### PR DESCRIPTION
This is temporary and allows changes to the PR for upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated eastl library to version 3.27.1 (stable)
  * Updated eabase library version
  * Refreshed dependency baselines and registry references to align package manifests and overrides

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->