### PR TITLE
fix(VR): depthbuffer culling when upscaling

### DIFF
--- a/features/Upscaling/Shaders/Upscaling/DepthUpscalePS.hlsl
+++ b/features/Upscaling/Shaders/Upscaling/DepthUpscalePS.hlsl
@@ -8,18 +8,12 @@
  * resolution, objects may be incorrectly culled (appearing to flicker in/out of view).
  *
  * This shader upscales the low-resolution depth buffer to full resolution using a
- * conservative approach that prevents incorrect culling. The key insight is that
- * for culling to be "safe", we need to preserve the closest depth values - an object
- * should only be culled if it's truly behind other geometry at ALL sub-pixel locations.
+ * conservative approach: minimum depth from a 2x2 neighborhood blended with point-
+ * sampled depth. Near the HMD hidden area mask (depth == 0 in reversed-Z), point
+ * sampling is used exclusively to prevent mask bleed from bilinear filtering.
  *
- * The shader uses a hybrid approach:
- * - Bilinear interpolation for smooth depth gradients (reduces artifacts on edges)
- * - Minimum depth from 2x2 neighborhood for conservative culling
- * - Configurable blending between the two approaches
-
- * - Depth upscaling approach by vrnord
- * - https://github.com/vrnord/skyrim-community-shaders-VR-DLSS
-
+ * Based on depth upscaling approach by vrnord
+ * https://github.com/vrnord/skyrim-community-shaders-VR-DLSS
  */
 
 #include "Upscaling/UpscaleVS.hlsl"
@@ -43,59 +37,11 @@ SamplerState LinearSampler : register(s0);
 
 cbuffer DepthUpscaleCB : register(b0)
 {
-	float2 SourceResolution;  // Low-res depth buffer dimensions
-	float2 TargetResolution;  // Full-res target dimensions
-	float2 ResolutionScale;   // SourceResolution / TargetResolution
-	float2 TexelSize;         // 1.0 / SourceResolution
+	float2 SourceDim;    // Full texture dimensions (texels)
+	float2 InvSourceDim; // 1.0 / SourceDim
+	float2 Scale;        // resolutionScale (render/display ratio)
+	float2 Pad;
 };
