### PR TITLE
chore(UI): add subtext font to tooltips

### DIFF
--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -3,6 +3,7 @@
 #include "../WeatherEditor/EditorWindow.h"
 #include "FileSystem.h"
 #include "Menu.h"
+#include "Menu/Fonts.h"
 #include "Menu/IconLoader.h"
 #include "Menu/ThemeManager.h"
 #include "ShaderCache.h"
@@ -41,18 +42,29 @@
 
 namespace Util
 {
-	HoverTooltipWrapper::HoverTooltipWrapper()
+	HoverTooltipWrapper::HoverTooltipWrapper() :
+		previousFont(nullptr)
 	{
 		hovered = ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal | ImGuiHoveredFlags_AllowWhenDisabled);
 		if (hovered) {
 			ImGui::BeginTooltip();
 			ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+			// Apply Subtext font for consistent tooltip styling
+			if (auto* menu = globals::menu) {
+				if (auto* subtextFont = menu->GetFont(Menu::FontRole::Subtext)) {
+					previousFont = ImGui::GetFont();
+					ImGui::PushFont(subtextFont);
+				}
+			}
 		}
 	}
 
 	HoverTooltipWrapper::~HoverTooltipWrapper()
 	{
 		if (hovered) {
+			if (previousFont) {
+				ImGui::PopFont();
+			}
 			ImGui::PopTextWrapPos();
 			ImGui::EndTooltip();
 		}

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -53,7 +53,7 @@ namespace Util
 	 * if (auto _tt = Util::HoverTooltipWrapper()){
 	 *     ImGui::Text("What the tooltip says.");
 	 * }
-	 * 
+	 *
 	 * Automatically applies the Subtext font role for consistent tooltip styling.
 	*/
 	class HoverTooltipWrapper

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -53,11 +53,14 @@ namespace Util
 	 * if (auto _tt = Util::HoverTooltipWrapper()){
 	 *     ImGui::Text("What the tooltip says.");
 	 * }
+	 * 
+	 * Automatically applies the Subtext font role for consistent tooltip styling.
 	*/
 	class HoverTooltipWrapper
 	{
 	private:
 		bool hovered;
+		ImFont* previousFont;
 
 	public:
 		HoverTooltipWrapper();


### PR DESCRIPTION
Applies newly added subtext font to tooltips to make them smaller. Requested by davo.

<img width="2560" height="1440" alt="Skyrim Special Edition 2_2_2026 4_43_33 AM" src="https://github.com/user-attachments/assets/8c90a7c9-db58-46d8-b0e3-39cc493d4371" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Tooltips now automatically apply the Subtext font for improved visual consistency throughout the application. Font state is properly managed during the tooltip lifecycle to maintain correct UI appearance and prevent styling conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->