### PR TITLE
feat(VR): add wand pointing

### DIFF
--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -60,7 +60,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	comboTimeout,
 	EnableDragToReposition,
 	kAutoHideSeconds,
-	VRMenuAutoResetDistance)
+	VRMenuAutoResetDistance,
+	EnableWandPointing)
 
 //=============================================================================
 // FEATURE BASE CLASS OVERRIDES
@@ -697,9 +698,25 @@ namespace
 		if (!vr.openVRInfo.isCompatible)
 			return;
 		VR::Settings& settings = vr.settings;
-		if (ImGui::CollapsingHeader("Mouse Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
+		if (ImGui::CollapsingHeader("Input Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
+			// Wand pointing settings
+			if (ImGui::Checkbox("Enable Wand Pointing", &settings.EnableWandPointing)) {
+				// Reset wand state when toggling
+				vr.wandState.isIntersecting = false;
+			}
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text("Use controller ray-casting to point at UI elements");
+			}
+			ImGui::Separator();
+			ImGui::Text("Joystick Settings");
 			ImGui::SliderFloat("Mouse Deadzone", &settings.mouseDeadzone, 0.0f, 1.0f, "%.2f");
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text("Thumbstick deadzone for joystick cursor movement");
+			}
 			ImGui::SliderFloat("Mouse Speed", &settings.mouseSpeed, 0.1f, 50.0f, "%.2f");
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text("Speed multiplier for joystick cursor movement");
+			}
 		}
 	}
 
@@ -1165,6 +1182,56 @@ namespace
 						}
 					}
 				}
+				ImGui::EndTable();
+			}
+
+			// Wand Pointing Diagnostics
+			ImGui::SeparatorText("Wand Pointing State");
+			if (ImGui::BeginTable("##WandPointingState", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
+				ImGui::TableSetupColumn("Property", ImGuiTableColumnFlags_WidthFixed, 200.0f);
+				ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
+				ImGui::TableHeadersRow();
+
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::Text("Wand Pointing Enabled");
+				ImGui::TableSetColumnIndex(1);
+				ImGui::Text("%s", settings.EnableWandPointing ? "Yes" : "No");
+
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::Text("Intersecting Overlay");
+				ImGui::TableSetColumnIndex(1);
+				if (vr.wandState.isIntersecting) {
+					ImGui::TextColored(menu->GetTheme().StatusPalette.InfoColor, "YES");
+				} else {
+					ImGui::Text("No");
+				}
+
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::Text("UV Coordinates");
+				ImGui::TableSetColumnIndex(1);
+				ImGui::Text("(%.3f, %.3f)", vr.wandState.uvCoordinates.x, vr.wandState.uvCoordinates.y);
+
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::Text("Controller Index");
+				ImGui::TableSetColumnIndex(1);
+				ImGui::Text("%u", vr.wandState.controllerIndex);
+
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::Text("Ray Origin");
+				ImGui::TableSetColumnIndex(1);
+				ImGui::Text("(%.2f, %.2f, %.2f)", vr.wandState.rayOrigin.x, vr.wandState.rayOrigin.y, vr.wandState.rayOrigin.z);
+
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				ImGui::Text("Ray Direction");
+				ImGui::TableSetColumnIndex(1);
+				ImGui::Text("(%.2f, %.2f, %.2f)", vr.wandState.rayDirection.x, vr.wandState.rayDirection.y, vr.wandState.rayDirection.z);
+
 				ImGui::EndTable();
 			}
 		}
@@ -1896,7 +1963,42 @@ void VR::UpdateControllerState(const Menu::KeyEvent& event)
 	}
 }
 