-
-/**
- * @brief Sample minimum depth from 2x2 neighborhood using GatherRed
- *
- * GatherRed efficiently fetches a 2x2 texel quad in a single operation.
- * For reversed-Z depth (smaller = closer), we take the minimum to ensure
- * conservative culling - objects will only be culled if behind ALL 4 samples.
- *
- * @param uv UV coordinates in low-resolution space
- * @return Minimum depth value from the 2x2 neighborhood
- */
-float SampleMinDepth2x2(float2 uv)
-{
-	// GatherRed returns: (0,1), (1,1), (1,0), (0,0) relative to sample point
-	float4 depthQuad = DepthLowRes.GatherRed(LinearSampler, uv);
-	return min(min(depthQuad.x, depthQuad.y), min(depthQuad.z, depthQuad.w));
-}
-
-/**
- * @brief Sample minimum depth from 3x3 neighborhood for higher upscale ratios
- *
- * For aggressive upscale ratios (e.g., Performance mode at 0.5x), a larger
- * neighborhood provides more robust coverage.
- *
- * @param uv UV coordinates in low-resolution space
- * @return Minimum depth value from the 3x3 neighborhood
- */
-float SampleMinDepth3x3(float2 uv)
-{
-	float2 texelPos = uv * SourceResolution;
-	int2 centerCoord = int2(floor(texelPos));
-
-	float minDepth = 1.0;  // Far plane in reversed-Z
-
-	[unroll] for (int y = -1; y <= 1; y++)
-	{
-		[unroll] for (int x = -1; x <= 1; x++)
-		{
-			int2 sampleCoord = centerCoord + int2(x, y);
-			sampleCoord = clamp(sampleCoord, int2(0, 0), int2(SourceResolution) - 1);
-			float sampleDepth = DepthLowRes.Load(int3(sampleCoord, 0));
-			minDepth = min(minDepth, sampleDepth);
-		}
-	}
-
-	return minDepth;
-}
-
 /**
  * @brief Main pixel shader entry point
  *
@@ -106,34 +52,37 @@ PS_OUTPUT main(PS_INPUT input)
 {
 	PS_OUTPUT psout;
 
-	// Transform UV from full-res to low-res space
-	float2 fullResUV = input.TexCoord;
-	float2 lowResUV = fullResUV * ResolutionScale;
-	lowResUV = saturate(lowResUV);
+	// Map full-res UV to render-res UV (same transform as the engine's
+	// GetDynamicResolutionAdjustedScreenPosition).
+	float2 uv = Scale * input.TexCoord;
 
-	// Calculate upscale ratio to determine filter size
-	float upscaleRatio = TargetResolution.x / SourceResolution.x;
+	// Per-eye clamping for SBS stereo: prevent sampling across the center seam.
+	bool isRight = input.TexCoord.x >= 0.5;
+	float halfScale = 0.5 * Scale.x;
+	uv.x = clamp(uv.x, isRight ? halfScale : 0.0, isRight ? Scale.x : halfScale);
+	uv.y = clamp(uv.y, 0.0, Scale.y);
 
-	// Bilinear interpolation for smooth base depth
-	float bilinearDepth = DepthLowRes.SampleLevel(LinearSampler, lowResUV, 0);
+	// Nearest texel coordinate for point sampling
+	int2 texel = int2(floor(uv * SourceDim));
 
-	// Conservative minimum depth
-	float minDepth;
-	if (upscaleRatio > 1.5) {
-		// Use 3x3 for aggressive upscaling (Performance/Ultra Performance modes)
-		minDepth = SampleMinDepth3x3(lowResUV);
-	} else {
-		// Use 2x2 for moderate upscaling (Quality/Balanced modes)
-		minDepth = SampleMinDepth2x2(lowResUV);
+	// GatherRed fetches the 2x2 texel quad around the sample point.
+	float4 depthQuad = DepthLowRes.GatherRed(LinearSampler, uv);
+	float minDepth = min(min(depthQuad.x, depthQuad.y), min(depthQuad.z, depthQuad.w));
+
+	// HMD hidden area mask: depth == 0 in reversed-Z.
+	// If ANY sample in the 2x2 quad is 0, we're at or near the mask boundary.
+	// Use point sampling only to avoid bilinear blending with mask pixels.
+	if (minDepth == 0.0) {
+		psout.Depth = DepthLowRes.Load(int3(texel, 0));
+		return psout;
 	}
 
-	// Blend between smooth and conservative
-	// Higher bias = more conservative (safer culling, potential popping)
-	// Lower bias = smoother (better visual, potential incorrect culling)
-	// 0.35 provides good balance for typical VR scenarios
-	const float conservativeBias = 0.35;
+	// All four neighbors are valid depth. Blend point-sampled depth toward
+	// the conservative minimum for safe culling.
+	float pointDepth = DepthLowRes.Load(int3(texel, 0));
 
-	psout.Depth = lerp(bilinearDepth, minDepth, conservativeBias);
+	const float conservativeBias = 0.35;
+	psout.Depth = lerp(pointDepth, minDepth, conservativeBias);
 
 	return psout;
 }

--- a/features/Upscaling/Shaders/Upscaling/DepthUpscalePS.hlsl
+++ b/features/Upscaling/Shaders/Upscaling/DepthUpscalePS.hlsl
@@ -1,19 +1,26 @@
-// Conservative depth buffer upscaling for VR depth-based culling
-//
-// When upscaling (FSR/DLSS) is active, the depth buffer is rendered at a lower
-// resolution than the display. Skyrim VR's depth-based culling (OBBOcclusionTesting)
-// reads from the depth buffer to determine object visibility, but with a mismatched
-// resolution, objects may be incorrectly culled (appearing to flicker in/out of view).
-//
-// This shader upscales the low-resolution depth buffer to full resolution using a
-// conservative approach that prevents incorrect culling. For reversed-Z depth
-// (smaller = closer), we take the minimum to ensure objects are only culled if
-// truly behind other geometry at all sub-pixel locations.
-//
-// Uses a hybrid approach: bilinear interpolation blended with min-depth sampling.
-//
-// Based on depth upscaling approach by vrnord
-// https://github.com/vrnord/skyrim-community-shaders-VR-DLSS
+/**
+ * @file DepthUpscalePS.hlsl
+ * @brief Conservative depth buffer upscaling for VR depth-based culling
+ *
+ * When upscaling (FSR/DLSS) is active, the depth buffer is rendered at a lower
+ * resolution than the display. Skyrim VR's depth-based culling (OBBOcclusionTesting)
+ * reads from the depth buffer to determine object visibility, but with a mismatched
+ * resolution, objects may be incorrectly culled (appearing to flicker in/out of view).
+ *
+ * This shader upscales the low-resolution depth buffer to full resolution using a
+ * conservative approach that prevents incorrect culling. The key insight is that
+ * for culling to be "safe", we need to preserve the closest depth values - an object
+ * should only be culled if it's truly behind other geometry at ALL sub-pixel locations.
+ *
+ * The shader uses a hybrid approach:
+ * - Bilinear interpolation for smooth depth gradients (reduces artifacts on edges)
+ * - Minimum depth from 2x2 neighborhood for conservative culling
+ * - Configurable blending between the two approaches
+
+* - Depth upscaling approach by vrnord
+* - https://github.com/vrnord/skyrim-community-shaders-VR-DLSS
+
+ */
 
 #include "Upscaling/UpscaleVS.hlsl"
 
@@ -25,78 +32,115 @@ typedef VS_OUTPUT PS_INPUT;
 
 struct PS_OUTPUT
 {
-	float Depth : SV_Depth;
+    float Depth : SV_Depth;
 };
 
