### PR TITLE
fix(unified-water): fix for mesh water jitter

### DIFF
--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -215,27 +215,19 @@ VS_OUTPUT main(VS_INPUT input)
 	float2 scrollAdjust2 = posAdjust / NormalsScale.yy;
 	float2 scrollAdjust3 = posAdjust / NormalsScale.zz;
 
-#						if defined(UNIFIED_WATER) && defined(NORMAL_TEXCOORD)
+#				if defined(UNIFIED_WATER) && defined(NORMAL_TEXCOORD)
 	float2 cellShift = float2(floor(ObjectUV.z * 0.5), floor((ObjectUV.z - 1.0) * 0.5));
 	float2 scaledUV = input.TexCoord0.xy * ObjectUV.z - cellShift;
-#						endif
+#				endif
 
 #				if !(defined(FLOWMAP) && (defined(REFRACTIONS) || defined(BLEND_NORMALS) || defined(DEPTH) || NUM_SPECULAR_LIGHTS == 0))
 #					if defined(NORMAL_TEXCOORD)
 	float3 normalsScale = 0.001 * NormalsScale.xyz;
-#						if defined(UNIFIED_WATER)
-	if (ObjectUV.x) {
-		scrollAdjust1 = scaledUV / normalsScale.xx;
-		scrollAdjust2 = scaledUV / normalsScale.yy;
-		scrollAdjust3 = scaledUV / normalsScale.zz;
-	}
-#						else
 	if (ObjectUV.x) {
 		scrollAdjust1 = input.TexCoord0.xy / normalsScale.xx;
 		scrollAdjust2 = input.TexCoord0.xy / normalsScale.yy;
 		scrollAdjust3 = input.TexCoord0.xy / normalsScale.zz;
 	}
-#						endif
 #					else
 	if (ObjectUV.x) {
 		scrollAdjust1 = 0.0;


### PR DESCRIPTION
removes conditional normal scrolling that was breaking in cities and other places with mesh water. caused a weird surface jitter as the normal map scrolled. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized water shader texture coordinate calculations by streamlining the computational pathway for improved rendering efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->