### PR TITLE
chore(UI): remove settings and about tabs

### DIFF
--- a/package/SKSE/Plugins/CommunityShaders/Themes/Default.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/Default.json
@@ -36,7 +36,7 @@
                 "Family": "Jost",
                 "Style": "Regular",
                 "File": "Jost/Jost-Regular.ttf",
-                "SizeScale": 0.85
+                "SizeScale": 0.9
             }
         ],
         "UseSimplePalette": false,

--- a/package/SKSE/Plugins/CommunityShaders/Themes/Default.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/Default.json
@@ -31,6 +31,12 @@
                 "Style": "Regular",
                 "File": "Jost/Jost-Regular.ttf",
                 "SizeScale": 1.0
+            },
+            {
+                "Family": "Jost",
+                "Style": "Regular",
+                "File": "Jost/Jost-Regular.ttf",
+                "SizeScale": 0.85
             }
         ],
         "UseSimplePalette": false,

--- a/package/SKSE/Plugins/CommunityShaders/Themes/DragonBlood.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/DragonBlood.json
@@ -31,6 +31,12 @@
                 "Style": "Light",
                 "File": "CrimsonPro/CrimsonPro-Light.ttf",
                 "SizeScale": 1.0
+            },
+            {
+                "Family": "Crimson Pro",
+                "Style": "Light",
+                "File": "CrimsonPro/CrimsonPro-Light.ttf",
+                "SizeScale": 0.85
             }
         ],
         "UseSimplePalette": false,

--- a/package/SKSE/Plugins/CommunityShaders/Themes/DragonBlood.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/DragonBlood.json
@@ -36,7 +36,7 @@
                 "Family": "Crimson Pro",
                 "Style": "Light",
                 "File": "CrimsonPro/CrimsonPro-Light.ttf",
-                "SizeScale": 0.85
+                "SizeScale": 0.9
             }
         ],
         "UseSimplePalette": false,

--- a/package/SKSE/Plugins/CommunityShaders/Themes/DwemerBronze.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/DwemerBronze.json
@@ -35,7 +35,7 @@
             {
                 "Family": "RobotoSlab",
                 "File": "RobotoSlab/RobotoSlab-Light.ttf",
-                "SizeScale": 0.85,
+                "SizeScale": 0.9,
                 "Style": "Light"
             }
         ],

--- a/package/SKSE/Plugins/CommunityShaders/Themes/DwemerBronze.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/DwemerBronze.json
@@ -31,6 +31,12 @@
                 "File": "RobotoSlab/RobotoSlab-Light.ttf",
                 "SizeScale": 1.0,
                 "Style": "Light"
+            },
+            {
+                "Family": "RobotoSlab",
+                "File": "RobotoSlab/RobotoSlab-Light.ttf",
+                "SizeScale": 0.85,
+                "Style": "Light"
             }
         ],
         "UseSimplePalette": false,

--- a/package/SKSE/Plugins/CommunityShaders/Themes/HighContrast.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/HighContrast.json
@@ -31,6 +31,12 @@
                 "Style": "Light",
                 "File": "Inter/Inter-Light.ttf",
                 "SizeScale": 1.0
+            },
+            {
+                "Family": "Inter",
+                "Style": "Light",
+                "File": "Inter/Inter-Light.ttf",
+                "SizeScale": 0.85
             }
         ],
         "UseSimplePalette": false,

--- a/package/SKSE/Plugins/CommunityShaders/Themes/HighContrast.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/HighContrast.json
@@ -36,7 +36,7 @@
                 "Family": "Inter",
                 "Style": "Light",
                 "File": "Inter/Inter-Light.ttf",
-                "SizeScale": 0.85
+                "SizeScale": 0.9
             }
         ],
         "UseSimplePalette": false,

--- a/package/SKSE/Plugins/CommunityShaders/Themes/Light.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/Light.json
@@ -36,7 +36,7 @@
                 "Family": "IBMPlex Sans",
                 "Style": "Condensed Light",
                 "File": "IBMPlexSans/IBMPlexSans_Condensed-Light.ttf",
-                "SizeScale": 0.85
+                "SizeScale": 0.9
             }
         ],
         "UseSimplePalette": false,

--- a/package/SKSE/Plugins/CommunityShaders/Themes/Light.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/Light.json
@@ -31,6 +31,12 @@
                 "Style": "Light",
                 "File": "IBMPlexSerif/IBMPlexSerif-Light.ttf",
                 "SizeScale": 1.0
+            },
+            {
+                "Family": "IBMPlex Sans",
+                "Style": "Condensed Light",
+                "File": "IBMPlexSans/IBMPlexSans_Condensed-Light.ttf",
+                "SizeScale": 0.85
             }
         ],
         "UseSimplePalette": false,

--- a/package/SKSE/Plugins/CommunityShaders/Themes/NordicFrost.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/NordicFrost.json
@@ -36,7 +36,7 @@
                 "Family": "Crimson Pro",
                 "Style": "Light",
                 "File": "CrimsonPro/CrimsonPro-Light.ttf",
-                "SizeScale": 0.85
+                "SizeScale": 0.9
             }
         ],
         "UseSimplePalette": false,

--- a/package/SKSE/Plugins/CommunityShaders/Themes/NordicFrost.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/NordicFrost.json
@@ -31,6 +31,12 @@
                 "Style": "Regular",
                 "File": "CrimsonPro/CrimsonPro-Regular.ttf",
                 "SizeScale": 1.0
+            },
+            {
+                "Family": "Crimson Pro",
+                "Style": "Light",
+                "File": "CrimsonPro/CrimsonPro-Light.ttf",
+                "SizeScale": 0.85
             }
         ],
         "UseSimplePalette": false,

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -86,6 +86,38 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	File,
 	SizeScale)
 
