### PR TITLE
fix(unified-water): LOD water cache mismatch

### DIFF
--- a/src/Features/UnifiedWater/WaterCache.cpp
+++ b/src/Features/UnifiedWater/WaterCache.cpp
@@ -41,7 +41,7 @@ bool WaterCache::SetCurrentWorldSpace(const RE::TESWorldSpace* worldSpace)
 
 std::vector<WaterCache::Instruction>* WaterCache::GetInstructions(const RE::TESWorldSpace* worldSpace, const uint32_t lodLevel, const uint32_t x, const uint32_t y)
 {
-	if (!currentCache && !SetCurrentWorldSpace(worldSpace)) {
+	if (!SetCurrentWorldSpace(worldSpace)) {
 		logger::error("[Unified Water] [Cache] Failed to set current cache to {} while getting instructions", worldSpace->GetFormEditorID());
 		return nullptr;
 	}


### PR DESCRIPTION
Current code only calls SetCurrentWorldSpace when currentCache is null. 

The problem scenario:

Player is in worldspace A → currentCache points to A's cache
Player loads into worldspace B
BGSTerrainBlock_Attach fires for worldspace B before TES_SetWorldSpace updates the cache
currentCache is NOT null (still points to A's cache), so SetCurrentWorldSpace is skipped
currentCache->GetInstructions() runs on A's cache with B's coordinates → returns nullptr or garbage
Falls back to vanilla LOD water

The fix ensures SetCurrentWorldSpace is always called, which has a fast early-return if already correct:
The fix just removes a micro-optimization. Worst case, it's slightly slower (one extra string comparison per terrain block attachment). Best case, it fixes the race condition probably causing the lod issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of water system caching by ensuring consistent initialization on each operation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->