### PR TITLE
fix(VR): fix Shadowmap Cascade Rasterizer

### DIFF
--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
@@ -3,9 +3,11 @@
 void ShadowmapRasterizerFix::Install()
 {
 	// This function is called once per cascade to begin the updating and rendering process
-	stl::write_thunk_call<BSShadowDirectionalLight_RenderShadowmaps_RenderCascade>(REL::RelocationID(101495, 108489).address() + REL::Relocate(0xC6, 0xC6));
+	stl::write_thunk_call<BSShadowDirectionalLight_RenderShadowmaps_RenderCascade>(REL::RelocationID(101495, 108489).address() + REL::Relocate(0xC6, 0xC6, 0xF6));
 
 	gRasterStates = reinterpret_cast<RasterStateArray*>(REL::RelocationID(524748, 411363).address());
+
+	numCascades = static_cast<uint>(Util::GetGameSettingValue<std::int32_t>("iNumSplits:Display", Settings.at("iNumSplits:Display")));
 }
 
 void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCascade::thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, uint32_t flags)
@@ -17,7 +19,7 @@ void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCas
 		//Backup
 		if (cascade == 0) {
 			std::memcpy(backupGameRasterStates, *gRasterStates, sizeof(RasterStateArray));
-			numCascades = std::min(RE::GetINISetting("iNumSplits:Display")->data.u, maxCascades);
+			numCascades = std::min(numCascades, maxCascades);
 		}
 
 		//Clone

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
@@ -54,6 +54,6 @@ struct ShadowmapRasterizerFix : EngineFix
 									"Controls the number of shadow map cascades used for directional lighting. "
 									"Higher values provide better shadow quality but use more GPU resources. "
 									"Maximum of 3 cascades supported. ",
-									REL::Relocate<uintptr_t>(0, 0, 0x1ed6350), 2, 1, 4 } },
+									REL::Relocate<uintptr_t>(0, 0, 0x1ed6350), 2, 1, 3 } },
 	};
 };

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
@@ -48,4 +48,12 @@ struct ShadowmapRasterizerFix : EngineFix
 		static void thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, uint32_t flags);
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
+
+	std::map<std::string, Util::GameSetting> Settings{
+		{ "iNumSplits:Display", { "Number of Shadow Map Cascades (INI) ",
+									"Controls the number of shadow map cascades used for directional lighting. "
+									"Higher values provide better shadow quality but use more GPU resources. "
+									"Maximum of 3 cascades supported. ",
+									REL::Relocate<uintptr_t>(0, 0, 0x1ed6350), 2, 1, 4 } },
+	};
 };

--- a/src/Utils/GameSetting.h
+++ b/src/Utils/GameSetting.h
@@ -104,6 +104,51 @@ namespace Util
 	void RenderImGuiElement(const std::string& settingName, const GameSetting& settingData, RE::Setting* setting, const std::string& collectionName = "");
 
 	/**
+	 * @brief Gets the value of a game setting, transparently handling INI-based and offset-based settings.
+	 *
+	 * For INI-based settings (offset == 0), tries INISettingCollection, INIPrefSettingCollection,
+	 * then GameSettingCollection. For offset-based settings (e.g., VR where INI entries don't exist),
+	 * reads directly from the memory address.
+	 *
+	 * @tparam T The expected value type (bool, float, std::int32_t, or std::uint32_t).
+	 * @param settingName The setting name (e.g., "iNumSplits:Display").
+	 * @param settingData The GameSetting metadata containing the offset and default value.
+	 * @return The current value of the setting, or the default value if not found.
+	 */
+	template <typename T>
+	T GetGameSettingValue(const std::string& settingName, const GameSetting& settingData)
+	{
+		if (settingData.offset == 0) {
+			auto* setting = RE::GetINISetting(settingName.c_str());
+			if (!setting) {
+				if (auto* collection = globals::game::gameSettingCollection)
+					setting = collection->GetSetting(settingName.data());
+			}
+			if (setting) {
+				T value{};
+				if constexpr (std::is_same_v<T, bool>)
+					value = setting->data.b;
+				else if constexpr (std::is_same_v<T, float>)
+					value = setting->data.f;
+				else if constexpr (std::is_same_v<T, std::int32_t>)
+					value = setting->data.i;
+				else if constexpr (std::is_same_v<T, std::uint32_t>)
+					value = setting->data.u;
+				logger::debug("GetGameSettingValue: '{}' = {} (from INI)", settingName, value);
+				return value;
+			}
+			auto defaultValue = std::get<T>(settingData.defaultValue);
+			logger::warn("GetGameSettingValue: '{}' not found in INI or GameSettingCollection, using default: {}", settingName, defaultValue);
+			return defaultValue;
+		} else {
+			auto address = REL::Offset{ settingData.offset }.address();
+			T value = *reinterpret_cast<T*>(address);
+			logger::debug("GetGameSettingValue: '{}' = {} (from offset 0x{:X})", settingName, value, settingData.offset);
+			return value;
+		}
+	}
+
+	/**
 	 * @brief Saves the provided game settings to the INI file.
 	 *
 	 * This function iterates through the settings map and saves settings that are managed via

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -142,7 +142,7 @@ bool Load()
 	}
 
 	if (REL::Module::IsVR()) {
-		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.193.0", true);
+		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.200.0", true);
 	}
 
 	auto privateProfileRedirectorVersion = Util::GetDllVersion(L"Data/SKSE/Plugins/PrivateProfileRedirector.dll");


### PR DESCRIPTION
Needed for #1690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Shadow cascade count is now read dynamically from the game's settings (configurable), improving consistency and reliability of shadow rendering.
  * Initial cascade handling is more robust to out-of-range values.
  * VR compatibility requirement raised to library version 0.200.0 for updated runtime support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->