+// Custom JSON handler for FontRoles array to handle version mismatches gracefully
+// When loading settings saved with fewer font roles, only the existing roles are updated,
+// new roles keep their default values. This prevents crashes when adding new FontRole types.
+namespace nlohmann
+{
+	template <>
+	struct adl_serializer<std::array<Menu::ThemeSettings::FontRoleSettings, static_cast<size_t>(Menu::FontRole::Count)>>
+	{
+		static void to_json(json& j, const std::array<Menu::ThemeSettings::FontRoleSettings, static_cast<size_t>(Menu::FontRole::Count)>& arr)
+		{
+			j = json::array();
+			for (const auto& item : arr) {
+				j.push_back(item);
+			}
+		}
+
+		static void from_json(const json& j, std::array<Menu::ThemeSettings::FontRoleSettings, static_cast<size_t>(Menu::FontRole::Count)>& arr)
+		{
+			// Start with default values
+			arr = Menu::ThemeSettings{}.FontRoles;
+
+			// Only read as many elements as exist in the JSON
+			if (j.is_array()) {
+				size_t count = std::min(j.size(), arr.size());
+				for (size_t i = 0; i < count; ++i) {
+					j.at(i).get_to(arr[i]);
+				}
+			}
+		}
+	};
+}
+
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ImGuiStyle,
 	WindowPadding,

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -86,38 +86,6 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	File,
 	SizeScale)
 
-// Custom JSON handler for FontRoles array to handle version mismatches gracefully
-// When loading settings saved with fewer font roles, only the existing roles are updated,
-// new roles keep their default values. This prevents crashes when adding new FontRole types.
-namespace nlohmann
-{
-	template <>
-	struct adl_serializer<std::array<Menu::ThemeSettings::FontRoleSettings, static_cast<size_t>(Menu::FontRole::Count)>>
-	{
-		static void to_json(json& j, const std::array<Menu::ThemeSettings::FontRoleSettings, static_cast<size_t>(Menu::FontRole::Count)>& arr)
-		{
-			j = json::array();
-			for (const auto& item : arr) {
-				j.push_back(item);
-			}
-		}
-
-		static void from_json(const json& j, std::array<Menu::ThemeSettings::FontRoleSettings, static_cast<size_t>(Menu::FontRole::Count)>& arr)
-		{
-			// Start with default values
-			arr = Menu::ThemeSettings{}.FontRoles;
-
-			// Only read as many elements as exist in the JSON
-			if (j.is_array()) {
-				size_t count = std::min(j.size(), arr.size());
-				for (size_t i = 0; i < count; ++i) {
-					j.at(i).get_to(arr[i]);
-				}
-			}
-		}
-	};
-}
-
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ImGuiStyle,
 	WindowPadding,
@@ -193,6 +161,24 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 bool IsEnabled = false;
 std::unordered_map<std::string, int> Menu::categoryCounts;
 
+// Pad FontRoles JSON array with defaults if shorter than FontRole::Count.
+// Prevents deserialization failure when loading old settings with fewer font roles.
+static void SanitizeFontRolesJson(json& themeJson)
+{
+	if (!themeJson.contains("FontRoles") || !themeJson["FontRoles"].is_array())
+		return;
+
+	auto& fontRoles = themeJson["FontRoles"];
+	const size_t expected = static_cast<size_t>(Menu::FontRole::Count);
+
+	if (fontRoles.size() < expected) {
+		auto defaults = Menu::ThemeSettings{}.FontRoles;
+		for (size_t i = fontRoles.size(); i < expected; ++i) {
+			fontRoles.push_back(defaults[i]);
+		}
+	}
+}
+
 std::optional<Menu::FontRole> Menu::ResolveFontRole(std::string_view key)
 {
 	for (size_t i = 0; i < FontRoleDescriptors.size(); ++i) {
@@ -260,6 +246,7 @@ void Menu::Load(json& o_json)
 	// Legacy support: If old config has Theme data and no SelectedThemePreset, load it
 	if (o_json.contains("Theme") && o_json["Theme"].is_object() && settings.SelectedThemePreset.empty()) {
 		bool hasFontRoles = o_json["Theme"].contains("FontRoles");
+		SanitizeFontRolesJson(o_json["Theme"]);
 		settings.Theme = o_json["Theme"];
 		MenuFonts::NormalizeFontRoles(settings.Theme, hasFontRoles);
 
@@ -315,6 +302,7 @@ void Menu::LoadTheme(json& o_json)
 {
 	if (o_json["Theme"].is_object()) {
 		bool hasFontRoles = o_json["Theme"].contains("FontRoles");
+		SanitizeFontRolesJson(o_json["Theme"]);
 		settings.Theme = o_json["Theme"];
 		MenuFonts::NormalizeFontRoles(settings.Theme, hasFontRoles);
 
@@ -399,6 +387,7 @@ bool Menu::LoadThemePreset(const std::string& themeName)
 				}
 				if (themeSettings.contains("FontRoles")) {
 					try {
+						SanitizeFontRolesJson(themeSettings);
 						settings.Theme.FontRoles = themeSettings["FontRoles"];
 					} catch (...) {}
 				}

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -74,7 +74,7 @@ public:
 		FontRoleDescriptor{ "Title", "Title", 1.0f },
 		FontRoleDescriptor{ "Heading", "Headings", 1.0f },
 		FontRoleDescriptor{ "Subheading", "Subheadings", 1.0f },
-		FontRoleDescriptor{ "Subtext", "Subtext", 0.85f }
+		FontRoleDescriptor{ "Subtext", "Subtext", 0.9f }
 	};
 
 	static constexpr std::string_view GetFontRoleKey(FontRole role)
@@ -242,7 +242,7 @@ public:
 			setRole(FontRole::Title, "Jost", "Regular", "Jost/Jost-Regular.ttf", 1.0f);
 			setRole(FontRole::Heading, "Jost", "Regular", "Jost/Jost-Regular.ttf", 1.0f);
 			setRole(FontRole::Subheading, "Jost", "Regular", "Jost/Jost-Regular.ttf", 1.0f);
-			setRole(FontRole::Subtext, "Jost", "Regular", "Jost/Jost-Regular.ttf", 0.85f);
+			setRole(FontRole::Subtext, "Jost", "Regular", "Jost/Jost-Regular.ttf", 0.9f);
 
 			return roles;
 		}();

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -58,6 +58,7 @@ public:
 		Title,       // Large title text (e.g., "Community Shaders" header)
 		Heading,     // Section headers (tabs, category labels)
 		Subheading,  // Subsection headers (feature names, separators)
+		Subtext,     // Smaller secondary text (descriptions, about content)
 		Count        // Total number of roles
 	};
 
@@ -72,7 +73,8 @@ public:
 		FontRoleDescriptor{ "Body", "Body Text", 1.0f },
 		FontRoleDescriptor{ "Title", "Title", 1.0f },
 		FontRoleDescriptor{ "Heading", "Headings", 1.0f },
-		FontRoleDescriptor{ "Subheading", "Subheadings", 1.0f }
+		FontRoleDescriptor{ "Subheading", "Subheadings", 1.0f },
+		FontRoleDescriptor{ "Subtext", "Subtext", 0.85f }
 	};
 
 	static constexpr std::string_view GetFontRoleKey(FontRole role)
