### PR TITLE
fix: replace original shaders off and not saveable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_POLICY_WARNING_CMP0116 OFF)
 project(
     # gersemi: ignore
     CommunityShaders
-    VERSION 1.4.10
+    VERSION 1.4.11
     LANGUAGES CXX
 )
 

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -8,6 +8,11 @@
 static constexpr uint CLUSTER_MAX_LIGHTS = 128;
 static constexpr uint MAX_LIGHTS = 1024;
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+	LightLimitFix::Settings,
+	EnableContactShadows,
+	LightsVisualisationMode)
+
 void LightLimitFix::DrawSettings()
 {
 	auto shaderCache = globals::shaderCache;
@@ -165,16 +170,19 @@ void LightLimitFix::SetupResources()
 	}
 }
 
-void LightLimitFix::LoadSettings(json&)
+void LightLimitFix::LoadSettings(json& o_json)
 {
+	settings = o_json;
 }
 
-void LightLimitFix::SaveSettings(json&)
+void LightLimitFix::SaveSettings(json& o_json)
 {
+	o_json = settings;
 }
 
 void LightLimitFix::RestoreDefaultSettings()
 {
+	settings = {};
 }
 
 RE::NiNode* GetParentRoomNode(RE::NiAVObject* object)

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -176,6 +176,7 @@ public:
 
 	struct Settings
 	{
+		bool EnableContactShadows = false;
 		bool EnableLightsVisualisation = false;
 		uint LightsVisualisationMode = 0;
 	};

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -407,6 +407,12 @@ void State::SaveToJson(nlohmann::json& settings)
 	auto& upscalingJson = settings[upscaling.GetShortName()];
 	upscaling.SaveSettings(upscalingJson);
 
+	json originalShaders;
+	ForEachShaderTypeWithIndex([&](auto type, int classIndex) {
+		originalShaders[magic_enum::enum_name(type)] = enabledClasses[classIndex];
+	});
+	settings["Replace Original Shaders"] = originalShaders;
+
 	json disabledFeaturesJson;
 	for (const auto& [featureName, isDisabled] : disabledFeatures) {
 		disabledFeaturesJson[featureName] = isDisabled;
@@ -471,6 +477,18 @@ void State::LoadFromJson(nlohmann::json& settings)
 			shaderCache->SetDiskCache(general["Enable Disk Cache"]);
 		if (general.contains("Enable Async") && general["Enable Async"].is_boolean())
 			shaderCache->SetAsync(general["Enable Async"]);
+	}
+
+	if (settings.contains("Replace Original Shaders") && settings["Replace Original Shaders"].is_object()) {
+		json& originalShaders = settings["Replace Original Shaders"];
+		ForEachShaderTypeWithIndex([&](auto type, int classIndex) {
+			auto name = magic_enum::enum_name(type);
+			if (originalShaders.contains(name) && originalShaders[name].is_boolean()) {
+				enabledClasses[classIndex] = originalShaders[name];
+			} else {
+				logger::warn("Invalid entry for shader class '{}', using current value", name);
+			}
+		});
 	}
 
 	// Load feature settings (only for already-loaded features)

--- a/src/State.h
+++ b/src/State.h
@@ -24,6 +24,7 @@ public:
 		for (auto& v : drawCalls) v = 0;
 		for (auto& v : frameTimePerType) v = 0.0f;
 		for (auto& v : smoothFrameTimePerType) v = 0.0f;
+		for (auto& v : enabledClasses) v = true;
 
 		// Initialize QueryPerformanceCounter frequency
 		frameTimingFrequency.QuadPart = 0;


### PR DESCRIPTION
Note this should be REBASED. Everyone will need to pull --rebase.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Contact Shadows configuration option to Light Limit Fix
  * Settings now persist and automatically restore when relaunching the application
  * Shader modification preferences are saved between sessions

* **Chores**
  * Updated version to 1.4.11

<!-- end of auto-generated comment: release notes by coderabbit.ai -->