### PR TITLE
fix(TerrainBlending): reduce offset depth to prevent ground artifacts

### DIFF
--- a/package/Shaders/Utility.hlsl
+++ b/package/Shaders/Utility.hlsl
@@ -270,7 +270,7 @@ VS_OUTPUT main(VS_INPUT input)
 #	endif
 
 #	if defined(OFFSET_DEPTH)
-	vsout.PositionCS.z += 5.0;
+	vsout.PositionCS.z += 1.25;
 #	endif
 
 #	ifdef VR

--- a/src/Features/WeatherEditor.h
+++ b/src/Features/WeatherEditor.h
@@ -17,6 +17,7 @@ public:
 	virtual inline std::string GetShortName() override { return "WeatherEditor"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "WEATHER"; }
 	virtual inline std::string_view GetCategory() const override { return "Utility"; }
+	virtual inline bool SupportsVR() override { return true; }
 	virtual inline std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{
 		return {
@@ -26,6 +27,7 @@ public:
 				"Real-time editing and previewing of effects" }
 		};
 	}
+	virtual bool SupportsVR() override { return true; }
 
 	virtual void DataLoaded() override;
 	virtual void DrawSettings() override;


### PR DESCRIPTION
Issue:
In VR with Terrain Blending, a rectangular ground shadow artifact can appears (not always). The artifact moves with the HMD, is visible in the shadowmask path, and is gone when TB is toggled off. The acrtifact scales with TB’s depth mismatch; lowering the bias removes it while keeping blending stable.

Fix: Decreasing Depth Offset Utility.hlsl to vsout.PositionCS.z += 1.25;  I could see no difference in blending on snow, rock etc when using values from 1.5 to 10.

--> I have not tested this extensively in flat! but in principle it should behave the same as VR.

Examples: vsout.PositionCS.z += 10;
<img width="1711" height="1401" alt="vs10" src="https://github.com/user-attachments/assets/f39cc304-5707-4851-b868-76044ffcd933" />

Examples: vsout.PositionCS.z += 5;  -> artifact only visible when looking straight down
<img width="1686" height="762" alt="vs5d" src="https://github.com/user-attachments/assets/fafab49f-015f-4ab4-adbd-5fad8b49ac26" />

Examples: vsout.PositionCS.z += 1.25; -> artifact not visible anymore in HMD
<img width="1632" height="1534" alt="vs125" src="https://github.com/user-attachments/assets/d8ea20e8-96af-4f47-862b-ba6e5acd5722" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced depth rendering offset to improve visual layering and reduce z-fighting in 3D scenes.
* **New Features**
  * Editor now advertises VR support, enabling VR-aware tooling and workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->