@@ -147,8 +149,10 @@ public:
 			files[static_cast<size_t>(role)] = std::move(value);
 		};
 		setFile(FontRole::Body, "Jost/Jost-Regular.ttf");
+		setFile(FontRole::Title, "Jost/Jost-Regular.ttf");
 		setFile(FontRole::Heading, "Jost/Jost-Regular.ttf");
 		setFile(FontRole::Subheading, "Jost/Jost-Regular.ttf");
+		setFile(FontRole::Subtext, "Jost/Jost-Regular.ttf");
 		return files;
 	}();
 	mutable std::array<float, static_cast<size_t>(FontRole::Count)> cachedFontPixelSizesByRole = {};
@@ -238,6 +242,7 @@ public:
 			setRole(FontRole::Title, "Jost", "Regular", "Jost/Jost-Regular.ttf", 1.0f);
 			setRole(FontRole::Heading, "Jost", "Regular", "Jost/Jost-Regular.ttf", 1.0f);
 			setRole(FontRole::Subheading, "Jost", "Regular", "Jost/Jost-Regular.ttf", 1.0f);
+			setRole(FontRole::Subtext, "Jost", "Regular", "Jost/Jost-Regular.ttf", 0.85f);
 
 			return roles;
 		}();

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -327,7 +327,6 @@ void FeatureListRenderer::RenderRightColumn(
 	size_t selectedMenu)
 {
 	ImGui::TableNextColumn();
-	ImGui::Dummy(ImVec2(0, ThemeManager::Constants::BUTTON_SPACING));  // spacing
 
 	if (selectedMenu < menuList.size()) {
 		std::visit(DrawMenuVisitor{}, menuList[selectedMenu]);
@@ -433,6 +432,10 @@ void FeatureListRenderer::ListMenuVisitor::operator()(Feature* feat)
 void FeatureListRenderer::DrawMenuVisitor::operator()(const BuiltInMenu& menu)
 {
 	if (ImGui::BeginChild("##FeatureConfigFrame", { 0, 0 }, true)) {
+		// Add spacing only for Home menu
+		if (menu.name == "Home") {
+			ImGui::Dummy(ImVec2(0, ThemeManager::Constants::BUTTON_SPACING));
+		}
 		menu.func();
 	}
 	ImGui::EndChild();
@@ -457,19 +460,20 @@ void FeatureListRenderer::DrawMenuVisitor::operator()(Feature* feat)
 	bool isLoaded = feat->loaded;
 	bool hasFailedMessage = !feat->failedLoadedMessage.empty();
 
-	float buttonPadding = ThemeManager::Constants::BUTTON_PADDING;
-	float buttonSpacing = ThemeManager::Constants::BUTTON_SPACING;
+	if (ImGui::BeginChild("##FeatureConfigFrame", { 0, 0 }, true)) {
+		// Render feature header with integrated action buttons
+		RenderFeatureHeader(feat, isDisabled, isLoaded);
 
-	MenuFonts::TabBarPaddingGuard tabPaddingGuard(Menu::FontRole::Subheading);
-	if (ImGui::BeginTabBar("##FeatureTabs", ImGuiTabBarFlags_Reorderable)) {
-		// Render Settings and About tabs
-		RenderFeatureSettingsTab(feat, isDisabled, isLoaded, hasFailedMessage);
-		RenderFeatureAboutTab(feat, isDisabled, isLoaded, hasFailedMessage);
+		// Render feature settings content
+		RenderFeatureSettings(feat, isDisabled, isLoaded, hasFailedMessage);
 
-		// Render action buttons positioned on the right side of the tab bar
-		RenderFeatureActionButtons(feat, isDisabled, isLoaded, buttonPadding, buttonSpacing);
+		// Render collapsible About section at the bottom
+		RenderFeatureAboutDropdown(feat, isLoaded);
+
+		// Render restore defaults button (floating in bottom-right)
+		RenderRestoreDefaultsButton(feat, isDisabled, isLoaded);
 	}
-	ImGui::EndTabBar();
+	ImGui::EndChild();
 }
 
 bool FeatureListRenderer::DrawMenuVisitor::IsFeatureInstalled(const std::string& featureName)
@@ -477,193 +481,16 @@ bool FeatureListRenderer::DrawMenuVisitor::IsFeatureInstalled(const std::string&
 	return std::filesystem::exists(Util::PathHelpers::GetFeatureIniPath(featureName));
 }
 
-void FeatureListRenderer::DrawMenuVisitor::RenderFeatureSettingsTab(Feature* feat, bool isDisabled, bool isLoaded, bool hasFailedMessage)
-{
-	if (!BeginTabItemWithFont("Settings", Menu::FontRole::Subheading)) {
-		return;
-	}
-
-	if (ImGui::BeginChild("##FeatureSettingsFrame", { 0, 0 }, true)) {
-		auto& themeSettings = globals::menu->GetSettings().Theme;
-
-		// Draw feature header with name and version
-		DrawFeatureHeader(feat->GetName(), isLoaded ? feat->version : "");
-
-		if (isDisabled) {
-			ImGui::TextColored(themeSettings.StatusPalette.Disable, "Feature settings are hidden because this feature is disabled at boot.");
-			ImGui::Spacing();
-			ImGui::Text("Enable the feature above to access its configuration options.");
-		} else {
-			if (isLoaded) {
-				auto weatherRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
-				if (weatherRegistry->HasWeatherSupport(feat->GetShortName())) {
-					bool paused = weatherRegistry->IsFeaturePaused(feat->GetShortName());
-					if (ImGui::Checkbox("Pause Weather Overrides", &paused)) {
-						weatherRegistry->SetFeaturePaused(feat->GetShortName(), paused);
-					}
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::Text(
-							"Temporarily disable weather-based setting adjustments for this feature.\n"
-							"This state is not saved.");
-					}
-					ImGui::Separator();
-				}
-
-				ImVec2 cursorPosBefore = ImGui::GetCursorPos();
-				feat->DrawSettings();
-				ImVec2 cursorPosAfter = ImGui::GetCursorPos();
-
-				const float epsilon = 0.1f;
-				bool cursorMoved = (std::abs(cursorPosAfter.x - cursorPosBefore.x) > epsilon ||
-									std::abs(cursorPosAfter.y - cursorPosBefore.y) > epsilon);
-				if (!cursorMoved) {
-					ImGui::TextColored(themeSettings.StatusPalette.Disable, "There are no settings available for this feature.");
-				}
-			} else {
-				if (FeatureIssues::IsObsoleteFeature(feat->GetShortName())) {
-					feat->DrawUnloadedUI();
-				} else if (IsFeatureInstalled(feat->GetShortName())) {
-					ImGui::Text("This feature will be available after restart.");
-				} else {
-					feat->DrawUnloadedUI();
-					if (!feat->GetFeatureModLink().empty()) {
-						ImGui::Spacing();
-						const auto downloadText = fmt::format("Click here to download this feature ({})", feat->GetFeatureModLink());
-						if (ImGui::Selectable(downloadText.c_str())) {
-							ShellExecuteA(NULL, "open", feat->GetFeatureModLink().c_str(), NULL, NULL, SW_SHOWNORMAL);
-						}
-						if (auto _tt = Util::HoverTooltipWrapper()) {
-							ImGui::Text("Download the feature from the mod page.");
-						}
-					}
-				}
-			}
-		}
-
-		if (hasFailedMessage && feat->DrawFailLoadMessage() && !FeatureIssues::IsObsoleteFeature(feat->GetShortName())) {
-			ImGui::Spacing();
-			SeparatorTextWithFont("Error", Menu::FontRole::Subheading);
-			ImGui::TextColored(themeSettings.StatusPalette.Error, feat->failedLoadedMessage.c_str());
-		}
-
-		if (!isDisabled && isLoaded) {
-			// Position button in screen coordinates so it stays fixed in viewport when scrolling
-			ImVec2 windowPos = ImGui::GetWindowPos();
-			ImVec2 windowSize = ImGui::GetWindowSize();
-			float scrollbarWidth = ImGui::GetScrollMaxY() > 0 ? ImGui::GetStyle().ScrollbarSize : 0.0f;
-
-			float iconDimension = ImGui::GetFrameHeight() * 1.2f;
-			ImVec2 iconSize = ImVec2(iconDimension, iconDimension);
-
-			float padding = 10.0f;
-			ImVec2 buttonPos = ImVec2(
-				windowPos.x + windowSize.x - iconSize.x - padding - scrollbarWidth,
-				windowPos.y + windowSize.y - iconSize.y - padding);
-			ImGui::SetCursorScreenPos(buttonPos);
-			auto& theme = globals::menu->GetTheme().Palette;
-			ImVec4 iconColor = theme.Text;
-			iconColor.w *= 0.7f;
-
-			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
-			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 1.0f, 1.0f, 0.3f));
-			ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
-
-			auto& menu = *globals::menu;
-			if (menu.uiIcons.featureSettingRevert.texture) {
-				if (ImGui::ImageButton("##RestoreDefaults", menu.uiIcons.featureSettingRevert.texture, iconSize)) {
-					feat->RestoreDefaultSettings();
-				}
-			} else {
-				if (ImGui::Button("R##RestoreDefaults", iconSize)) {
-					feat->RestoreDefaultSettings();
-				}
-			}
-
-			ImGui::PopStyleColor(3);
-
-			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text("Restore default settings for this feature");
-			}
-		}
-	}
-	ImGui::EndChild();
-	ImGui::EndTabItem();
-}
-
-void FeatureListRenderer::DrawMenuVisitor::RenderFeatureAboutTab(Feature* feat, bool isDisabled, bool isLoaded, bool hasFailedMessage)
-{
-	if (!BeginTabItemWithFont("About", Menu::FontRole::Subheading)) {
-		return;
-	}
-
-	if (ImGui::BeginChild("##FeatureAboutFrame", { 0, 0 }, true)) {
-		auto& themeSettings = globals::menu->GetSettings().Theme;
-
-		SeparatorTextWithFont("Status", Menu::FontRole::Subheading);
-
-		ImVec4 statusColor;
-		const char* statusText;
-		if (isDisabled) {
-			statusColor = themeSettings.StatusPalette.Disable;
-			statusText = "Disabled at boot.";
-		} else if (hasFailedMessage) {
-			statusColor = themeSettings.StatusPalette.Error;
-			statusText = "Failed to load.";
-		} else if (!isLoaded) {
-			if (!IsFeatureInstalled(feat->GetShortName())) {
-				statusColor = themeSettings.StatusPalette.Error;
-				statusText = "Not installed.";
-			} else {
-				statusColor = themeSettings.StatusPalette.RestartNeeded;
-				statusText = "Pending restart.";
-			}
-		} else {
-			statusColor = themeSettings.StatusPalette.SuccessColor;
-			statusText = "Active.";
-		}
-
-		ImGui::TextColored(statusColor, "Current State: %s", statusText);
-
-		if (isLoaded) {
-			auto [description, keyFeatures] = feat->GetFeatureSummary();
-			if (!description.empty()) {
-				ImGui::Spacing();
-				SeparatorTextWithFont("Description", Menu::FontRole::Subheading);
-				ImGui::TextWrapped("%s", description.c_str());
-
-				if (!keyFeatures.empty()) {
-					ImGui::Spacing();
-					SeparatorTextWithFont("Key Features", Menu::FontRole::Subheading);
-					for (const auto& feature : keyFeatures) {
-						ImGui::BulletText("%s", feature.c_str());
-					}
-				}
-			}
-		} else {
-			ImGui::Spacing();
-			SeparatorTextWithFont("Information", Menu::FontRole::Subheading);
-			if (hasFailedMessage) {
-				ImGui::TextColored(themeSettings.StatusPalette.Error, "%s", feat->failedLoadedMessage.c_str());
-			} else if (!IsFeatureInstalled(feat->GetShortName())) {
-				ImGui::Text("Feature installation details are available in the Settings tab.");
-			} else {
-				ImGui::Text("This feature is pending restart.");
-			}
-		}
-	}
-	ImGui::EndChild();
-	ImGui::EndTabItem();
-}
-
-void FeatureListRenderer::DrawMenuVisitor::RenderFeatureActionButtons(Feature* feat, bool isDisabled, bool isLoaded, float buttonPadding, float buttonSpacing)
+void FeatureListRenderer::DrawMenuVisitor::RenderFeatureHeader(Feature* feat, bool isDisabled, bool isLoaded)
 {
 	auto& themeSettings = globals::menu->GetSettings().Theme;
 	const auto featureName = feat->GetShortName();
 
-	// Calculate button widths based on text content
-	const char* overrideButtonText = "Apply Override";
+	// Calculate action button widths
+	float buttonPadding = ThemeManager::Constants::BUTTON_PADDING;
+	float buttonSpacing = ThemeManager::Constants::BUTTON_SPACING;
 
-	// Toggle is more compact without label - just the toggle width
+	const char* overrideButtonText = "Apply Override";
 	float bootToggleWidth = ImGui::GetFrameHeight() * 1.6f;
 	float overrideButtonWidth = ImGui::CalcTextSize(overrideButtonText).x + buttonPadding;
 
@@ -676,13 +503,24 @@ void FeatureListRenderer::DrawMenuVisitor::RenderFeatureActionButtons(Feature* f
 		totalButtonWidth += overrideButtonWidth + buttonSpacing;
 	}
 
-	// Position buttons on the right side of the tab bar
-	ImGui::SameLine();
-	float availableSpace = ImGui::GetContentRegionAvail().x;
-	float rightOffset = availableSpace - totalButtonWidth;
-	if (rightOffset > 0) {
-		ImGui::SetCursorPosX(ImGui::GetCursorPosX() + rightOffset);
-	}
+	// Get available content width for positioning
+	float availableWidth = ImGui::GetContentRegionAvail().x;
+
+	// Save position before drawing title
+	ImVec2 titleStartPos = ImGui::GetCursorScreenPos();
+
+	// Draw feature title and version on the left
+	DrawFeatureHeader(feat->GetName(), isLoaded ? feat->version : "");
+
+	// Position action buttons to the right of the header, middle-aligned with title
+	ImVec2 cursorPosAfterTitle = ImGui::GetCursorScreenPos();
+	float titleHeight = cursorPosAfterTitle.y - titleStartPos.y;
+	float buttonHeight = ImGui::GetFrameHeight();
+
+	// Calculate Y position to middle-align buttons with title (before separator)
+	float buttonY = titleStartPos.y + (titleHeight - buttonHeight) * 0.5f;
+
+	ImGui::SetCursorScreenPos(ImVec2(titleStartPos.x + availableWidth - totalButtonWidth, buttonY));
 
 	// Enable/Disable at boot toggle
 	bool bootEnabled = !isDisabled;
@@ -727,5 +565,150 @@ void FeatureListRenderer::DrawMenuVisitor::RenderFeatureActionButtons(Feature* f
 				"This will discard your customizations and revert to\n"
 				"the mod author's recommended settings.");
 		}
