### PR TITLE
feat(upscaling): custom DLSS preset

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -24,8 +24,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	streamlineLogLevel,
 	sharpnessFSR,
 	sharpnessDLSS,
-	useCustomDLSSPresets,
-	DLSSPreset);
+	presetDLSS);
 
 decltype(&D3D11CreateDeviceAndSwapChain) ptrD3D11CreateDeviceAndSwapChainUpscaling;
 
@@ -230,15 +229,13 @@ void Upscaling::DrawSettings()
 		} else if (upscaleMethod == UpscaleMethod::kDLSS) {
 			ImGui::SliderFloat("Sharpness", &settings.sharpnessDLSS, 0.0f, 1.0f, "%.1f");
 
-			ImGui::Checkbox("Use Custom DLSS Model Preset", (bool*)&settings.useCustomDLSSPresets);
+			const char* presets[] = { "Default", "Preset J", "Preset K", "Preset L", "Preset M" };
+			ImGui::Combo("DLSS Model Preset", (int*)&settings.presetDLSS, presets, 5);
 			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text("Manually choose which DLSS AI model to use.");
-				ImGui::Text("Each model offers different visual quality and performance.");
-				ImGui::Text("Leave disabled for automatic selection based on your settings.");
-			}
-			if (settings.useCustomDLSSPresets) {
-				const char* presets[] = { "J", "K", "L", "M" };
-				ImGui::SliderInt("DLSS Preset", (int*)&settings.DLSSPreset, 0, 3, presets[settings.DLSSPreset]);
+				ImGui::Text("Choose which DLSS AI model preset to use.");
+				ImGui::Text("Each model offers different visual quality, performance, and motion stability.");
+				ImGui::Text("Set to 'Default' for automatic selection based on your Upscale Preset and hardware.");
+				ImGui::Text("Changing this setting requires a restart to take effect.");
 			}
 		}
 	}

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -442,6 +442,10 @@ void Upscaling::LoadSettings(json& o_json)
 		logger::warn("[Upscaling] Loaded upscaleMethodNoDLSS {} out of range, clamping to {}", settings.upscaleMethodNoDLSS, enumCount ? enumCount - 1 : 0);
 		settings.upscaleMethodNoDLSS = enumCount ? enumCount - 1 : 0;
 	}
+	if (settings.presetDLSS > 4) {
+		logger::warn("[Upscaling] Loaded presetDLSS {} out of range, resetting to 0 (Default)", settings.presetDLSS);
+		settings.presetDLSS = 0;
+	}
 	auto iniSettingCollection = globals::game::iniPrefSettingCollection;
 	if (iniSettingCollection) {
 		auto setting = iniSettingCollection->GetSetting("bUseTAA:Display");

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -23,7 +23,9 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	frameGenerationForceEnable,
 	streamlineLogLevel,
 	sharpnessFSR,
-	sharpnessDLSS);
+	sharpnessDLSS,
+	useCustomDLSSPresets,
+	DLSSPreset);
 
 decltype(&D3D11CreateDeviceAndSwapChain) ptrD3D11CreateDeviceAndSwapChainUpscaling;
 
@@ -227,6 +229,17 @@ void Upscaling::DrawSettings()
 			ImGui::SliderFloat("Sharpness", &settings.sharpnessFSR, 0.0f, 1.0f, "%.1f");
 		} else if (upscaleMethod == UpscaleMethod::kDLSS) {
 			ImGui::SliderFloat("Sharpness", &settings.sharpnessDLSS, 0.0f, 1.0f, "%.1f");
+
+			ImGui::Checkbox("Use Custom DLSS Model Preset", (bool*)&settings.useCustomDLSSPresets);
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text("Manually choose which DLSS AI model to use.");
+				ImGui::Text("Each model offers different visual quality and performance.");
+				ImGui::Text("Leave disabled for automatic selection based on your settings.");
+			}
+			if (settings.useCustomDLSSPresets) {
+				const char* presets[] = { "J", "K", "L", "M" };
+				ImGui::SliderInt("DLSS Preset", (int*)&settings.DLSSPreset, 0, 3, presets[settings.DLSSPreset]);
+			}
 		}
 	}
 

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -59,6 +59,8 @@ public:
 		uint streamlineLogLevel = 0;  // 0=Off, 1=Default, 2=Verbose
 		float sharpnessFSR = 0.0f;
 		float sharpnessDLSS = 0.0f;
+		bool useCustomDLSSPresets = false;
+		uint DLSSPreset = 0;  // 0=J, 1=K, 2=L, 3=M
 	};
 
 	Settings settings;

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -59,8 +59,7 @@ public:
 		uint streamlineLogLevel = 0;  // 0=Off, 1=Default, 2=Verbose
 		float sharpnessFSR = 0.0f;
 		float sharpnessDLSS = 0.0f;
-		bool useCustomDLSSPresets = false;
-		uint DLSSPreset = 0;  // 0=J, 1=K, 2=L, 3=M
+		uint presetDLSS = 0;  // 0=Default, 1=J, 2=K, 3=L, 4=M
 	};
 
 	Settings settings;

