### PR TITLE
chore(llf): remove LLF settings loading

### DIFF
--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -8,11 +8,6 @@
 static constexpr uint CLUSTER_MAX_LIGHTS = 128;
 static constexpr uint MAX_LIGHTS = 1024;
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
-	LightLimitFix::Settings,
-	EnableContactShadows,
-	LightsVisualisationMode)
-
 void LightLimitFix::DrawSettings()
 {
 	auto shaderCache = globals::shaderCache;
@@ -168,16 +163,6 @@ void LightLimitFix::SetupResources()
 	{
 		strictLightDataCB = new ConstantBuffer(ConstantBufferDesc<StrictLightDataCB>());
 	}
-}
-
-void LightLimitFix::LoadSettings(json& o_json)
-{
-	settings = o_json;
-}
-
-void LightLimitFix::SaveSettings(json& o_json)
-{
-	o_json = settings;
 }
 
 void LightLimitFix::RestoreDefaultSettings()

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -151,9 +151,6 @@ public:
 
 	virtual void SetupResources() override;
 
-	virtual void LoadSettings(json& o_json) override;
-	virtual void SaveSettings(json& o_json) override;
-
 	virtual void RestoreDefaultSettings() override;
 
 	virtual void DrawSettings() override;
@@ -176,7 +173,6 @@ public:
 
 	struct Settings
 	{
-		bool EnableContactShadows = false;
 		bool EnableLightsVisualisation = false;
 		uint LightsVisualisationMode = 0;
 	};


### PR DESCRIPTION
Re-attempt https://github.com/doodlum/skyrim-community-shaders/pull/1834.

Going to be tackling some simpler issues to sort of onboard and make use of the dev title.

These changes were originally reverted to solve issues for 1.4.11 release but the changes seem safe, unrelated to the issues caused in the 1.4.10 release.

The original issue was to remove the contact shadows setting, but it seems completely redundant to be saving any of these debug settings at all. Aims to resolve https://github.com/doodlum/skyrim-community-shaders/issues/1836.

Tested in game, restarted several times and toggled the settings. They persist during the session and are reset in the next session, as expected. The JSON entry is null as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Light Limit Fix settings persistence (save/load functionality) has been removed
* Removed the "Enable Contact Shadows" configuration option from Light Limit Fix settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->