-// Converts VR controller thumbstick input to ImGui mouse and scroll events for the overlay UI
+// Helper function to process thumbstick input for scrolling
+void VR::ProcessThumbstickScroll(RE::VRControllerState& controllerState, size_t thumbstickIndex, float deadzone, ImGuiIO& io)
+{
+	bool usingScrollStickX = (std::abs(controllerState.thumbsticks[thumbstickIndex].x) > deadzone);
+	bool usingScrollStickY = (std::abs(controllerState.thumbsticks[thumbstickIndex].y) > deadzone);
+
+	if (usingScrollStickX || usingScrollStickY) {
+		static float scrollAccumX = 0.0f;
+		static float scrollAccumY = 0.0f;
+
+		// Accumulate scroll input with sensitivity scaling
+		scrollAccumX += controllerState.thumbsticks[thumbstickIndex].x * 0.1f;
+		scrollAccumY += controllerState.thumbsticks[thumbstickIndex].y * 0.1f;
+
+		// Send scroll events when accumulated enough input
+		float scrollEventX = 0.0f;
+		float scrollEventY = 0.0f;
+
+		if (std::abs(scrollAccumX) > 0.3f) {
+			scrollEventX = scrollAccumX > 0 ? 1.0f : -1.0f;
+			scrollAccumX = 0.0f;
+		}
+		if (std::abs(scrollAccumY) > 0.3f) {
+			scrollEventY = scrollAccumY > 0 ? 1.0f : -1.0f;
+			scrollAccumY = 0.0f;
+		}
+
+		// Send both horizontal and vertical scroll events if needed
+		if (scrollEventX != 0.0f || scrollEventY != 0.0f) {
+			io.AddMouseWheelEvent(scrollEventX, scrollEventY);
+		}
+	}
+}
+
+// Converts VR controller input to ImGui mouse and scroll events for the overlay UI
+// Supports both modern wand pointing and traditional thumbstick control
 void VR::ProcessControllerInputForImGui()
 {
 	if (!globals::menu->IsEnabled)
@@ -1907,95 +2009,74 @@ void VR::ProcessControllerInputForImGui()
 	ImGuiIO& io = ImGui::GetIO();
 	io.ConfigFlags &= ~ImGuiConfigFlags_NoMouseCursorChange;
 	io.WantSetMousePos = false;
+
+	// Try wand pointing first
+	bool wandHandledCursor = false;
+	if (!testMode && settings.EnableWandPointing) {
+		UpdateCursorFromWandPointing();
+		wandHandledCursor = wandState.isIntersecting;
+	}
+
 	if (!testMode) {
-		// Determine which controller should handle cursor vs scrolling based on attachment mode
-		bool useAttachedControllerForCursor = (settings.attachMode == VR::Settings::OverlayAttachMode::ControllerOnly ||
-											   settings.attachMode == VR::Settings::OverlayAttachMode::Both);
+		// When wand is handling cursor, BOTH thumbsticks become scroll controls
+		// When wand is NOT active, use traditional cursor/scroll assignment
+		if (wandHandledCursor) {
+			// Wand mode: Both thumbsticks scroll
+			ProcessThumbstickScroll(primaryControllerState, static_cast<size_t>(RE::ControllerRole::Primary), mouseDeadzone, io);
+			ProcessThumbstickScroll(secondaryControllerState, static_cast<size_t>(RE::ControllerRole::Secondary), mouseDeadzone, io);
+		} else {
+			// Traditional mode: Determine which controller handles cursor vs scrolling
+			bool useAttachedControllerForCursor = (settings.attachMode == VR::Settings::OverlayAttachMode::ControllerOnly ||
+												   settings.attachMode == VR::Settings::OverlayAttachMode::Both);
 
-		// Assign cursor and scroll controllers based on settings
-		RE::VRControllerState* cursorController = nullptr;
-		RE::VRControllerState* scrollController = nullptr;
+			RE::VRControllerState* cursorController = nullptr;
+			RE::VRControllerState* scrollController = nullptr;
 
-		if (useAttachedControllerForCursor) {
-			// When attached to controller: attached controller = cursor, other controller = scrolling
-			if (settings.VRMenuAttachController == ControllerDevice::Primary) {
+			if (useAttachedControllerForCursor) {
+				// When attached to controller: attached controller = cursor, other controller = scrolling
+				if (settings.VRMenuAttachController == ControllerDevice::Primary) {
+					cursorController = &primaryControllerState;
+					scrollController = &secondaryControllerState;
+				} else {
+					cursorController = &secondaryControllerState;
+					scrollController = &primaryControllerState;
+				}
+			} else {
+				// HMD mode: primary = cursor, secondary = scroll (traditional)
 				cursorController = &primaryControllerState;
 				scrollController = &secondaryControllerState;
-			} else {
-				cursorController = &secondaryControllerState;
-				scrollController = &primaryControllerState;
 			}
-		} else {
-			// HMD mode: primary = cursor, secondary = scroll (traditional)
-			cursorController = &primaryControllerState;
-			scrollController = &secondaryControllerState;
-		}
 
-		// Cursor movement (from determined cursor controller)
-		if (cursorController) {
-			// Determine the correct thumbstick index based on which controller we're using
-			size_t thumbstickIndex = (cursorController == &primaryControllerState) ?
-			                             static_cast<size_t>(RE::ControllerRole::Primary) :
-			                             static_cast<size_t>(RE::ControllerRole::Secondary);
+			// Cursor movement (from determined cursor controller)
+			if (cursorController) {
+				size_t thumbstickIndex = (cursorController == &primaryControllerState) ?
+				                             static_cast<size_t>(RE::ControllerRole::Primary) :
+				                             static_cast<size_t>(RE::ControllerRole::Secondary);
 
-			float thumbstickX = cursorController->thumbsticks[thumbstickIndex].x;
-			float thumbstickY = cursorController->thumbsticks[thumbstickIndex].y;
-			bool usingCursorStick = (std::abs(thumbstickX) > mouseDeadzone || std::abs(thumbstickY) > mouseDeadzone);
-			if (usingCursorStick) {
-				ImVec2 mousePos = io.MousePos;
-				mousePos.x += thumbstickX * mouseSpeed;
-				mousePos.y -= thumbstickY * mouseSpeed;
-				if (mousePos.x < 0)
-					mousePos.x = 0;
-				if (mousePos.y < 0)
-					mousePos.y = 0;
-				if (mousePos.x > io.DisplaySize.x)
-					mousePos.x = io.DisplaySize.x;
-				if (mousePos.y > io.DisplaySize.y)
-					mousePos.y = io.DisplaySize.y;
-				io.MousePos = mousePos;
-				io.AddMousePosEvent(mousePos.x, mousePos.y);
-				io.MouseDrawCursor = true;
-				io.WantSetMousePos = true;
-				io.AddMouseButtonEvent(ImGuiMouseButton_Left, false);
+				float thumbstickX = cursorController->thumbsticks[thumbstickIndex].x;
+				float thumbstickY = cursorController->thumbsticks[thumbstickIndex].y;
+				bool usingCursorStick = (std::abs(thumbstickX) > mouseDeadzone || std::abs(thumbstickY) > mouseDeadzone);
+
+				if (usingCursorStick) {
+					ImVec2 mousePos = io.MousePos;
+					mousePos.x += thumbstickX * mouseSpeed;
+					mousePos.y -= thumbstickY * mouseSpeed;
+					mousePos.x = std::clamp(mousePos.x, 0.0f, io.DisplaySize.x);
+					mousePos.y = std::clamp(mousePos.y, 0.0f, io.DisplaySize.y);
+					io.MousePos = mousePos;
+					io.AddMousePosEvent(mousePos.x, mousePos.y);
+					io.MouseDrawCursor = true;
+					io.WantSetMousePos = true;
+					io.AddMouseButtonEvent(ImGuiMouseButton_Left, false);
+				}
 			}
-		}
 
-		// Scrolling (from determined scroll controller) - both horizontal and vertical
-		if (scrollController) {
-			// Determine the correct thumbstick index based on which controller we're using
-			size_t thumbstickIndex = (scrollController == &primaryControllerState) ?
-			                             static_cast<size_t>(RE::ControllerRole::Primary) :
-			                             static_cast<size_t>(RE::ControllerRole::Secondary);
-
-			bool usingScrollStickX = (std::abs(scrollController->thumbsticks[thumbstickIndex].x) > mouseDeadzone);
-			bool usingScrollStickY = (std::abs(scrollController->thumbsticks[thumbstickIndex].y) > mouseDeadzone);
-
-			if (usingScrollStickX || usingScrollStickY) {
-				static float scrollAccumX = 0.0f;
-				static float scrollAccumY = 0.0f;
-
-				// Accumulate scroll input with sensitivity scaling
-				scrollAccumX += scrollController->thumbsticks[thumbstickIndex].x * 0.1f;
-				scrollAccumY += scrollController->thumbsticks[thumbstickIndex].y * 0.1f;
-
-				// Send scroll events when accumulated enough input
-				float scrollEventX = 0.0f;
-				float scrollEventY = 0.0f;
-
-				if (std::abs(scrollAccumX) > 0.3f) {
-					scrollEventX = scrollAccumX > 0 ? 1.0f : -1.0f;
-					scrollAccumX = 0.0f;
-				}
-				if (std::abs(scrollAccumY) > 0.3f) {
-					scrollEventY = scrollAccumY > 0 ? 1.0f : -1.0f;
-					scrollAccumY = 0.0f;
-				}
-
-				// Send both horizontal and vertical scroll events if needed
-				if (scrollEventX != 0.0f || scrollEventY != 0.0f) {
-					io.AddMouseWheelEvent(scrollEventX, scrollEventY);
-				}
+			// Scrolling (from determined scroll controller)
+			if (scrollController) {
+				size_t thumbstickIndex = (scrollController == &primaryControllerState) ?
+				                             static_cast<size_t>(RE::ControllerRole::Primary) :
+				                             static_cast<size_t>(RE::ControllerRole::Secondary);
+				ProcessThumbstickScroll(*scrollController, thumbstickIndex, mouseDeadzone, io);
 			}
 		}
 	}
@@ -2454,4 +2535,109 @@ bool VR::IsOpenVRCompatible() const
 	}
 
 	return false;  // Not compatible unless explicitly whitelisted
+}
+
+//=============================================================================
+// WAND POINTING IMPLEMENTATION
+//=============================================================================
+
+bool VR::ComputeWandIntersection(vr::VROverlayHandle_t overlayHandle, vr::TrackedDeviceIndex_t controllerIndex, ImVec2& outUV)
+{
+	Util::OpenVRContext ctx;
+	if (!ctx.HasOverlay())
+		return false;
+
+	// Use utility function for core intersection logic
+	bool intersected = Util::ComputeWandIntersection(ctx.overlay, overlayHandle, controllerIndex, outUV);
+
+	if (intersected) {
+		// Update wand state for debugging and visualization
+		wandState.isIntersecting = true;
+		wandState.uvCoordinates = outUV;
+		wandState.controllerIndex = controllerIndex;
+
+		// Get controller pose for ray geometry (for debugging/laser visualization)
+		vr::TrackedDevicePose_t poses[vr::k_unMaxTrackedDeviceCount];
+		if (Util::GetDeviceToAbsoluteTrackingPoseCompatible(vr::TrackingUniverseStanding, 0, poses, vr::k_unMaxTrackedDeviceCount)) {
+			if (poses[controllerIndex].bPoseIsValid) {
+				wandState.rayOrigin = Vector3(
+					poses[controllerIndex].mDeviceToAbsoluteTracking.m[0][3],
+					poses[controllerIndex].mDeviceToAbsoluteTracking.m[1][3],
+					poses[controllerIndex].mDeviceToAbsoluteTracking.m[2][3]);
+				wandState.rayDirection = Vector3(
+					-poses[controllerIndex].mDeviceToAbsoluteTracking.m[0][2],
+					-poses[controllerIndex].mDeviceToAbsoluteTracking.m[1][2],
+					-poses[controllerIndex].mDeviceToAbsoluteTracking.m[2][2]);
+			}
+		}
+	} else {
+		wandState.isIntersecting = false;
+	}
+
+	return intersected;
+}
+
+void VR::UpdateCursorFromWandPointing()
+{
+	// Only update cursor when menu is active (ImGui must be initialized)
+	if (!settings.EnableWandPointing || !globals::menu->IsEnabled)
+		return;
+
+	ImGuiIO& io = ImGui::GetIO();
+
+	// Determine which controller should be used for pointing
+	// Use non-attached controller (free hand points at menu on other hand)
+	vr::TrackedDeviceIndex_t pointingController = vr::k_unTrackedDeviceIndexInvalid;
+
+	if (settings.attachMode == AttachMode::ControllerOnly || settings.attachMode == AttachMode::Both) {
+		// If menu is attached to a controller, use the OTHER controller for pointing
+		ControllerDevice oppositeController = (settings.VRMenuAttachController == ControllerDevice::Primary) ?
+		                                          ControllerDevice::Secondary :
+		                                          ControllerDevice::Primary;
+		pointingController = Util::GetControllerIndexForDevice(oppositeController, lastKnownLeftHandedMode);
+	} else {
+		// HMD-only mode: use primary (dominant) hand for pointing
+		pointingController = Util::GetControllerIndexForDevice(ControllerDevice::Primary, lastKnownLeftHandedMode);
+	}
+
+	if (pointingController == vr::k_unTrackedDeviceIndexInvalid)
+		return;
+
+	// Try to get intersection with active overlay
+	ImVec2 uv;
+	bool intersected = false;
+	vr::VROverlayHandle_t activeOverlay = vr::k_ulOverlayHandleInvalid;
+
+	// Check HMD overlay first
+	if (menuOverlayHandle != vr::k_ulOverlayHandleInvalid) {
+		if (ComputeWandIntersection(menuOverlayHandle, pointingController, uv)) {
+			intersected = true;
+			activeOverlay = menuOverlayHandle;
+		}
+	}
+
+	// If HMD overlay didn't intersect, try controller overlay
+	if (!intersected && menuControllerOverlayHandle != vr::k_ulOverlayHandleInvalid) {
+		if (ComputeWandIntersection(menuControllerOverlayHandle, pointingController, uv)) {
+			intersected = true;
+			activeOverlay = menuControllerOverlayHandle;
+		}
+	}
+
+	// Update cursor position from intersection
+	if (intersected) {
+		// Convert UV (0-1) to screen pixel coordinates
+		// Invert Y to match laser visualization (OpenVR UV has 0 at bottom)
+		float screenX = uv.x * io.DisplaySize.x;
+		float screenY = (1.0f - uv.y) * io.DisplaySize.y;
+
+		// Clamp to screen bounds
+		screenX = std::clamp(screenX, 0.0f, io.DisplaySize.x - 1.0f);
+		screenY = std::clamp(screenY, 0.0f, io.DisplaySize.y - 1.0f);
+
+		io.MousePos = ImVec2(screenX, screenY);
+		io.AddMousePosEvent(screenX, screenY);
+		io.MouseDrawCursor = true;
+		io.WantSetMousePos = true;
+	}
 }

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -1970,24 +1970,30 @@ void VR::ProcessThumbstickScroll(RE::VRControllerState& controllerState, size_t 
 	bool usingScrollStickY = (std::abs(controllerState.thumbsticks[thumbstickIndex].y) > deadzone);
 
 	if (usingScrollStickX || usingScrollStickY) {
-		static float scrollAccumX = 0.0f;
-		static float scrollAccumY = 0.0f;
+		// Per-controller scroll accumulation to prevent interference between controllers
+		struct ScrollAccum
+		{
+			float x = 0.0f;
+			float y = 0.0f;
+		};
+		static std::unordered_map<size_t, ScrollAccum> scrollAccums;
+		ScrollAccum& accum = scrollAccums[thumbstickIndex];
 
 		// Accumulate scroll input with sensitivity scaling
-		scrollAccumX += controllerState.thumbsticks[thumbstickIndex].x * 0.1f;
-		scrollAccumY += controllerState.thumbsticks[thumbstickIndex].y * 0.1f;
+		accum.x += controllerState.thumbsticks[thumbstickIndex].x * 0.1f;
+		accum.y += controllerState.thumbsticks[thumbstickIndex].y * 0.1f;
 
 		// Send scroll events when accumulated enough input
 		float scrollEventX = 0.0f;
 		float scrollEventY = 0.0f;
 
-		if (std::abs(scrollAccumX) > 0.3f) {
-			scrollEventX = scrollAccumX > 0 ? 1.0f : -1.0f;
-			scrollAccumX = 0.0f;
+		if (std::abs(accum.x) > 0.3f) {
+			scrollEventX = accum.x > 0 ? 1.0f : -1.0f;
+			accum.x = 0.0f;
 		}
-		if (std::abs(scrollAccumY) > 0.3f) {
-			scrollEventY = scrollAccumY > 0 ? 1.0f : -1.0f;
-			scrollAccumY = 0.0f;
+		if (std::abs(accum.y) > 0.3f) {
+			scrollEventY = accum.y > 0 ? 1.0f : -1.0f;
+			accum.y = 0.0f;
 		}
 
 		// Send both horizontal and vertical scroll events if needed
@@ -2600,19 +2606,19 @@ void VR::UpdateCursorFromWandPointing()
 		pointingController = Util::GetControllerIndexForDevice(ControllerDevice::Primary, lastKnownLeftHandedMode);
 	}
 
-	if (pointingController == vr::k_unTrackedDeviceIndexInvalid)
+	if (pointingController == vr::k_unTrackedDeviceIndexInvalid) {
+		wandState.isIntersecting = false;
 		return;
+	}
 
 	// Try to get intersection with active overlay
 	ImVec2 uv;
 	bool intersected = false;
-	vr::VROverlayHandle_t activeOverlay = vr::k_ulOverlayHandleInvalid;
 
 	// Check HMD overlay first
 	if (menuOverlayHandle != vr::k_ulOverlayHandleInvalid) {
 		if (ComputeWandIntersection(menuOverlayHandle, pointingController, uv)) {
 			intersected = true;
-			activeOverlay = menuOverlayHandle;
 		}
 	}
 
@@ -2620,7 +2626,6 @@ void VR::UpdateCursorFromWandPointing()
 	if (!intersected && menuControllerOverlayHandle != vr::k_ulOverlayHandleInvalid) {
 		if (ComputeWandIntersection(menuControllerOverlayHandle, pointingController, uv)) {
 			intersected = true;
-			activeOverlay = menuControllerOverlayHandle;
 		}
 	}
 
@@ -2639,5 +2644,8 @@ void VR::UpdateCursorFromWandPointing()
 		io.AddMousePosEvent(screenX, screenY);
 		io.MouseDrawCursor = true;
 		io.WantSetMousePos = true;
+	} else {
+		// Ensure wand state is cleared if no intersection
+		wandState.isIntersecting = false;
 	}
 }

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -2636,9 +2636,9 @@ void VR::UpdateCursorFromWandPointing()
 		float screenX = uv.x * io.DisplaySize.x;
 		float screenY = (1.0f - uv.y) * io.DisplaySize.y;
 
-		// Clamp to screen bounds
-		screenX = std::clamp(screenX, 0.0f, io.DisplaySize.x - 1.0f);
-		screenY = std::clamp(screenY, 0.0f, io.DisplaySize.y - 1.0f);
+		// Clamp to screen bounds (allow full display size, consistent with thumbstick cursor)
+		screenX = std::clamp(screenX, 0.0f, io.DisplaySize.x);
+		screenY = std::clamp(screenY, 0.0f, io.DisplaySize.y);
 
 		io.MousePos = ImVec2(screenX, screenY);
 		io.AddMousePosEvent(screenX, screenY);

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -349,6 +349,9 @@ public:
 		float mouseDeadzone = Config::kDefaultMouseDeadzone;  ///< Thumbstick deadzone for mouse input (0.0-1.0)
 		float mouseSpeed = Config::kDefaultMouseSpeed;        ///< Mouse speed multiplier (0.1-50.0)
 
+		// Wand pointing settings
+		bool EnableWandPointing = true;  ///< Enable controller wand/ray-cast pointing (modern VR input)
+
 		// Visual customization
 		std::array<float, 4> dragHighlightColor = { 1.0f, 1.0f, 0.0f, 0.3f };  ///< RGBA color for drag highlight
 
@@ -419,9 +422,14 @@ public:
 	void UpdateVROverlayControllerPosition();
 
 	void ProcessVREvents(std::vector<Menu::KeyEvent>& vrEvents);
+
+	// Wand pointing methods
+	bool ComputeWandIntersection(vr::VROverlayHandle_t overlayHandle, vr::TrackedDeviceIndex_t controllerIndex, ImVec2& outUV);
+	void UpdateCursorFromWandPointing();
 	void UpdateOverlayMenuStateFromInput();
 	void ProcessVRButtonEvent(const Menu::KeyEvent& event);
 	void UpdateControllerState(const Menu::KeyEvent& event);
+	void ProcessThumbstickScroll(RE::VRControllerState& controllerState, size_t thumbstickIndex, float deadzone, ImGuiIO& io);
 	void ProcessControllerInputForImGui();
 
 	void EnsureOverlayInitialized();
@@ -584,6 +592,16 @@ public:
 	} openVRInfo;
 
 	RE::NiPoint3 savedPlayerWorldPos = RE::NiPoint3();  // Used for auto-reset distance check
+
+	// Wand pointing state
+	struct WandIntersectionState
+	{
+		bool isIntersecting = false;
+		ImVec2 uvCoordinates = ImVec2(0.0f, 0.0f);
+		vr::TrackedDeviceIndex_t controllerIndex = vr::k_unTrackedDeviceIndexInvalid;
+		Vector3 rayOrigin = Vector3::Zero;
+		Vector3 rayDirection = Vector3::Zero;
+	} wandState;
 
 public:
 	//=============================================================================

--- a/src/Utils/VRUtils.cpp
+++ b/src/Utils/VRUtils.cpp
@@ -290,4 +290,45 @@ namespace Util
 		// If compositor methods failed, return false rather than using the problematic direct call
 		return false;
 	}
+
+	//=============================================================================
+	// WAND POINTING IMPLEMENTATION
+	//=============================================================================
+
+	bool ComputeWandIntersection(vr::IVROverlay* overlay, vr::VROverlayHandle_t overlayHandle,
+		vr::TrackedDeviceIndex_t controllerIndex, ImVec2& outUV)
+	{
+		if (!overlay || overlayHandle == vr::k_ulOverlayHandleInvalid || controllerIndex == vr::k_unTrackedDeviceIndexInvalid)
+			return false;
+
+		// Get controller pose
+		vr::TrackedDevicePose_t poses[vr::k_unMaxTrackedDeviceCount];
+		if (!GetDeviceToAbsoluteTrackingPoseCompatible(vr::TrackingUniverseStanding, 0, poses, vr::k_unMaxTrackedDeviceCount))
+			return false;
+
+		if (!poses[controllerIndex].bPoseIsValid)
+			return false;
+
+		// Compute intersection using OpenVR's built-in ray-casting
+		vr::VROverlayIntersectionParams_t params;
+		params.eOrigin = vr::TrackingUniverseStanding;
+		params.vSource.v[0] = poses[controllerIndex].mDeviceToAbsoluteTracking.m[0][3];
+		params.vSource.v[1] = poses[controllerIndex].mDeviceToAbsoluteTracking.m[1][3];
+		params.vSource.v[2] = poses[controllerIndex].mDeviceToAbsoluteTracking.m[2][3];
+
+		// Ray direction is the -Z axis of the controller (forward vector)
+		params.vDirection.v[0] = -poses[controllerIndex].mDeviceToAbsoluteTracking.m[0][2];
+		params.vDirection.v[1] = -poses[controllerIndex].mDeviceToAbsoluteTracking.m[1][2];
+		params.vDirection.v[2] = -poses[controllerIndex].mDeviceToAbsoluteTracking.m[2][2];
+
+		vr::VROverlayIntersectionResults_t results;
+		if (overlay->ComputeOverlayIntersection(overlayHandle, &params, &results)) {
+			// Convert UV coordinates (0-1 range) to output
+			outUV.x = results.vUVs.v[0];
+			outUV.y = results.vUVs.v[1];
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/src/Utils/VRUtils.cpp
+++ b/src/Utils/VRUtils.cpp
@@ -301,6 +301,10 @@ namespace Util
 		if (!overlay || overlayHandle == vr::k_ulOverlayHandleInvalid || controllerIndex == vr::k_unTrackedDeviceIndexInvalid)
 			return false;
 
+		// Bounds check to prevent array out-of-bounds access
+		if (controllerIndex >= vr::k_unMaxTrackedDeviceCount)
+			return false;
+
 		// Get controller pose
 		vr::TrackedDevicePose_t poses[vr::k_unMaxTrackedDeviceCount];
 		if (!GetDeviceToAbsoluteTrackingPoseCompatible(vr::TrackingUniverseStanding, 0, poses, vr::k_unMaxTrackedDeviceCount))

--- a/src/Utils/VRUtils.h
+++ b/src/Utils/VRUtils.h
@@ -237,4 +237,24 @@ namespace Util
 		return mat;
 	}
 
+	//=============================================================================
+	// WAND POINTING UTILITIES
+	//=============================================================================
+
+	/**
+	 * @brief Computes controller ray intersection with a VR overlay
+	 * @param overlay OpenVR overlay interface
+	 * @param overlayHandle Handle to the overlay to test intersection with
+	 * @param controllerIndex Tracked device index of the controller
+	 * @param outUV Output UV coordinates (0-1 range) of intersection point
+	 * @return true if the controller ray intersects the overlay, false otherwise
+	 *
+	 * This function uses OpenVR's ComputeOverlayIntersection to perform ray-casting
+	 * from the controller's position and forward direction to detect if it's pointing
+	 * at the specified overlay. If an intersection is found, the UV coordinates are
+	 * returned in the outUV parameter.
+	 */
+	bool ComputeWandIntersection(vr::IVROverlay* overlay, vr::VROverlayHandle_t overlayHandle,
+		vr::TrackedDeviceIndex_t controllerIndex, ImVec2& outUV);
+
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wand pointing as an alternate, toggleable input method for VR overlays with wand-driven cursor and dual-stick scrolling.
  * Renamed settings section to "Input Settings" and added a Wand Pointing toggle plus thumbstick deadzone/scroll behavior.
  * Added wand-first input behavior with automatic fallback to thumbstick/cursor.
  * Added a Wand Pointing diagnostics panel showing enable state, intersection status, UVs, controller index, and ray info.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->