### PR TITLE
fix(linearlighting): return correct buffer when ll feature off

### DIFF
--- a/src/Features/LinearLighting.cpp
+++ b/src/Features/LinearLighting.cpp
@@ -145,6 +145,11 @@ void LinearLighting::PostPostLoad()
 
 LinearLighting::PerFrameData LinearLighting::GetCommonBufferData()
 {
+	if (!loaded) {
+		auto data = PerFrameData{};
+		data.enableLinearLighting = false;
+		return data;
+	}
 	bool isMainLoadingMenu = globals::game::ui && (globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || globals::game::ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME));
 	auto data = PerFrameData{};
 	data.enableLinearLighting = settings.enableLinearLighting && !isMainLoadingMenu;


### PR DESCRIPTION
This pull request introduces a safeguard to the `GetCommonBufferData` method in `LinearLighting.cpp` to ensure that linear lighting is not enabled if the system is not fully loaded. This prevents potential issues during initialization or when the system is in an unloaded state.

Error handling and initialization:

* Added a check in `LinearLighting::GetCommonBufferData()` to return a default `PerFrameData` with `enableLinearLighting` set to `false` if the `loaded` flag is not set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of the LinearLighting feature by ensuring proper fallback behavior when the module is not loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->