### PR TITLE
chore: edit welcome dialogue behavior

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -929,7 +929,7 @@ void Menu::ProcessInputEventQueue()
 						std::function<void()> action;
 					};
 					KeyAction keyActions[] = {
-						{ settings.ToggleKey, [this]() { IsEnabled = !IsEnabled; } },
+						{ settings.ToggleKey, [this]() { if (!HomePageRenderer::ShouldShowFirstTimeSetup()) IsEnabled = !IsEnabled; } },
 						{ settings.SkipCompilationKey, [shaderCache]() { shaderCache->backgroundCompilation = true; } },
 						{ settings.EffectToggleKey, [shaderCache]() { shaderCache->SetEnabled(!shaderCache->IsEnabled()); } },
 						{ settings.ShaderBlockPrevKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(); } },

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -255,6 +255,12 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	io.WantCaptureKeyboard = true;
 	io.MouseDrawCursor = true;  // Show ImGui cursor
 
+	// Draw semi-transparent dark overlay behind the dialog for depth
+	ImGui::GetBackgroundDrawList()->AddRectFilled(
+		ImVec2(0, 0),
+		io.DisplaySize,
+		IM_COL32(0, 0, 0, 160));
+
 	// Center the window properly with rounded corners and thin border
 	ImVec2 center = ImVec2(io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f);
 	ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
@@ -317,142 +323,97 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 
 	// Center all content
 	float windowWidth = ImGui::GetWindowWidth();
+	auto centerText = [windowWidth](const char* text) {
+		ImGui::SetCursorPosX((windowWidth - ImGui::CalcTextSize(text).x) * 0.5f);
+	};
 
-	// Welcome title - centered
-	const char* welcomeTitle = "Welcome to Community Shaders!";
-	float welcomeTitleWidth = ImGui::CalcTextSize(welcomeTitle).x;
-	ImGui::SetCursorPosX((windowWidth - welcomeTitleWidth) * 0.5f);
-	ImGui::Text("%s", welcomeTitle);
-
-	ImGui::Spacing();
-
-	// Version text - wrapped and centered
-	const char* versionText = "This appears to be a new install, update, or reinstallation of Community Shaders.";
-	float textPadding = 40.0f;  // Padding from window edges
-
-	// Use a centered region for wrapped text
-	ImGui::SetCursorPosX(textPadding);
-	ImGui::BeginGroup();
-	ImGui::PushTextWrapPos(windowWidth - textPadding);
-
-	// Calculate the wrapped text size to center it
-	ImVec2 textSize = ImGui::CalcTextSize(versionText, nullptr, true, windowWidth - textPadding * 2);
-	float centerOffset = (windowWidth - textPadding * 2 - textSize.x) * 0.5f;
-	if (centerOffset > 0) {
-		ImGui::SetCursorPosX(textPadding + centerOffset);
-	}
-
-	ImGui::TextWrapped("%s", versionText);
-	ImGui::PopTextWrapPos();
-	ImGui::EndGroup();
+	// Version text - two lines, both centered (reduced spacing between lines)
+	const char* versionLine1 = "This appears to be a new install, update, or";
+	const char* versionLine2 = "reinstallation of Community Shaders.";
+	
+	centerText(versionLine1);
+	ImGui::Text("%s", versionLine1);
+	ImGui::SetCursorPosY(ImGui::GetCursorPosY() - 4.0f);
+	centerText(versionLine2);
+	ImGui::Text("%s", versionLine2);
 
 	ImGui::Spacing();
 
 	// Description - centered
-	const char* description = "Please select a hotkey to access the menu:";
-	float descWidth = ImGui::CalcTextSize(description).x;
-	ImGui::SetCursorPosX((windowWidth - descWidth) * 0.5f);
+	const char* description = "Please choose a hotkey to access the menu:";
+	centerText(description);
 	ImGui::Text("%s", description);
 
 	// Hotkey selection - clickable hotkey text
-	// Show current toggle key and allow user to change it by clicking on it
 	auto& themeSettings = menu->GetTheme();
-	const char* currentKeyName = Util::Input::KeyIdToString(menu->GetSettings().ToggleKey);
+	bool isCapturing = menu->settingToggleKey;
 
