### PR TITLE
fix(upscaling): warn about max nvidia resolution

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -182,6 +182,17 @@ void Upscaling::DrawSettings()
 	// Check the current upscale method
 	auto upscaleMethod = GetUpscaleMethod();
 
+	// Display warning for DLSS resolution limits
+	if (upscaleMethod == UpscaleMethod::kDLSS) {
+		auto screenSize = globals::state->screenSize;
+		if (screenSize.x > streamline.MAX_RESOLUTION || screenSize.y > streamline.MAX_RESOLUTION) {
+			ImGui::PushStyleColor(ImGuiCol_Text, Util::Colors::GetWarning());
+			ImGui::Text("Warning: Requested resolution %.0f x %.0f exceeds maximum supported resolution %d x %d for DLSS.", screenSize.x, screenSize.y, streamline.MAX_RESOLUTION, streamline.MAX_RESOLUTION);
+			ImGui::Text("DLSS will not function. Lower your resolution or select a different upscaling method.");
+			ImGui::PopStyleColor();
+		}
+	}
+
 	// Display upscaling settings if applicable
 	if (upscaleMethod != UpscaleMethod::kNONE && upscaleMethod != UpscaleMethod::kTAA) {
 		const char* upscalePresetsDLSS[] = { "Ultra Performance", "Performance", "Balanced", "Quality", "DLAA" };

--- a/src/Features/Upscaling/Streamline.cpp
+++ b/src/Features/Upscaling/Streamline.cpp
@@ -363,7 +363,7 @@ float2 Streamline::GetInputResolutionScale(uint32_t outputWidth, uint32_t output
 	sl::Result result = slDLSSGetOptimalSettings(dlssOptions, optimalSettings);
 	if (result != sl::Result::eOk) {
 		if (outputWidth > MAX_RESOLUTION || outputHeight > MAX_RESOLUTION) {
-			logger::critical("[Streamline] Requested resolution {} x {} is higher than Max allowed resolution {} x {}, lower your resolution to enable Streamline.", outputWidth, outputHeight, MAX_RESOLUTION, MAX_RESOLUTION);
+			logger::critical("[Streamline] Requested resolution {} x {} exceeds the maximum allowed resolution of {} x {}. Lower your resolution to enable Streamline.", outputWidth, outputHeight, MAX_RESOLUTION, MAX_RESOLUTION);
 		}
 		logger::critical("[Streamline] Failed to get DLSS optimal settings, error code: {}({})", magic_enum::enum_name(result), (int)result);
 		return { 1.0f, 1.0f };

--- a/src/Features/Upscaling/Streamline.cpp
+++ b/src/Features/Upscaling/Streamline.cpp
@@ -362,7 +362,10 @@ float2 Streamline::GetInputResolutionScale(uint32_t outputWidth, uint32_t output
 	sl::DLSSOptimalSettings optimalSettings{};
 	sl::Result result = slDLSSGetOptimalSettings(dlssOptions, optimalSettings);
 	if (result != sl::Result::eOk) {
-		logger::critical("[Streamline] Failed to get DLSS optimal settings, error code: {}", (int)result);
+		if (outputWidth > MAX_RESOLUTION || outputHeight > MAX_RESOLUTION) {
+			logger::critical("[Streamline] Requested resolution {} x {} is higher than Max allowed resolution {} x {}, lower your resolution to enable Streamline.", outputWidth, outputHeight, MAX_RESOLUTION, MAX_RESOLUTION);
+		}
+		logger::critical("[Streamline] Failed to get DLSS optimal settings, error code: {}({})", magic_enum::enum_name(result), (int)result);
 		return { 1.0f, 1.0f };
 	}
 

--- a/src/Features/Upscaling/Streamline.h
+++ b/src/Features/Upscaling/Streamline.h
@@ -33,7 +33,7 @@ public:
 	bool featureDLSS = false;
 
 	sl::ViewportHandle viewport{ 0 };
-	const uint32_t MAX_RESOLUTION = 8192;
+	static constexpr uint32_t MAX_RESOLUTION = 8192;
 	HMODULE interposer = NULL;
 
 	// SL Interposer Functions

--- a/src/Features/Upscaling/Streamline.h
+++ b/src/Features/Upscaling/Streamline.h
@@ -33,7 +33,7 @@ public:
 	bool featureDLSS = false;
 
 	sl::ViewportHandle viewport{ 0 };
-
+	const uint32_t MAX_RESOLUTION = 8192;
 	HMODULE interposer = NULL;
 
 	// SL Interposer Functions


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show warnings when using DLSS upscaling at very high resolutions (above 8192 pixels).

* **Bug Fixes**
  * Improved diagnostic logging when DLSS settings retrieval fails, making failures easier to identify and troubleshoot.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->