### PR TITLE
fix: move ResolveMonoUVForEye outside VR guard

### DIFF
--- a/package/Shaders/Common/VR.hlsli
+++ b/package/Shaders/Common/VR.hlsli
@@ -214,6 +214,7 @@ namespace Stereo
 	*/
 	float3 ConvertMonoUVToOtherEye(float3 monoUV, uint eyeIndex, bool dynamicres = false)
 	{
+	{
 		// Convert from dynamic res to true UV space if necessary
 		if (dynamicres)
 			monoUV.xy *= FrameBuffer::DynamicResolutionParams2.xy;
@@ -241,6 +242,7 @@ namespace Stereo
 
 		return monoUVOtherEye;
 	}
+#	endif  // VR
 
 	/**
 	* @brief Resolves a mono UV to the eye that can see it, crossing to the other eye if needed.
@@ -273,6 +275,7 @@ namespace Stereo
 #		endif
 	}
 
+#	ifdef VR
 	/**
 	* @brief Adjusts UV coordinates for VR stereo rendering when transitioning between eyes or handling boundary conditions.
 	*

--- a/package/Shaders/Common/VR.hlsli
+++ b/package/Shaders/Common/VR.hlsli
@@ -214,7 +214,6 @@ namespace Stereo
 	*/
 	float3 ConvertMonoUVToOtherEye(float3 monoUV, uint eyeIndex, bool dynamicres = false)
 	{
-	{
 		// Convert from dynamic res to true UV space if necessary
 		if (dynamicres)
 			monoUV.xy *= FrameBuffer::DynamicResolutionParams2.xy;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized internal code compilation by refining platform-specific build configurations to improve build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->