-	// Increase font size for hotkey text
-	ImGui::SetWindowFontScale(fontScale * HOTKEY_TEXT_SCALE_MULTIPLIER);
+	// Increase font size for hotkey text - bigger when capturing
+	ImGui::SetWindowFontScale(fontScale * (isCapturing ? 2.0f : 1.6f));
 
-	// Calculate text dimensions for centering and button area
-	float hotkeyWidth = ImGui::CalcTextSize(currentKeyName).x;
-	float centerX = (windowWidth - hotkeyWidth) * 0.5f;
-	ImGui::SetCursorPosX(centerX);
+	// Format hotkey with brackets to make it look like a button
+	std::string hotkeyDisplay = isCapturing ? "[ ... ]" : std::string("[ ") + Util::Input::KeyIdToString(menu->GetSettings().ToggleKey) + " ]";
+	ImVec2 hotkeyTextSize = ImGui::CalcTextSize(hotkeyDisplay.c_str());
+
+	ImGui::SetCursorPosX((windowWidth - hotkeyTextSize.x) * 0.5f);
+	ImVec2 buttonPos = ImGui::GetCursorScreenPos();
 
 	// Create invisible button for hover detection and clicking
-	ImVec2 buttonPos = ImGui::GetCursorScreenPos();
-	ImVec2 hotkeyTextSize = ImGui::CalcTextSize(currentKeyName);
-	bool hovered = false;
-	bool clicked = false;
-
 	ImGui::PushID("HotkeyButton");
-	if (ImGui::InvisibleButton("##HotkeyClick", hotkeyTextSize)) {
-		clicked = true;
-	}
-	hovered = ImGui::IsItemHovered();
+	bool clicked = ImGui::InvisibleButton("##HotkeyClick", hotkeyTextSize);
+	bool hovered = ImGui::IsItemHovered();
 	ImGui::PopID();
 
-	// Set cursor position back for text rendering
 	ImGui::SetCursorScreenPos(buttonPos);
 
-	// Choose color based on hover state - darken when hovered.
-	ImVec4 hotkeyColor = hovered ?
-	                         ImVec4(themeSettings.StatusPalette.CurrentHotkey.x * 0.7f,
-								 themeSettings.StatusPalette.CurrentHotkey.y * 0.7f,
-								 themeSettings.StatusPalette.CurrentHotkey.z * 0.7f,
-								 themeSettings.StatusPalette.CurrentHotkey.w) :
-	                         themeSettings.StatusPalette.CurrentHotkey;
+	// Choose color based on state
+	ImVec4 hotkeyColor;
+	if (isCapturing) {
+		float pulse = 0.7f + 0.3f * sinf((float)ImGui::GetTime() * 4.0f);
+		hotkeyColor = ImVec4(pulse, pulse * 0.8f, 0.2f, 1.0f);
+	} else if (hovered) {
+		hotkeyColor = ImVec4(themeSettings.StatusPalette.CurrentHotkey.x * 0.7f,
+			themeSettings.StatusPalette.CurrentHotkey.y * 0.7f,
+			themeSettings.StatusPalette.CurrentHotkey.z * 0.7f,
+			themeSettings.StatusPalette.CurrentHotkey.w);
+	} else {
+		hotkeyColor = themeSettings.StatusPalette.CurrentHotkey;
+	}
 
-	ImGui::TextColored(hotkeyColor, "%s", currentKeyName);
-
-	// Reset font scale
+	ImGui::TextColored(hotkeyColor, "%s", hotkeyDisplay.c_str());
 	ImGui::SetWindowFontScale(fontScale);
 