--- a/src/Features/Upscaling/Streamline.cpp
+++ b/src/Features/Upscaling/Streamline.cpp
@@ -344,32 +344,29 @@ void Streamline::SetDLSSOptions(sl::ViewportHandle p_viewport, uint32_t width)
 	}
 	dlssOptions.useAutoExposure = sl::Boolean::eTrue;
 
-	std::optional<sl::DLSSPreset> preset;
-	if (globals::features::upscaling.settings.useCustomDLSSPresets)
-	{
-		switch (globals::features::upscaling.settings.DLSSPreset) {
-		case 0:
-			preset = sl::DLSSPreset::ePresetJ;
-			break;
-		case 1:
-			preset = sl::DLSSPreset::ePresetK;
-			break;
-		case 2:
-			preset = sl::DLSSPreset::ePresetL;
-			break;
-		case 3:
-			preset = sl::DLSSPreset::ePresetM;
-			break;
-		}
+	std::optional<sl::DLSSPreset> customPreset;
+	switch (globals::features::upscaling.settings.presetDLSS) {
+	case 1:
+		customPreset = sl::DLSSPreset::ePresetJ;
+		break;
+	case 2:
+		customPreset = sl::DLSSPreset::ePresetK;
+		break;
+	case 3:
+		customPreset = sl::DLSSPreset::ePresetL;
+		break;
+	case 4:
+		customPreset = sl::DLSSPreset::ePresetM;
+		break;
 	}
 
-	if (preset.has_value()) {
-		dlssOptions.dlaaPreset = preset.value();
-		dlssOptions.ultraQualityPreset = preset.value();
-		dlssOptions.qualityPreset = preset.value();
-		dlssOptions.balancedPreset = preset.value();
-		dlssOptions.performancePreset = preset.value();
-		dlssOptions.ultraPerformancePreset = preset.value();
+	if (customPreset.has_value()) {
+		dlssOptions.dlaaPreset = customPreset.value();
+		dlssOptions.ultraQualityPreset = customPreset.value();
+		dlssOptions.qualityPreset = customPreset.value();
+		dlssOptions.balancedPreset = customPreset.value();
+		dlssOptions.performancePreset = customPreset.value();
+		dlssOptions.ultraPerformancePreset = customPreset.value();
 	} else if (isRTXBelow40series) {
 		dlssOptions.dlaaPreset = sl::DLSSPreset::ePresetJ;
 		dlssOptions.ultraQualityPreset = sl::DLSSPreset::ePresetJ;

--- a/src/Features/Upscaling/Streamline.cpp
+++ b/src/Features/Upscaling/Streamline.cpp
@@ -344,7 +344,33 @@ void Streamline::SetDLSSOptions(sl::ViewportHandle p_viewport, uint32_t width)
 	}
 	dlssOptions.useAutoExposure = sl::Boolean::eTrue;
 
-	if (isRTXBelow40series) {
+	std::optional<sl::DLSSPreset> preset;
+	if (globals::features::upscaling.settings.useCustomDLSSPresets)
+	{
+		switch (globals::features::upscaling.settings.DLSSPreset) {
+		case 0:
+			preset = sl::DLSSPreset::ePresetJ;
+			break;
+		case 1:
+			preset = sl::DLSSPreset::ePresetK;
+			break;
+		case 2:
+			preset = sl::DLSSPreset::ePresetL;
+			break;
+		case 3:
+			preset = sl::DLSSPreset::ePresetM;
+			break;
+		}
+	}
+
+	if (preset.has_value()) {
+		dlssOptions.dlaaPreset = preset.value();
+		dlssOptions.ultraQualityPreset = preset.value();
+		dlssOptions.qualityPreset = preset.value();
+		dlssOptions.balancedPreset = preset.value();
+		dlssOptions.performancePreset = preset.value();
+		dlssOptions.ultraPerformancePreset = preset.value();
+	} else if (isRTXBelow40series) {
 		dlssOptions.dlaaPreset = sl::DLSSPreset::ePresetJ;
 		dlssOptions.ultraQualityPreset = sl::DLSSPreset::ePresetJ;
 		dlssOptions.qualityPreset = sl::DLSSPreset::ePresetJ;


### PR DESCRIPTION
Customizable DLSS AI model preset.

![Screenshot 2026-02-07 153010](https://github.com/user-attachments/assets/83ddebad-85e2-41c1-b12d-7c9b950dbc3a)

![Screenshot 2026-02-07 153307](https://github.com/user-attachments/assets/b9e840ef-085e-43db-901a-c8c11d05ccaf)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DLSS Model Preset selection with five configurable options (Default, J, K, L, M) to upscaling settings.
  * Extended DLSS configuration UI with a new combo dropdown for model preset selection and hover tooltip for preset descriptions.

* **Bug Fixes**
  * Added validation to clamp preset values to valid range on settings load, with fallback to default if out-of-range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->