### PR TITLE
feat(ssgi): add vanilla SSAO toggle

### DIFF
--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -669,11 +669,9 @@ void ScreenSpaceGI::DrawSSGI()
 	auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
 	GET_INSTANCE_MEMBER(BSImagespaceShaderISSAOBlurH, imageSpaceManager);
 
-	// Disable vanilla SSAO
-	if (auto* ssaoBlur = BSImagespaceShaderISSAOBlurH.get()) {
-		auto* enableSSAO = reinterpret_cast<bool*>(reinterpret_cast<uintptr_t>(ssaoBlur) + 0x50LL);
+	// Toggle vanilla SSAO
+	static bool* enableSSAO = reinterpret_cast<bool*>(reinterpret_cast<uintptr_t>(BSImagespaceShaderISSAOBlurH.get()) + 0x50LL);
 		*enableSSAO = settings.EnableVanillaSSAO;
-	}
 
 	if (!(settings.Enabled && ShadersOK())) {
 		FLOAT clr[4] = { 0.f, 0.f, 0.f, 0.f };

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -670,8 +670,7 @@ void ScreenSpaceGI::DrawSSGI()
 	GET_INSTANCE_MEMBER(BSImagespaceShaderISSAOBlurH, imageSpaceManager);
 
 	// Disable vanilla SSAO
-	if (auto* ssaoBlur = BSImagespaceShaderISSAOBlurH.get())
-	{
+	if (auto* ssaoBlur = BSImagespaceShaderISSAOBlurH.get()) {
 		auto* enableSSAO = reinterpret_cast<bool*>(reinterpret_cast<uintptr_t>(ssaoBlur) + 0x50LL);
 		*enableSSAO = settings.EnableVanillaSSAO;
 	}

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -11,6 +11,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	Enabled,
 	EnableGI,
 	EnableExperimentalSpecularGI,
+	EnableVanillaSSAO,
 	NumSlices,
 	NumSteps,
 	ResolutionMode,
@@ -64,6 +65,10 @@ void ScreenSpaceGI::DrawSettings()
 			recompileFlag |= ImGui::Checkbox("Indirect Lighting (IL)", &settings.EnableGI);
 		}
 		ImGui::TableNextColumn();
+		ImGui::Checkbox("Vanilla SSAO", &settings.EnableVanillaSSAO);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Enable Skyrim's built-in SSAO. Usually disabled when using SSGI to avoid double-darkening.");
+		}
 		if (showAdvanced) {
 			recompileFlag |= ImGui::Checkbox("(Experimental) HQ Specular IL", &settings.EnableExperimentalSpecularGI);
 			if (auto _tt = Util::HoverTooltipWrapper())
@@ -665,7 +670,9 @@ void ScreenSpaceGI::DrawSSGI()
 
 	// Disable vanilla SSAO
 	bool* enableSSAO = reinterpret_cast<bool*>(reinterpret_cast<uintptr_t>(BSImagespaceShaderISSAOBlurH.get()) + 0x50LL);
-	*enableSSAO = false;
+	if (enableSSAO) {
+		*enableSSAO = settings.EnableVanillaSSAO;
+	}
 
 	if (!(settings.Enabled && ShadersOK())) {
 		FLOAT clr[4] = { 0.f, 0.f, 0.f, 0.f };

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -671,7 +671,7 @@ void ScreenSpaceGI::DrawSSGI()
 
 	// Toggle vanilla SSAO
 	static bool* enableSSAO = reinterpret_cast<bool*>(reinterpret_cast<uintptr_t>(BSImagespaceShaderISSAOBlurH.get()) + 0x50LL);
-		*enableSSAO = settings.EnableVanillaSSAO;
+	*enableSSAO = settings.EnableVanillaSSAO;
 
 	if (!(settings.Enabled && ShadersOK())) {
 		FLOAT clr[4] = { 0.f, 0.f, 0.f, 0.f };

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -52,7 +52,7 @@ void ScreenSpaceGI::DrawSettings()
 
 	ImGui::Checkbox("Show Advanced Options", &showAdvanced);
 
-	if (ImGui::BeginTable("Toggles", 3)) {
+	if (ImGui::BeginTable("Toggles", 4)) {
 		ImGui::TableNextColumn();
 		ImGui::Checkbox("Enabled", &settings.Enabled);
 		if (auto _tt = Util::HoverTooltipWrapper()) {
@@ -69,6 +69,7 @@ void ScreenSpaceGI::DrawSettings()
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Enable Skyrim's built-in SSAO. Usually disabled when using SSGI to avoid double-darkening.");
 		}
+		ImGui::TableNextColumn();
 		if (showAdvanced) {
 			recompileFlag |= ImGui::Checkbox("(Experimental) HQ Specular IL", &settings.EnableExperimentalSpecularGI);
 			if (auto _tt = Util::HoverTooltipWrapper())
@@ -669,8 +670,9 @@ void ScreenSpaceGI::DrawSSGI()
 	GET_INSTANCE_MEMBER(BSImagespaceShaderISSAOBlurH, imageSpaceManager);
 
 	// Disable vanilla SSAO
-	bool* enableSSAO = reinterpret_cast<bool*>(reinterpret_cast<uintptr_t>(BSImagespaceShaderISSAOBlurH.get()) + 0x50LL);
-	if (enableSSAO) {
+	if (auto* ssaoBlur = BSImagespaceShaderISSAOBlurH.get())
+	{
+		auto* enableSSAO = reinterpret_cast<bool*>(reinterpret_cast<uintptr_t>(ssaoBlur) + 0x50LL);
 		*enableSSAO = settings.EnableVanillaSSAO;
 	}
 

--- a/src/Features/ScreenSpaceGI.h
+++ b/src/Features/ScreenSpaceGI.h
@@ -62,6 +62,7 @@ public:
 		bool Enabled = REL::Module::IsVR() ? false : true;   // disabled in VR by default
 		bool EnableGI = REL::Module::IsVR() ? false : true;  // AO only for VR by default
 		bool EnableExperimentalSpecularGI = false;
+		bool EnableVanillaSSAO = false;
 		// performance/quality
 		uint NumSlices = REL::Module::IsVR() ? 1u : 4u;  // AO preset for VR
 		uint NumSteps = REL::Module::IsVR() ? 6u : 8u;   // AO preset for VR


### PR DESCRIPTION
Adds checkbox button in UI menu to enable/disable vanilla AO. For those who dig it. Disabled by default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Vanilla SSAO" toggle in Screen Space Global Illumination settings and expanded the settings UI layout to show more columns.
* **Bug Fixes / Behavior**
  * SSAO enablement now respects the new toggle at runtime and is applied only when SSAO is available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->