+	}
+
+	// Restore cursor position after the title and separator
+	ImGui::SetCursorScreenPos(cursorPosAfterTitle);
+}
+
+void FeatureListRenderer::DrawMenuVisitor::RenderFeatureSettings(Feature* feat, bool isDisabled, bool isLoaded, bool hasFailedMessage)
+{
+	auto& themeSettings = globals::menu->GetSettings().Theme;
+
+	if (isDisabled) {
+		ImGui::TextColored(themeSettings.StatusPalette.Disable, "Feature settings are hidden because this feature is disabled at boot.");
+		ImGui::Spacing();
+		ImGui::Text("Enable the feature above to access its configuration options.");
+	} else {
+		if (isLoaded) {
+			auto weatherRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
+			if (weatherRegistry->HasWeatherSupport(feat->GetShortName())) {
+				bool paused = weatherRegistry->IsFeaturePaused(feat->GetShortName());
+				if (ImGui::Checkbox("Pause Weather Overrides", &paused)) {
+					weatherRegistry->SetFeaturePaused(feat->GetShortName(), paused);
+				}
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					ImGui::Text(
+						"Temporarily disable weather-based setting adjustments for this feature.\n"
+						"This state is not saved.");
+				}
+				ImGui::Separator();
+			}
+
+			ImVec2 cursorPosBefore = ImGui::GetCursorPos();
+			feat->DrawSettings();
+			ImVec2 cursorPosAfter = ImGui::GetCursorPos();
+
+			const float cursorEpsilon = 0.1f;
+			bool cursorMoved = (std::abs(cursorPosAfter.x - cursorPosBefore.x) > cursorEpsilon ||
+								std::abs(cursorPosAfter.y - cursorPosBefore.y) > cursorEpsilon);
+			if (!cursorMoved) {
+				ImGui::TextColored(themeSettings.StatusPalette.Disable, "There are no settings available for this feature.");
+			}
+		} else {
+			if (FeatureIssues::IsObsoleteFeature(feat->GetShortName())) {
+				feat->DrawUnloadedUI();
+			} else if (IsFeatureInstalled(feat->GetShortName())) {
+				ImGui::Text("This feature will be available after restart.");
+			} else {
+				feat->DrawUnloadedUI();
+				if (!feat->GetFeatureModLink().empty()) {
+					ImGui::Spacing();
+					const auto downloadText = fmt::format("Click here to download this feature ({})", feat->GetFeatureModLink());
+					if (ImGui::Selectable(downloadText.c_str())) {
+						ShellExecuteA(NULL, "open", feat->GetFeatureModLink().c_str(), NULL, NULL, SW_SHOWNORMAL);
+					}
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::Text("Download the feature from the mod page.");
+					}
+				}
+			}
+		}
+	}
+
+	if (hasFailedMessage && feat->DrawFailLoadMessage() && !FeatureIssues::IsObsoleteFeature(feat->GetShortName())) {
+		ImGui::Spacing();
+		SeparatorTextWithFont("Error", Menu::FontRole::Subheading);
+		ImGui::TextColored(themeSettings.StatusPalette.Error, feat->failedLoadedMessage.c_str());
+	}
+}
+
+void FeatureListRenderer::DrawMenuVisitor::RenderFeatureAboutDropdown(Feature* feat, bool isLoaded)
+{
+	// Only show About dropdown for loaded features with content
+	if (!isLoaded) {
+		return;
+	}
+
+	auto [description, keyFeatures] = feat->GetFeatureSummary();
+	if (description.empty() && keyFeatures.empty()) {
+		return;
+	}
+
+	ImGui::Spacing();
+	ImGui::Separator();
+	ImGui::Spacing();
+
+	// Use collapsible header for About section (collapsed by default)
+	ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_None;  // Collapsed by default (no DefaultOpen)
+	{
+		MenuFonts::FontRoleGuard fontGuard(Menu::FontRole::Subheading);
+		if (ImGui::CollapsingHeader("About", flags)) {
+			if (!description.empty()) {
+				ImGui::Spacing();
+				SeparatorTextWithFont("Description", Menu::FontRole::Subheading);
+				ImGui::TextWrapped("%s", description.c_str());
+			}
+
+			if (!keyFeatures.empty()) {
+				ImGui::Spacing();
+				SeparatorTextWithFont("Key Features", Menu::FontRole::Subheading);
+				for (const auto& feature : keyFeatures) {
+					ImGui::BulletText("%s", feature.c_str());
+				}
+			}
+		}
+	}
+}
+
+void FeatureListRenderer::DrawMenuVisitor::RenderRestoreDefaultsButton(Feature* feat, bool isDisabled, bool isLoaded)
+{
+	if (isDisabled || !isLoaded) {
+		return;
+	}
+
+	// Position button in screen coordinates so it stays fixed in viewport when scrolling
+	ImVec2 windowPos = ImGui::GetWindowPos();
+	ImVec2 windowSize = ImGui::GetWindowSize();
+	float scrollbarWidth = ImGui::GetScrollMaxY() > 0 ? ImGui::GetStyle().ScrollbarSize : 0.0f;
+
+	float iconDimension = ImGui::GetFrameHeight() * 1.2f;
+	ImVec2 iconSize = ImVec2(iconDimension, iconDimension);
+
+	float padding = ThemeManager::Constants::OVERLAY_WINDOW_POSITION;
+	ImVec2 buttonPos = ImVec2(
+		windowPos.x + windowSize.x - iconSize.x - padding - scrollbarWidth,
+		windowPos.y + windowSize.y - iconSize.y - padding);
+	ImGui::SetCursorScreenPos(buttonPos);
+
+	ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
+	ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 1.0f, 1.0f, 0.3f));
+	ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+
+	auto& menu = *globals::menu;
+	if (menu.uiIcons.featureSettingRevert.texture) {
+		if (ImGui::ImageButton("##RestoreDefaults", menu.uiIcons.featureSettingRevert.texture, iconSize)) {
+			feat->RestoreDefaultSettings();
+		}
+	} else {
+		if (ImGui::Button("R##RestoreDefaults", iconSize)) {
+			feat->RestoreDefaultSettings();
+		}
+	}
+
+	ImGui::PopStyleColor(3);
+
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text("Restore default settings for this feature");
 	}
 }

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -657,7 +657,7 @@ void FeatureListRenderer::DrawMenuVisitor::RenderFeatureAboutDropdown(Feature* f
 		if (ImGui::TreeNodeEx("About", flags)) {
 			// Use Subtext font for About content (smaller secondary text)
 			MenuFonts::FontRoleGuard contentGuard(Menu::FontRole::Subtext);
-			
+
 			if (!description.empty()) {
 				ImGui::TextWrapped("%s", description.c_str());
 			}

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -50,8 +50,10 @@ namespace
 	 * @brief Draws a feature header with the feature name in large text and version in smaller text
 	 * @param featureName The display name of the feature
 	 * @param version The version string (can be empty)
+	 * @param description Short description shown below the title (single line, truncated if too long)
+	 * @return The height of just the title line (for button alignment)
 	 */
-	void DrawFeatureHeader(const std::string& featureName, const std::string& version)
+	float DrawFeatureHeader(const std::string& featureName, const std::string& version, const std::string& description = "")
 	{
 		auto& themeSettings = globals::menu->GetTheme();
 		auto& palette = themeSettings.Palette;
@@ -78,6 +80,9 @@ namespace
 			ImGui::TextUnformatted(featureName.c_str());
 			ImGui::SetWindowFontScale(1.0f);
 		}
+
+		// Store the title-only height for return value
+		float titleOnlyHeight = titleSize.y;
 
 		// Draw version on same line with Body font, bottom-aligned if version exists
 		if (!version.empty()) {
@@ -111,12 +116,22 @@ namespace
 				ImGui::SetWindowFontScale(1.0f);
 			}
 
-			// Reset cursor to after the title block
-			ImGui::SetCursorScreenPos(ImVec2(startPos.x, startPos.y + titleSize.y + ImGui::GetStyle().ItemSpacing.y));
+			// Reset cursor to after the title block (reduced spacing for tighter layout)
+			ImGui::SetCursorScreenPos(ImVec2(startPos.x, startPos.y + titleSize.y + 2.0f));
+		}
+
+		// Draw description if provided (single line, truncated)
+		if (!description.empty()) {
+			MenuFonts::FontRoleGuard subtextGuard(Menu::FontRole::Subtext);
+			ImVec4 descColor = palette.Text;
+			descColor.w *= 0.7f;  // Slightly dimmed
+			ImGui::TextColored(descColor, "%s", description.c_str());
 		}
 
 		// Draw plain separator below
 		ImGui::Separator();
+
+		return titleOnlyHeight;
 	}
 }
 
