### PR TITLE
fix(linear lighting): fix horizon seam

### DIFF
--- a/src/Features/LinearLighting.cpp
+++ b/src/Features/LinearLighting.cpp
@@ -117,24 +117,36 @@ void LinearLighting::ConvertClearColor()
 	if (renderer) {
 		auto& rendererData = renderer->GetRendererData();
 
-		// Check if we've already converted this exact color (avoid double conversion)
-		// This handles the case where cubemap and main pass both call us without engine reset
-		if (rendererData.clearColor[0] == lastConvertedClearColor[0] &&
+		const bool isAlreadyConverted =
+			rendererData.clearColor[0] == lastConvertedClearColor[0] &&
 			rendererData.clearColor[1] == lastConvertedClearColor[1] &&
-			rendererData.clearColor[2] == lastConvertedClearColor[2]) {
+			rendererData.clearColor[2] == lastConvertedClearColor[2];
+
+		// Only refresh the source color when the engine has changed it
+		if (!isAlreadyConverted &&
+			(rendererData.clearColor[0] != lastOriginalClearColor[0] ||
+				rendererData.clearColor[1] != lastOriginalClearColor[1] ||
+				rendererData.clearColor[2] != lastOriginalClearColor[2])) {
+			lastOriginalClearColor[0] = rendererData.clearColor[0];
+			lastOriginalClearColor[1] = rendererData.clearColor[1];
+			lastOriginalClearColor[2] = rendererData.clearColor[2];
+		}
+
+		float gamma = std::clamp(settings.clearRenderGamma, 0.1f, 3.0f);
+		if (isAlreadyConverted && gamma == lastConvertedClearGamma) {
 			return;
 		}
 
-		float gamma = settings.clearRenderGamma;
-		rendererData.clearColor[0] = std::pow(rendererData.clearColor[0], gamma);
-		rendererData.clearColor[1] = std::pow(rendererData.clearColor[1], gamma);
-		rendererData.clearColor[2] = std::pow(rendererData.clearColor[2], gamma);
+		rendererData.clearColor[0] = std::pow(lastOriginalClearColor[0], gamma);
+		rendererData.clearColor[1] = std::pow(lastOriginalClearColor[1], gamma);
+		rendererData.clearColor[2] = std::pow(lastOriginalClearColor[2], gamma);
 		// Alpha (clearColor[3]) typically doesn't need gamma correction
 
 		// Remember what we converted to
 		lastConvertedClearColor[0] = rendererData.clearColor[0];
 		lastConvertedClearColor[1] = rendererData.clearColor[1];
 		lastConvertedClearColor[2] = rendererData.clearColor[2];
+		lastConvertedClearGamma = gamma;
 	}
 }
 

--- a/src/Features/LinearLighting.cpp
+++ b/src/Features/LinearLighting.cpp
@@ -4,6 +4,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	LinearLighting::Settings,
 	enableLinearLighting,
 	enableGammaCorrection,
+	clearRenderGamma,
 	lightGamma,
 	colorGamma,
 	emitColorGamma,
@@ -48,6 +49,7 @@ void LinearLighting::DrawSettings()
 	ImGui::SliderFloat("Effect Gamma", &settings.effectGamma, 0.1f, 3.0f, "%.2f");
 	ImGui::SliderFloat("Effect Transparency Gamma", &settings.effectAlphaGamma, 0.1f, 3.0f, "%.2f");
 	ImGui::SliderFloat("Sky Gamma", &settings.skyGamma, 0.1f, 3.0f, "%.2f");
+	ImGui::SliderFloat("Clear Render Gamma", &settings.clearRenderGamma, 0.1f, 3.0f, "%.2f");
 	ImGui::SliderFloat("Water Gamma", &settings.waterGamma, 0.1f, 3.0f, "%.2f");
 	ImGui::SliderFloat("Volumetric Lighting Gamma", &settings.vlGamma, 0.1f, 3.0f, "%.2f");
 

--- a/src/Features/LinearLighting.cpp
+++ b/src/Features/LinearLighting.cpp
@@ -95,6 +95,49 @@ void LinearLighting::SetupResources()
 	PerGeometryCB = new ConstantBuffer(ConstantBufferDesc<PerGeometryData>());
 }
 
