### PR TITLE
fix(TerrainBlending): prevent ground artifact shadows

### DIFF
--- a/package/Shaders/Utility.hlsl
+++ b/package/Shaders/Utility.hlsl
@@ -270,7 +270,7 @@ VS_OUTPUT main(VS_INPUT input)
 #	endif
 
 #	if defined(OFFSET_DEPTH)
-	vsout.PositionCS.z += 5.0;
+	vsout.PositionCS.z += 1.25;
 #	endif
 
 #	ifdef VR


### PR DESCRIPTION
Issue:
In VR with Terrain Blending, a rectangular ground shadow artifact can appears (not always). The artifact moves with the HMD, is visible in the shadowmask path, and is gone when TB is toggled off. The acrtifact scales with TB’s depth mismatch; lowering the bias removes it while keeping blending stable.

Fix: Decreasing Depth Offset Utility.hlsl to vsout.PositionCS.z += 1.25; I could see no difference in blending on snow, rock etc when using values from 1.5 to 10.

--> I have not tested this extensively in flat! but in principle it should behave the same as VR.

Example: vsout.PositionCS.z += 10;
<img width="1711" height="1401" alt="vs10" src="https://github.com/user-attachments/assets/de609694-a309-43b9-bd40-85dc255e1e57" />

Example: vsout.PositionCS.z += 5; -> artifact only visible when looking straight down
<img width="1686" height="762" alt="vs5d" src="https://github.com/user-attachments/assets/1043fb9d-e59a-4582-9a91-6d6ef2b6e16a" />

Example: vsout.PositionCS.z += 1.25; -> artifact not visible anymore in HMD
<img width="1632" height="1534" alt="vs125" src="https://github.com/user-attachments/assets/9b6a4114-a2a8-4967-afdc-d64301079daf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted depth offset calculations to enhance rendering accuracy in shadow mapping and VR scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->