### PR TITLE
feat(grass lighting): add wrapped lighting toggle

### DIFF
--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -33,7 +33,8 @@ namespace SharedData
 		bool OverrideComplexGrassSettings;
 
 		float BasicGrassBrightness;
-		float3 pad0;
+		bool EnableWrappedLighting;
+		float2 pad0;
 	};
 
 	struct CPMSettings

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -629,7 +629,18 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	dirLightColor *= dirShadow;
 	dirLightColor *= dirDetailShadow;
 
-	lightsDiffuseColor += dirLightColor * saturate(dirLightAngle) * Color::GrassDiffuseMult();
+		if (SharedData::grassLightingSettings.EnableWrappedLighting) 
+    {
+        // Old Wrapped Model
+        float wrapAmount = saturate(input.VertexNormal.w * 10.0)* 0.5 * !complex;;
+        float wrappedDirLight = saturate(dirLightAngle + wrapAmount) / (1.0 + wrapAmount);
+        lightsDiffuseColor += dirLightColor * saturate(wrappedDirLight) * dirDetailShadow;
+    }
+			else 
+    {
+        // Original Standard Model
+        lightsDiffuseColor += dirLightColor * saturate(dirLightAngle) * Color::GrassDiffuseMult();
+    }
 
 	float3 vertexColor = input.VertexColor.xyz;
 

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -629,14 +629,14 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	dirLightColor *= dirShadow;
 	dirLightColor *= dirDetailShadow;
 
-		if (SharedData::grassLightingSettings.EnableWrappedLighting) 
+		if (SharedData::grassLightingSettings.EnableWrappedLighting)
     {
         // Old Wrapped Model
         float wrapAmount = saturate(input.VertexNormal.w * 10.0)* 0.5 * (!complex);
         float wrappedDirLight = saturate(dirLightAngle + wrapAmount) / (1.0 + wrapAmount);
         lightsDiffuseColor += dirLightColor * saturate(wrappedDirLight) * Color::GrassDiffuseMult();
     }