+void LinearLighting::EarlyPrepass()
+{
+	ConvertClearColor();
+}
+
+void LinearLighting::ReflectionsPrepass()
+{
+	ConvertClearColor();
+}
+
+void LinearLighting::ConvertClearColor()
+{
+	bool isMainLoadingMenu = globals::game::ui && (globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || globals::game::ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME));
+	if (!settings.enableLinearLighting || isMainLoadingMenu)
+		return;
+
+	// Convert clear color from gamma space to linear space at the source
+	// This affects the background color visible at worldspace edges and in water reflections
+	auto renderer = globals::game::renderer;
+	if (renderer) {
+		auto& rendererData = renderer->GetRendererData();
+
+		// Check if we've already converted this exact color (avoid double conversion)
+		// This handles the case where cubemap and main pass both call us without engine reset
+		if (rendererData.clearColor[0] == lastConvertedClearColor[0] &&
+			rendererData.clearColor[1] == lastConvertedClearColor[1] &&
+			rendererData.clearColor[2] == lastConvertedClearColor[2]) {
+			return;
+		}
+
+		float gamma = settings.clearRenderGamma;
+		rendererData.clearColor[0] = std::pow(rendererData.clearColor[0], gamma);
+		rendererData.clearColor[1] = std::pow(rendererData.clearColor[1], gamma);
+		rendererData.clearColor[2] = std::pow(rendererData.clearColor[2], gamma);
+		// Alpha (clearColor[3]) typically doesn't need gamma correction
+
+		// Remember what we converted to
+		lastConvertedClearColor[0] = rendererData.clearColor[0];
+		lastConvertedClearColor[1] = rendererData.clearColor[1];
+		lastConvertedClearColor[2] = rendererData.clearColor[2];
+	}
+}
+
 void LinearLighting::Prepass()
 {
 	bool isMainLoadingMenu = globals::game::ui && (globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || globals::game::ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME));

--- a/src/Features/LinearLighting.h
+++ b/src/Features/LinearLighting.h
@@ -110,6 +110,8 @@ struct LinearLighting : Feature
 	uint isDirLightLinear = false;
 	float dirLightMult = 1.0f;
 	float lastConvertedClearColor[3] = { -1.0f, -1.0f, -1.0f };  // Track to avoid double conversion
+	float lastOriginalClearColor[3] = { -1.0f, -1.0f, -1.0f };   // Source gamma-space color
+	float lastConvertedClearGamma = -1.0f;
 
 	virtual void DrawSettings() override;
 

--- a/src/Features/LinearLighting.h
+++ b/src/Features/LinearLighting.h
@@ -109,6 +109,7 @@ struct LinearLighting : Feature
 
 	uint isDirLightLinear = false;
 	float dirLightMult = 1.0f;
+	float lastConvertedClearColor[3] = { -1.0f, -1.0f, -1.0f };  // Track to avoid double conversion
 
 	virtual void DrawSettings() override;
 
@@ -117,6 +118,8 @@ struct LinearLighting : Feature
 
 	virtual void RestoreDefaultSettings() override;
 
+	virtual void EarlyPrepass() override;
+	virtual void ReflectionsPrepass() override;
 	virtual void Prepass() override;
 	virtual void PostPostLoad() override;
 
@@ -127,6 +130,8 @@ struct LinearLighting : Feature
 	RE::NiColor ColorToLinear(RE::NiColor inColor, float gamma);
 
 	void BSLightingShader_SetupGeometry(RE::BSRenderPass* a_pass);
+
+	void ConvertClearColor();
 
 	struct Hooks;
 };

