### PR TITLE
fix(grass collision): collision radius math 

### DIFF
--- a/src/Utils/ActorUtils.cpp
+++ b/src/Utils/ActorUtils.cpp
@@ -40,9 +40,9 @@ namespace Util
 			float y_neg = project(0.0f, -1.0f, 0.0f);
 			float z_pos = project(0.0f, 0.0f, 1.0f);
 			float z_neg = project(0.0f, 0.0f, -1.0f);
-			hx = 0.5f * (x_pos + x_neg);
-			hy = 0.5f * (y_pos + y_neg);
-			hz = 0.5f * (z_pos + z_neg);
+			hx = 0.5f * (x_pos - x_neg);
+			hy = 0.5f * (y_pos - y_neg);
+			hz = 0.5f * (z_pos - z_neg);
 		};
 		auto halfDiagonal = [](float hx, float hy, float hz) {
 			return sqrtf(hx * hx + hy * hy + hz * hz);


### PR DESCRIPTION
Calculate actual half extent size not the center offset.
Fixes issue #1734 
Tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shape boundary extent calculations to properly compute half-extents for supported shapes, improving accuracy of radius and diagonal measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->