### PR TITLE
build: bump tracy to 0.13.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure patch files always use LF line endings
+*.patch text eol=lf

--- a/cmake/ports/tracy/build-tools.patch
+++ b/cmake/ports/tracy/build-tools.patch
@@ -7,8 +7,8 @@ index 72901a8c..365724a8 100644
      add_subdirectory(python)
  endif()
 +
-+option(VCPKG_CLI_TOOLS "library" OFF)
-+option(VCPKG_GUI_TOOLS "library" OFF)
++option(VCPKG_CLI_TOOLS "Build Tracy command-line tools (csvexport, capture, import, update)" OFF)
++option(VCPKG_GUI_TOOLS "Build Tracy GUI profiler application" OFF)
 +if(VCPKG_CLI_TOOLS)
 +    add_subdirectory(csvexport)
 +    add_subdirectory(capture)

--- a/cmake/ports/tracy/build-tools.patch
+++ b/cmake/ports/tracy/build-tools.patch
@@ -1,0 +1,38 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 72901a8c..365724a8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -193,3 +193,15 @@ if(TRACY_CLIENT_PYTHON)
+
+     add_subdirectory(python)
+ endif()
++
++option(VCPKG_CLI_TOOLS "library" OFF)
++option(VCPKG_GUI_TOOLS "library" OFF)
++if(VCPKG_CLI_TOOLS)
++    add_subdirectory(csvexport)
++    add_subdirectory(capture)
++    add_subdirectory(import)
++    add_subdirectory(update)
++endif()
++if(VCPKG_GUI_TOOLS)
++    add_subdirectory(profiler)
++endif()
+diff --git a/cmake/server.cmake b/cmake/server.cmake
+index c12a3408..0d55cf91 100644
+--- a/cmake/server.cmake
++++ b/cmake/server.cmake
+@@ -1,3 +1,4 @@
++include_guard(GLOBAL)
+ set(TRACY_COMMON_DIR ${CMAKE_CURRENT_LIST_DIR}/../public/common)
+
+ set(TRACY_COMMON_SOURCES
+diff --git a/cmake/vendor.cmake b/cmake/vendor.cmake
+index 29f12cfa..40b3e078 100644
+--- a/cmake/vendor.cmake
++++ b/cmake/vendor.cmake
+@@ -1,3 +1,4 @@
++include_guard(GLOBAL)
+ # Vendor Specific CMake
+ # The Tracy project keeps most vendor source locally
+

--- a/cmake/ports/tracy/portfile.cmake
+++ b/cmake/ports/tracy/portfile.cmake
@@ -1,0 +1,66 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO wolfpld/tracy
+    REF "v${VERSION}"
+    SHA512 18c0c589a1d97d0760958c8ab00ba2135bc602fd359d48445b5d8ed76e5b08742d818bb8f835b599149030f455e553a92db86fb7bae049b47820e4401cf9f935
+    HEAD_REF master
+    PATCHES
+        build-tools.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        on-demand TRACY_ON_DEMAND
+        fibers	  TRACY_FIBERS
+        verbose   TRACY_VERBOSE
+    INVERTED_FEATURES
+        crash-handler TRACY_NO_CRASH_HANDLER
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS TOOLS_OPTIONS
+    FEATURES
+        cli-tools VCPKG_CLI_TOOLS
+        gui-tools VCPKG_GUI_TOOLS
+)
+
+if("cli-tools" IN_LIST FEATURES OR "gui-tools" IN_LIST FEATURES)
+    vcpkg_find_acquire_program(PKGCONFIG)
+    list(APPEND TOOLS_OPTIONS "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DDOWNLOAD_CAPSTONE=OFF
+        -DLEGACY=ON
+        ${FEATURE_OPTIONS}
+    OPTIONS_RELEASE
+        ${TOOLS_OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        DOWNLOAD_CAPSTONE
+        LEGACY
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME Tracy CONFIG_PATH lib/cmake/Tracy)
+
+function(tracy_copy_tool tool_name tool_dir)
+    vcpkg_copy_tools(
+        TOOL_NAMES "${tool_name}"
+        SEARCH_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/${tool_dir}"
+    )
+endfunction()
+
+if("cli-tools" IN_LIST FEATURES)
+    tracy_copy_tool(tracy-capture capture)
+    tracy_copy_tool(tracy-csvexport csvexport)
+    tracy_copy_tool(tracy-import-chrome import)
+    tracy_copy_tool(tracy-import-fuchsia import)
+    tracy_copy_tool(tracy-update update)
+endif()
+if("gui-tools" IN_LIST FEATURES)
+    tracy_copy_tool(tracy-profiler profiler)
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/cmake/ports/tracy/vcpkg.json
+++ b/cmake/ports/tracy/vcpkg.json
@@ -1,0 +1,79 @@
+{
+    "name": "tracy",
+    "version": "0.13.1",
+    "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
+    "homepage": "https://github.com/wolfpld/tracy",
+    "license": "BSD-3-Clause",
+    "supports": "!(windows & (arm | uwp))",
+    "dependencies": [
+        {
+            "name": "pthreads",
+            "platform": "!windows"
+        },
+        {
+            "name": "vcpkg-cmake",
+            "host": true
+        },
+        {
+            "name": "vcpkg-cmake-config",
+            "host": true
+        }
+    ],
+    "default-features": ["crash-handler"],
+    "features": {
+        "cli-tools": {
+            "description": "Build Tracy command-line tools: `capture`, `csvexport`, `import-chrome`, `import-fuchsia` and `update`",
+            "supports": "!(windows & x86)",
+            "dependencies": [
+                {
+                    "name": "capstone",
+                    "features": ["arm", "arm64", "x86"]
+                },
+                {
+                    "name": "dbus",
+                    "default-features": false,
+                    "platform": "!windows"
+                },
+                "freetype",
+                "glfw3",
+                {
+                    "name": "tbb",
+                    "platform": "!windows"
+                }
+            ]
+        },
+        "crash-handler": {
+            "description": "Enable crash handler"
+        },
+        "fibers": {
+            "description": "Enable fibers support"
+        },
+        "gui-tools": {
+            "description": "Build Tracy GUI tool: `profiler` (aka `Tracy` executable)",
+            "supports": "!(windows & x86)",
+            "dependencies": [
+                {
+                    "name": "capstone",
+                    "features": ["arm", "arm64", "x86"]
+                },
+                {
+                    "name": "dbus",
+                    "default-features": false,
+                    "platform": "!windows"
+                },
+                "freetype",
+                "glfw3",
+                {
+                    "name": "tbb",
+                    "platform": "!windows"
+                }
+            ]
+        },
+        "on-demand": {
+            "description": "Enable on-demand profiling"
+        },
+        "verbose": {
+            "description": "Enables verbose logging"
+        }
+    }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -48,7 +48,10 @@
             "name": "imgui",
             "version": "1.90"
         },
-
+        {
+            "name": "tracy",
+            "version": "0.13.1"
+        },
         {
             "name": "directx-headers",
             "version": "1.606.4"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -48,10 +48,7 @@
             "name": "imgui",
             "version": "1.90"
         },
-        {
-            "name": "tracy",
-            "version": "0.11.0"
-        },
+
         {
             "name": "directx-headers",
             "version": "1.606.4"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable profiling tool support with optional CLI and GUI utilities and toggles for on-demand mode, fiber support, crash-handler, and verbose logging.
  * Optional installation/copying of individual profiling utilities when CLI/GUI tools are enabled.

* **Chores**
  * Added a package manifest for the profiler and bumped the packaged profiler version.
  * Enforced LF line endings for patch files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->