-	// Handle click to start hotkey capture
-	if (clicked) {
+	if (clicked && !isCapturing) {
 		menu->settingToggleKey = true;
 	}
 
-	// Show hotkey capture message or hotkey text
-	if (menu->settingToggleKey) {
+	if (isCapturing) {
 		const char* pressKeyText = "Press any key to set as toggle key...";
-		float pressKeyWidth = ImGui::CalcTextSize(pressKeyText).x;
-		ImGui::SetCursorPosX((windowWidth - pressKeyWidth) * 0.5f);
-		ImGui::Text("%s", pressKeyText);
+		centerText(pressKeyText);
+		ImGui::TextDisabled("%s", pressKeyText);
 	}
 
 	ImGui::Spacing();
 
-	// "You can change this later" text - wrapped and centered
 	const char* laterText = "You can change this later in General > Keybindings.";
-	float laterWidth = ImGui::CalcTextSize(laterText).x;
-	if (laterWidth > windowWidth - 40.0f) {
-		// Text is too wide, use wrapped text with centering
-		float laterTextPadding = 40.0f;
-
-		ImGui::SetCursorPosX(laterTextPadding);
-		ImGui::BeginGroup();
-		ImGui::PushTextWrapPos(windowWidth - laterTextPadding);
-
-		// Calculate the wrapped text size to center it
-		ImVec2 laterTextSize = ImGui::CalcTextSize(laterText, nullptr, true, windowWidth - laterTextPadding * 2);
-		float laterCenterOffset = (windowWidth - laterTextPadding * 2 - laterTextSize.x) * 0.5f;
-		if (laterCenterOffset > 0) {
-			ImGui::SetCursorPosX(laterTextPadding + laterCenterOffset);
-		}
-
-		ImGui::TextWrapped("%s", laterText);
-		ImGui::PopTextWrapPos();
-		ImGui::EndGroup();
-	} else {
-		// Text fits, center it normally
-		ImGui::SetCursorPosX((windowWidth - laterWidth) * 0.5f);
-		ImGui::Text("%s", laterText);
-	}
+	centerText(laterText);
+	ImGui::Text("%s", laterText);
 
 	ImGui::Spacing();
 
 	// Check for Enter or Escape key to close, but only if not capturing a hotkey
-	bool shouldClose = (ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_Escape)) && !menu->settingToggleKey;
-
-	if (shouldClose) {
+	if ((ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_Escape)) && !isCapturing) {
 		MarkFirstTimeSetupComplete();
-		// Note: Settings are automatically saved to ensure welcome screen won't show again
 	}
 
-	// Center the help text
+	// Help text with breathing animation
 	const char* helpText = "Press Escape or Enter to continue";
-	float helpWidth = ImGui::CalcTextSize(helpText).x;
-	ImGui::SetCursorPosX((windowWidth - helpWidth) * 0.5f);
-	ImGui::TextDisabled("%s", helpText);
+	float breathe = 0.7f + 0.3f * sinf((float)ImGui::GetTime() * 2.5f);
+	
+	ImGui::SetWindowFontScale(fontScale * 1.35f);
+	centerText(helpText);
+	ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, breathe), "%s", helpText);
+	ImGui::SetWindowFontScale(fontScale);
 
 	ImGui::End();
 	ImGui::PopStyleVar(2);

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -256,10 +256,7 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	io.MouseDrawCursor = true;  // Show ImGui cursor
 
 	// Draw semi-transparent dark overlay behind the dialog for depth
-	ImGui::GetBackgroundDrawList()->AddRectFilled(
-		ImVec2(0, 0),
-		io.DisplaySize,
-		IM_COL32(0, 0, 0, 160));
+	Util::DrawModalBackground();
 
 	// Center the window properly with rounded corners and thin border
 	ImVec2 center = ImVec2(io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f);
@@ -326,6 +323,9 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	auto centerText = [windowWidth](const char* text) {
 		ImGui::SetCursorPosX((windowWidth - ImGui::CalcTextSize(text).x) * 0.5f);
 	};
+	auto centerWidth = [windowWidth](float width) {
+		ImGui::SetCursorPosX((windowWidth - width) * 0.5f);
+	};
 
 	// Version text - two lines, both centered (reduced spacing between lines)
 	const char* versionLine1 = "This appears to be a new install, update, or";
@@ -350,13 +350,13 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	bool isCapturing = menu->settingToggleKey;
 
 	// Increase font size for hotkey text - bigger when capturing
-	ImGui::SetWindowFontScale(fontScale * (isCapturing ? 2.0f : 1.6f));
+	ImGui::SetWindowFontScale(fontScale * (isCapturing ? HOTKEY_TEXT_SCALE_CAPTURING : HOTKEY_TEXT_SCALE));
 
 	// Format hotkey with brackets to make it look like a button
 	std::string hotkeyDisplay = isCapturing ? "[ ... ]" : std::string("[ ") + Util::Input::KeyIdToString(menu->GetSettings().ToggleKey) + " ]";
 	ImVec2 hotkeyTextSize = ImGui::CalcTextSize(hotkeyDisplay.c_str());
 