+// Low-resolution depth buffer (copy of main depth at render resolution)
 Texture2D<float> DepthLowRes : register(t0);
 
+// Linear sampler for bilinear interpolation
 SamplerState LinearSampler : register(s0);
 
 cbuffer DepthUpscaleCB : register(b0)
 {
-	float2 SourceResolution;
-	float2 TargetResolution;
-	float2 ResolutionScale;
-	float2 TexelSize;
+    float2 SourceResolution;    // Low-res depth buffer dimensions
+    float2 TargetResolution;    // Full-res target dimensions
+    float2 ResolutionScale;     // SourceResolution / TargetResolution
+    float2 TexelSize;           // 1.0 / SourceResolution
 };
 
-// Sample minimum depth from 2x2 neighborhood using GatherRed.
-// For reversed-Z (smaller = closer), minimum ensures conservative culling.
+/**
+ * @brief Sample minimum depth from 2x2 neighborhood using GatherRed
+ *
+ * GatherRed efficiently fetches a 2x2 texel quad in a single operation.
+ * For reversed-Z depth (smaller = closer), we take the minimum to ensure
+ * conservative culling - objects will only be culled if behind ALL 4 samples.
+ *
+ * @param uv UV coordinates in low-resolution space
+ * @return Minimum depth value from the 2x2 neighborhood
+ */
 float SampleMinDepth2x2(float2 uv)
 {
-	float4 depthQuad = DepthLowRes.GatherRed(LinearSampler, uv);
-	return min(min(depthQuad.x, depthQuad.y), min(depthQuad.z, depthQuad.w));
+    // GatherRed returns: (0,1), (1,1), (1,0), (0,0) relative to sample point
+    float4 depthQuad = DepthLowRes.GatherRed(LinearSampler, uv);
+    return min(min(depthQuad.x, depthQuad.y), min(depthQuad.z, depthQuad.w));
 }
 
-// Sample minimum depth from 3x3 neighborhood for higher upscale ratios.
+/**
+ * @brief Sample minimum depth from 3x3 neighborhood for higher upscale ratios
+ *
+ * For aggressive upscale ratios (e.g., Performance mode at 0.5x), a larger
+ * neighborhood provides more robust coverage.
+ *
+ * @param uv UV coordinates in low-resolution space
+ * @return Minimum depth value from the 3x3 neighborhood
+ */
 float SampleMinDepth3x3(float2 uv)
 {
-	float2 texelPos = uv * SourceResolution;
-	int2 centerCoord = int2(floor(texelPos));
+    float2 texelPos = uv * SourceResolution;
+    int2 centerCoord = int2(floor(texelPos));
 
-	float minDepth = 1.0;
+    float minDepth = 1.0;  // Far plane in reversed-Z
 
-	[unroll]
-	for (int y = -1; y <= 1; y++) {
-		[unroll]
-		for (int x = -1; x <= 1; x++) {
-			int2 sampleCoord = centerCoord + int2(x, y);
-			sampleCoord = clamp(sampleCoord, int2(0, 0), int2(SourceResolution) - 1);
-			float sampleDepth = DepthLowRes.Load(int3(sampleCoord, 0));
-			minDepth = min(minDepth, sampleDepth);
-		}
-	}
+    [unroll]
+    for (int y = -1; y <= 1; y++)
+    {
+        [unroll]
+        for (int x = -1; x <= 1; x++)
+        {
+            int2 sampleCoord = centerCoord + int2(x, y);
+            sampleCoord = clamp(sampleCoord, int2(0, 0), int2(SourceResolution) - 1);
+            float sampleDepth = DepthLowRes.Load(int3(sampleCoord, 0));
+            minDepth = min(minDepth, sampleDepth);
+        }
+    }
 
-	return minDepth;
+    return minDepth;
 }
 