--- a/src/Features/LinearLighting.h
+++ b/src/Features/LinearLighting.h
@@ -28,6 +28,7 @@ struct LinearLighting : Feature
 	{
 		uint enableLinearLighting = false;
 		uint enableGammaCorrection = true;
+		float clearRenderGamma = 1.62f;
 		float lightGamma = 1.8f;
 		float colorGamma = 1.8f;
 		float emitColorGamma = 1.8f;

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -255,66 +255,6 @@ namespace globals
 	};
 
 	/**
-	 * @brief Hooked implementation of ID3D11DeviceContext::ClearRenderTargetView for linear lighting support.
-	 *
-	 * When linear lighting is enabled, converts the clear color from gamma space to linear space
-	 * for the MAIN render target and reflections cubemap. This ensures the background color is
-	 * properly represented in linear color space, which is visible in areas where the sky
-	 * doesn't cover (e.g., worldspace edges) and in water reflections.
-	 */
-	struct ID3D11DeviceContext_ClearRenderTargetView
-	{
-		static void thunk(ID3D11DeviceContext* This, ID3D11RenderTargetView* pRenderTargetView, const FLOAT ColorRGBA[4])
-		{
-			if (!pRenderTargetView) {
-				func(This, pRenderTargetView, ColorRGBA);
-				return;
-			}
-
-			auto& linearLighting = features::linearLighting;
-
-			// Check if linear lighting is enabled (matching the same menu check as LinearLighting::Prepass)
-			bool isMainLoadingMenu = game::ui && (game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || game::ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME));
-
-			if (linearLighting.settings.enableLinearLighting && !isMainLoadingMenu && game::renderer) {
-				// Get the resource associated with this RTV to compare by texture instead of RTV pointer
-				// (multiple RTVs can be created for the same texture)
-				ID3D11Resource* rtvResource = nullptr;
-				pRenderTargetView->GetResource(&rtvResource);
-
-				bool needsConversion = false;
-				auto mainTexture = game::renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN].texture;
-				auto& reflectionsCubemap = game::renderer->GetRendererData().cubemapRenderTargets[RE::RENDER_TARGET_CUBEMAP::kREFLECTIONS];
-
-				if (rtvResource == mainTexture || rtvResource == reflectionsCubemap.texture) {
-					needsConversion = true;
-				}
-
-				// Release the resource reference we obtained
-				if (rtvResource) {
-					rtvResource->Release();
-				}
-
-				if (needsConversion) {
-					// Convert clear color from gamma space to linear space
-					float gamma = linearLighting.settings.clearRenderGamma;
-					float linearColor[4] = {
-						std::pow(ColorRGBA[0], gamma),
-						std::pow(ColorRGBA[1], gamma),
-						std::pow(ColorRGBA[2], gamma),
-						ColorRGBA[3]  // Alpha typically doesn't need gamma correction
-					};
-					func(This, pRenderTargetView, linearColor);
-					return;
-				}
-			}
-
-			func(This, pRenderTargetView, ColorRGBA);
-		}
-		static inline REL::Relocation<decltype(thunk)> func;
-	};
-
-	/**
  * @brief Installs hooks on the Map and Unmap methods of the provided D3D11 device context.
  *
  * This enables interception of resource mapping and unmapping operations for frame buffer caching.
@@ -323,6 +263,5 @@ namespace globals
 	{
 		stl::detour_vfunc<14, ID3D11DeviceContext_Map>(a_context);
 		stl::detour_vfunc<15, ID3D11DeviceContext_Unmap>(a_context);
-		stl::detour_vfunc<50, ID3D11DeviceContext_ClearRenderTargetView>(a_context);
 	}
 }

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -258,8 +258,8 @@ namespace globals
 	 * @brief Hooked implementation of ID3D11DeviceContext::ClearRenderTargetView for linear lighting support.
 	 *
 	 * When linear lighting is enabled, converts the clear color from gamma space to linear space
-	 * for the MAIN render target and reflections cubemap. This ensures the background color is 
-	 * properly represented in linear color space, which is visible in areas where the sky 
+	 * for the MAIN render target and reflections cubemap. This ensures the background color is
+	 * properly represented in linear color space, which is visible in areas where the sky
 	 * doesn't cover (e.g., worldspace edges) and in water reflections.
 	 */
 	struct ID3D11DeviceContext_ClearRenderTargetView
@@ -267,29 +267,29 @@ namespace globals
 		static void thunk(ID3D11DeviceContext* This, ID3D11RenderTargetView* pRenderTargetView, const FLOAT ColorRGBA[4])
 		{
 			auto& linearLighting = features::linearLighting;
-			
+
 			// Check if linear lighting is enabled (matching the same menu check as LinearLighting::Prepass)
 			bool isMainLoadingMenu = game::ui && (game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || game::ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME));
-			
+
 			if (linearLighting.settings.enableLinearLighting && !isMainLoadingMenu && game::renderer) {
 				// Get the resource associated with this RTV to compare by texture instead of RTV pointer
 				// (multiple RTVs can be created for the same texture)
 				ID3D11Resource* rtvResource = nullptr;
 				pRenderTargetView->GetResource(&rtvResource);
-				
+
 				bool needsConversion = false;
 				auto mainTexture = game::renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN].texture;
 				auto& reflectionsCubemap = game::renderer->GetRendererData().cubemapRenderTargets[RE::RENDER_TARGET_CUBEMAP::kREFLECTIONS];
-				
+
 				if (rtvResource == mainTexture || rtvResource == reflectionsCubemap.texture) {
 					needsConversion = true;
 				}