-	ImGui::SetCursorPosX((windowWidth - hotkeyTextSize.x) * 0.5f);
+	centerWidth(hotkeyTextSize.x);
 	ImVec2 buttonPos = ImGui::GetCursorScreenPos();
 
 	// Create invisible button for hover detection and clicking
@@ -371,12 +371,17 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	// Choose color based on state
 	ImVec4 hotkeyColor;
 	if (isCapturing) {
+		// Pulsing effect using theme's hotkey color
 		float pulse = 0.7f + 0.3f * sinf((float)ImGui::GetTime() * 4.0f);
-		hotkeyColor = ImVec4(pulse, pulse * 0.8f, 0.2f, 1.0f);
+		hotkeyColor = ImVec4(
+			themeSettings.StatusPalette.CurrentHotkey.x * pulse,
+			themeSettings.StatusPalette.CurrentHotkey.y * pulse,
+			themeSettings.StatusPalette.CurrentHotkey.z * pulse,
+			themeSettings.StatusPalette.CurrentHotkey.w);
 	} else if (hovered) {
-		hotkeyColor = ImVec4(themeSettings.StatusPalette.CurrentHotkey.x * 0.7f,
-			themeSettings.StatusPalette.CurrentHotkey.y * 0.7f,
-			themeSettings.StatusPalette.CurrentHotkey.z * 0.7f,
+		hotkeyColor = ImVec4(themeSettings.StatusPalette.CurrentHotkey.x * HOTKEY_HOVER_DIM_FACTOR,
+			themeSettings.StatusPalette.CurrentHotkey.y * HOTKEY_HOVER_DIM_FACTOR,
+			themeSettings.StatusPalette.CurrentHotkey.z * HOTKEY_HOVER_DIM_FACTOR,
 			themeSettings.StatusPalette.CurrentHotkey.w);
 	} else {
 		hotkeyColor = themeSettings.StatusPalette.CurrentHotkey;
@@ -415,11 +420,10 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 
 	// Help text with breathing animation
 	const char* helpText = "Press Escape or Enter to continue";
-	float breathe = 0.7f + 0.3f * sinf((float)ImGui::GetTime() * 2.5f);
 
-	ImGui::SetWindowFontScale(fontScale * 1.35f);
+	ImGui::SetWindowFontScale(fontScale * HELP_TEXT_SCALE);
 	centerText(helpText);
-	ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, breathe), "%s", helpText);
+	Util::DrawBreathingText(helpText);
 
 	// Reset font scale
 	ImGui::SetWindowFontScale(fontScale);

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -372,12 +372,7 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	ImVec4 hotkeyColor;
 	if (isCapturing) {
 		// Pulsing effect using theme's hotkey color
-		float pulse = 0.7f + 0.3f * sinf((float)ImGui::GetTime() * 4.0f);
-		hotkeyColor = ImVec4(
-			themeSettings.StatusPalette.CurrentHotkey.x * pulse,
-			themeSettings.StatusPalette.CurrentHotkey.y * pulse,
-			themeSettings.StatusPalette.CurrentHotkey.z * pulse,
-			themeSettings.StatusPalette.CurrentHotkey.w);
+		hotkeyColor = Util::GetPulsingColor(themeSettings.StatusPalette.CurrentHotkey);
 	} else if (hovered) {
 		hotkeyColor = ImVec4(themeSettings.StatusPalette.CurrentHotkey.x * HOTKEY_HOVER_DIM_FACTOR,
 			themeSettings.StatusPalette.CurrentHotkey.y * HOTKEY_HOVER_DIM_FACTOR,

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -345,6 +345,7 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	ImGui::Text("%s", description);
 
 	// Hotkey selection - clickable hotkey text
+	// Show current toggle key and allow user to change it by clicking on it
 	auto& themeSettings = menu->GetTheme();
 	bool isCapturing = menu->settingToggleKey;
 

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -365,6 +365,7 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	bool hovered = ImGui::IsItemHovered();
 	ImGui::PopID();
 
+	// Set cursor position back for text rendering
 	ImGui::SetCursorScreenPos(buttonPos);
 
 	// Choose color based on state
@@ -382,12 +383,16 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	}
 
 	ImGui::TextColored(hotkeyColor, "%s", hotkeyDisplay.c_str());
+
+	// Reset font scale
 	ImGui::SetWindowFontScale(fontScale);
 
+	// Handle click to start hotkey capture
 	if (clicked && !isCapturing) {
 		menu->settingToggleKey = true;
 	}
 
+	// Show hotkey capture message when in capture mode
 	if (isCapturing) {
 		const char* pressKeyText = "Press any key to set as toggle key...";
 		centerText(pressKeyText);
@@ -405,6 +410,7 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	// Check for Enter or Escape key to close, but only if not capturing a hotkey
 	if ((ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_Escape)) && !isCapturing) {
 		MarkFirstTimeSetupComplete();
+		// Note: Settings are automatically saved to ensure welcome screen won't show again
 	}
 
 	// Help text with breathing animation
@@ -414,6 +420,8 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	ImGui::SetWindowFontScale(fontScale * 1.35f);
 	centerText(helpText);
 	ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, breathe), "%s", helpText);
