### PR TITLE
fix(grass-lighting) better basic grass brightness default

### DIFF
--- a/src/Features/GrassLighting.h
+++ b/src/Features/GrassLighting.h
@@ -34,7 +34,7 @@ public:
 		float SpecularStrength = 0.5f;
 		float SubsurfaceScatteringAmount = 0.5f;
 		uint OverrideComplexGrassSettings = false;
-		float BasicGrassBrightness = 1.0f;
+		float BasicGrassBrightness = 0.33f;
 		uint EnableWrappedLighting = false;
 		float ComplexGrassThreshold = 0.03f;
 		uint pad1;


### PR DESCRIPTION
changes value from 1.0 to 0.33 to better match vanilla.
![2068D2~1](https://github.com/user-attachments/assets/72531fdc-4cf2-4760-93e8-2f3b98941f6e)
![200A05~1](https://github.com/user-attachments/assets/5b54a9e4-b635-4a01-b2f4-8899868aff86)
![20ABE6~1](https://github.com/user-attachments/assets/ee2a4cbd-7819-4439-98fc-fdb3ad46f4c5)
pic 1 new value, pic 2 grass shader off, pic 3 1.0 brightness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated default grass lighting brightness for more natural and balanced outdoor environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->