@@ -468,9 +483,6 @@ void FeatureListRenderer::DrawMenuVisitor::operator()(Feature* feat)
 		// Render feature settings content
 		RenderFeatureSettings(feat, isDisabled, isLoaded, hasFailedMessage);
 
-		// Render collapsible About section at the bottom
-		RenderFeatureAboutDropdown(feat, isLoaded);
-
 		// Render restore defaults button (floating in bottom-right)
 		RenderRestoreDefaultsButton(feat, isDisabled, isLoaded);
 	}
@@ -512,16 +524,22 @@ void FeatureListRenderer::DrawMenuVisitor::RenderFeatureHeader(Feature* feat, bo
 	// Save position before drawing title
 	ImVec2 titleStartPos = ImGui::GetCursorScreenPos();
 
-	// Draw feature title and version on the left
-	DrawFeatureHeader(feat->GetName(), isLoaded ? feat->version : "");
+	// Get feature description for subtitle
+	auto [description, keyFeatures] = feat->GetFeatureSummary();
+	(void)keyFeatures;  // Not used for subtitle display
 
-	// Position action buttons to the right of the header, middle-aligned with title
-	ImVec2 cursorPosAfterTitle = ImGui::GetCursorScreenPos();
-	float titleHeight = cursorPosAfterTitle.y - titleStartPos.y;
+	// Draw feature title, version, and description on the left
+	// Returns title-only height for button alignment
+	float titleOnlyHeight = DrawFeatureHeader(feat->GetName(), isLoaded ? feat->version : "", description);
+
+	// Save cursor position after header (for restoring after buttons are drawn)
+	ImVec2 cursorPosAfterHeader = ImGui::GetCursorScreenPos();
+
+	// Position action buttons to the right of the header, middle-aligned with title only
 	float buttonHeight = ImGui::GetFrameHeight();
 
-	// Calculate Y position to middle-align buttons with title (before separator)
-	float buttonY = titleStartPos.y + (titleHeight - buttonHeight) * 0.5f;
+	// Calculate Y position to middle-align buttons with title text only (not description)
+	float buttonY = titleStartPos.y + (titleOnlyHeight - buttonHeight) * 0.5f;
 
 	ImGui::SetCursorScreenPos(ImVec2(titleStartPos.x + availableWidth - totalButtonWidth, buttonY));
 
@@ -571,7 +589,7 @@ void FeatureListRenderer::DrawMenuVisitor::RenderFeatureHeader(Feature* feat, bo
 	}
 
 	// Restore cursor position after the title and separator
-	ImGui::SetCursorScreenPos(cursorPosAfterTitle);
+	ImGui::SetCursorScreenPos(cursorPosAfterHeader);
 }
 
 void FeatureListRenderer::DrawMenuVisitor::RenderFeatureSettings(Feature* feat, bool isDisabled, bool isLoaded, bool hasFailedMessage)
