### PR TITLE
chore(UI): theme consistency

### DIFF
--- a/package/SKSE/Plugins/CommunityShaders/Themes/Default.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/Default.json
@@ -68,7 +68,7 @@
             "ThumbActive": 0.8
         },
         "Style": {
-            "WindowBorderSize": 0.0,
+            "WindowBorderSize": 2.0,
             "ChildBorderSize": 0.0,
             "FrameBorderSize": 0.0,
             "WindowPadding": [8.0, 8.0],

--- a/package/SKSE/Plugins/CommunityShaders/Themes/DragonBlood.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/DragonBlood.json
@@ -36,6 +36,7 @@
         "UseSimplePalette": false,
         "ShowActionIcons": true,
         "UseMonochromeIcons": true,
+        "CenterHeader": true,
         "TooltipHoverDelay": 0.5,
         "BackgroundBlurEnabled": false,
         "Palette": {

--- a/package/SKSE/Plugins/CommunityShaders/Themes/HighContrast.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/HighContrast.json
@@ -36,6 +36,7 @@
         "UseSimplePalette": false,
         "ShowActionIcons": true,
         "UseMonochromeIcons": false,
+        "CenterHeader": true,
         "TooltipHoverDelay": 0.5,
         "BackgroundBlurEnabled": false,
         "Palette": {

--- a/package/SKSE/Plugins/CommunityShaders/Themes/NordicFrost.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/NordicFrost.json
@@ -36,6 +36,7 @@
         "UseSimplePalette": false,
         "ShowActionIcons": true,
         "UseMonochromeIcons": true,
+        "CenterHeader": true,
         "TooltipHoverDelay": 0.5,
         "BackgroundBlurEnabled": false,
         "Palette": {


### PR DESCRIPTION
Centers the headers by default for all themes.

Changes the default window boarder size to 2.0 for the default theme to make borders of the window visible on a black background (for example the loading screen).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved window border visibility in the Default theme with increased border thickness
  * Added centered header layout option to multiple UI themes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->