### PR TITLE
fix: fix pbr heap crash

### DIFF
--- a/src/TruePBR/BSLightingShaderMaterialPBR.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBR.cpp
@@ -9,8 +9,8 @@ BSLightingShaderMaterialPBR::~BSLightingShaderMaterialPBR()
 
 BSLightingShaderMaterialPBR* BSLightingShaderMaterialPBR::Make()
 {
-	static auto scrapHeap = RE::MemoryManager::GetSingleton()->GetThreadScrapHeap();
-	auto material = static_cast<BSLightingShaderMaterialPBR*>(scrapHeap->Allocate(sizeof(BSLightingShaderMaterialPBR), 8));
+	static auto memoryManager = RE::MemoryManager::GetSingleton();
+	auto material = static_cast<BSLightingShaderMaterialPBR*>(memoryManager->GetThreadScrapHeap()->Allocate(sizeof(BSLightingShaderMaterialPBR), 8));
 	return material;
 }
 

--- a/src/TruePBR/BSLightingShaderMaterialPBR.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBR.cpp
@@ -11,7 +11,8 @@ BSLightingShaderMaterialPBR* BSLightingShaderMaterialPBR::Make()
 {
 	static auto memoryManager = RE::MemoryManager::GetSingleton();
 	auto memory = static_cast<BSLightingShaderMaterialPBR*>(memoryManager->GetThreadScrapHeap()->Allocate(sizeof(BSLightingShaderMaterialPBR), alignof(BSLightingShaderMaterialPBR)));
-	return new (memory) BSLightingShaderMaterialPBR();
+	*memory = {};
+	return memory;
 }
 
 RE::BSShaderMaterial* BSLightingShaderMaterialPBR::Create()

--- a/src/TruePBR/BSLightingShaderMaterialPBR.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBR.cpp
@@ -10,7 +10,7 @@ BSLightingShaderMaterialPBR::~BSLightingShaderMaterialPBR()
 BSLightingShaderMaterialPBR* BSLightingShaderMaterialPBR::Make()
 {
 	static auto memoryManager = RE::MemoryManager::GetSingleton();
-	auto memory = static_cast<BSLightingShaderMaterialPBR*>(memoryManager->GetThreadScrapHeap()->Allocate(sizeof(BSLightingShaderMaterialPBR), 8));
+	auto memory = static_cast<BSLightingShaderMaterialPBR*>(memoryManager->GetThreadScrapHeap()->Allocate(sizeof(BSLightingShaderMaterialPBR), alignof(BSLightingShaderMaterialPBR)));
 	return new (memory) BSLightingShaderMaterialPBR();
 }
 

--- a/src/TruePBR/BSLightingShaderMaterialPBR.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBR.cpp
@@ -10,8 +10,8 @@ BSLightingShaderMaterialPBR::~BSLightingShaderMaterialPBR()
 BSLightingShaderMaterialPBR* BSLightingShaderMaterialPBR::Make()
 {
 	static auto memoryManager = RE::MemoryManager::GetSingleton();
-	auto material = static_cast<BSLightingShaderMaterialPBR*>(memoryManager->GetThreadScrapHeap()->Allocate(sizeof(BSLightingShaderMaterialPBR), 8));
-	return material;
+	auto memory = static_cast<BSLightingShaderMaterialPBR*>(memoryManager->GetThreadScrapHeap()->Allocate(sizeof(BSLightingShaderMaterialPBR), 8));
+	return new (memory) BSLightingShaderMaterialPBR();
 }
 
 RE::BSShaderMaterial* BSLightingShaderMaterialPBR::Create()

--- a/src/TruePBR/BSLightingShaderMaterialPBR.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBR.cpp
@@ -10,9 +10,8 @@ BSLightingShaderMaterialPBR::~BSLightingShaderMaterialPBR()
 BSLightingShaderMaterialPBR* BSLightingShaderMaterialPBR::Make()
 {
 	static auto memoryManager = RE::MemoryManager::GetSingleton();
-	auto memory = static_cast<BSLightingShaderMaterialPBR*>(memoryManager->GetThreadScrapHeap()->Allocate(sizeof(BSLightingShaderMaterialPBR), alignof(BSLightingShaderMaterialPBR)));
-	*memory = {};
-	return memory;
+	auto memory = static_cast<BSLightingShaderMaterialPBR*>(memoryManager->GetThreadScrapHeap()->Allocate(sizeof(BSLightingShaderMaterialPBR), 8));
+	return new (memory) BSLightingShaderMaterialPBR();
 }
 
 RE::BSShaderMaterial* BSLightingShaderMaterialPBR::Create()

