### PR TITLE
chore: disable feature constraints in dev mode

### DIFF
--- a/src/FeatureConstraints.cpp
+++ b/src/FeatureConstraints.cpp
@@ -1,5 +1,7 @@
 #include "FeatureConstraints.h"
 #include "Feature.h"
+#include "Globals.h"
+#include "State.h"
 
 #include <unordered_set>
 
@@ -7,6 +9,8 @@ namespace FeatureConstraints
 {
 	ConstraintResult GetConstraints(const SettingId& setting)
 	{
+		if (globals::state && globals::state->IsDeveloperMode())
+			return {};
 		ConstraintResult result;
 
 		for (auto* feature : Feature::GetFeatureList()) {
@@ -40,6 +44,8 @@ namespace FeatureConstraints
 
 	std::vector<std::pair<SettingId, ConstraintResult>> GetAllActiveConstraints()
 	{
+		if (globals::state && globals::state->IsDeveloperMode())
+			return {};
 		std::vector<std::pair<SettingId, ConstraintResult>> allConstraints;
 		std::unordered_set<std::string> processedKeys;  // featureShortName|settingPath for O(1) lookup
 

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -7,7 +7,6 @@
 #include "Upscaling/FidelityFX.h"
 #include "Upscaling/Streamline.h"
 #include "Utils/UI.h"
-#include "VR.h"
 #include <Windows.h>
 #include <algorithm>
 #include <directx/d3dx12.h>
@@ -1087,24 +1086,6 @@ void Upscaling::ConfigureUpscaling(RE::BSGraphics::State* a_viewport)
 	// Disable dynamic resolution unless the game explicitly enables it
 	if (!globals::game::isVR)
 		runtimeData.dynamicResolutionLock = 1;
-
-	// If running in VR and an external upscaler is active, force-disable
-	// the engine's depth-buffer culling immediately. This ensures that
-	// enabling upscaling at runtime (after game load) does not leave the
-	// VR depth-buffer culling enabled which can cause incorrect occlusion.
-	if (globals::game::isVR) {
-		auto& vr = globals::features::vr;
-		if (IsUpscalingActive()) {
-			if (vr.gDepthBufferCulling) {
-				if (*vr.gDepthBufferCulling) {
-					*vr.gDepthBufferCulling = false;
-					logger::info("[Upscaling] VR detected - forcing depth buffer culling OFF due to active downscaling upscaler (scale={})", resolutionScale.x);
-				}
-			} else {
-				logger::warn("[Upscaling] VR depth buffer culling pointer is null, cannot force disable");
-			}
-		}
-	}
 }
 
 void Upscaling::SetupResources()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When developer mode is enabled, constraint checks are now bypassed so settings and workflows are no longer blocked during development.
  * VR behavior: using an external upscaler no longer forcibly disables VR depth-buffer culling, preventing unintended occlusion changes while preserving existing upscaling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->