+/**
+ * @brief Main pixel shader entry point
+ *
+ * Performs conservative depth upscaling by blending bilinear interpolation
+ * (for smooth gradients) with minimum depth (for safe culling).
+ */
 PS_OUTPUT main(PS_INPUT input)
 {
-	PS_OUTPUT psout;
+    PS_OUTPUT psout;
 
-	float2 fullResUV = input.TexCoord;
-	float2 lowResUV = fullResUV * ResolutionScale;
-	lowResUV = saturate(lowResUV);
+    // Transform UV from full-res to low-res space
+    float2 fullResUV = input.TexCoord;
+    float2 lowResUV = fullResUV * ResolutionScale;
+    lowResUV = saturate(lowResUV);
 
-	float upscaleRatio = TargetResolution.x / SourceResolution.x;
+    // Calculate upscale ratio to determine filter size
+    float upscaleRatio = TargetResolution.x / SourceResolution.x;
 
-	float bilinearDepth = DepthLowRes.SampleLevel(LinearSampler, lowResUV, 0);
+    // Bilinear interpolation for smooth base depth
+    float bilinearDepth = DepthLowRes.SampleLevel(LinearSampler, lowResUV, 0);
 
-	float minDepth;
-	if (upscaleRatio > 1.5) {
-		minDepth = SampleMinDepth3x3(lowResUV);
-	} else {
-		minDepth = SampleMinDepth2x2(lowResUV);
-	}
+    // Conservative minimum depth
+    float minDepth;
+    if (upscaleRatio > 1.5)
+    {
+        // Use 3x3 for aggressive upscaling (Performance/Ultra Performance modes)
+        minDepth = SampleMinDepth3x3(lowResUV);
+    }
+    else
+    {
+        // Use 2x2 for moderate upscaling (Quality/Balanced modes)
+        minDepth = SampleMinDepth2x2(lowResUV);
+    }
 
-	// Blend between smooth and conservative depth.
-	// Higher bias = more conservative (safer culling, potential popping).
-	// Lower bias = smoother (better visual, potential incorrect culling).
-	const float conservativeBias = 0.35;
+    // Blend between smooth and conservative
+    // Higher bias = more conservative (safer culling, potential popping)
+    // Lower bias = smoother (better visual, potential incorrect culling)
+    // 0.35 provides good balance for typical VR scenarios
+    const float conservativeBias = 0.35;
 
-	psout.Depth = lerp(bilinearDepth, minDepth, conservativeBias);
+    psout.Depth = lerp(bilinearDepth, minDepth, conservativeBias);
 
-	return psout;
+    return psout;
 }
 
 #endif

--- a/features/Upscaling/Shaders/Upscaling/DepthUpscalePS.hlsl
+++ b/features/Upscaling/Shaders/Upscaling/DepthUpscalePS.hlsl
@@ -17,22 +17,22 @@
  * - Minimum depth from 2x2 neighborhood for conservative culling
  * - Configurable blending between the two approaches
 
-* - Depth upscaling approach by vrnord
-* - https://github.com/vrnord/skyrim-community-shaders-VR-DLSS
+ * - Depth upscaling approach by vrnord
+ * - https://github.com/vrnord/skyrim-community-shaders-VR-DLSS
 
  */
 
 #include "Upscaling/UpscaleVS.hlsl"
 
 #if defined(PSHADER)
-#include "Common/FrameBuffer.hlsli"
-#include "Common/SharedData.hlsli"
+#	include "Common/FrameBuffer.hlsli"
+#	include "Common/SharedData.hlsli"
 
 typedef VS_OUTPUT PS_INPUT;
 
 struct PS_OUTPUT
 {
-    float Depth : SV_Depth;
+	float Depth : SV_Depth;
 };
 
 // Low-resolution depth buffer (copy of main depth at render resolution)
