### PR TITLE
refactor: core feature version mismatch UI enhancement

### DIFF
--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -96,7 +96,9 @@ void Feature::Load(json& o_json)
 
 					std::string minimalVersionString = Util::GetFormattedVersion(minimalFeatureVersion);
 
-					if (majorVersionMismatch) {
+					if (IsCore()) {
+						failedLoadedMessage = std::format("This feature is already included as part of the core Community Shaders installation. Uninstall this feature with your mod manager.");
+					} else if (majorVersionMismatch) {
 						failedLoadedMessage = std::format("{} {} is too old, major version incompatibility detected. Required: {}", GetShortName(), value, minimalVersionString);
 					} else {
 						failedLoadedMessage = std::format("{} {} is an old feature version, required: {}", GetShortName(), value, minimalVersionString);

--- a/src/FeatureIssues.cpp
+++ b/src/FeatureIssues.cpp
@@ -9,6 +9,7 @@ namespace FeatureIssues
 {
 	// Forward declarations
 	static void DrawFeatureIssue(const FeatureIssueInfo& issue, const ImVec4& color);
+	static bool IsVersionMismatchForCoreFeature(const FeatureIssueInfo& issue);
 
 	// Static storage for feature issues
 	static std::vector<FeatureIssueInfo> s_featureIssues;
@@ -401,7 +402,7 @@ namespace FeatureIssues
 		}
 		// Version Mismatch Section
 		if (auto section = Util::SectionWrapper("Wrong Version Features",
-				"The following features have version compatibility issues and were disabled automatically. Updating them may resolve the issues.",
+				"The following features have version compatibility issues and were disabled automatically. Please check for any updates or if the feature is considered obsolete.",
 				theme.StatusPalette.Warning, !versionIssues.empty())) {
 			for (const auto* issue : versionIssues) {
 				DrawFeatureIssue(*issue, theme.StatusPalette.Warning);
@@ -574,7 +575,13 @@ namespace FeatureIssues
 		}
 
 		// Handle download action for version mismatch features
-		if (issue.IsVersionMismatch()) {
+		if (IsVersionMismatchForCoreFeature(issue)) {
+			ImGui::SameLine();
+			ImGui::Text("Core feature already installed");
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::TextWrapped("This feature is already included as part of the core Community Shaders installation. Uninstall this feature with your mod manager.");
+			}
+		} else if (issue.IsVersionMismatch()) {
 			ImGui::SameLine();
 
 			if (!issue.replacementFeatureModLink.empty()) {
@@ -625,7 +632,7 @@ namespace FeatureIssues
 		// Show delete button for:
 		// 1. Features that don't modify shader directories (safe to delete)
 		// 2. Obsolete features with replacements (user can install replacement after deletion)
-		bool canSafelyDelete = !issue.ModifiedShaderDirectory() || (issue.IsObsolete() && !issue.replacementFeature.empty());
+		bool canSafelyDelete = (!issue.ModifiedShaderDirectory() || (issue.IsObsolete() && !issue.replacementFeature.empty())) && !IsVersionMismatchForCoreFeature(issue);
 		if (canSafelyDelete) {
 			ImGui::SameLine();
 			std::string deleteButtonId = "Delete##" + issue.shortName;
@@ -697,6 +704,14 @@ namespace FeatureIssues
 			}
 		}
 		ImGui::PopID();
+	}
+
+	static bool IsVersionMismatchForCoreFeature(const FeatureIssueInfo& issue)
+	{
+		if (!issue.IsVersionMismatch())
+			return false;
+		Feature* f = s_featureLookupCache.FindFeature(issue.shortName);
+		return f && f->IsCore();
 	}
 
 	bool IsReplacementFeatureInstalled(const std::string& featureName)


### PR DESCRIPTION
Core features should never have a version mismatch. Unless the core feature was originally a separate feature and the user installed the old separate download. Telling the user that it's a version mismatch and to download a new version is misleading.

Here's an example of a screenshot a user posted asking for support.
<img src="https://i.postimg.cc/hGGRDLwq/The-Elder-Scrolls-V-Skyrim-Special-Edition-Screenshot-2026-02-12-17-55-10-70.png" />

This is what it should look like now. (I've also changed the "wrong version" subtext, but the screenshot is from a older build)
<img width="1488" height="562" alt="image" src="https://github.com/user-attachments/assets/63031fe2-8bc5-4777-87c7-f4384eed876b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined error messages when features are incompatible, distinguishing between core-included and non-core installations to provide appropriate guidance.
  * Improved detection and UI presentation of version compatibility issues with updated messaging for better user clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->