+
+	// Reset font scale
 	ImGui::SetWindowFontScale(fontScale);
 
 	ImGui::End();

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -330,7 +330,7 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	// Version text - two lines, both centered (reduced spacing between lines)
 	const char* versionLine1 = "This appears to be a new install, update, or";
 	const char* versionLine2 = "reinstallation of Community Shaders.";
-	
+
 	centerText(versionLine1);
 	ImGui::Text("%s", versionLine1);
 	ImGui::SetCursorPosY(ImGui::GetCursorPosY() - 4.0f);
@@ -416,7 +416,7 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	// Help text with breathing animation
 	const char* helpText = "Press Escape or Enter to continue";
 	float breathe = 0.7f + 0.3f * sinf((float)ImGui::GetTime() * 2.5f);
-	
+
 	ImGui::SetWindowFontScale(fontScale * 1.35f);
 	centerText(helpText);
 	ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, breathe), "%s", helpText);

--- a/src/Menu/HomePageRenderer.h
+++ b/src/Menu/HomePageRenderer.h
@@ -8,7 +8,10 @@ public:
 	// Constants
 	static constexpr const char* DISCORD_URL = "https://discord.com/invite/nkrQybAsyy";
 	static constexpr float TITLE_FONT_SCALE = 2.0f;
-	static constexpr float HOTKEY_TEXT_SCALE_MULTIPLIER = 1.25f;
+	static constexpr float HOTKEY_TEXT_SCALE = 1.6f;
+	static constexpr float HOTKEY_TEXT_SCALE_CAPTURING = 2.0f;
+	static constexpr float HOTKEY_HOVER_DIM_FACTOR = 0.7f;
+	static constexpr float HELP_TEXT_SCALE = 1.35f;
 	static constexpr float QUICK_LINKS_BUTTON_WIDTH = 180.0f;
 	static constexpr float LOGO_WATERMARK_HEIGHT = 200.0f;
 

--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -636,6 +636,24 @@ namespace Util
 		return lowerText.find(lowerQuery) != std::string::npos;
 	}
 