@@ -43,10 +43,10 @@ SamplerState LinearSampler : register(s0);
 
 cbuffer DepthUpscaleCB : register(b0)
 {
-    float2 SourceResolution;    // Low-res depth buffer dimensions
-    float2 TargetResolution;    // Full-res target dimensions
-    float2 ResolutionScale;     // SourceResolution / TargetResolution
-    float2 TexelSize;           // 1.0 / SourceResolution
+	float2 SourceResolution;  // Low-res depth buffer dimensions
+	float2 TargetResolution;  // Full-res target dimensions
+	float2 ResolutionScale;   // SourceResolution / TargetResolution
+	float2 TexelSize;         // 1.0 / SourceResolution
 };
 
 /**
@@ -61,9 +61,9 @@ cbuffer DepthUpscaleCB : register(b0)
  */
 float SampleMinDepth2x2(float2 uv)
 {
-    // GatherRed returns: (0,1), (1,1), (1,0), (0,0) relative to sample point
-    float4 depthQuad = DepthLowRes.GatherRed(LinearSampler, uv);
-    return min(min(depthQuad.x, depthQuad.y), min(depthQuad.z, depthQuad.w));
+	// GatherRed returns: (0,1), (1,1), (1,0), (0,0) relative to sample point
+	float4 depthQuad = DepthLowRes.GatherRed(LinearSampler, uv);
+	return min(min(depthQuad.x, depthQuad.y), min(depthQuad.z, depthQuad.w));
 }
 
 /**
@@ -77,25 +77,23 @@ float SampleMinDepth2x2(float2 uv)
  */
 float SampleMinDepth3x3(float2 uv)
 {
-    float2 texelPos = uv * SourceResolution;
-    int2 centerCoord = int2(floor(texelPos));
+	float2 texelPos = uv * SourceResolution;
+	int2 centerCoord = int2(floor(texelPos));
 
-    float minDepth = 1.0;  // Far plane in reversed-Z
+	float minDepth = 1.0;  // Far plane in reversed-Z
 
-    [unroll]
-    for (int y = -1; y <= 1; y++)
-    {
-        [unroll]
-        for (int x = -1; x <= 1; x++)
-        {
-            int2 sampleCoord = centerCoord + int2(x, y);
-            sampleCoord = clamp(sampleCoord, int2(0, 0), int2(SourceResolution) - 1);
-            float sampleDepth = DepthLowRes.Load(int3(sampleCoord, 0));
-            minDepth = min(minDepth, sampleDepth);
-        }
-    }
+	[unroll] for (int y = -1; y <= 1; y++)
+	{
+		[unroll] for (int x = -1; x <= 1; x++)
+		{
+			int2 sampleCoord = centerCoord + int2(x, y);
+			sampleCoord = clamp(sampleCoord, int2(0, 0), int2(SourceResolution) - 1);
+			float sampleDepth = DepthLowRes.Load(int3(sampleCoord, 0));
+			minDepth = min(minDepth, sampleDepth);
+		}
+	}
 
-    return minDepth;
+	return minDepth;
 }
 
 /**
@@ -106,41 +104,38 @@ float SampleMinDepth3x3(float2 uv)
  */
 PS_OUTPUT main(PS_INPUT input)
 {
-    PS_OUTPUT psout;
+	PS_OUTPUT psout;
 
-    // Transform UV from full-res to low-res space
-    float2 fullResUV = input.TexCoord;
-    float2 lowResUV = fullResUV * ResolutionScale;
-    lowResUV = saturate(lowResUV);
+	// Transform UV from full-res to low-res space
+	float2 fullResUV = input.TexCoord;
+	float2 lowResUV = fullResUV * ResolutionScale;
+	lowResUV = saturate(lowResUV);
 
-    // Calculate upscale ratio to determine filter size
-    float upscaleRatio = TargetResolution.x / SourceResolution.x;
+	// Calculate upscale ratio to determine filter size
+	float upscaleRatio = TargetResolution.x / SourceResolution.x;
 
-    // Bilinear interpolation for smooth base depth
-    float bilinearDepth = DepthLowRes.SampleLevel(LinearSampler, lowResUV, 0);
+	// Bilinear interpolation for smooth base depth
+	float bilinearDepth = DepthLowRes.SampleLevel(LinearSampler, lowResUV, 0);
 
-    // Conservative minimum depth
-    float minDepth;
-    if (upscaleRatio > 1.5)
-    {
-        // Use 3x3 for aggressive upscaling (Performance/Ultra Performance modes)
-        minDepth = SampleMinDepth3x3(lowResUV);
-    }
-    else
-    {
-        // Use 2x2 for moderate upscaling (Quality/Balanced modes)
-        minDepth = SampleMinDepth2x2(lowResUV);
-    }
+	// Conservative minimum depth
+	float minDepth;
+	if (upscaleRatio > 1.5) {
+		// Use 3x3 for aggressive upscaling (Performance/Ultra Performance modes)
+		minDepth = SampleMinDepth3x3(lowResUV);
+	} else {
+		// Use 2x2 for moderate upscaling (Quality/Balanced modes)
+		minDepth = SampleMinDepth2x2(lowResUV);
+	}
 
-    // Blend between smooth and conservative
-    // Higher bias = more conservative (safer culling, potential popping)
-    // Lower bias = smoother (better visual, potential incorrect culling)
-    // 0.35 provides good balance for typical VR scenarios
-    const float conservativeBias = 0.35;
+	// Blend between smooth and conservative
+	// Higher bias = more conservative (safer culling, potential popping)
+	// Lower bias = smoother (better visual, potential incorrect culling)
+	// 0.35 provides good balance for typical VR scenarios
+	const float conservativeBias = 0.35;
 
-    psout.Depth = lerp(bilinearDepth, minDepth, conservativeBias);
+	psout.Depth = lerp(bilinearDepth, minDepth, conservativeBias);
 
-    return psout;
+	return psout;
 }
 
 #endif

