### PR TITLE
chore(Linear Lighting): separate directional light multiplier sliders

### DIFF
--- a/src/Features/LinearLighting.cpp
+++ b/src/Features/LinearLighting.cpp
@@ -22,7 +22,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	grassSpecularMult,
 	vanillaDiffuseColorMult,
 	lightMult,
-	directionalLightMult,
+	directionalLightMultExterior,
+	directionalLightMultInterior,
 	pointLightMult,
 	emitColorMult,
 	glowmapMult,
@@ -58,7 +59,8 @@ void LinearLighting::DrawSettings()
 	ImGui::SliderFloat("Grass Specular Multiplier", &settings.grassSpecularMult, 0.0f, 10.0f, "%.2f");
 	ImGui::SliderFloat("Vanilla Diffuse Color Multiplier", &settings.vanillaDiffuseColorMult, 0.0f, 10.0f, "%.2f");
 	ImGui::SliderFloat("Light Multiplier", &settings.lightMult, 0.0f, 10.0f, "%.2f");
-	ImGui::SliderFloat("Directional Light Multiplier", &settings.directionalLightMult, 0.0f, 10.0f, "%.2f");
+	ImGui::SliderFloat("Exterior Directional Light Multiplier", &settings.directionalLightMultExterior, 0.0f, 10.0f, "%.2f");
+	ImGui::SliderFloat("Interior Directional Light Multiplier", &settings.directionalLightMultInterior, 0.0f, 10.0f, "%.2f");
 	ImGui::SliderFloat("Point Light Multiplier", &settings.pointLightMult, 0.0f, 10.0f, "%.2f");
 	ImGui::SliderFloat("Emissive Color Multiplier", &settings.emitColorMult, 0.0f, 10.0f, "%.2f");
 	ImGui::SliderFloat("Glowmap Multiplier", &settings.glowmapMult, 0.0f, 10.0f, "%.2f");
@@ -157,7 +159,7 @@ LinearLighting::PerFrameData LinearLighting::GetCommonBufferData()
 	data.grassSpecularMult = settings.grassSpecularMult;
 	data.vanillaDiffuseColorMult = settings.vanillaDiffuseColorMult;
 	data.lightMult = settings.lightMult;
-	data.directionalLightMult = settings.directionalLightMult;
+	data.directionalLightMult = Util::IsInterior() ? settings.directionalLightMultInterior : settings.directionalLightMultExterior;
 	data.pointLightMult = settings.pointLightMult;
 	data.emitColorMult = settings.emitColorMult;
 	data.glowmapMult = settings.glowmapMult;

--- a/src/Features/LinearLighting.h
+++ b/src/Features/LinearLighting.h
@@ -48,7 +48,8 @@ struct LinearLighting : Feature
 		float grassSpecularMult = 0.32f;
 		float vanillaDiffuseColorMult = 1.5f;
 		float lightMult = 1.0f;
-		float directionalLightMult = 1.0f;
+		float directionalLightMultExterior = 1.0f;
+		float directionalLightMultInterior = 1.0f;
 		float pointLightMult = 1.0f;
 		float emitColorMult = 1.0f;
 		float glowmapMult = 0.5f;
@@ -86,7 +87,7 @@ struct LinearLighting : Feature
 		float grassSpecularMult;
 		float vanillaDiffuseColorMult;
 		float lightMult;
-		float directionalLightMult;
+		float directionalLightMult;  // Computed based on interior/exterior
 		float pointLightMult;
 		float emitColorMult;
 		float glowmapMult;


### PR DESCRIPTION
Separated directional light multiplier for interiors vs exteriors. 

For compatibility with interior sun.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Directional light multiplier now split into separate Exterior and Interior controls with individual adjustment sliders.
  * The app automatically applies the appropriate lighting multiplier based on your current location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->