@@ -633,45 +651,6 @@ void FeatureListRenderer::DrawMenuVisitor::RenderFeatureSettings(Feature* feat, 
 		ImGui::Spacing();
 		SeparatorTextWithFont("Error", Menu::FontRole::Subheading);
 		ImGui::TextColored(themeSettings.StatusPalette.Error, feat->failedLoadedMessage.c_str());
-	}
-}
-
-void FeatureListRenderer::DrawMenuVisitor::RenderFeatureAboutDropdown(Feature* feat, bool isLoaded)
-{
-	// Only show About dropdown for loaded features with content
-	if (!isLoaded) {
-		return;
-	}
-
-	auto [description, keyFeatures] = feat->GetFeatureSummary();
-	if (description.empty() && keyFeatures.empty()) {
-		return;
-	}
-
-	ImGui::Spacing();
-
-	// Use tree node for About section (non-colored, expanded by default)
-	ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_SpanAvailWidth;
-	{
-		MenuFonts::FontRoleGuard headerGuard(Menu::FontRole::Subheading);
-		if (ImGui::TreeNodeEx("About", flags)) {
-			// Use Subtext font for About content (smaller secondary text)
-			MenuFonts::FontRoleGuard contentGuard(Menu::FontRole::Subtext);
-
-			if (!description.empty()) {
-				ImGui::TextWrapped("%s", description.c_str());
-			}
-
-			if (!keyFeatures.empty()) {
-				if (!description.empty()) {
-					ImGui::Spacing();
-				}
-				for (const auto& feature : keyFeatures) {
-					ImGui::BulletText("%s", feature.c_str());
-				}
-			}
-			ImGui::TreePop();
-		}
 	}
 }
 

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -6,6 +6,7 @@
 #include <format>
 #include <imgui.h>
 #include <ranges>
