### PR TITLE
fix(PBR): skip IrradianceToLinear on specular in vanilla

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2934,7 +2934,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		specularColor = 0;
 #	endif
 
+#	if !defined(TRUE_PBR)
+	// Vanilla specular needs gamma-to-linear conversion; PBR specular is already in linear space
 	specularColor = Color::IrradianceToLinear(specularColor);
+#	endif
 
 	diffuseColor = reflectionDiffuseColor;
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2934,10 +2934,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		specularColor = 0;
 #	endif
 
-#	if !defined(TRUE_PBR)
-	// Vanilla specular needs gamma-to-linear conversion; PBR specular is already in linear space
 	specularColor = Color::IrradianceToLinear(specularColor);
-#	endif
 
 	diffuseColor = reflectionDiffuseColor;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected specular color handling in shader rendering to ensure proper lighting appearance based on build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->