-				
+
 				// Release the resource reference we obtained
 				if (rtvResource) {
 					rtvResource->Release();
 				}
-				
+
 				if (needsConversion) {
 					// Convert clear color from gamma space to linear space
 					float gamma = linearLighting.settings.clearRenderGamma;
@@ -303,7 +303,7 @@ namespace globals
 					return;
 				}
 			}
-			
+
 			func(This, pRenderTargetView, ColorRGBA);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -266,6 +266,11 @@ namespace globals
 	{
 		static void thunk(ID3D11DeviceContext* This, ID3D11RenderTargetView* pRenderTargetView, const FLOAT ColorRGBA[4])
 		{
+			if (!pRenderTargetView) {
+				func(This, pRenderTargetView, ColorRGBA);
+				return;
+			}
+
 			auto& linearLighting = features::linearLighting;
 			
 			// Check if linear lighting is enabled (matching the same menu check as LinearLighting::Prepass)

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -255,6 +255,61 @@ namespace globals
 	};
 
 	/**
+	 * @brief Hooked implementation of ID3D11DeviceContext::ClearRenderTargetView for linear lighting support.
+	 *
+	 * When linear lighting is enabled, converts the clear color from gamma space to linear space
+	 * for the MAIN render target and reflections cubemap. This ensures the background color is 
+	 * properly represented in linear color space, which is visible in areas where the sky 
+	 * doesn't cover (e.g., worldspace edges) and in water reflections.
+	 */
+	struct ID3D11DeviceContext_ClearRenderTargetView
+	{
+		static void thunk(ID3D11DeviceContext* This, ID3D11RenderTargetView* pRenderTargetView, const FLOAT ColorRGBA[4])
+		{
+			auto& linearLighting = features::linearLighting;
+			
+			// Check if linear lighting is enabled (matching the same menu check as LinearLighting::Prepass)
+			bool isMainLoadingMenu = game::ui && (game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || game::ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME));
+			
+			if (linearLighting.settings.enableLinearLighting && !isMainLoadingMenu && game::renderer) {
+				// Get the resource associated with this RTV to compare by texture instead of RTV pointer
+				// (multiple RTVs can be created for the same texture)
+				ID3D11Resource* rtvResource = nullptr;
+				pRenderTargetView->GetResource(&rtvResource);
+				
+				bool needsConversion = false;
+				auto mainTexture = game::renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN].texture;
+				auto& reflectionsCubemap = game::renderer->GetRendererData().cubemapRenderTargets[RE::RENDER_TARGET_CUBEMAP::kREFLECTIONS];
+				
+				if (rtvResource == mainTexture || rtvResource == reflectionsCubemap.texture) {
+					needsConversion = true;
+				}
+				
+				// Release the resource reference we obtained
+				if (rtvResource) {
+					rtvResource->Release();
+				}
+				
+				if (needsConversion) {
+					// Convert clear color from gamma space to linear space
+					float gamma = linearLighting.settings.clearRenderGamma;
+					float linearColor[4] = {
+						std::pow(ColorRGBA[0], gamma),
+						std::pow(ColorRGBA[1], gamma),
+						std::pow(ColorRGBA[2], gamma),
+						ColorRGBA[3]  // Alpha typically doesn't need gamma correction
+					};
+					func(This, pRenderTargetView, linearColor);
+					return;
+				}
+			}
+			
+			func(This, pRenderTargetView, ColorRGBA);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	/**
  * @brief Installs hooks on the Map and Unmap methods of the provided D3D11 device context.
  *
  * This enables interception of resource mapping and unmapping operations for frame buffer caching.
@@ -263,5 +318,6 @@ namespace globals
 	{
 		stl::detour_vfunc<14, ID3D11DeviceContext_Map>(a_context);
 		stl::detour_vfunc<15, ID3D11DeviceContext_Unmap>(a_context);
+		stl::detour_vfunc<50, ID3D11DeviceContext_ClearRenderTargetView>(a_context);
 	}
 }


### PR DESCRIPTION
Pushes the clear render (horizon seam) through linear conversion. Added slider for clear render with default set at 1.62.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Clear Render Gamma" setting with a default of 1.62 and an adjustable slider in the settings UI to control gamma correction of the renderer background when linear lighting is enabled.

* **Bug Fixes**
  * Prevents repeated or incorrect gamma conversions of the background color to keep rendered clear color stable and accurate.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->