+#include <system_error>
 
 #include "Feature.h"
 #include "FeatureIssues.h"
@@ -478,7 +479,9 @@ void FeatureListRenderer::DrawMenuVisitor::operator()(Feature* feat)
 
 bool FeatureListRenderer::DrawMenuVisitor::IsFeatureInstalled(const std::string& featureName)
 {
-	return std::filesystem::exists(Util::PathHelpers::GetFeatureIniPath(featureName));
+	const auto path = Util::PathHelpers::GetFeatureIniPath(featureName);
+	std::error_code ec;
+	return std::filesystem::exists(path, ec);
 }
 
 void FeatureListRenderer::DrawMenuVisitor::RenderFeatureHeader(Feature* feat, bool isDisabled, bool isLoaded)
@@ -646,27 +649,28 @@ void FeatureListRenderer::DrawMenuVisitor::RenderFeatureAboutDropdown(Feature* f
 	}
 
 	ImGui::Spacing();
-	ImGui::Separator();
-	ImGui::Spacing();
 
-	// Use collapsible header for About section (collapsed by default)
-	ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_None;  // Collapsed by default (no DefaultOpen)
+	// Use tree node for About section (non-colored, expanded by default)
+	ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_SpanAvailWidth;
 	{
-		MenuFonts::FontRoleGuard fontGuard(Menu::FontRole::Subheading);
-		if (ImGui::CollapsingHeader("About", flags)) {
+		MenuFonts::FontRoleGuard headerGuard(Menu::FontRole::Subheading);
+		if (ImGui::TreeNodeEx("About", flags)) {
+			// Use Subtext font for About content (smaller secondary text)
+			MenuFonts::FontRoleGuard contentGuard(Menu::FontRole::Subtext);
+			
 			if (!description.empty()) {
-				ImGui::Spacing();
-				SeparatorTextWithFont("Description", Menu::FontRole::Subheading);
 				ImGui::TextWrapped("%s", description.c_str());
 			}
 
 			if (!keyFeatures.empty()) {
-				ImGui::Spacing();
-				SeparatorTextWithFont("Key Features", Menu::FontRole::Subheading);
+				if (!description.empty()) {
+					ImGui::Spacing();
+				}
 				for (const auto& feature : keyFeatures) {
 					ImGui::BulletText("%s", feature.c_str());
 				}
 			}
+			ImGui::TreePop();
 		}
 	}
 }

