### PR TITLE
fix(settings-override): rework override .json order 

### DIFF
--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -279,19 +279,24 @@ bool Feature::ToggleAtBootSetting()
 bool Feature::ReapplyOverrideSettings()
 {
 	auto overrideManager = SettingsOverrideManager::GetSingleton();
-	if (!overrideManager || !overrideManager->HasFeatureOverrides(GetShortName())) {
+	std::string featureName = GetShortName();
+
+	if (!overrideManager || !overrideManager->HasFeatureOverrides(featureName)) {
 		return false;
 	}
 
-	// Get current settings as JSON
+	// Delete user override file to restore original override behavior
+	overrideManager->DeleteUserOverride(featureName);
+
+	// Get base settings and apply overrides fresh
 	json featureJson;
 	SaveSettings(featureJson);
 
-	// Apply overrides to the current settings
-	size_t appliedCount = overrideManager->ReapplyFeatureOverrides(GetShortName(), featureJson);
+	// Apply overrides to the settings (without user customizations)
+	size_t appliedCount = overrideManager->ReapplyFeatureOverrides(featureName, featureJson);
 
 	if (appliedCount > 0) {
-		// Load the modified settings back into the feature
+		// Load the override settings back into the feature
 		LoadSettings(featureJson);
 		return true;
 	}

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -647,9 +647,9 @@ void FeatureListRenderer::DrawMenuVisitor::RenderFeatureActionButtons(Feature* f
 
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
-				"Reapplies override settings from mod override JSON files. "
-				"This will overwrite current settings with override values. "
-				"You will still need to Save Settings to make these changes permanent.");
+				"Restores original override settings from mod files.\n"
+				"This will discard your customizations and revert to\n"
+				"the mod author's recommended settings.");
 		}
 	}
 }