--- a/features/Upscaling/Shaders/Upscaling/DepthUpscalePS.hlsl
+++ b/features/Upscaling/Shaders/Upscaling/DepthUpscalePS.hlsl
@@ -1,0 +1,102 @@
+// Conservative depth buffer upscaling for VR depth-based culling
+//
+// When upscaling (FSR/DLSS) is active, the depth buffer is rendered at a lower
+// resolution than the display. Skyrim VR's depth-based culling (OBBOcclusionTesting)
+// reads from the depth buffer to determine object visibility, but with a mismatched
+// resolution, objects may be incorrectly culled (appearing to flicker in/out of view).
+//
+// This shader upscales the low-resolution depth buffer to full resolution using a
+// conservative approach that prevents incorrect culling. For reversed-Z depth
+// (smaller = closer), we take the minimum to ensure objects are only culled if
+// truly behind other geometry at all sub-pixel locations.
+//
+// Uses a hybrid approach: bilinear interpolation blended with min-depth sampling.
+//
+// Based on depth upscaling approach by vrnord
+// https://github.com/vrnord/skyrim-community-shaders-VR-DLSS
+
+#include "Upscaling/UpscaleVS.hlsl"
+
+#if defined(PSHADER)
+#include "Common/FrameBuffer.hlsli"
+#include "Common/SharedData.hlsli"
+
+typedef VS_OUTPUT PS_INPUT;
+
+struct PS_OUTPUT
+{
+	float Depth : SV_Depth;
+};
+
+Texture2D<float> DepthLowRes : register(t0);
+
+SamplerState LinearSampler : register(s0);
+
+cbuffer DepthUpscaleCB : register(b0)
+{
+	float2 SourceResolution;
+	float2 TargetResolution;
+	float2 ResolutionScale;
+	float2 TexelSize;
+};
+
+// Sample minimum depth from 2x2 neighborhood using GatherRed.
+// For reversed-Z (smaller = closer), minimum ensures conservative culling.
+float SampleMinDepth2x2(float2 uv)
+{
+	float4 depthQuad = DepthLowRes.GatherRed(LinearSampler, uv);
+	return min(min(depthQuad.x, depthQuad.y), min(depthQuad.z, depthQuad.w));
+}
+
+// Sample minimum depth from 3x3 neighborhood for higher upscale ratios.
+float SampleMinDepth3x3(float2 uv)
+{
+	float2 texelPos = uv * SourceResolution;
+	int2 centerCoord = int2(floor(texelPos));
+
+	float minDepth = 1.0;
+
+	[unroll]
+	for (int y = -1; y <= 1; y++) {
+		[unroll]
+		for (int x = -1; x <= 1; x++) {
+			int2 sampleCoord = centerCoord + int2(x, y);
+			sampleCoord = clamp(sampleCoord, int2(0, 0), int2(SourceResolution) - 1);
+			float sampleDepth = DepthLowRes.Load(int3(sampleCoord, 0));
+			minDepth = min(minDepth, sampleDepth);
+		}
+	}
+
+	return minDepth;
+}
+
+PS_OUTPUT main(PS_INPUT input)
+{
+	PS_OUTPUT psout;
+
+	float2 fullResUV = input.TexCoord;
+	float2 lowResUV = fullResUV * ResolutionScale;
+	lowResUV = saturate(lowResUV);
+
+	float upscaleRatio = TargetResolution.x / SourceResolution.x;
+
+	float bilinearDepth = DepthLowRes.SampleLevel(LinearSampler, lowResUV, 0);
+
+	float minDepth;
+	if (upscaleRatio > 1.5) {
+		minDepth = SampleMinDepth3x3(lowResUV);
+	} else {
+		minDepth = SampleMinDepth2x2(lowResUV);
+	}
+
+	// Blend between smooth and conservative depth.
+	// Higher bias = more conservative (safer culling, potential popping).
+	// Lower bias = smoother (better visual, potential incorrect culling).
+	const float conservativeBias = 0.35;
+
+	psout.Depth = lerp(bilinearDepth, minDepth, conservativeBias);
+
+	return psout;
+}
+
+#endif

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
@@ -7,7 +7,8 @@ void ShadowmapRasterizerFix::Install()
 
 	gRasterStates = reinterpret_cast<RasterStateArray*>(REL::RelocationID(524748, 411363).address());
 
-	numCascades = static_cast<uint>(Util::GetGameSettingValue<std::int32_t>("iNumSplits:Display", Settings.at("iNumSplits:Display")));
+	auto rawCascades = Util::GetGameSettingValue<std::int32_t>("iNumSplits:Display", Settings.at("iNumSplits:Display"));
+	numCascades = static_cast<uint>(std::clamp(rawCascades, std::int32_t(1), std::int32_t(maxCascades)));
 }
 
 void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCascade::thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, uint32_t flags)

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
@@ -50,10 +50,10 @@ struct ShadowmapRasterizerFix : EngineFix
 	};
 
 	std::map<std::string, Util::GameSetting> Settings{
-		{ "iNumSplits:Display", { "Number of Shadow Map Cascades (INI) ",
+		{ "iNumSplits:Display", { "Number of Shadow Map Cascades (INI)",
 									"Controls the number of shadow map cascades used for directional lighting. "
 									"Higher values provide better shadow quality but use more GPU resources. "
-									"Maximum of 3 cascades supported. ",
+									"Maximum of 3 cascades supported.",
 									REL::Relocate<uintptr_t>(0, 0, 0x1ed6350), 2, 1, 3 } },
 	};
 };

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1623,13 +1623,12 @@ void Upscaling::UpscaleDepth()
 		auto& depthCopy = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN_COPY];
 
 		auto screenSize = globals::state->screenSize;
-		float2 renderSize = screenSize * resolutionScale;
 
 		DepthUpscaleCB cbData;
-		cbData.SourceResolution = renderSize;
-		cbData.TargetResolution = screenSize;
-		cbData.ResolutionScale = renderSize / screenSize;
-		cbData.TexelSize = float2(1.0f / renderSize.x, 1.0f / renderSize.y);
+		cbData.SourceDim = screenSize;
+		cbData.InvSourceDim = float2(1.0f / screenSize.x, 1.0f / screenSize.y);
+		cbData.Scale = resolutionScale;
+		cbData.Pad = { 0, 0 };
 
 		depthUpscaleCB->Update(cbData);
 		auto bufferArray = depthUpscaleCB->CB();

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -747,6 +747,17 @@ ID3D11PixelShader* Upscaling::GetUnderwaterMaskUpscalePS()
 	return underwaterMaskUpscalePS.get();
 }
 
