### PR TITLE
fix(terrain blending): VR and when VL disabled

### DIFF
--- a/src/Features/TerrainBlending.cpp
+++ b/src/Features/TerrainBlending.cpp
@@ -117,8 +117,6 @@ void TerrainBlending::SetupResources()
 		depthStencilDesc.StencilEnable = false;
 		DX::ThrowIfFailed(device->CreateDepthStencilState(&depthStencilDesc, &terrainDepthStencilState));
 	}
-
-	gSetCameraData = reinterpret_cast<decltype(gSetCameraData)>(REL::RelocationID(75694, 77503).address());
 }
 
 void TerrainBlending::PostPostLoad()
@@ -233,7 +231,7 @@ void TerrainBlending::Hooks::Main_RenderDepth::thunk(bool a1, bool a2)
 	auto& mainDepth = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
 	auto& zPrepassCopy = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kPOST_ZPREPASS_COPY];
 
-	singleton.gSetCameraData(globals::game::graphicsState, RE::Main::WorldRootCamera(), 1);
+	globals::game::graphicsState->SetCameraData(RE::Main::WorldRootCamera(), 1);
 
 	singleton.averageEyePosition = Util::GetAverageEyePosition();
 

--- a/src/Features/TerrainBlending.cpp
+++ b/src/Features/TerrainBlending.cpp
@@ -117,6 +117,8 @@ void TerrainBlending::SetupResources()
 		depthStencilDesc.StencilEnable = false;
 		DX::ThrowIfFailed(device->CreateDepthStencilState(&depthStencilDesc, &terrainDepthStencilState));
 	}
+
+	gSetCameraData = reinterpret_cast<decltype(gSetCameraData)>(REL::RelocationID(75694, 77503).address());
 }
 
 void TerrainBlending::PostPostLoad()
@@ -230,6 +232,8 @@ void TerrainBlending::Hooks::Main_RenderDepth::thunk(bool a1, bool a2)
 
 	auto& mainDepth = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
 	auto& zPrepassCopy = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kPOST_ZPREPASS_COPY];
+
+	singleton.gSetCameraData(globals::game::graphicsState, RE::Main::WorldRootCamera(), 1);
 
 	singleton.averageEyePosition = Util::GetAverageEyePosition();
 

--- a/src/Features/TerrainBlending.h
+++ b/src/Features/TerrainBlending.h
@@ -69,6 +69,8 @@ public:
 	void ResetTerrainDepth();
 	void BlendPrepassDepths();
 
+	void(__fastcall* gSetCameraData)(RE::BSGraphics::State*, RE::NiCamera*, uint32_t) = nullptr;
+
 	Texture2D* blendedDepthTexture = nullptr;
 	Texture2D* blendedDepthTexture16 = nullptr;
 

--- a/src/Features/TerrainBlending.h
+++ b/src/Features/TerrainBlending.h
@@ -69,8 +69,6 @@ public:
 	void ResetTerrainDepth();
 	void BlendPrepassDepths();
 
-	void(__fastcall* gSetCameraData)(RE::BSGraphics::State*, RE::NiCamera*, uint32_t) = nullptr;
-
 	Texture2D* blendedDepthTexture = nullptr;
 	Texture2D* blendedDepthTexture16 = nullptr;
 

--- a/src/Features/TerrainBlending.h
+++ b/src/Features/TerrainBlending.h
@@ -112,5 +112,5 @@ public:
 			logger::info("[Terrain Blending] Installed hooks");
 		}
 	};
-	virtual bool SupportsVR() override { return true; };
+	virtual bool SupportsVR() override { return false; };
 };

--- a/src/Features/TerrainBlending.h
+++ b/src/Features/TerrainBlending.h
@@ -112,5 +112,5 @@ public:
 			logger::info("[Terrain Blending] Installed hooks");
 		}
 	};
-	virtual bool SupportsVR() override { return false; };
+	virtual bool SupportsVR() override { return true; };
 };


### PR DESCRIPTION
This PR addresses an issue where terrain blending breaks when volumetric lighting is disabled.
The issue is caused by a missing function call that updates camera data. When volumetric lighting is turned off the given function is never called(see pic below).

This PR adds a call to the missing function inside the main depth hook.
Func ref: https://github.com/Nukem9/skyrimse-test/blob/master/skyrim64_test/src/patches/TES/BSGraphics/BSGraphicsState.cpp

Control flow:
![flow](https://github.com/user-attachments/assets/edc20b90-94cb-4d3c-a191-49bd66a53c6a)

With VL disabled before
![ScreenShot7](https://github.com/user-attachments/assets/0721a523-261c-4f16-8805-8083f22c7bd4)

With VL disabled now
![ScreenShot9](https://github.com/user-attachments/assets/76431241-5775-4750-ac43-8362245ed75c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Initialize and apply camera data earlier during depth rendering to improve depth processing and reduce compositing artifacts.

* **New Features**
  * Terrain blending now reports VR support, enabling VR-related rendering paths where applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->