### PR TITLE
revert: "fix: stop shader compilation on game exit"

### DIFF
--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -106,7 +106,6 @@ namespace globals
 		RE::BSUtilityShader* utilityShader = nullptr;
 		RE::Sky* sky = nullptr;
 		RE::UI* ui = nullptr;
-		RE::Main* main = nullptr;
 
 		RE::BSGraphics::PixelShader** currentPixelShader = nullptr;
 		RE::BSGraphics::VertexShader** currentVertexShader = nullptr;
@@ -198,7 +197,6 @@ namespace globals
 	void OnDataLoaded()
 	{
 		using namespace game;
-		main = RE::Main::GetSingleton();
 		sky = RE::Sky::GetSingleton();
 		utilityShader = RE::BSUtilityShader::GetSingleton();
 
@@ -206,13 +204,6 @@ namespace globals
 
 		bShadowsOnGrass = RE::GetINISetting("bShadowsOnGrass:Display");
 		shadowMaskQuarter = RE::GetINISetting("iShadowMaskQuarter:Display");
-	}
-
-	void OnGameWindowClose()
-	{
-		if (shaderCache) {
-			shaderCache->StopCompilation();
-		}
 	}
 
 	/**

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -219,7 +219,6 @@ namespace globals
 		extern RE::BSUtilityShader* utilityShader;
 		extern RE::Sky* sky;
 		extern RE::UI* ui;
-		extern RE::Main* main;
 
 		extern RE::BSGraphics::PixelShader** currentPixelShader;
 		extern RE::BSGraphics::VertexShader** currentVertexShader;
@@ -256,6 +255,5 @@ namespace globals
 	void OnInit();
 	void ReInit();
 	void OnDataLoaded();
-	void OnGameWindowClose();
 	void InstallD3DHooks(ID3D11DeviceContext* a_context);
 }

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -465,9 +465,6 @@ namespace Hooks
 			if ((a_msg == WM_KILLFOCUS || a_msg == WM_SETFOCUS) && menu->initialized) {
 				menu->focusChanged = true;
 			}
-			if (a_msg == WM_CLOSE) {
-				globals::OnGameWindowClose();
-			}
 			return func(a_hwnd, a_msg, a_wParam, a_lParam);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -2206,15 +2206,6 @@ namespace SIE
 		return compilationSet.totalTasks && compilationSet.completedTasks + compilationSet.failedTasks < compilationSet.totalTasks;
 	}
 
-	void ShaderCache::StopCompilation()
-	{
-		if (IsCompiling()) {
-			logger::info("Stopping {} remaining shader compilation tasks", compilationSet.totalTasks - compilationSet.completedTasks - compilationSet.failedTasks);
-		}
-		ssource.request_stop();
-		compilationSet.Clear();
-	}
-
 	bool ShaderCache::IsEnabled() const
 	{
 		return isEnabled;

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -332,7 +332,6 @@ namespace SIE
 		void SetAsync(bool value);
 		bool IsDump() const;
 		void SetDump(bool value);
-		void StopCompilation();
 
 		bool IsDiskCache() const;
 		void SetDiskCache(bool value);

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -113,16 +113,8 @@ void MessageHandler(SKSE::MessagingInterface::Message* message)
 
 				auto shaderCache = globals::shaderCache;
 				shaderCache->menuLoaded = true;
-
-				auto* main = globals::game::main;
-
-				while (shaderCache->IsCompiling() && !shaderCache->backgroundCompilation && !(main && main->quitGame)) {
+				while (shaderCache->IsCompiling() && !shaderCache->backgroundCompilation) {
 					std::this_thread::sleep_for(100ms);
-				}
-
-				if (main && main->quitGame) {
-					logger::info("Game was closed, skipping feature DataLoaded methods");
-					break;
 				}
 
 				if (shaderCache->IsDiskCache()) {


### PR DESCRIPTION
Reverts doodlum/skyrim-community-shaders#1867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed internal shutdown handlers and simplified message processing logic.
  * Removed explicit shader compilation stop functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->