--- a/src/SettingsOverrideManager.cpp
+++ b/src/SettingsOverrideManager.cpp
@@ -228,33 +228,8 @@ bool SettingsOverrideManager::HasFeatureOverrides(const std::string& featureName
 
 size_t SettingsOverrideManager::ReapplyFeatureOverrides(const std::string& featureName, json& featureJson)
 {
-	if (!enabled || !discovered) {
-		return 0;
-	}
-
-	size_t appliedCount = 0;
-
-	auto it = featureOverrideMap.find(featureName);
-	if (it != featureOverrideMap.end()) {
-		for (size_t index : it->second) {
-			const auto& override = overrides[index];
-			if (override.enabled) {
-				try {
-					MergeJson(featureJson, override.overrideData);
-					appliedCount++;
-					logger::info("Manually reapplied override from {} to {}", override.modName, featureName);
-				} catch (const std::exception& e) {
-					logger::warn("Failed to manually reapply override from {} to {}: {}",
-						override.modName, featureName, e.what());
-
-					// Report reapplication failure to Feature Issues
-					ReportOverrideFailure(override.modName, featureName, "Failed to reapply override: " + std::string(e.what()));
-				}
-			}
-		}
-	}
-
-	return appliedCount;
+	// Reuse ApplyOverrides - same logic, just different use case
+	return ApplyOverrides(featureName, featureJson);
 }
 
 void SettingsOverrideManager::SetOverrideEnabled(const std::string& modName, const std::string& featureName, bool isEnabled)
@@ -319,23 +294,27 @@ json SettingsOverrideManager::LoadAppliedOverridesTracking() const
 					logger::info("Applied overrides tracking file contains invalid data structure, resetting");
 					appliedOverrides = json::object();
 				} else {
-					// Validate each tracking entry
+					// Validate each tracking entry - allow both old format (objects) and new format (strings)
 					auto it = appliedOverrides.begin();
 					while (it != appliedOverrides.end()) {
 						const std::string& key = it.key();
 						const auto& value = it.value();
 
-						// Validate tracking entry structure
-						if (!value.is_object() ||
-							!value.contains("hash") ||
-							!value.contains("firstApplied") ||
-							!value["hash"].is_string() ||
-							!value["firstApplied"].is_number()) {
-							logger::info("Invalid tracking entry for '{}', removing", key);
-							it = appliedOverrides.erase(it);
-						} else {
+						// New format: simple string hash for "_hash" keys
+						if (key.ends_with("_hash") && value.is_string()) {
 							++it;
+							continue;
 						}
+
+						// Old format: object with hash and firstApplied (kept for compatibility)
+						if (value.is_object() && value.contains("hash") && value["hash"].is_string()) {
+							++it;
+							continue;
+						}
+
+						// Invalid entry
+						logger::info("Invalid tracking entry for '{}', removing", key);
+						it = appliedOverrides.erase(it);
 					}
 				}
 			} catch (const json::parse_error& e) {
@@ -405,208 +384,6 @@ void SettingsOverrideManager::SaveAppliedOverridesTracking(const json& appliedOv
 std::filesystem::path SettingsOverrideManager::GetAppliedOverridesTrackingPath() const
 {
 	return Util::PathHelpers::GetAppliedOverridesPath();
-}
-
-size_t SettingsOverrideManager::ApplyNewOverrides(json& baseSettings, json& appliedOverrides)
-{
-	if (!enabled || !discovered) {
-		return 0;
-	}
-
-	// Validate input parameters
-	if (!baseSettings.is_object()) {
-		logger::info("Cannot apply overrides - base settings is not a JSON object");
-		return 0;
-	}
-
-	if (!appliedOverrides.is_object()) {
-		logger::info("Applied overrides tracking data is not a JSON object, resetting");
-		appliedOverrides = json::object();
-	}
-
-	size_t appliedCount = 0;
-	auto currentTime = std::time(nullptr);
-
-	for (const auto& override : overrides) {
-		if (!override.enabled || !override.isGlobal) {
-			continue;
-		}
-
-		try {
-			// Create tracking key
-			std::string trackingKey = override.modName + "_Global";
-
-			// Validate tracking key length
-			if (trackingKey.length() > MAX_STRING_LENGTH) {
-				logger::info("Skipping override with overly long tracking key: {}", override.modName);
-				continue;
-			}
-
-			// Check if this override has been applied before
-			bool shouldApply = false;
-			if (!appliedOverrides.contains(trackingKey)) {
-				// First time seeing this override
-				shouldApply = true;
-			} else {
-				// Check if the override file has changed
-				auto& tracking = appliedOverrides[trackingKey];
-				if (!tracking.is_object()) {
-					// Invalid tracking data, reapply
-					shouldApply = true;
-					logger::info("Invalid tracking data for {}, reapplying", override.modName);
-				} else {
-					std::string currentHash = tracking.value("hash", "");
-					if (currentHash != override.fileHash) {
-						// Override file has changed, reapply
-						shouldApply = true;
-						logger::info("Override file {} has changed, reapplying", override.modName);
-					}
-				}
-			}
-
-			if (shouldApply) {
-				// Validate override data before merging
-				if (!override.overrideData.is_object()) {
-					logger::info("Skipping override from {} - invalid data structure", override.modName);
-					continue;
-				}
-
-				// Create a backup of base settings for rollback if needed
-				json backupSettings = baseSettings;
-
-				try {
-					MergeJson(baseSettings, override.overrideData);
-					appliedCount++;
-
-					// Update tracking
-					appliedOverrides[trackingKey] = {
-						{ "hash", override.fileHash },
-						{ "firstApplied", currentTime },
-						{ "lastApplied", currentTime },
-						{ "version", override.version }
-					};
-
-					logger::info("Applied global override from {}", override.modName);
-				} catch (const std::exception& mergeError) {
-					// Rollback on merge failure
-					baseSettings = backupSettings;
-					logger::info("Failed to merge global override from {}, rolled back: {}", override.modName, mergeError.what());
-				}
-			}
-		} catch (const std::exception& e) {
-			logger::info("Error processing global override from {}: {}", override.modName, e.what());
-		}
-	}
-
-	return appliedCount;
-}
-
-size_t SettingsOverrideManager::ApplyNewFeatureOverrides(const std::string& featureName, json& featureJson, json& appliedOverrides)
-{
-	if (!enabled || !discovered) {
-		return 0;
-	}
-
-	// Validate input parameters
-	if (featureName.empty() || featureName.length() > MAX_STRING_LENGTH) {
-		logger::info("Cannot apply overrides - invalid feature name");
-		return 0;
-	}
-
-	if (!featureJson.is_object()) {
-		logger::info("Cannot apply overrides to {} - feature JSON is not an object", featureName);
-		return 0;
-	}
-
-	if (!appliedOverrides.is_object()) {
-		logger::info("Applied overrides tracking data is not a JSON object, resetting");
-		appliedOverrides = json::object();
-	}
-
-	size_t appliedCount = 0;
-	auto currentTime = std::time(nullptr);
-
-	auto it = featureOverrideMap.find(featureName);
-	if (it != featureOverrideMap.end()) {
-		for (size_t index : it->second) {
-			if (index >= overrides.size()) {
-				logger::info("Invalid override index {} for feature {}", index, featureName);
-				continue;
-			}
-
-			const auto& override = overrides[index];
-			if (!override.enabled) {
-				continue;
-			}
-
-			try {
-				// Create tracking key
-				std::string trackingKey = override.modName + "_" + featureName;
-
-				// Validate tracking key length
-				if (trackingKey.length() > MAX_STRING_LENGTH) {
-					logger::info("Skipping override with overly long tracking key: {}_{}", override.modName, featureName);
-					continue;
-				}
-
-				// Check if this override has been applied before
-				bool shouldApply = false;
-				if (!appliedOverrides.contains(trackingKey)) {
-					// First time seeing this override
-					shouldApply = true;
-				} else {
-					// Check if the override file has changed
-					auto& tracking = appliedOverrides[trackingKey];
-					if (!tracking.is_object()) {
-						// Invalid tracking data, reapply
-						shouldApply = true;
-						logger::info("Invalid tracking data for {} on {}, reapplying", override.modName, featureName);
-					} else {
-						std::string currentHash = tracking.value("hash", "");
-						if (currentHash != override.fileHash) {
-							// Override file has changed, reapply
-							shouldApply = true;
-							logger::info("Override file {} for {} has changed, reapplying", override.modName, featureName);
-						}
-					}
-				}
-
-				if (shouldApply) {
-					// Validate override data before merging
-					if (!override.overrideData.is_object()) {
-						logger::info("Skipping override from {} for {} - invalid data structure", override.modName, featureName);
-						continue;
-					}
-
-					// Create a backup of feature settings for rollback if needed
-					json backupSettings = featureJson;
-
-					try {
-						MergeJson(featureJson, override.overrideData);
-						appliedCount++;
-
-						// Update tracking
-						appliedOverrides[trackingKey] = {
-							{ "hash", override.fileHash },
-							{ "firstApplied", currentTime },
-							{ "lastApplied", currentTime },
-							{ "version", override.version }
-						};
-
-						logger::info("Applied override from {} to {}", override.modName, featureName);
-					} catch (const std::exception& mergeError) {
-						// Rollback on merge failure
-						featureJson = backupSettings;
-						logger::info("Failed to merge override from {} to {}, rolled back: {}", override.modName, featureName, mergeError.what());
-					}
-				}
-			} catch (const std::exception& e) {
-				logger::info("Error processing override from {} for {}: {}", override.modName, featureName, e.what());
-			}
-		}
-	}
-
-	return appliedCount;
 }
 
 std::unique_ptr<SettingsOverrideManager::OverrideInfo> SettingsOverrideManager::LoadOverrideFile(const std::filesystem::path& filePath)
@@ -744,15 +521,13 @@ std::pair<std::string, std::string> SettingsOverrideManager::ParseOverrideFilena
 	// Remove .json extension
 	std::string nameWithoutExt = filename;
 	const std::string jsonExt = ".json";
-	if (nameWithoutExt.length() >= jsonExt.length() &&
-		nameWithoutExt.substr(nameWithoutExt.length() - jsonExt.length()) == jsonExt) {
+	if (nameWithoutExt.ends_with(jsonExt)) {
 		nameWithoutExt = nameWithoutExt.substr(0, nameWithoutExt.length() - jsonExt.length());
 	}
 
 	// Check for global override
 	const std::string globalSuffix = "_Global";
-	if (nameWithoutExt.length() >= globalSuffix.length() &&
-		nameWithoutExt.substr(nameWithoutExt.length() - globalSuffix.length()) == globalSuffix) {
+	if (nameWithoutExt.ends_with(globalSuffix)) {
 		std::string modName = nameWithoutExt.substr(0, nameWithoutExt.length() - globalSuffix.length());
 		return { modName, "" };  // Empty feature name indicates global
 	}
@@ -1167,3 +942,271 @@ void SettingsOverrideManager::ReportOverrideFailure(const std::string& modName, 
 		FeatureIssues::FeatureIssueInfo::IssueType::OVERRIDE_FAILED,
 		fileInfo);
 }
+
+// === NEW: User Override System Implementation ===
+
+std::filesystem::path SettingsOverrideManager::GetUserOverridesDirectory() const
+{
+	return Util::PathHelpers::GetUserOverridesPath();
+}
+
+bool SettingsOverrideManager::LoadUserOverride(const std::string& featureName, json& featureJson)
+{
+	if (!enabled || featureName.empty()) {
+		return false;
+	}
+
+	auto userFilePath = GetUserOverridesDirectory() / (featureName + ".user.json");
+
+	std::error_code ec;
+	if (!std::filesystem::exists(userFilePath, ec)) {
+		return false;
+	}
+
+	try {
+		auto fileSize = std::filesystem::file_size(userFilePath, ec);
+		if (ec || fileSize == 0 || fileSize > 1024 * 1024) {
+			logger::info("User override file invalid size: {}", userFilePath.string());
+			return false;
+		}
+
+		std::ifstream file(userFilePath);
+		if (!file.is_open()) {
+			return false;
+		}
+
+		json userJson;
+		file >> userJson;
+		file.close();
+
+		if (!userJson.is_object()) {
+			logger::info("User override file is not a JSON object: {}", userFilePath.string());
+			return false;
+		}
+
+		// Merge user settings on top
+		MergeJson(featureJson, userJson);
+		logger::info("Loaded user override for {}", featureName);
+		return true;
+
+	} catch (const std::exception& e) {
+		logger::info("Error loading user override for {}: {}", featureName, e.what());
+		return false;
+	}
+}
+
+bool SettingsOverrideManager::SaveUserOverride(const std::string& featureName, const json& currentSettings, const json& overrideSettings)
+{
+	if (!enabled || featureName.empty()) {
+		return false;
+	}
+
+	// Compare only the keys that BOTH exist in overrides AND in current settings
+	// Keys that the override defines but the feature doesn't save should be ignored
+	// (they might be for nested settings or deprecated options)
+	bool hasDifferences = false;
+	for (const auto& [key, overrideValue] : overrideSettings.items()) {
+		// Skip keys that the feature doesn't save - can't track user changes to them
+		if (!currentSettings.contains(key)) {
+			continue;
+		}
+		
+		const auto& currentValue = currentSettings[key];
+		
+		// For numeric values, compare with tolerance to handle float32/float64 precision differences
+		// JSON stores floats as float64, but C++ features often use float32, causing precision loss
+		if (currentValue.is_number() && overrideValue.is_number()) {
+			double current = currentValue.get<double>();
+			double override = overrideValue.get<double>();
+			double diff = std::abs(current - override);
+			// Use relative tolerance for larger values, absolute for small values
+			double tolerance = std::max(1e-6, std::abs(override) * 1e-5);
+			if (diff > tolerance) {
+				hasDifferences = true;
+				break;
+			}
+		} else if (currentValue != overrideValue) {
+			hasDifferences = true;
+			break;
+		}
+	}
+
+	if (!hasDifferences) {
+		// User hasn't changed any overridden settings, delete user file if it exists
+		DeleteUserOverride(featureName);
+		return false;
+	}
+
+	try {
+		auto userDir = GetUserOverridesDirectory();
+		std::filesystem::create_directories(userDir);
+
+		auto userFilePath = userDir / (featureName + ".user.json");
+
+		std::ofstream file(userFilePath);
+		if (!file.is_open()) {
+			logger::info("Could not create user override file: {}", userFilePath.string());
+			return false;
+		}
+
+		file << currentSettings.dump(1);
+		file.close();
+
+		// Store the current override hash so we can detect if overrides change later
+		json tracking = LoadAppliedOverridesTracking();
+		std::string trackingKey = featureName + "_hash";
+		tracking[trackingKey] = GetCombinedOverrideHash(featureName);
+		SaveAppliedOverridesTracking(tracking);
+
+		logger::info("Saved user override for {}", featureName);
+		return true;
+
+	} catch (const std::exception& e) {
+		logger::info("Error saving user override for {}: {}", featureName, e.what());
+		return false;
+	}
+}
+
+bool SettingsOverrideManager::HasUserOverride(const std::string& featureName) const
+{
+	if (!enabled || featureName.empty()) {
+		return false;
+	}
+
+	auto userFilePath = GetUserOverridesDirectory() / (featureName + ".user.json");
+	std::error_code ec;
+	return std::filesystem::exists(userFilePath, ec);
+}
+
+bool SettingsOverrideManager::DeleteUserOverride(const std::string& featureName)
+{
+	if (featureName.empty()) {
+		return false;
+	}
+
+	auto userFilePath = GetUserOverridesDirectory() / (featureName + ".user.json");
+
+	std::error_code ec;
+	if (!std::filesystem::exists(userFilePath, ec)) {
+		return true;  // Already doesn't exist
+	}
+
+	try {
+		std::filesystem::remove(userFilePath, ec);
+		if (ec) {
+			logger::info("Failed to delete user override file: {}", ec.message());
+			return false;
+		}
+
+		// Clean up tracking entry
+		json tracking = LoadAppliedOverridesTracking();
+		std::string trackingKey = featureName + "_hash";
+		if (tracking.contains(trackingKey)) {
+			tracking.erase(trackingKey);
+			SaveAppliedOverridesTracking(tracking);
+		}
+
+		logger::info("Deleted user override for {}", featureName);
+		return true;
+	} catch (const std::exception& e) {
+		logger::info("Error deleting user override for {}: {}", featureName, e.what());
+		return false;
+	}
+}
+
+std::string SettingsOverrideManager::GetCombinedOverrideHash(const std::string& featureName) const
+{
+	if (!enabled || !discovered) {
+		return "";
+	}
+
+	std::string combinedHashes;
+
+	auto it = featureOverrideMap.find(featureName);
+	if (it != featureOverrideMap.end()) {
+		for (size_t index : it->second) {
+			if (index < overrides.size()) {
+				combinedHashes += overrides[index].fileHash;
+			}
+		}
+	}
+
+	if (combinedHashes.empty()) {
+		return "";
+	}
+
+	return ComputeContentHash(combinedHashes);
+}
+
+void SettingsOverrideManager::CleanupStaleUserOverrides()
+{
+	if (!enabled || !discovered) {
+		return;
+	}
+
+	auto userDir = GetUserOverridesDirectory();
+	std::error_code ec;
+
+	if (!std::filesystem::exists(userDir, ec)) {
+		return;
+	}
+
+	json tracking = LoadAppliedOverridesTracking();
+
+	try {
+		for (const auto& entry : std::filesystem::directory_iterator(userDir)) {
+			if (!entry.is_regular_file()) {
+				continue;
+			}
+
+			std::string filename = entry.path().filename().string();
+
+			// Check for .user.json extension
+			const std::string suffix = ".user.json";
+			if (!filename.ends_with(suffix)) {
+				continue;
+			}
+
+			// Extract feature name
+			std::string featureName = filename.substr(0, filename.length() - suffix.length());
+
+			// Check if this feature still has overrides
+			if (!HasFeatureOverrides(featureName) && featureName != "Global") {
+				// Override was removed, delete user file
+				logger::info("Cleaning up orphaned user override: {}", featureName);
+				std::filesystem::remove(entry.path(), ec);
+				continue;
+			}
+
+			// Check if override hash has changed
+			std::string currentHash = GetCombinedOverrideHash(featureName);
+			std::string trackingKey = featureName + "_hash";
+
+			if (tracking.contains(trackingKey)) {
+				std::string storedHash = tracking[trackingKey].get<std::string>();
+				if (storedHash != currentHash) {
+					// Override file changed, delete user customizations
+					logger::info("Override changed for {}, removing stale user override", featureName);
+					std::filesystem::remove(entry.path(), ec);
+
+					// Update stored hash
+					tracking[trackingKey] = currentHash;
+				}
+			} else {
+				// First time tracking this feature's hash
+				tracking[trackingKey] = currentHash;
+			}
+		}
+
+		SaveAppliedOverridesTracking(tracking);
+
+	} catch (const std::exception& e) {
+		logger::info("Error during user override cleanup: {}", e.what());
+	}
+}
+
+json SettingsOverrideManager::GetMergedOverrideSettings(const std::string& featureName, const json& baseSettings)
+{
+	json merged = baseSettings;
+	ApplyOverrides(featureName, merged);
+	return merged;}

--- a/src/SettingsOverrideManager.cpp
+++ b/src/SettingsOverrideManager.cpp
@@ -1010,9 +1010,9 @@ bool SettingsOverrideManager::SaveUserOverride(const std::string& featureName, c
 		if (!currentSettings.contains(key)) {
 			continue;
 		}
-		
+
 		const auto& currentValue = currentSettings[key];
-		
+
 		// For numeric values, compare with tolerance to handle float32/float64 precision differences
 		// JSON stores floats as float64, but C++ features often use float32, causing precision loss
 		if (currentValue.is_number() && overrideValue.is_number()) {
@@ -1209,4 +1209,5 @@ json SettingsOverrideManager::GetMergedOverrideSettings(const std::string& featu
 {
 	json merged = baseSettings;
 	ApplyOverrides(featureName, merged);
-	return merged;}
+	return merged;
+}

--- a/src/SettingsOverrideManager.cpp
+++ b/src/SettingsOverrideManager.cpp
@@ -943,8 +943,6 @@ void SettingsOverrideManager::ReportOverrideFailure(const std::string& modName, 
 		fileInfo);
 }
 
-// === NEW: User Override System Implementation ===
-
 std::filesystem::path SettingsOverrideManager::GetUserOverridesDirectory() const
 {
 	return Util::PathHelpers::GetUserOverridesPath();

--- a/src/SettingsOverrideManager.cpp
+++ b/src/SettingsOverrideManager.cpp
@@ -1050,6 +1050,14 @@ bool SettingsOverrideManager::SaveUserOverride(const std::string& featureName, c
 		}
 
 		file << currentSettings.dump(1);
+		file.flush();
+
+		if (file.fail()) {
+			logger::info("Failed to write user override file: {}", userFilePath.string());
+			file.close();
+			return false;
+		}
+
 		file.close();
 
 		// Store the current override hash so we can detect if overrides change later
@@ -1182,7 +1190,7 @@ void SettingsOverrideManager::CleanupStaleUserOverrides()
 			std::string currentHash = GetCombinedOverrideHash(featureName);
 			std::string trackingKey = featureName + "_hash";
 
-			if (tracking.contains(trackingKey)) {
+			if (tracking.contains(trackingKey) && tracking[trackingKey].is_string()) {
 				std::string storedHash = tracking[trackingKey].get<std::string>();
 				if (storedHash != currentHash) {
 					// Override file changed, delete user customizations
@@ -1193,7 +1201,7 @@ void SettingsOverrideManager::CleanupStaleUserOverrides()
 					tracking[trackingKey] = currentHash;
 				}
 			} else {
-				// First time tracking this feature's hash
+				// First time tracking or invalid entry, set the hash
 				tracking[trackingKey] = currentHash;
 			}
 		}

--- a/src/SettingsOverrideManager.cpp
+++ b/src/SettingsOverrideManager.cpp
@@ -294,20 +294,14 @@ json SettingsOverrideManager::LoadAppliedOverridesTracking() const
 					logger::info("Applied overrides tracking file contains invalid data structure, resetting");
 					appliedOverrides = json::object();
 				} else {
-					// Validate each tracking entry - allow both old format (objects) and new format (strings)
+					// Validate each tracking entry - must be string hash with "_hash" key suffix
 					auto it = appliedOverrides.begin();
 					while (it != appliedOverrides.end()) {
 						const std::string& key = it.key();
 						const auto& value = it.value();
 
-						// New format: simple string hash for "_hash" keys
+						// Valid format: simple string hash for "_hash" keys
 						if (key.ends_with("_hash") && value.is_string()) {
-							++it;
-							continue;
-						}
-
-						// Old format: object with hash and firstApplied (kept for compatibility)
-						if (value.is_object() && value.contains("hash") && value["hash"].is_string()) {
 							++it;
 							continue;
 						}

--- a/src/SettingsOverrideManager.h
+++ b/src/SettingsOverrideManager.h
@@ -146,8 +146,6 @@ public:
 	 */
 	void ReportOverrideFailure(const std::string& modName, const std::string& featureName, const std::string& errorMessage);
 
-	// === NEW: User Override System ===
-
 	/**
 	 * @brief Gets the user overrides directory path (Overrides/User/)
 	 */

--- a/src/SettingsOverrideManager.h
+++ b/src/SettingsOverrideManager.h
@@ -34,9 +34,8 @@ public:
 		std::string description;
 		bool enabled = true;
 
-		// Tracking for first-time application
-		std::string fileHash;          // Hash of override file content for change detection
-		std::time_t firstApplied = 0;  // Timestamp when first applied
+		// Hash for change detection
+		std::string fileHash;
 	};
 
 	static SettingsOverrideManager* GetSingleton()
@@ -52,29 +51,12 @@ public:
 	size_t DiscoverOverrides();
 
 	/**
-	 * @brief Applies overrides to settings JSON, respecting applied override tracking
-	 * @param baseSettings The default settings to start with
-	 * @param appliedOverrides Reference to tracking data for applied overrides
-	 * @return Modified settings with overrides applied (only new/changed overrides)
-	 */
-	size_t ApplyNewOverrides(json& baseSettings, json& appliedOverrides);
-
-	/**
 	 * @brief Applies overrides to a specific feature's settings JSON
 	 * @param featureName The short name of the feature
 	 * @param featureJson The feature's JSON settings to modify
 	 * @return Number of overrides applied
 	 */
 	size_t ApplyOverrides(const std::string& featureName, json& featureJson);
-
-	/**
-	 * @brief Applies feature-specific overrides respecting applied override tracking
-	 * @param featureName The short name of the feature
-	 * @param featureJson The feature's JSON settings to modify
-	 * @param appliedOverrides Reference to tracking data for applied overrides
-	 * @return Number of new overrides applied
-	 */
-	size_t ApplyNewFeatureOverrides(const std::string& featureName, json& featureJson, json& appliedOverrides);
 
 	/**
 	 * @brief Applies global overrides to the main settings JSON
@@ -163,6 +145,67 @@ public:
 	 * @param errorMessage Description of the failure
 	 */
 	void ReportOverrideFailure(const std::string& modName, const std::string& featureName, const std::string& errorMessage);
+
+	// === NEW: User Override System ===
+
+	/**
+	 * @brief Gets the user overrides directory path (Overrides/User/)
+	 */
+	std::filesystem::path GetUserOverridesDirectory() const;
+
+	/**
+	 * @brief Loads user override file for a feature if it exists
+	 * @param featureName The short name of the feature (or "Global")
+	 * @param featureJson JSON to merge user overrides into
+	 * @return True if user override was loaded and applied
+	 */
+	bool LoadUserOverride(const std::string& featureName, json& featureJson);
+
+	/**
+	 * @brief Saves user modifications to the user override file
+	 * Only saves if current settings differ from the merged override state
+	 * @param featureName The short name of the feature (or "Global")
+	 * @param currentSettings Current settings to compare and potentially save
+	 * @param overrideSettings The base override settings (after all overrides applied)
+	 * @return True if user override file was created/updated, false if no changes needed
+	 */
+	bool SaveUserOverride(const std::string& featureName, const json& currentSettings, const json& overrideSettings);
+
+	/**
+	 * @brief Checks if a feature has user modifications on top of overrides
+	 * @param featureName The short name of the feature (or "Global")
+	 * @return True if a .user file exists for this feature
+	 */
+	bool HasUserOverride(const std::string& featureName) const;
+
+	/**
+	 * @brief Deletes user override file for a feature (used by "Apply Override" button)
+	 * @param featureName The short name of the feature (or "Global")
+	 * @return True if file was deleted or didn't exist
+	 */
+	bool DeleteUserOverride(const std::string& featureName);
+
+	/**
+	 * @brief Computes combined hash of all override files for a feature
+	 * Used to detect when overrides have changed (mod update/reinstall)
+	 * @param featureName The short name of the feature
+	 * @return Combined hash string, empty if no overrides
+	 */
+	std::string GetCombinedOverrideHash(const std::string& featureName) const;
+
+	/**
+	 * @brief Validates and cleans up user override files
+	 * Deletes .user files whose corresponding override hashes have changed
+	 */
+	void CleanupStaleUserOverrides();
+
+	/**
+	 * @brief Gets the merged override settings for a feature (all overrides applied, no user modifications)
+	 * @param featureName The short name of the feature
+	 * @param baseSettings The base settings to start with
+	 * @return Settings with all overrides applied
+	 */
+	json GetMergedOverrideSettings(const std::string& featureName, const json& baseSettings);
 
 private:
 	SettingsOverrideManager() = default;

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -215,7 +215,7 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 		}
 	};
 
-	// NEW LOADING ORDER: Default → Overrides → User
+	// LOADING ORDER: Default → User → Overrides → User Overrides (.user files)
 
 	// Step 1: Always start with default settings
 	logger::info("Loading default settings from: {}", defaultConfigFilePath);
@@ -230,22 +230,7 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 		}
 	}
 
-	// Step 2: Apply overrides (only new/changed ones) to default settings
-	auto overrideManager = SettingsOverrideManager::GetSingleton();
-	size_t overridesDiscovered = overrideManager->DiscoverOverrides();
-	json appliedOverrides = overrideManager->LoadAppliedOverridesTracking();
-
-	if (overridesDiscovered > 0) {
-		logger::info("Discovered {} override files", overridesDiscovered);
-
-		// Apply global overrides to main settings (only new/changed ones)
-		size_t newGlobalOverrides = overrideManager->ApplyNewOverrides(settings, appliedOverrides);
-		if (newGlobalOverrides > 0) {
-			logger::info("Applied {} new/changed global override(s)", newGlobalOverrides);
-		}
-	}
-
-	// Step 3: Apply user settings on top of default + overrides
+	// Step 2: Apply user settings on top of defaults (user preferences)
 	if (a_configMode == ConfigMode::USER) {
 		json userSettings;
 		std::ifstream userFile(userConfigFilePath);
@@ -254,7 +239,7 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 				userFile >> userSettings;
 				userFile.close();
 
-				// Merge user settings on top of (default + overrides)
+				// Merge user settings on top of defaults
 				for (auto& [key, value] : userSettings.items()) {
 					settings[key] = value;
 				}
@@ -265,6 +250,27 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 			}
 		} else {
 			logger::info("No user config file found at: {}", userConfigFilePath);
+		}
+	}
+
+	// Step 3: Discover and prepare overrides (applied after user settings, so overrides take priority)
+	auto overrideManager = SettingsOverrideManager::GetSingleton();
+	size_t overridesDiscovered = overrideManager->DiscoverOverrides();
+
+	// Cleanup stale user override files (where override hash has changed)
+	if (overridesDiscovered > 0) {
+		logger::info("Discovered {} override files", overridesDiscovered);
+		overrideManager->CleanupStaleUserOverrides();
+
+		// Apply global overrides to main settings
+		size_t globalOverrides = overrideManager->ApplyGlobalOverrides(settings);
+		if (globalOverrides > 0) {
+			logger::info("Applied {} global override(s)", globalOverrides);
+		}
+
+		// Apply global user overrides on top (if any)
+		if (overrideManager->LoadUserOverride("Global", settings)) {
+			logger::info("Applied global user override customizations");
 		}
 	}
 
