### PR TITLE
feat(linear lighting): add ambient multiplier

### DIFF
--- a/package/Shaders/Common/Color.hlsli
+++ b/package/Shaders/Common/Color.hlsli
@@ -194,7 +194,7 @@ namespace Color
 
 	float3 Ambient(float3 color)
 	{
-		return ENABLE_LL ? pow(abs(color), SharedData::linearLightingSettings.ambientGamma) : color;
+		return ENABLE_LL ? pow(abs(color), SharedData::linearLightingSettings.ambientGamma) * SharedData::linearLightingSettings.ambientMult : color;
 	}
 
 	float3 Fog(float3 color)

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -221,6 +221,7 @@ namespace SharedData
 		float vanillaDiffuseColorMult;
 		float directionalLightMult;
 		float pointLightMult;
+		float ambientMult;
 		float emitColorMult;
 		float glowmapMult;
 		float effectLightingMult;
@@ -229,7 +230,6 @@ namespace SharedData
 		float projectedEffectMult;
 		float deferredEffectMult;
 		float otherEffectMult;
-		float pad0;
 	};
 
 	struct TerrainBlendingSettings

--- a/src/Features/LinearLighting.cpp
+++ b/src/Features/LinearLighting.cpp
@@ -20,6 +20,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	directionalLightMultExterior,
 	directionalLightMultInterior,
 	pointLightMult,
+	ambientMult,
 	emitColorMult,
 	glowmapMult,
 	effectLightingMult,
@@ -46,6 +47,7 @@ void LinearLighting::DrawSettings()
 			ImGui::SeparatorText("Multipliers");
 			ImGui::SliderFloat("Exterior Directional Light Multiplier", &settings.directionalLightMultExterior, 0.0f, 10.0f, "%.2f");
 			ImGui::SliderFloat("Interior Directional Light Multiplier", &settings.directionalLightMultInterior, 0.0f, 10.0f, "%.2f");
+			ImGui::SliderFloat("Ambient Multiplier", &settings.ambientMult, 0.0f, 10.0f, "%.2f");
 			ImGui::SliderFloat("Glowmap Multiplier", &settings.glowmapMult, 0.0f, 10.0f, "%.2f");
 
 			ImGui::EndTabItem();
@@ -164,6 +166,7 @@ LinearLighting::PerFrameData LinearLighting::GetCommonBufferData()
 	data.vanillaDiffuseColorMult = settings.vanillaDiffuseColorMult;
 	data.directionalLightMult = Util::IsInterior() ? settings.directionalLightMultInterior : settings.directionalLightMultExterior;
 	data.pointLightMult = settings.pointLightMult;
+	data.ambientMult = settings.ambientMult;
 	data.emitColorMult = settings.emitColorMult;
 	data.glowmapMult = settings.glowmapMult;
 	data.effectLightingMult = settings.effectLightingMult;

--- a/src/Features/LinearLighting.h
+++ b/src/Features/LinearLighting.h
@@ -46,6 +46,7 @@ struct LinearLighting : Feature
 		float directionalLightMultExterior = 1.0f;
 		float directionalLightMultInterior = 1.0f;
 		float pointLightMult = 1.0f;
+		float ambientMult = 0.67f;
 		float emitColorMult = 1.0f;
 		float glowmapMult = 0.5f;
 
@@ -79,6 +80,7 @@ struct LinearLighting : Feature
 		float vanillaDiffuseColorMult;
 		float directionalLightMult;  // Computed based on interior/exterior
 		float pointLightMult;
+		float ambientMult;
 		float emitColorMult;
 		float glowmapMult;
 		float effectLightingMult;
@@ -87,7 +89,6 @@ struct LinearLighting : Feature
 		float projectedEffectMult;
 		float deferredEffectMult;
 		float otherEffectMult;
-		float pad0;
 	};
 
 	struct alignas(16) PerGeometryData


### PR DESCRIPTION
Added ambient multiplier slider with default set to 0.67.

Linear converts ambience already with a gamma slider but the overall brightness of ambience comes out more then twice as bright then vanilla. Adjusting the gamma slider does not fully address the issue. Settings the ambient multiplier to 0.67 ensures ambience can be defined within the game records realistically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Ambient Multiplier slider to Linear Lighting settings (General tab), allowing adjustment of ambient lighting intensity in your scenes with a default multiplier of 0.67.
  * Ambient lighting calculations now properly apply the multiplier factor when Linear Lighting is enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->