+ID3D11PixelShader* Upscaling::GetDepthUpscalePS()
+{
+	if (!depthUpscalePS) {
+		logger::debug("Compiling DepthUpscalePS.hlsl");
+		std::vector<std::pair<const char*, const char*>> defines = { { "PSHADER", "" } };
+		depthUpscalePS.attach((ID3D11PixelShader*)Util::CompileShader(L"Data/Shaders/Upscaling/DepthUpscalePS.hlsl", defines, "ps_5_0"));
+	}
+
+	return depthUpscalePS.get();
+}
+
 ID3D11VertexShader* Upscaling::GetUpscaleVS()
 {
 	if (!upscaleVS) {
@@ -1087,24 +1098,6 @@ void Upscaling::ConfigureUpscaling(RE::BSGraphics::State* a_viewport)
 	// Disable dynamic resolution unless the game explicitly enables it
 	if (!globals::game::isVR)
 		runtimeData.dynamicResolutionLock = 1;
-
-	// If running in VR and an external upscaler is active, force-disable
-	// the engine's depth-buffer culling immediately. This ensures that
-	// enabling upscaling at runtime (after game load) does not leave the
-	// VR depth-buffer culling enabled which can cause incorrect occlusion.
-	if (globals::game::isVR) {
-		auto& vr = globals::features::vr;
-		if (IsUpscalingActive()) {
-			if (vr.gDepthBufferCulling) {
-				if (*vr.gDepthBufferCulling) {
-					*vr.gDepthBufferCulling = false;
-					logger::info("[Upscaling] VR detected - forcing depth buffer culling OFF due to active downscaling upscaler (scale={})", resolutionScale.x);
-				}
-			} else {
-				logger::warn("[Upscaling] VR depth buffer culling pointer is null, cannot force disable");
-			}
-		}
-	}
 }
 
 void Upscaling::SetupResources()
@@ -1149,6 +1142,9 @@ void Upscaling::SetupResources()
 		depthStencilDesc.BackFace.StencilDepthFailOp = depthStencilDesc.FrontFace.StencilDepthFailOp;
 		depthStencilDesc.BackFace.StencilPassOp = depthStencilDesc.FrontFace.StencilPassOp;
 		depthStencilDesc.BackFace.StencilFunc = depthStencilDesc.FrontFace.StencilFunc;
+
+		// Create depth upscale constant buffer for VR depth culling support
+		depthUpscaleCB = new ConstantBuffer(ConstantBufferDesc<DepthUpscaleCB>());
 	} else {
 		depthStencilDesc.StencilEnable = false;  // Disable stencil testing
 	}
@@ -1202,6 +1198,7 @@ void Upscaling::ClearShaderCache()
 	depthRefractionUpscalePS = nullptr;  // com_ptr automatically releases
 	underwaterMaskUpscalePS = nullptr;   // com_ptr automatically releases
 	upscaleVS = nullptr;                 // com_ptr automatically releases
+	depthUpscalePS = nullptr;            // com_ptr automatically releases
 }
 
 void Upscaling::CopySharedD3D12Resources()
@@ -1413,31 +1410,6 @@ bool Upscaling::IsUpscalingActive() const
 	return resolutionScale.x < .99f;
 }
 
