### PR TITLE
fix(water): remove final colour saturate

### DIFF
--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -1350,7 +1350,7 @@ finalColorPreFog = lerp(finalColorPreFog, preFogColor * PosAdjust[eyeIndex].w, C
 
 #				endif
 #			endif
-	psout.Lighting = saturate(float4(finalColor, isSpecular));
+	psout.Lighting = float4(finalColor, isSpecular);
 #		endif
 
 #		if defined(STENCIL)


### PR DESCRIPTION
i think this accidentally slipped through in unified water.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed water shader color processing to improve lighting accuracy and visual quality of water rendering. The adjustment allows more precise color value handling in water scenes, delivering enhanced lighting effects and improved visual fidelity throughout the environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->