### PR TITLE
feat(weather overrides): add weather override pause checkbox

### DIFF
--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -426,8 +426,9 @@ void FeatureListRenderer::DrawMenuVisitor::RenderFeatureSettingsTab(Feature* fea
 						weatherRegistry->SetFeaturePaused(feat->GetShortName(), paused);
 					}
 					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::Text("Temporarily disable weather-based setting adjustments for this feature.\n"
-									"This state is not saved.");
+						ImGui::Text(
+							"Temporarily disable weather-based setting adjustments for this feature.\n"
+							"This state is not saved.");
 					}
 					ImGui::Separator();
 				}

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -16,6 +16,7 @@
 #include "SettingsOverrideManager.h"
 #include "State.h"
 #include "Util.h"
+#include "WeatherVariableRegistry.h"
 
 namespace
 {
@@ -418,6 +419,19 @@ void FeatureListRenderer::DrawMenuVisitor::RenderFeatureSettingsTab(Feature* fea
 			ImGui::Text("Enable the feature above to access its configuration options.");
 		} else {
 			if (isLoaded) {
+				auto weatherRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
+				if (weatherRegistry->HasWeatherSupport(feat->GetShortName())) {
+					bool paused = weatherRegistry->IsFeaturePaused(feat->GetShortName());
+					if (ImGui::Checkbox("Pause Weather Overrides", &paused)) {
+						weatherRegistry->SetFeaturePaused(feat->GetShortName(), paused);
+					}
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::Text("Temporarily disable weather-based setting adjustments for this feature.\n"
+									"This state is not saved.");
+					}
+					ImGui::Separator();
+				}
+
 				ImVec2 cursorPosBefore = ImGui::GetCursorPos();
 				feat->DrawSettings();
 				ImVec2 cursorPosAfter = ImGui::GetCursorPos();

--- a/src/WeatherVariableRegistry.h
+++ b/src/WeatherVariableRegistry.h
@@ -331,10 +331,28 @@ namespace WeatherVariables
 
 		void UpdateFeatureFromWeathers(const std::string& featureName, const json& currWeather, const json& nextWeather, float lerpFactor)
 		{
+			if (IsFeaturePaused(featureName)) {
+				return;
+			}
+
 			auto* registry = GetFeatureRegistry(featureName);
 			if (registry) {
 				registry->LerpAllVariables(currWeather, nextWeather, lerpFactor);
 			}
+		}
+
+		bool IsFeaturePaused(const std::string& featureName)
+		{
+			auto it = pausedFeatures.find(featureName);
+			if (it != pausedFeatures.end()) {
+				return it->second;
+			}
+			return false;
+		}
+
+		void SetFeaturePaused(const std::string& featureName, bool paused)
+		{
+			pausedFeatures[featureName] = paused;
 		}
 
 		void SaveFeatureToJson(const std::string& featureName, json& j) const
@@ -360,5 +378,6 @@ namespace WeatherVariables
 		GlobalWeatherRegistry& operator=(const GlobalWeatherRegistry&) = delete;
 
 		std::map<std::string, std::unique_ptr<FeatureWeatherRegistry>> featureRegistries;
+		std::map<std::string, bool> pausedFeatures;
 	};
 }


### PR DESCRIPTION
This pull request adds functionality to temporarily pause weather-based overrides for individual features in the menu, allowing users to disable weather-driven adjustments without affecting saved settings. The changes introduce new UI elements and internal state management to support this feature.

**Weather override pause feature:**

* Added a "Pause Weather Overrides" checkbox to the feature settings tab in the menu UI, allowing users to temporarily disable weather-based adjustments for each feature. The checkbox state is not persisted. (`src/Menu/FeatureListRenderer.cpp`)
* Integrated `WeatherVariableRegistry.h` into the menu renderer to support weather override functionality. (`src/Menu/FeatureListRenderer.cpp`)

**Weather registry enhancements:**

* Updated `GlobalWeatherRegistry` to track paused features using a new `pausedFeatures` map. (`src/WeatherVariableRegistry.h`)
* Added `IsFeaturePaused` and `SetFeaturePaused` methods to manage the paused state for each feature. (`src/WeatherVariableRegistry.h`)
* Modified weather update logic to skip updates for paused features, ensuring weather-based changes are not applied when paused. (`src/WeatherVariableRegistry.h`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added "Pause Weather Overrides" checkbox in feature settings that allows temporary pausing of weather modifications on a per-feature basis. Each pause option includes a tooltip explaining its temporary nature. When a feature is paused, its weather updates are suspended until the pause is disabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->