--- a/src/TruePBR/BSLightingShaderMaterialPBR.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBR.cpp
@@ -9,7 +9,9 @@ BSLightingShaderMaterialPBR::~BSLightingShaderMaterialPBR()
 
 BSLightingShaderMaterialPBR* BSLightingShaderMaterialPBR::Make()
 {
-	return new BSLightingShaderMaterialPBR;
+	static auto scrapHeap = RE::MemoryManager::GetSingleton()->GetThreadScrapHeap();
+	auto material = static_cast<BSLightingShaderMaterialPBR*>(scrapHeap->Allocate(sizeof(BSLightingShaderMaterialPBR), 8));
+	return material;
 }
 
 RE::BSShaderMaterial* BSLightingShaderMaterialPBR::Create()

--- a/src/TruePBR/BSLightingShaderMaterialPBR.h
+++ b/src/TruePBR/BSLightingShaderMaterialPBR.h
@@ -49,6 +49,9 @@ public:
 
 	~BSLightingShaderMaterialPBR();
 
+	// Placement delete to match inherited placement new from BSIntrusiveRefCounted
+	static void operator delete(void* ptr, void*) noexcept { RE::free(ptr); }
+
 	// override (BSLightingShaderMaterialBase)
 	RE::BSShaderMaterial* Create() override;                                                                                      // 01
 	void CopyMembers(RE::BSShaderMaterial* that) override;                                                                        // 02

--- a/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
@@ -16,8 +16,8 @@ BSLightingShaderMaterialPBRLandscape::~BSLightingShaderMaterialPBRLandscape()
 BSLightingShaderMaterialPBRLandscape* BSLightingShaderMaterialPBRLandscape::Make()
 {
 	static auto memoryManager = RE::MemoryManager::GetSingleton();
-	auto material = static_cast<BSLightingShaderMaterialPBRLandscape*>(memoryManagerr->GetThreadScrapHeap()->Allocate(sizeof(BSLightingShaderMaterialPBRLandscape), 8));
-	return material;
+	auto memory = static_cast<BSLightingShaderMaterialPBRLandscape*>(memoryManagerr->GetThreadScrapHeap()->Allocate(sizeof(BSLightingShaderMaterialPBRLandscape), 8));
+	return new (memory) BSLightingShaderMaterialPBRLandscape();
 }
 
 RE::BSShaderMaterial* BSLightingShaderMaterialPBRLandscape::Create()

--- a/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
@@ -15,7 +15,9 @@ BSLightingShaderMaterialPBRLandscape::~BSLightingShaderMaterialPBRLandscape()
 
 BSLightingShaderMaterialPBRLandscape* BSLightingShaderMaterialPBRLandscape::Make()
 {
-	return new BSLightingShaderMaterialPBRLandscape;
+	static auto scrapHeap = RE::MemoryManager::GetSingleton()->GetThreadScrapHeap();
+	auto material = static_cast<BSLightingShaderMaterialPBRLandscape*>(scrapHeap->Allocate(sizeof(BSLightingShaderMaterialPBRLandscape), 8));
+	return material;
 }
 
 RE::BSShaderMaterial* BSLightingShaderMaterialPBRLandscape::Create()

--- a/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
@@ -15,8 +15,8 @@ BSLightingShaderMaterialPBRLandscape::~BSLightingShaderMaterialPBRLandscape()
 
 BSLightingShaderMaterialPBRLandscape* BSLightingShaderMaterialPBRLandscape::Make()
 {
-	static auto scrapHeap = RE::MemoryManager::GetSingleton()->GetThreadScrapHeap();
-	auto material = static_cast<BSLightingShaderMaterialPBRLandscape*>(scrapHeap->Allocate(sizeof(BSLightingShaderMaterialPBRLandscape), 8));
+	static auto memoryManager = RE::MemoryManager::GetSingleton();
+	auto material = static_cast<BSLightingShaderMaterialPBRLandscape*>(memoryManagerr->GetThreadScrapHeap()->Allocate(sizeof(BSLightingShaderMaterialPBRLandscape), 8));
 	return material;
 }
 