--- a/src/Menu/FeatureListRenderer.h
+++ b/src/Menu/FeatureListRenderer.h
@@ -56,9 +56,10 @@ private:
 	private:
 		// Helper methods for Feature rendering
 		static bool IsFeatureInstalled(const std::string& featureName);
-		static void RenderFeatureSettingsTab(Feature* feat, bool isDisabled, bool isLoaded, bool hasFailedMessage);
-		static void RenderFeatureAboutTab(Feature* feat, bool isDisabled, bool isLoaded, bool hasFailedMessage);
-		static void RenderFeatureActionButtons(Feature* feat, bool isDisabled, bool isLoaded, float buttonPadding, float buttonSpacing);
+		static void RenderFeatureHeader(Feature* feat, bool isDisabled, bool isLoaded);
+		static void RenderFeatureSettings(Feature* feat, bool isDisabled, bool isLoaded, bool hasFailedMessage);
+		static void RenderFeatureAboutDropdown(Feature* feat, bool isLoaded);
+		static void RenderRestoreDefaultsButton(Feature* feat, bool isDisabled, bool isLoaded);
 	};
 
 	static std::vector<MenuFuncInfo> BuildMenuList(

--- a/src/Menu/FeatureListRenderer.h
+++ b/src/Menu/FeatureListRenderer.h
@@ -58,7 +58,6 @@ private:
 		static bool IsFeatureInstalled(const std::string& featureName);
 		static void RenderFeatureHeader(Feature* feat, bool isDisabled, bool isLoaded);
 		static void RenderFeatureSettings(Feature* feat, bool isDisabled, bool isLoaded, bool hasFailedMessage);
-		static void RenderFeatureAboutDropdown(Feature* feat, bool isLoaded);
 		static void RenderRestoreDefaultsButton(Feature* feat, bool isDisabled, bool isLoaded);
 	};
 


### PR DESCRIPTION
Removed settings and about tabs for each feature requested by davo. Added description of each feature under feature title to replace about tab. 

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/7c4640fa-58d9-439e-a331-779e1d5fe699" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Right-side feature panel redesigned with unified header, integrated actions and a visible "Restore Defaults" control.
  * Added a new "Subtext" typography role for finer text styling.

* **Bug Fixes / Improvements**
  * Theme/font loading is more tolerant of missing/legacy font entries; added smaller-size font variants across themes.

* **Refactor**
  * Rendering flow reorganized for more consistent layout, spacing, and button positioning.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->