@@ -355,19 +361,27 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 					// Register weather variables (features opt-in by implementing this)
 					feature->RegisterWeatherVariables();
 
-					// Apply new/changed feature-specific overrides if any
-					if (overridesDiscovered > 0) {
+					// Apply feature-specific overrides on top (overrides take priority over user settings)
+					if (overridesDiscovered > 0 && overrideManager->HasFeatureOverrides(featureName)) {
 						json featureJson;
 						feature->SaveSettings(featureJson);  // Get current settings as JSON
 
-						size_t newFeatureOverrides = overrideManager->ApplyNewFeatureOverrides(featureName, featureJson, appliedOverrides);
-						if (newFeatureOverrides > 0) {
-							logger::info("Applied {} new/changed override(s) to {}", newFeatureOverrides, feature->GetName());
-							try {
-								feature->LoadSettings(featureJson);  // Reload with new overrides applied
-							} catch (...) {
-								logger::warn("Invalid override settings for {}, keeping original settings.", feature->GetName());
-							}
+						// Apply overrides
+						size_t appliedOverrides = overrideManager->ApplyOverrides(featureName, featureJson);
+						if (appliedOverrides > 0) {
+							logger::info("Applied {} override(s) to {}", appliedOverrides, feature->GetName());
+						}
+
+						// Apply user override customizations on top (if any)
+						if (overrideManager->LoadUserOverride(featureName, featureJson)) {
+							logger::info("Applied user override customizations to {}", feature->GetName());
+						}
+
+						// Reload settings with overrides applied
+						try {
+							feature->LoadSettings(featureJson);
+						} catch (...) {
+							logger::warn("Invalid override settings for {}, keeping original settings.", feature->GetName());
 						}
 					}
 				} else {
@@ -379,11 +393,6 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 				                                   (feature->failedLoadedMessage + "\n" + feature->GetName() + " failed to load. Check CommunityShaders.log");
 				logger::warn("Error loading setting for feature '{}': {}", feature->GetShortName(), e.what());
 			}
-		}
-
-		// Save updated applied overrides tracking
-		if (overridesDiscovered > 0) {
-			overrideManager->SaveAppliedOverridesTracking(appliedOverrides);
 		}
 
 		if (settings["Version"].is_string() && settings["Version"].get<std::string>() != Plugin::VERSION.string()) {
@@ -465,8 +474,24 @@ void State::Save(ConfigMode a_configMode)
 
 	settings["Version"] = Plugin::VERSION.string();
 
-	for (auto* feature : Feature::GetFeatureList())
+	// Save feature settings and user overrides
+	auto overrideManager = SettingsOverrideManager::GetSingleton();
+	for (auto* feature : Feature::GetFeatureList()) {
 		feature->Save(settings);
+
+		// If feature has overrides, save user modifications to .user file
+		const std::string featureName = feature->GetShortName();
+		if (overrideManager->HasFeatureOverrides(featureName) && feature->loaded) {
+			json currentSettings;
+			feature->SaveSettings(currentSettings);
+
+			// Get the merged override settings (all overrides applied to empty base)
+			json overrideSettings = overrideManager->GetMergedOverrideSettings(featureName, json::object());
+
+			// Save user override only if settings differ from override
+			overrideManager->SaveUserOverride(featureName, currentSettings, overrideSettings);
+		}
+	}
 
 	try {
 		o << settings.dump(1);

--- a/src/Utils/FileSystem.cpp
+++ b/src/Utils/FileSystem.cpp
@@ -86,6 +86,11 @@ namespace Util
 			return GetCommunityShaderPath() / "Overrides";
 		}
 
+		std::filesystem::path GetUserOverridesPath()
+		{
+			return GetOverridesPath() / "User";
+		}
+
 		std::filesystem::path GetAppliedOverridesPath()
 		{
 			return GetCommunityShaderPath() / "AppliedOverrides.json";

--- a/src/Utils/FileSystem.h
+++ b/src/Utils/FileSystem.h
@@ -98,6 +98,12 @@ namespace Util
 		std::filesystem::path GetOverridesPath();
 
 		/**
+		 * Gets the User Overrides directory path (for user modifications to overrides)
+		 * @return CommunityShaderPath / "Overrides" / "User"
+		 */
+		std::filesystem::path GetUserOverridesPath();
+
+		/**
 		 * Gets the AppliedOverrides.json file path
 		 * @return CommunityShaderPath / "AppliedOverrides.json"
 		 */


### PR DESCRIPTION
Changes flow of overwrite system to Default → User → Overrides → User Overrides (.user files)

It is now very unlikely that the overwrite system will fail. It allows for user customization that is preserved and takes priority, while retaining the original overwrite files so they can be reverted if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-feature user override system: save, load, delete, view merged user/mod overrides; dedicated user-overrides directory.

* **Bug Fixes**
  * Failed-load messages display using error color and include required version details.
  * Reapply overrides now reliably restores mod-recommended defaults and discards local customizations.

* **Improvements**
  * Unified override application flow and revised settings load/save order to better preserve user customizations.
  * Updated help text for the override reapply action.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->