--- a/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
@@ -16,9 +16,8 @@ BSLightingShaderMaterialPBRLandscape::~BSLightingShaderMaterialPBRLandscape()
 BSLightingShaderMaterialPBRLandscape* BSLightingShaderMaterialPBRLandscape::Make()
 {
 	static auto memoryManager = RE::MemoryManager::GetSingleton();
-	auto memory = static_cast<BSLightingShaderMaterialPBRLandscape*>(memoryManager->GetThreadScrapHeap()->Allocate(sizeof(BSLightingShaderMaterialPBRLandscape), alignof(BSLightingShaderMaterialPBRLandscape)));
-	*memory = {};
-	return memory;
+	auto memory = static_cast<BSLightingShaderMaterialPBRLandscape*>(memoryManager->GetThreadScrapHeap()->Allocate(sizeof(BSLightingShaderMaterialPBRLandscape), 8));
+	return new (memory) BSLightingShaderMaterialPBRLandscape();
 }
 
 RE::BSShaderMaterial* BSLightingShaderMaterialPBRLandscape::Create()

--- a/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
@@ -16,7 +16,7 @@ BSLightingShaderMaterialPBRLandscape::~BSLightingShaderMaterialPBRLandscape()
 BSLightingShaderMaterialPBRLandscape* BSLightingShaderMaterialPBRLandscape::Make()
 {
 	static auto memoryManager = RE::MemoryManager::GetSingleton();
-	auto memory = static_cast<BSLightingShaderMaterialPBRLandscape*>(memoryManagerr->GetThreadScrapHeap()->Allocate(sizeof(BSLightingShaderMaterialPBRLandscape), 8));
+	auto memory = static_cast<BSLightingShaderMaterialPBRLandscape*>(memoryManager->GetThreadScrapHeap()->Allocate(sizeof(BSLightingShaderMaterialPBRLandscape), alignof(BSLightingShaderMaterialPBRLandscape)));
 	return new (memory) BSLightingShaderMaterialPBRLandscape();
 }
 

--- a/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
@@ -17,7 +17,8 @@ BSLightingShaderMaterialPBRLandscape* BSLightingShaderMaterialPBRLandscape::Make
 {
 	static auto memoryManager = RE::MemoryManager::GetSingleton();
 	auto memory = static_cast<BSLightingShaderMaterialPBRLandscape*>(memoryManager->GetThreadScrapHeap()->Allocate(sizeof(BSLightingShaderMaterialPBRLandscape), alignof(BSLightingShaderMaterialPBRLandscape)));
-	return new (memory) BSLightingShaderMaterialPBRLandscape();
+	*memory = {};
+	return memory;
 }
 
 RE::BSShaderMaterial* BSLightingShaderMaterialPBRLandscape::Create()

--- a/src/TruePBR/BSLightingShaderMaterialPBRLandscape.h
+++ b/src/TruePBR/BSLightingShaderMaterialPBRLandscape.h
@@ -17,6 +17,9 @@ public:
 	BSLightingShaderMaterialPBRLandscape();
 	~BSLightingShaderMaterialPBRLandscape();
 
+	// Placement delete to match inherited placement new from BSIntrusiveRefCounted
+	static void operator delete(void* ptr, void*) noexcept { RE::free(ptr); }
+
 	// override (BSLightingShaderMaterialBase)
 	RE::BSShaderMaterial* Create() override;                                                                                      // 01
 	void CopyMembers(RE::BSShaderMaterial* that) override;                                                                        // 02


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changed internal allocation for shader material components to use per-thread scrap heaps, improving runtime allocation efficiency and reducing overhead.
* **Bug Fixes / Stability**
  * Added safer placement-deallocation handling for shader materials to reduce leak risk and improve stability during resource cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->