### PR TITLE
fix(UI): conflicting esc key on welcome hotkey dialogue

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -919,6 +919,12 @@ void Menu::ProcessInputEventQueue()
 			if (key == event.keyCode)
 				key = MapVirtualKeyEx(event.keyCode, MAPVK_VSC_TO_VK_EX, GetKeyboardLayout(0));
 			if (!event.IsPressed()) {
+				// Skip key release if it was used to close the first-time setup dialog
+				if (HomePageRenderer::ShouldSkipKeyRelease(key)) {
+					io.AddKeyEvent(Util::Input::VirtualKeyToImGuiKey(key), event.IsPressed());
+					continue;
+				}
+
 				struct HotkeyAction
 				{
 					uint32_t* settingKey;

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -11,6 +11,16 @@
 
 // Static member definitions
 bool HomePageRenderer::isFirstTimeSetupShown = false;
+uint32_t HomePageRenderer::keyThatClosedDialog = 0;
+
+bool HomePageRenderer::ShouldSkipKeyRelease(uint32_t key)
+{
+	if (keyThatClosedDialog && key == keyThatClosedDialog) {
+		keyThatClosedDialog = 0;
+		return true;
+	}
+	return false;
+}
 
 void HomePageRenderer::RenderHomePage()
 {
@@ -249,6 +259,10 @@ void HomePageRenderer::RenderFAQSection()
 
 void HomePageRenderer::RenderFirstTimeSetupDialog()
 {
+	if (!ShouldShowFirstTimeSetup()) {
+		return;
+	}
+
 	// Block input to the game and make cursor visible - input blocking is handled by ShouldSwallowInput()
 	auto& io = ImGui::GetIO();
 	io.WantCaptureMouse = true;
@@ -408,9 +422,9 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	ImGui::Spacing();
 
 	// Check for Enter or Escape key to close, but only if not capturing a hotkey
-	if ((ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_Escape)) && !isCapturing) {
-		MarkFirstTimeSetupComplete();
-		// Note: Settings are automatically saved to ensure welcome screen won't show again
+	bool escapePressed = ImGui::IsKeyPressed(ImGuiKey_Escape);
+	if ((ImGui::IsKeyPressed(ImGuiKey_Enter) || escapePressed) && !isCapturing) {
+		MarkFirstTimeSetupComplete(escapePressed ? VK_ESCAPE : VK_RETURN);
 	}
 
 	// Help text with breathing animation
@@ -444,7 +458,7 @@ bool HomePageRenderer::ShouldShowFirstTimeSetup()
 	return !menu->GetSettings().FirstTimeSetupCompleted;
 }
 
-void HomePageRenderer::MarkFirstTimeSetupComplete()
+void HomePageRenderer::MarkFirstTimeSetupComplete(uint32_t closingKey)
 {
 	// Set the flag in the Menu settings
 	auto menu = Menu::GetSingleton();
@@ -454,5 +468,6 @@ void HomePageRenderer::MarkFirstTimeSetupComplete()
 	// This prevents the welcome screen from showing again even if user doesn't manually save
 	globals::state->Save();
 
-	isFirstTimeSetupShown = true;  // Mark as shown this session
+	isFirstTimeSetupShown = true;
+	keyThatClosedDialog = closingKey;
 }

--- a/src/Menu/HomePageRenderer.h
+++ b/src/Menu/HomePageRenderer.h
@@ -26,7 +26,7 @@ public:
 	// First-time setup management
 	static bool ShouldShowFirstTimeSetup();
 	static void RenderFirstTimeSetupDialog();
-	
+
 	// Returns true and clears state if key release should be skipped (was used to close dialog)
 	static bool ShouldSkipKeyRelease(uint32_t key);
 

--- a/src/Menu/HomePageRenderer.h
+++ b/src/Menu/HomePageRenderer.h
@@ -26,14 +26,18 @@ public:
 	// First-time setup management
 	static bool ShouldShowFirstTimeSetup();
 	static void RenderFirstTimeSetupDialog();
+	
+	// Returns true and clears state if key release should be skipped (was used to close dialog)
+	static bool ShouldSkipKeyRelease(uint32_t key);
 
 private:
 	static void RenderWelcomeSection();
 	static void RenderQuickLinksSection();
 	static void RenderFAQSection();
 
-	static void MarkFirstTimeSetupComplete();
+	static void MarkFirstTimeSetupComplete(uint32_t closingKey);
 
 	// State
 	static bool isFirstTimeSetupShown;
+	static uint32_t keyThatClosedDialog;
 };


### PR DESCRIPTION
Fixes the conflicting toggles (esc) with the startup box toggle and the shader cache. Now when pressing esc to dismiss the startup box it will not force background compilation of shader cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard input handling for the first-time setup dialog to prevent unintended hotkey triggers when closing the dialog. Key presses used to dismiss the dialog are now properly tracked to avoid activating other actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->