-std::vector<FeatureConstraints::Constraint> Upscaling::GetActiveConstraints() const
-{
-	std::vector<FeatureConstraints::Constraint> constraints;
-
-	if (!IsUpscalingActive()) {
-		return constraints;
-	}
-
-	// When upscaling is active in VR, depth buffer culling must be disabled
-	// because upscalers modify the depth buffer, causing incorrect occlusion
-	if (globals::game::isVR) {
-		constraints.push_back({ { "VR", "EnableDepthBufferCullingExterior" },
-			false,
-			"Upscaling modifies the depth buffer, causing incorrect VR occlusion tests in exteriors.",
-			false });
-
-		constraints.push_back({ { "VR", "EnableDepthBufferCullingInterior" },
-			false,
-			"Upscaling modifies the depth buffer, causing incorrect VR occlusion tests in interiors.",
-			false });
-	}
-
-	return constraints;
-}
-
 /**
  * @brief Retrieves the current frame time for frame generation.
  *
@@ -1636,6 +1608,69 @@ void Upscaling::PerformUpscaling()
 
 void Upscaling::UpscaleDepth()
 {
+	// VR-specific: Conservative depth buffer upscale for OBBOcclusionTesting compatibility.
+	// Runs a dedicated depth-only pass that writes conservative (min-depth) values to the
+	// main depth buffer at display resolution, allowing VR depth-based culling to work
+	// correctly when an upscaler is active.
+	// Based on approach by vrnord (https://github.com/vrnord/skyrim-community-shaders-VR-DLSS)
+	if (globals::game::isVR && enableVRDepthUpscale && resolutionScale.x != 1.0f) {
+		globals::state->BeginPerfEvent("VR Depth Buffer Upscale");
+
+		auto renderer = globals::game::renderer;
+		auto context = globals::d3d::context;
+
+		auto& depth = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
+		auto& depthCopy = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN_COPY];
+
+		auto screenSize = globals::state->screenSize;
+		float2 renderSize = screenSize * resolutionScale;
+
+		DepthUpscaleCB cbData;
+		cbData.SourceResolution = renderSize;
+		cbData.TargetResolution = screenSize;
+		cbData.ResolutionScale = renderSize / screenSize;
+		cbData.TexelSize = float2(1.0f / renderSize.x, 1.0f / renderSize.y);
+
+		depthUpscaleCB->Update(cbData);
+		auto bufferArray = depthUpscaleCB->CB();
+		context->PSSetConstantBuffers(0, 1, &bufferArray);
+
+		context->IASetInputLayout(nullptr);
+		context->IASetVertexBuffers(0, 0, nullptr, nullptr, nullptr);
+		context->IASetIndexBuffer(nullptr, DXGI_FORMAT_UNKNOWN, 0);
+		context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+		context->VSSetShader(GetUpscaleVS(), nullptr, 0);
+
+		D3D11_VIEWPORT viewport = {};
+		viewport.Width = screenSize.x;
+		viewport.Height = screenSize.y;
+		viewport.MaxDepth = 1.0f;
+		context->RSSetViewports(1, &viewport);
+
+		context->RSSetState(upscaleRasterizerState.get());
+		context->OMSetDepthStencilState(upscaleDepthStencilState.get(), 0);
+
+		context->CopyResource(depthCopy.texture, depth.texture);
+
+		auto deferred = globals::deferred;
+		ID3D11SamplerState* samplers[] = { deferred->linearSampler };
+		context->PSSetSamplers(0, ARRAYSIZE(samplers), samplers);
+
+		ID3D11ShaderResourceView* srvs[] = { depthCopy.depthSRV };
+		context->PSSetShaderResources(0, ARRAYSIZE(srvs), srvs);
+
+		context->OMSetRenderTargets(0, nullptr, depth.views[0]);
+
+		context->PSSetShader(GetDepthUpscalePS(), nullptr, 0);
+		context->Draw(3, 0);
+
+		ID3D11ShaderResourceView* nullSRVs[1] = { nullptr };
+		context->PSSetShaderResources(0, 1, nullSRVs);
+
+		globals::state->EndPerfEvent();
+	}
+
 	if (resolutionScale.x != 1.0f) {
 		globals::state->BeginPerfEvent("Render Target Upscaling");
 

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -116,10 +116,10 @@ public:
 
 	struct DepthUpscaleCB
 	{
-		float2 SourceResolution;
-		float2 TargetResolution;
-		float2 ResolutionScale;
-		float2 TexelSize;
+		float2 SourceDim;     // Full texture dimensions (texels)
+		float2 InvSourceDim;  // 1.0 / SourceDim
+		float2 Scale;         // resolutionScale (render/display ratio)
+		float2 Pad;
 	};
 
 	ConstantBuffer* depthUpscaleCB = nullptr;

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -36,8 +36,6 @@ public:
 		};
 	}
 
-	virtual std::vector<FeatureConstraints::Constraint> GetActiveConstraints() const override;
-
 	float2 jitter = { 0, 0 };
 
 	enum class UpscaleMethod
@@ -110,6 +108,22 @@ public:
 	virtual void Load() override;
 	virtual void PostPostLoad() override;
 	virtual void SetupResources() override;
+
+	// VR Depth Buffer Upscaling for depth-based culling compatibility
+	// Based on approach by vrnord (https://github.com/vrnord/skyrim-community-shaders-VR-DLSS)
+	winrt::com_ptr<ID3D11PixelShader> depthUpscalePS;
+	ID3D11PixelShader* GetDepthUpscalePS();
+
+	struct DepthUpscaleCB
+	{
+		float2 SourceResolution;
+		float2 TargetResolution;
+		float2 ResolutionScale;
+		float2 TexelSize;
+	};
+
+	ConstantBuffer* depthUpscaleCB = nullptr;
+	bool enableVRDepthUpscale = true;
 
 	UpscaleMethod GetUpscaleMethod() const;
 


### PR DESCRIPTION
Depends on #1888 

Fix by @vrnord from
https://github.com/vrnord/skyrim-community-shaders-VR-DLSS/tree/vr-depth-upscale-taa-reorder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Shadow map cascade settings are now properly validated and bounded to supported limits, preventing invalid configurations.

* **New Features**
  * Added depth buffer optimization for VR rendering, improving performance and visual quality in virtual reality mode.

* **Style**
  * Corrected minor formatting inconsistencies in settings descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->