-			else 
+			else
     {
         // Original Standard Model
         lightsDiffuseColor += dirLightColor * saturate(dirLightAngle) * Color::GrassDiffuseMult();

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -629,14 +629,14 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	dirLightColor *= dirShadow;
 	dirLightColor *= dirDetailShadow;
 
-		if (SharedData::grassLightingSettings.EnableWrappedLighting) 
+		if (SharedData::grassLightingSettings.EnableWrappedLighting)
     {
         // Old Wrapped Model
         float wrapAmount = saturate(input.VertexNormal.w * 10.0)* 0.5 * !complex;;
         float wrappedDirLight = saturate(dirLightAngle + wrapAmount) / (1.0 + wrapAmount);
         lightsDiffuseColor += dirLightColor * saturate(wrappedDirLight) * dirDetailShadow;
     }
-			else 
+			else
     {
         // Original Standard Model
         lightsDiffuseColor += dirLightColor * saturate(dirLightAngle) * Color::GrassDiffuseMult();

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -629,14 +629,14 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	dirLightColor *= dirShadow;
 	dirLightColor *= dirDetailShadow;
 
-		if (SharedData::grassLightingSettings.EnableWrappedLighting)
+		if (SharedData::grassLightingSettings.EnableWrappedLighting) 
     {
         // Old Wrapped Model
-        float wrapAmount = saturate(input.VertexNormal.w * 10.0)* 0.5 * !complex;;
+        float wrapAmount = saturate(input.VertexNormal.w * 10.0)* 0.5 * (!complex);
         float wrappedDirLight = saturate(dirLightAngle + wrapAmount) / (1.0 + wrapAmount);
-        lightsDiffuseColor += dirLightColor * saturate(wrappedDirLight) * dirDetailShadow;
+        lightsDiffuseColor += dirLightColor * saturate(wrappedDirLight) * Color::GrassDiffuseMult();
     }
-			else
+			else 
     {
         // Original Standard Model
         lightsDiffuseColor += dirLightColor * saturate(dirLightAngle) * Color::GrassDiffuseMult();
@@ -644,7 +644,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	float3 vertexColor = input.VertexColor.xyz;
 
-#				if defined(SKYLIGHTING)
+#if defined(SKYLIGHTING)
 	float skylightingFadeOutFactor = 1.0;
 	if (!SharedData::InInterior) {
 		skylightingFadeOutFactor = Skylighting::getFadeOutFactor(input.WorldPosition.xyz);

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -629,14 +629,14 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	dirLightColor *= dirShadow;
 	dirLightColor *= dirDetailShadow;
 
-		if (SharedData::grassLightingSettings.EnableWrappedLighting)
+		if (SharedData::grassLightingSettings.EnableWrappedLighting) 
     {
         // Old Wrapped Model
         float wrapAmount = saturate(input.VertexNormal.w * 10.0)* 0.5 * (!complex);
         float wrappedDirLight = saturate(dirLightAngle + wrapAmount) / (1.0 + wrapAmount);
         lightsDiffuseColor += dirLightColor * saturate(wrappedDirLight) * Color::GrassDiffuseMult();
     }
-			else
+			else 
     {
         // Original Standard Model
         lightsDiffuseColor += dirLightColor * saturate(dirLightAngle) * Color::GrassDiffuseMult();
@@ -715,8 +715,18 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 				float lightAngle = dot(normal, normalizedLightDirection);
 				float lightNoL = dot(normalizedLightDirection.xyz, viewDirection);
+				float3 lightDiffuseColor;
 
-				float3 lightDiffuseColor = lightColor * saturate(lightAngle);
+				if (SharedData::grassLightingSettings.EnableWrappedLighting) 
+				{
+					float wrapAmount = saturate(input.VertexNormal.w * 10.0)* 0.5 * (!complex);
+                    float wrappedLight = saturate(lightAngle + wrapAmount) / (1.0 + wrapAmount);
+					lightDiffuseColor = lightColor * wrappedLight;
+				}
+                else 
+                {
+                    lightDiffuseColor = lightColor * saturate(lightAngle);
+                }
 
 				sss += lightColor * saturate(-lightAngle);
 
@@ -724,7 +734,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 				if (complex)
 					lightsSpecularColor += GrassLighting::GetLightSpecularInput(normalizedLightDirection, viewDirection, normal, lightColor, SharedData::grassLightingSettings.Glossiness) * Color::GrassSpecularMult();
-#				endif
+#endif
 			}
 		}
 	}

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -628,11 +628,12 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	dirLightColor *= dirLightColorMultiplier;
 	dirLightColor *= dirShadow;
 	dirLightColor *= dirDetailShadow;
-
+	
+    float wrapAmount = saturate(input.VertexNormal.w * 10.0)* 0.5 * (!complex);
+	
 		if (SharedData::grassLightingSettings.EnableWrappedLighting)
     {
         // Old Wrapped Model
-        float wrapAmount = saturate(input.VertexNormal.w * 10.0)* 0.5 * (!complex);
         float wrappedDirLight = saturate(dirLightAngle + wrapAmount) / (1.0 + wrapAmount);
         lightsDiffuseColor += dirLightColor * saturate(wrappedDirLight) * Color::GrassDiffuseMult();
     }
@@ -719,7 +720,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 				if (SharedData::grassLightingSettings.EnableWrappedLighting)
 				{
-					float wrapAmount = saturate(input.VertexNormal.w * 10.0)* 0.5 * (!complex);
                     float wrappedLight = saturate(lightAngle + wrapAmount) / (1.0 + wrapAmount);
 					lightDiffuseColor = lightColor * wrappedLight;
 				}

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -628,9 +628,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	dirLightColor *= dirLightColorMultiplier;
 	dirLightColor *= dirShadow;
 	dirLightColor *= dirDetailShadow;
-	
+
     float wrapAmount = saturate(input.VertexNormal.w * 10.0)* 0.5 * (!complex);
-	
+
 		if (SharedData::grassLightingSettings.EnableWrappedLighting)
     {
         // Old Wrapped Model

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -629,14 +629,14 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	dirLightColor *= dirShadow;
 	dirLightColor *= dirDetailShadow;
 
-		if (SharedData::grassLightingSettings.EnableWrappedLighting) 
+		if (SharedData::grassLightingSettings.EnableWrappedLighting)
     {
         // Old Wrapped Model
         float wrapAmount = saturate(input.VertexNormal.w * 10.0)* 0.5 * (!complex);
         float wrappedDirLight = saturate(dirLightAngle + wrapAmount) / (1.0 + wrapAmount);
         lightsDiffuseColor += dirLightColor * saturate(wrappedDirLight) * Color::GrassDiffuseMult();
     }
-			else 
+			else
     {
         // Original Standard Model
         lightsDiffuseColor += dirLightColor * saturate(dirLightAngle) * Color::GrassDiffuseMult();
@@ -717,13 +717,13 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 				float lightNoL = dot(normalizedLightDirection.xyz, viewDirection);
 				float3 lightDiffuseColor;
 
-				if (SharedData::grassLightingSettings.EnableWrappedLighting) 
+				if (SharedData::grassLightingSettings.EnableWrappedLighting)
 				{
 					float wrapAmount = saturate(input.VertexNormal.w * 10.0)* 0.5 * (!complex);
                     float wrappedLight = saturate(lightAngle + wrapAmount) / (1.0 + wrapAmount);
 					lightDiffuseColor = lightColor * wrappedLight;
 				}
-                else 
+                else
                 {
                     lightDiffuseColor = lightColor * saturate(lightAngle);
                 }

--- a/src/Features/GrassLighting.cpp
+++ b/src/Features/GrassLighting.cpp
@@ -6,7 +6,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	SpecularStrength,
 	SubsurfaceScatteringAmount,
 	OverrideComplexGrassSettings,
-	BasicGrassBrightness)
+	BasicGrassBrightness,
+	EnableWrappedLighting)
 
 void GrassLighting::DrawSettings()
 {
@@ -43,6 +44,12 @@ void GrassLighting::DrawSettings()
 	}
 
 	if (ImGui::TreeNodeEx("Lighting", ImGuiTreeNodeFlags_DefaultOpen)) {
+		ImGui::Checkbox("Enable Wrapped Lighting", (bool*)&settings.EnableWrappedLighting);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Old wrapped lighting model from CS 1.3.");
+		}
+		ImGui::Spacing();
+		ImGui::Spacing();
 		ImGui::Checkbox("Override Complex Grass Lighting Settings", (bool*)&settings.OverrideComplexGrassSettings);
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(

--- a/src/Features/GrassLighting.cpp
+++ b/src/Features/GrassLighting.cpp
@@ -46,7 +46,7 @@ void GrassLighting::DrawSettings()
 	if (ImGui::TreeNodeEx("Lighting", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Checkbox("Enable Wrapped Lighting", (bool*)&settings.EnableWrappedLighting);
 		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text("Old wrapped lighting model from CS 1.3.");
+			ImGui::Text("Enables a softer-looking wrapped lighting model from CS 1.3. Useful for certain non-complex grass textures that look too dark during mid day, when the sun is directly overhead.");
 		}
 		ImGui::Spacing();
 		ImGui::Spacing();

--- a/src/Features/GrassLighting.h
+++ b/src/Features/GrassLighting.h
@@ -35,7 +35,8 @@ public:
 		float SubsurfaceScatteringAmount = 0.5f;
 		uint OverrideComplexGrassSettings = false;
 		float BasicGrassBrightness = 1.0f;
-		uint pad[3];
+		uint EnableWrappedLighting = false;
+		uint pad[2];
 	};
 	STATIC_ASSERT_ALIGNAS_16(Settings);
 


### PR DESCRIPTION
Adds the option to enable a wrapped lighting model on grass, a function taken from a CS v1.3. Prevents certain grass mods from looking too dark when sunlight is directly overhead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Enable Wrapped Lighting" toggle for grass lighting; renderer now supports both wrapped and standard diffuse lighting modes and the setting is persisted.

* **UI**
  * Lighting settings include a new checkbox with a hover tooltip explaining wrapped lighting, plus adjusted spacing for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->