### PR TITLE
feat(terrainblending): Add terrain blending strength and depth culling controls

### DIFF
--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -239,7 +239,9 @@ namespace SharedData
 	struct TerrainBlendingSettings
 	{
 		uint Enabled;
-		uint3 _padding;
+		float BlendStrength;
+		float TerrainDepthCullingDistance;
+		float pad0;
 	};
 
 	cbuffer FeatureData : register(b6)

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -997,7 +997,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float depthSampledLinear = SharedData::GetScreenDepth(depthSampled);
 		float depthPixelLinear = SharedData::GetScreenDepth(input.Position.z);
 
-		blendFactorTerrain = saturate((depthSampledLinear - depthPixelLinear) / 10.0);
+		float blendStrength = max(SharedData::terrainBlendingSettings.BlendStrength * 10.0f, 0.001f);
+		blendFactorTerrain = saturate((depthSampledLinear - depthPixelLinear) / blendStrength);
 
 		if (input.Position.z == depthSampled)
 			blendFactorTerrain = 1;

--- a/src/Features/TerrainBlending.cpp
+++ b/src/Features/TerrainBlending.cpp
@@ -6,13 +6,30 @@
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	TerrainBlending::Settings,
-	Enabled)
+	Enabled,
+	BlendStrength,
+	TerrainDepthCullingDistance)
 
 void TerrainBlending::DrawSettings()
 {
 	ImGui::Checkbox("Enable Terrain Blending", (bool*)&settings.Enabled);
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text("Enable seamless blending between terrain and objects.");
+	}
+
+	ImGui::SliderFloat("Blend Strength", &settings.BlendStrength, 0.125f, 1.25f, "%.3f");
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text(
+			"Controls degree of blending.\n"
+			"Lower values create a tighter transition.");
+	}
+
+	ImGui::SeparatorText("Performance Option");
+	ImGui::SliderFloat("Terrain Depth Culling Distance", &settings.TerrainDepthCullingDistance, 256.0f, 8192.0f, "%.0f units");
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text(
+			"Skips terrain depth blending beyond this distance.\n"
+			"Decrease to just before blending stops to save performance.");
 	}
 }
 
@@ -271,7 +288,7 @@ void TerrainBlending::Hooks::BSBatchRenderer__RenderPassImmediately::thunk(RE::B
 			bool inTerrain = a_pass->shaderProperty && a_pass->shaderProperty->flags.all(RE::BSShaderProperty::EShaderPropertyFlag::kMultiTextureLandscape);
 
 			if (inTerrain) {
-				if ((a_pass->geometry->worldBound.center.GetDistance(singleton.averageEyePosition) - a_pass->geometry->worldBound.radius) > 2048.0f) {
+				if ((a_pass->geometry->worldBound.center.GetDistance(singleton.averageEyePosition) - a_pass->geometry->worldBound.radius) > singleton.settings.TerrainDepthCullingDistance) {
 					inTerrain = false;
 				}
 			}

--- a/src/Features/TerrainBlending.h
+++ b/src/Features/TerrainBlending.h
@@ -23,7 +23,9 @@ public:
 	struct Settings
 	{
 		uint32_t Enabled = true;
-		uint32_t pad[3];
+		float BlendStrength = 1.0f;
+		float TerrainDepthCullingDistance = 2048.0f;
+		float pad0 = 0.0f;
 	};
 	STATIC_ASSERT_ALIGNAS_16(Settings);
 


### PR DESCRIPTION
- Adds Terrain Blending controls for Blend Strength and Terrain Depth Culling Distance, wired through settings → feature buffer → shader constants and used in blend falloff and depth‑pass culling.

- Updates Terrain Blending UI with a Performance Option header, Blend Strength slider (0.125–1.25, default 1.0), and Depth Culling Distance slider (256–8192, default 2048) plus updated tooltips.

Note: The chosen defaults recapitulate previous default setting of TB. For VR I recomment Blend Strength = 0.5 and Depth Culling Distance = 1024 - but with the slider users can decide themselves - no need for clutter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable terrain blending parameters, including adjustable blend strength and terrain depth culling distance for enhanced control over blending effects.

* **Bug Fixes**
  * Improved terrain blend calculations with division-by-zero protection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->