### PR TITLE
fix(wetness): fix water roughness and normal

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2306,7 +2306,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #	if defined(WETNESS_EFFECTS)
 	// Initialize wetness parameters
 	float wetness = 0.0;
-	float3 wetnessNormal = worldNormal;
+	float3 wetnessNormal = vertexNormal.xyz;
 
 	// Calculate shore wetness factors
 	float wetnessDistToWater = abs(input.WorldPosition.z - waterHeight);
@@ -2315,7 +2315,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	// Calculate wetness angle and occlusion
 	float minWetnessValue = SharedData::wetnessEffectsSettings.MinRainWetness;
-	float minWetnessAngle = saturate(max(minWetnessValue, worldNormal.z));
+	float minWetnessAngle = saturate(max(minWetnessValue, vertexNormal.z));
 #		if defined(SKYLIGHTING)
 	float wetnessOcclusion = inWorld ? saturate(SphericalHarmonics::Unproject(skylightingSH, float3(0, 0, 1))) : 0.0;
 #		else
@@ -2337,7 +2337,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		else
 		float3 ripplePosition = !FrameBuffer::FrameParams.y ? input.ModelPosition.xyz : input.WorldPosition.xyz + FrameBuffer::CameraPosAdjust[eyeIndex].xyz;
 #		endif
-		raindropInfo = WetnessEffects::GetRainDrops(ripplePosition, SharedData::wetnessEffectsSettings.Time, worldNormal, flatnessAmount);
+		raindropInfo = WetnessEffects::GetRainDrops(ripplePosition, SharedData::wetnessEffectsSettings.Time, wetnessNormal, flatnessAmount);
 	}
 
 	// Calculate different wetness types
@@ -2366,6 +2366,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	// Apply occlusion and distance factors
 	puddle *= saturate(wetnessOcclusion * 2.0) * nearFactor;
+	wetnessNormal = lerp(worldNormal.xyz, wetnessNormal, saturate(puddle));
 
 	// Calculate wetness glossiness factors
 	float wetnessGlossinessAlbedo = max(puddle, shoreFactorAlbedo * SharedData::wetnessEffectsSettings.MaxShoreWetness);
@@ -3170,7 +3171,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	indirectLobeWeights.specular += wetnessReflectance;
 	if (waterRoughnessSpecular < 1) {
 		screenSpaceNormal = lerp(screenSpaceNormal, normalize(FrameBuffer::WorldToView(wetnessNormal, false, eyeIndex)), saturate(wetnessGlossinessSpecular));
-		material.Roughness = lerp(material.Roughness, waterRoughnessSpecular, wetnessReflectance.x);
+		material.Roughness = lerp(material.Roughness, waterRoughnessSpecular, wetnessGlossinessSpecular);
 	}
 #		endif
 


### PR DESCRIPTION
This pull request updates the wetness effects calculations in the `Lighting.hlsl` shader to use `vertexNormal` instead of `worldNormal` for several key computations. The changes improve the accuracy of wetness rendering by ensuring the correct normal is used for wetness-related factors, and by refining how wetness influences material roughness and normal blending.

Wetness effects improvements:

* Changed initialization of `wetnessNormal` to use `vertexNormal.xyz` instead of `worldNormal`, ensuring wetness calculations are based on the actual vertex normal.
* Updated calculation of `minWetnessAngle` to use `vertexNormal.z` for more precise wetness angle determination.
* Modified the call to `WetnessEffects::GetRainDrops` to use `wetnessNormal` instead of `worldNormal`, improving raindrop placement accuracy.
* Blended `wetnessNormal` with `worldNormal` based on puddle intensity, making the final normal more representative of wet surface conditions.

Material property adjustments:

* Changed the interpolation of `material.Roughness` to use `wetnessGlossinessSpecular` instead of `wetnessReflectance.x`, providing a more consistent response to wetness glossiness in the material properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wet-surface shading: raindrop highlights and occlusion now render more consistently.
  * Smoother puddle blending between dry and wet regions for more realistic reflectivity and roughness.
  * Enhanced overall lighting on wet materials for more accurate wetness appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->