### PR TITLE
fix: match grass brightness of vanilla

### DIFF
--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -868,6 +868,8 @@ PS_OUTPUT main(PS_INPUT input)
 	psout.PS.w = diffuseAlpha;
 #		else
 
+	float grassBrightnessMultiplier = 1.0 / 2.8 // Match brightness of ISSkyrimClearDAY;
+
 	uint eyeIndex = Stereo::GetEyeIndexPS(input.HPosition, VPOSOffset);
 
 	float3 viewPosition = mul(FrameBuffer::CameraView[eyeIndex], float4(input.WorldPosition.xyz, 1)).xyz;
@@ -896,7 +898,7 @@ PS_OUTPUT main(PS_INPUT input)
 	}
 
 	float llDirLightMult = (SharedData::linearLightingSettings.enableLinearLighting && !SharedData::linearLightingSettings.isDirLightLinear) ? SharedData::linearLightingSettings.dirLightMult : 1.0f;
-	float3 diffuseColor = Color::DirectionalLight(SharedData::DirLightColor.xyz / max(llDirLightMult, 1e-5), SharedData::linearLightingSettings.isDirLightLinear) * dirShadow * dirDetailShadow * 0.5 * llDirLightMult;
+	float3 diffuseColor = Color::DirectionalLight(SharedData::DirLightColor.xyz / max(llDirLightMult, 1e-5), SharedData::linearLightingSettings.isDirLightLinear) * dirShadow * dirDetailShadow * grassBrightnessMultiplier * llDirLightMult;
 
 #			if defined(LIGHT_LIMIT_FIX)
 	uint clusterIndex = 0;
@@ -940,7 +942,7 @@ PS_OUTPUT main(PS_INPUT input)
 
 				lightColor *= lightShadow;
 
-				diffuseColor += lightColor * 0.5;
+				diffuseColor += lightColor * grassBrightnessMultiplier;
 			}
 		}
 	}

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -868,7 +868,7 @@ PS_OUTPUT main(PS_INPUT input)
 	psout.PS.w = diffuseAlpha;
 #		else
 
-	float grassBrightnessMultiplier = 1.0 / 2.8 // Match brightness of ISSkyrimClearDAY;
+	baseColor.xyz /= 2.8; // Match brightness of ISSkyrimClearDAY;
 
 	uint eyeIndex = Stereo::GetEyeIndexPS(input.HPosition, VPOSOffset);
 
@@ -898,7 +898,7 @@ PS_OUTPUT main(PS_INPUT input)
 	}
 
 	float llDirLightMult = (SharedData::linearLightingSettings.enableLinearLighting && !SharedData::linearLightingSettings.isDirLightLinear) ? SharedData::linearLightingSettings.dirLightMult : 1.0f;
-	float3 diffuseColor = Color::DirectionalLight(SharedData::DirLightColor.xyz / max(llDirLightMult, 1e-5), SharedData::linearLightingSettings.isDirLightLinear) * dirShadow * dirDetailShadow * grassBrightnessMultiplier * llDirLightMult;
+	float3 diffuseColor = Color::DirectionalLight(SharedData::DirLightColor.xyz / max(llDirLightMult, 1e-5), SharedData::linearLightingSettings.isDirLightLinear) * dirShadow * dirDetailShadow * llDirLightMult;
 
 #			if defined(LIGHT_LIMIT_FIX)
 	uint clusterIndex = 0;
@@ -942,7 +942,7 @@ PS_OUTPUT main(PS_INPUT input)
 
 				lightColor *= lightShadow;
 
-				diffuseColor += lightColor * grassBrightnessMultiplier;
+				diffuseColor += lightColor;
 			}
 		}
 	}

--- a/src/Features/GrassLighting.h
+++ b/src/Features/GrassLighting.h
@@ -34,7 +34,7 @@ public:
 		float SpecularStrength = 0.5f;
 		float SubsurfaceScatteringAmount = 0.5f;
 		uint OverrideComplexGrassSettings = false;
-		float BasicGrassBrightness = 0.36f; // Match brightness of ISSkyrimClearDAY
+		float BasicGrassBrightness = 0.36f;  // Match brightness of ISSkyrimClearDAY
 		uint EnableWrappedLighting = false;
 		float ComplexGrassThreshold = 0.03f;
 		uint pad1;

--- a/src/Features/GrassLighting.h
+++ b/src/Features/GrassLighting.h
@@ -34,7 +34,7 @@ public:
 		float SpecularStrength = 0.5f;
 		float SubsurfaceScatteringAmount = 0.5f;
 		uint OverrideComplexGrassSettings = false;
-		float BasicGrassBrightness = 0.36f;  // Match brightness of ISSkyrimClearDAY
+		float BasicGrassBrightness = 1.0f / 2.8f;  // Match brightness of ISSkyrimClearDAY
 		uint EnableWrappedLighting = false;
 		float ComplexGrassThreshold = 0.03f;
 		uint pad1;

--- a/src/Features/GrassLighting.h
+++ b/src/Features/GrassLighting.h
@@ -34,7 +34,7 @@ public:
 		float SpecularStrength = 0.5f;
 		float SubsurfaceScatteringAmount = 0.5f;
 		uint OverrideComplexGrassSettings = false;
-		float BasicGrassBrightness = 0.33f;
+		float BasicGrassBrightness = 0.36f; // Match brightness of ISSkyrimClearDAY
 		uint EnableWrappedLighting = false;
 		float ComplexGrassThreshold = 0.03f;
 		uint pad1;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Graphics & Lighting**
  * Refined grass lighting brightness calculations by implementing consistent multiplier constants across diffuse lighting contributions.
  * Updated default grass brightness settings for improved visual consistency and appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->