### PR TITLE
fix: fix flickering particles

### DIFF
--- a/package/Shaders/Particle.hlsl
+++ b/package/Shaders/Particle.hlsl
@@ -312,7 +312,7 @@ PS_OUTPUT main(PS_INPUT input)
 #	if defined(LIGHT_LIMIT_FIX)
 	uint lightCount = 0;
 	{
-		float3 viewPosition = FrameBuffer::WorldToView(positionWS, true, eyeIndex);
+		float3 viewPosition = FrameBuffer::WorldToView(positionWS.xyz, true, eyeIndex);
 		float2 screenUV = FrameBuffer::ViewToUV(viewPosition, true, eyeIndex);
 
 		uint clusterIndex = 0;

--- a/package/Shaders/Particle.hlsl
+++ b/package/Shaders/Particle.hlsl
@@ -34,7 +34,6 @@ struct VS_OUTPUT
 	float CullDistance : SV_CullDistance0;  // p11
 	uint EyeIndex : EYEIDX0;
 #endif  // VR
-	float3 ViewPositionVS : TEXCOORD2;
 };
 
 #ifdef VSHADER
@@ -113,21 +112,6 @@ VS_OUTPUT main(VS_INPUT input)
 #		endif
 	vsout.Position.xy = positionOffset + finalViewPosition.xy;
 	vsout.Position.zw = finalViewPosition.zw;
-
-    // Compute view-space for precipitation motion blend
-#	if defined(ENVCUBE)
-#  		if defined(RAIN)
-    float3 viewVS             = mul(WorldView[eyeIndex], msPosition).xyz;
-    float3 adjustedViewVS     = mul(WorldView[eyeIndex], adjustedMsPosition).xyz;
-    float3 finalViewPositionVS = lerp(adjustedViewVS, viewVS, positionBlendParam);
-    vsout.ViewPositionVS = finalViewPositionVS;
-#  		else
-    vsout.ViewPositionVS = mul(WorldView[eyeIndex], msPosition).xyz;
-#  		endif
-#	else
-    vsout.ViewPositionVS = mul(WorldView[eyeIndex], msPosition).xyz;
-#	endif
-
 	vsout.Color.xyz = 1.0.xxx;
 	vsout.Color.w = fVars1.w;
 
@@ -179,8 +163,6 @@ VS_OUTPUT main(VS_INPUT input)
 	float4 viewPosition = mul(WorldViewProj[eyeIndex], msPosition);
 	vsout.Position.xy = positionOffset * ScaleAdjust + viewPosition.xy;
 	vsout.Position.zw = viewPosition.zw;
-
-    vsout.ViewPositionVS = mul(WorldView[eyeIndex], msPosition).xyz;
 
 	float4 color1, color2;
 	float colorTmp1, colorTmp2;
@@ -265,6 +247,17 @@ cbuffer PerGeometry : register(b2)
 	float3 TextureSize : packoffset(c1);
 };
 
+#	if defined(TERRAIN_SHADOWS)
+#		include "TerrainShadows/TerrainShadows.hlsli"
+#	endif
+
+#	if defined(CLOUD_SHADOWS)
+#		include "CloudShadows/CloudShadows.hlsli"
+#	endif
+
+#	define LinearSampler SampSourceTexture
+#	include "Common/ShadowSampling.hlsli"
+
 PS_OUTPUT main(PS_INPUT input)
 {
 	PS_OUTPUT psout;
@@ -304,18 +297,22 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float3 propertyColor = 0.0;
 
-	float3 dirLightColor = SharedData::DirLightColor.xyz * 0.5;
+	float2 uv = Stereo::ConvertFromStereoUV(input.Position.xy * SharedData::BufferDim.zw, eyeIndex);
+
+	float4 positionWS = float4(2 * float2(uv.x, -uv.y + 1) - 1, input.Position.z, 1);
+	positionWS = mul(FrameBuffer::CameraViewProjInverse[eyeIndex], positionWS);
+	positionWS.xyz = positionWS.xyz / positionWS.w;
+
+	float3 dirLightColor = SharedData::DirLightColor.xyz * ShadowSampling::GetWorldShadow(positionWS.xyz, FrameBuffer::CameraPosAdjust[eyeIndex].xyz, eyeIndex);
 	float3 ambientColor = max(0, mul(SharedData::DirectionalAmbient, float4(0, 0, 1, 1)).xyz);
 
 	propertyColor += dirLightColor;
 	propertyColor += ambientColor;
 
-	float3 viewPosition = input.ViewPositionVS.xyz;
-	float3 worldPosition = FrameBuffer::ViewToWorld(viewPosition);
-
 #	if defined(LIGHT_LIMIT_FIX)
 	uint lightCount = 0;
 	{
+		float3 viewPosition = FrameBuffer::WorldToView(positionWS, true, eyeIndex);
 		float2 screenUV = FrameBuffer::ViewToUV(viewPosition, true, eyeIndex);
 
 		uint clusterIndex = 0;
@@ -329,7 +326,7 @@ PS_OUTPUT main(PS_INPUT input)
 				if (LightLimitFix::IsLightIgnored(light) || light.lightFlags & LightLimitFix::LightFlags::Shadow) {
 					continue;
 				}
-				float3 lightDirection = light.positionWS[eyeIndex].xyz - worldPosition.xyz;
+				float3 lightDirection = light.positionWS[eyeIndex].xyz - positionWS.xyz;
 				float lightDist = length(lightDirection);
 
 #			if defined(ISL)
@@ -339,7 +336,7 @@ PS_OUTPUT main(PS_INPUT input)
 				float intensityMultiplier = 1 - intensityFactor * intensityFactor;
 #			endif
 
-				float3 lightColor = light.color.xyz * intensityMultiplier * 0.5;
+				float3 lightColor = light.color.xyz * intensityMultiplier;
 				propertyColor += lightColor;
 			}
 		}


### PR DESCRIPTION
Fixes particles flickering due to operating in the wrong space.
Applies very minor changes to prevent other instances of incorrect lighting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Particle rendering now uses direct world-space positions and integrated terrain/cloud shadow sampling for more accurate, consistent lighting.
  * Removed per-vertex view-position outputs and simplified shading paths, improving rendering efficiency and preserving VR behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->