### PR TITLE
fix(unified-water): underwater fog flicker

### DIFF
--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -1263,7 +1263,7 @@ PS_OUTPUT main(PS_INPUT input)
 
 #				if defined(UNDERWATER)
 	float3 finalSpecularColor = lerp(Color::Water(ShallowColor.xyz), specularColor, 0.5);
-	float3 finalColor = saturate(1 - input.WPosition.w * 0.002) * ((1 - fresnel) * (diffuseColor - finalSpecularColor)) + finalSpecularColor;
+	float3 finalColor = saturate(1 - length(input.WPosition.xyz) * 0.002) * ((1 - fresnel) * (diffuseColor - finalSpecularColor)) + finalSpecularColor;
 	// Add ripple and splash color effects for underwater
 #					if defined(WETNESS_EFFECTS) && defined(DEBUG_WETNESS_EFFECTS)
 	// DEBUG MODE: Override water color with debug visualization (darker for underwater)


### PR DESCRIPTION
same fix as https://github.com/doodlum/skyrim-community-shaders/commit/245a43376980adf08541db4af5d05aeed1f9750c

 
![20765E~1](https://github.com/user-attachments/assets/a67dc594-b70f-4452-9bdd-0215ae201da1)
![208A2C~1](https://github.com/user-attachments/assets/a9a2ae8e-9897-425e-ab16-30fd58847460)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved underwater color attenuation and visual depth effects to enhance how colors blend in water environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->