### PR TITLE
feat(UI): feature headings

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -69,7 +69,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	Menu::ThemeSettings::FeatureHeadingColors,
 	ColorDefault,
 	ColorHovered,
-	MinimizedFactor)
+	MinimizedFactor,
+	FeatureTitleScale)
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	Menu::ThemeSettings::ScrollbarOpacitySettings,

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -282,8 +282,8 @@ public:
 		{
 			ImVec4 ColorDefault{ 0.8f, 0.8f, 0.8f, 1.0f };
 			ImVec4 ColorHovered{ 0.6f, 0.6f, 0.6f, 1.0f };
-			float MinimizedFactor = 0.7f;      // 70% of original alpha for when the header is minimized
-			float FeatureTitleScale = 1.5f;    // Scale multiplier for feature title text in settings tab
+			float MinimizedFactor = 0.7f;    // 70% of original alpha for when the header is minimized
+			float FeatureTitleScale = 1.5f;  // Scale multiplier for feature title text in settings tab
 		} FeatureHeading;
 
 		ImGuiStyle Style = []() {

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -282,7 +282,8 @@ public:
 		{
 			ImVec4 ColorDefault{ 0.8f, 0.8f, 0.8f, 1.0f };
 			ImVec4 ColorHovered{ 0.6f, 0.6f, 0.6f, 1.0f };
-			float MinimizedFactor = 0.7f;  // 70% of original alpha for when the header is minimized
+			float MinimizedFactor = 0.7f;      // 70% of original alpha for when the header is minimized
+			float FeatureTitleScale = 1.5f;    // Scale multiplier for feature title text in settings tab
 		} FeatureHeading;
 
 		ImGuiStyle Style = []() {

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -1,6 +1,7 @@
 #include "FeatureListRenderer.h"
 
 #include <algorithm>
+#include <cmath>
 #include <filesystem>
 #include <format>
 #include <imgui.h>
@@ -55,8 +56,12 @@ namespace
 		auto& palette = themeSettings.Palette;
 		auto& featureHeading = themeSettings.FeatureHeading;
 
-		// Clamp to UI slider range to prevent malformed theme JSON from destabilizing layout
-		const float titleScale = std::clamp(featureHeading.FeatureTitleScale, 1.0f, 3.0f);
+		// Sanitize and clamp to UI slider range to prevent malformed theme JSON from destabilizing layout
+		float titleScale = featureHeading.FeatureTitleScale;
+		if (!std::isfinite(titleScale)) {
+			titleScale = ThemeManager::Constants::DEFAULT_FEATURE_TITLE_SCALE;
+		}
+		titleScale = std::clamp(titleScale, 1.0f, 3.0f);
 
 		ImVec2 startPos = ImGui::GetCursorScreenPos();
 
@@ -98,9 +103,12 @@ namespace
 			ImVec4 versionColor = palette.Text;
 			versionColor.w *= ThemeManager::Constants::VERSION_TEXT_OPACITY;
 
-			ImGui::SetWindowFontScale(titleScale);
-			ImGui::TextColored(versionColor, "v%s", formattedVersion.c_str());
-			ImGui::SetWindowFontScale(1.0f);
+			{
+				MenuFonts::FontRoleGuard bodyGuard(Menu::FontRole::Body);
+				ImGui::SetWindowFontScale(titleScale);
+				ImGui::TextColored(versionColor, "v%s", formattedVersion.c_str());
+				ImGui::SetWindowFontScale(1.0f);
+			}
 
 			// Reset cursor to after the title block
 			ImGui::SetCursorScreenPos(ImVec2(startPos.x, startPos.y + titleSize.y + ImGui::GetStyle().ItemSpacing.y));

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -1,6 +1,7 @@
 #include "FeatureListRenderer.h"
 
 #include <algorithm>
+#include <cmath>
 #include <filesystem>
 #include <format>
 #include <imgui.h>

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -1,7 +1,6 @@
 #include "FeatureListRenderer.h"
 
 #include <algorithm>
-#include <cmath>
 #include <filesystem>
 #include <format>
 #include <imgui.h>
@@ -59,24 +58,16 @@ namespace
 		// Clamp to UI slider range to prevent malformed theme JSON from destabilizing layout
 		const float titleScale = std::clamp(featureHeading.FeatureTitleScale, 1.0f, 3.0f);
 
-		// Calculate text sizes for positioning
+		ImVec2 startPos = ImGui::GetCursorScreenPos();
+
+		// Calculate title size and draw feature name with Title font
 		ImVec2 titleSize;
 		{
 			MenuFonts::FontRoleGuard titleGuard(Menu::FontRole::Title);
 			titleSize = ImGui::CalcTextSize(featureName.c_str());
 			titleSize.x *= titleScale;
 			titleSize.y *= titleScale;
-		}
 
-		// Pixel-align cursor position for sharper text rendering
-		ImVec2 startPos = ImGui::GetCursorScreenPos();
-		startPos.x = std::round(startPos.x);
-		startPos.y = std::round(startPos.y);
-		ImGui::SetCursorScreenPos(startPos);
-
-		// Draw feature name with Title font
-		{
-			MenuFonts::FontRoleGuard titleGuard(Menu::FontRole::Title);
 			ImGui::SetWindowFontScale(titleScale);
 			ImGui::TextUnformatted(featureName.c_str());
 			ImGui::SetWindowFontScale(1.0f);
@@ -97,9 +88,9 @@ namespace
 				versionSize.y *= titleScale;
 			}
 
-			// Position version text: right of title, bottom-aligned, pixel-aligned
-			float versionX = std::round(startPos.x + titleSize.x + ImGui::GetStyle().ItemSpacing.x);
-			float versionY = std::round(startPos.y + titleSize.y - versionSize.y);
+			// Position version text: right of title, bottom-aligned
+			float versionX = startPos.x + titleSize.x + ImGui::GetStyle().ItemSpacing.x;
+			float versionY = startPos.y + titleSize.y - versionSize.y;
 
 			ImGui::SetCursorScreenPos(ImVec2(versionX, versionY));
 
@@ -112,7 +103,7 @@ namespace
 			ImGui::SetWindowFontScale(1.0f);
 
 			// Reset cursor to after the title block
-			ImGui::SetCursorScreenPos(ImVec2(startPos.x, std::round(startPos.y + titleSize.y + ImGui::GetStyle().ItemSpacing.y)));
+			ImGui::SetCursorScreenPos(ImVec2(startPos.x, startPos.y + titleSize.y + ImGui::GetStyle().ItemSpacing.y));
 		}
 
 		// Draw plain separator below

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -43,6 +43,79 @@ namespace
 	{
 		return MenuFonts::BeginTabItemWithFont(label, role, flags);
 	}
+
+	/**
+	 * @brief Draws a feature header with the feature name in large text and version in smaller text
+	 * @param featureName The display name of the feature
+	 * @param version The version string (can be empty)
+	 */
+	void DrawFeatureHeader(const std::string& featureName, const std::string& version)
+	{
+		auto& themeSettings = globals::menu->GetTheme();
+		auto& palette = themeSettings.Palette;
+		auto& featureHeading = themeSettings.FeatureHeading;
+
+		const float titleScale = featureHeading.FeatureTitleScale;
+
+		// Calculate text sizes for positioning
+		ImVec2 titleSize;
+		{
+			MenuFonts::FontRoleGuard titleGuard(Menu::FontRole::Title);
+			titleSize = ImGui::CalcTextSize(featureName.c_str());
+			titleSize.x *= titleScale;
+			titleSize.y *= titleScale;
+		}
+
+		// Pixel-align cursor position for sharper text rendering
+		ImVec2 startPos = ImGui::GetCursorScreenPos();
+		startPos.x = std::round(startPos.x);
+		startPos.y = std::round(startPos.y);
+		ImGui::SetCursorScreenPos(startPos);
+
+		// Draw feature name with Title font
+		{
+			MenuFonts::FontRoleGuard titleGuard(Menu::FontRole::Title);
+			ImGui::SetWindowFontScale(titleScale);
+			ImGui::TextUnformatted(featureName.c_str());
+			ImGui::SetWindowFontScale(1.0f);
+		}
+
+		// Draw version on same line with Body font, bottom-aligned if version exists
+		if (!version.empty()) {
+			// Format version: replace dashes with dots for consistency
+			std::string formattedVersion = version;
+			std::replace(formattedVersion.begin(), formattedVersion.end(), '-', '.');
+
+			// Calculate version text size at scaled size
+			ImVec2 versionSize;
+			{
+				MenuFonts::FontRoleGuard bodyGuard(Menu::FontRole::Body);
+				versionSize = ImGui::CalcTextSize(("v" + formattedVersion).c_str());
+				versionSize.x *= titleScale;
+				versionSize.y *= titleScale;
+			}
+
+			// Position version text: right of title, bottom-aligned, pixel-aligned
+			float versionX = std::round(startPos.x + titleSize.x + ImGui::GetStyle().ItemSpacing.x);
+			float versionY = std::round(startPos.y + titleSize.y - versionSize.y);
+
+			ImGui::SetCursorScreenPos(ImVec2(versionX, versionY));
+
+			// Use dimmed text color for version
+			ImVec4 versionColor = palette.Text;
+			versionColor.w *= ThemeManager::Constants::VERSION_TEXT_OPACITY;
+
+			ImGui::SetWindowFontScale(titleScale);
+			ImGui::TextColored(versionColor, "v%s", formattedVersion.c_str());
+			ImGui::SetWindowFontScale(1.0f);
+
+			// Reset cursor to after the title block
+			ImGui::SetCursorScreenPos(ImVec2(startPos.x, std::round(startPos.y + titleSize.y + ImGui::GetStyle().ItemSpacing.y)));
+		}
+
+		// Draw plain separator below
+		ImGui::Separator();
+	}
 }
 
 void FeatureListRenderer::RenderFeatureList(
@@ -412,7 +485,9 @@ void FeatureListRenderer::DrawMenuVisitor::RenderFeatureSettingsTab(Feature* fea
 	if (ImGui::BeginChild("##FeatureSettingsFrame", { 0, 0 }, true)) {
 		auto& themeSettings = globals::menu->GetSettings().Theme;
 
-		SeparatorTextWithFont("Feature Settings", Menu::FontRole::Subheading);
+		// Draw feature header with name and version
+		DrawFeatureHeader(feat->GetName(), isLoaded ? feat->version : "");
+
 		if (isDisabled) {
 			ImGui::TextColored(themeSettings.StatusPalette.Disable, "Feature settings are hidden because this feature is disabled at boot.");
 			ImGui::Spacing();

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -55,7 +55,8 @@ namespace
 		auto& palette = themeSettings.Palette;
 		auto& featureHeading = themeSettings.FeatureHeading;
 
-		const float titleScale = featureHeading.FeatureTitleScale;
+		// Clamp to UI slider range to prevent malformed theme JSON from destabilizing layout
+		const float titleScale = std::clamp(featureHeading.FeatureTitleScale, 1.0f, 3.0f);
 
 		// Calculate text sizes for positioning
 		ImVec2 titleSize;

--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -818,6 +818,18 @@ void SettingsTabRenderer::RenderFontsTab()
 				menuInstance->pendingFontReload = true;
 			}
 
+			// Add Feature Title Scale slider under Title font role
+			if (role == Menu::FontRole::Title) {
+				ImGui::SliderFloat("Feature Header Scale", &themeSettings.FeatureHeading.FeatureTitleScale, 1.0f, 3.0f, "%.1fx", ImGuiSliderFlags_AlwaysClamp);
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					ImGui::Text("Scale multiplier for feature title text in the Settings tab.");
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("Reset##FeatureHeaderScale")) {
+					themeSettings.FeatureHeading.FeatureTitleScale = ThemeManager::Constants::DEFAULT_FEATURE_TITLE_SCALE;
+				}
+			}
+
 			ImGui::Separator();
 			ImGui::PopID();
 		}

--- a/src/Menu/ThemeManager.h
+++ b/src/Menu/ThemeManager.h
@@ -180,6 +180,10 @@ public:
 		static constexpr float SEPARATOR_THICKNESS = 3.0f;
 		static constexpr float UNDOCKED_ICON_ITEM_SPACING = 6.0f;
 		static constexpr float POPUP_BUTTON_WIDTH = 180.0f;
+
+		// Feature header constants
+		static constexpr float DEFAULT_FEATURE_TITLE_SCALE = 1.5f;  // Default scale for feature title text
+		static constexpr float VERSION_TEXT_OPACITY = 0.6f;         // Opacity for version text next to feature title
 	};
 
 	static ThemeManager* GetSingleton()


### PR DESCRIPTION
Adds headings to the individual features.

<img width="2560" height="1440" alt="Skyrim Special Edition 1_22_2026 1_54_26 AM" src="https://i.postimg.cc/fTnhjB5n/Skyrim-Special-Edition-1-30-2026-9-01-50-AM.png" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Feature Header Scale" slider in Fonts settings (range 1.0–3.0) with Reset and tooltip to adjust feature header text size.
  * Settings tab headers now display the feature name with an adjacent, dimmed version string when available.

* **Chores**
  * Added default values for feature header scale and version text opacity for consistent appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->