+	void DrawModalBackground(uint8_t alpha)
+	{
+		auto& io = ImGui::GetIO();
+		ImGui::GetBackgroundDrawList()->AddRectFilled(
+			ImVec2(0, 0),
+			io.DisplaySize,
+			IM_COL32(0, 0, 0, alpha));
+	}
+
+	void DrawBreathingText(const char* text, float speed, float minAlpha, float maxAlpha)
+	{
+		float alphaRange = maxAlpha - minAlpha;
+		float breathe = minAlpha + alphaRange * sinf((float)ImGui::GetTime() * speed);
+		auto& theme = globals::menu->GetTheme().Palette;
+		ImVec4 color = ImVec4(theme.Text.x, theme.Text.y, theme.Text.z, breathe);
+		ImGui::TextColored(color, "%s", text);
+	}
+
 	void DrawSearchIcon(const ImVec2& position, float size, float alpha)
 	{
 		ImDrawList* drawList = ImGui::GetWindowDrawList();

--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -648,7 +648,7 @@ namespace Util
 	void DrawBreathingText(const char* text, float speed, float minAlpha, float maxAlpha)
 	{
 		float alphaRange = maxAlpha - minAlpha;
-		float breathe = minAlpha + alphaRange * sinf((float)ImGui::GetTime() * speed);
+		float breathe = minAlpha + alphaRange * 0.5f * (1.0f + sinf((float)ImGui::GetTime() * speed));
 		auto& theme = globals::menu->GetTheme().Palette;
 		ImVec4 color = ImVec4(theme.Text.x, theme.Text.y, theme.Text.z, breathe);
 		ImGui::TextColored(color, "%s", text);

--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -654,6 +654,17 @@ namespace Util
 		ImGui::TextColored(color, "%s", text);
 	}
 
+	ImVec4 GetPulsingColor(const ImVec4& baseColor, float speed, float minBrightness, float maxBrightness)
+	{
+		float brightnessRange = maxBrightness - minBrightness;
+		float pulse = minBrightness + brightnessRange * 0.5f * (1.0f + sinf((float)ImGui::GetTime() * speed));
+		return ImVec4(
+			baseColor.x * pulse,
+			baseColor.y * pulse,
+			baseColor.z * pulse,
+			baseColor.w);
+	}
+
 	void DrawSearchIcon(const ImVec2& position, float size, float alpha)
 	{
 		ImDrawList* drawList = ImGui::GetWindowDrawList();

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -620,6 +620,16 @@ namespace Util
 	void DrawBreathingText(const char* text, float speed = 2.5f, float minAlpha = 0.7f, float maxAlpha = 1.0f);
 
 	/**
+	 * @brief Returns a color with pulsing brightness animation applied.
+	 * @param baseColor The base color to pulse
+	 * @param speed Animation speed multiplier (default: 4.0f)
+	 * @param minBrightness Minimum brightness multiplier (default: 0.7f)
+	 * @param maxBrightness Maximum brightness multiplier (default: 1.0f)
+	 * @return The color with pulsing brightness applied (alpha unchanged)
+	 */
+	ImVec4 GetPulsingColor(const ImVec4& baseColor, float speed = 4.0f, float minBrightness = 0.7f, float maxBrightness = 1.0f);
+
+	/**
 	 * @brief Draws the feature search bar with magnifying glass icon.
 	 * @param searchString Reference to the search string to modify
 	 * @param availableWidth The available width for the search bar

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -605,6 +605,21 @@ namespace Util
 	void DrawSearchIcon(const ImVec2& position, float size = 20.0f, float alpha = 0.7f);
 
 	/**
+	 * @brief Draws a semi-transparent dark overlay behind modal dialogs for depth.
+	 * @param alpha The alpha value for the overlay (0-255, default: 160)
+	 */
+	void DrawModalBackground(uint8_t alpha = 160);
+
+	/**
+	 * @brief Draws text with a breathing/pulsing alpha animation using theme text color.
+	 * @param text The text to display
+	 * @param speed Animation speed multiplier (default: 2.5f)
+	 * @param minAlpha Minimum alpha value (default: 0.7f)
+	 * @param maxAlpha Maximum alpha value (default: 1.0f)
+	 */
+	void DrawBreathingText(const char* text, float speed = 2.5f, float minAlpha = 0.7f, float maxAlpha = 1.0f);
+
+	/**
 	 * @brief Draws the feature search bar with magnifying glass icon.
 	 * @param searchString Reference to the search string to modify
 	 * @param availableWidth The available width for the search bar


### PR DESCRIPTION
Edited behavior of welcome dialogue to be more user friendly and intuitive. 

<img width="2560" height="1440" alt="Skyrim Special Edition 1_22_2026 1_54_26 AM" src="https://github.com/user-attachments/assets/1878594d-4bf0-4cf8-b745-587e917a5317" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Keyboard toggle no longer activates while the first-time setup dialog is visible.

* **New Features**
  * Click-to-capture hotkey flow with enlarged, bracketed key display and pulsing capture state; prevents re-entry while capturing.

* **Style**
  * Semi-transparent modal backdrop, improved centered text layout (including two-line version), refined hover/capture color feedback, and a breathing animation for help text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->