### PR TITLE
fix(UI): resolution based font

### DIFF
--- a/package/SKSE/Plugins/CommunityShaders/Themes/Default.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/Default.json
@@ -4,7 +4,7 @@
     "Version": "1.0.0",
     "Author": "Community Shaders Team",
     "Theme": {
-        "FontSize": 27.0,
+        "FontSize": 0.0,
         "FontName": "Jost/Jost-Regular.ttf",
         "GlobalScale": 0.0,
         "FontRoles": [

--- a/package/SKSE/Plugins/CommunityShaders/Themes/DragonBlood.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/DragonBlood.json
@@ -4,7 +4,7 @@
     "Version": "1.0.0",
     "Author": "Community Shaders Team",
     "Theme": {
-        "FontSize": 27.0,
+        "FontSize": 0.0,
         "FontName": "Jost/Jost-Regular.ttf",
         "GlobalScale": 0.0,
         "FontRoles": [

--- a/package/SKSE/Plugins/CommunityShaders/Themes/DwemerBronze.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/DwemerBronze.json
@@ -4,7 +4,7 @@
     "Version": "1.0.0",
     "Author": "Community Shaders Team",
     "Theme": {
-        "FontSize": 27.0,
+        "FontSize": 0.0,
         "FontName": "Jost/Jost-Regular.ttf",
         "GlobalScale": 0.0,
         "FontRoles": [

--- a/package/SKSE/Plugins/CommunityShaders/Themes/HighContrast.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/HighContrast.json
@@ -4,7 +4,7 @@
     "Version": "1.0.0",
     "Author": "Community Shaders Team",
     "Theme": {
-        "FontSize": 27.0,
+        "FontSize": 0.0,
         "FontName": "Jost/Jost-Regular.ttf",
         "GlobalScale": 0.0,
         "FontRoles": [

--- a/package/SKSE/Plugins/CommunityShaders/Themes/Light.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/Light.json
@@ -4,7 +4,7 @@
     "Version": "1.0.0",
     "Author": "Community Shaders Team",
     "Theme": {
-        "FontSize": 27.0,
+        "FontSize": 0.0,
         "FontName": "Jost/Jost-Regular.ttf",
         "GlobalScale": 0.0,
         "FontRoles": [

--- a/package/SKSE/Plugins/CommunityShaders/Themes/NordicFrost.json
+++ b/package/SKSE/Plugins/CommunityShaders/Themes/NordicFrost.json
@@ -4,7 +4,7 @@
     "Version": "1.0.0",
     "Author": "Community Shaders Team",
     "Theme": {
-        "FontSize": 27.0,
+        "FontSize": 0.0,
         "FontName": "Jost/Jost-Regular.ttf",
         "GlobalScale": 0.0,
         "FontRoles": [

--- a/src/Menu/ThemeManager.h
+++ b/src/Menu/ThemeManager.h
@@ -145,10 +145,10 @@ public:
 	struct Constants
 	{
 		// Font size constants
-		static constexpr float DEFAULT_SCREEN_HEIGHT = 1080.0f;  // Default screen resolution to use for subsequent calculations
+		static constexpr float DEFAULT_SCREEN_HEIGHT = 1080.0f;       // Default screen resolution to use for subsequent calculations
 		static constexpr float DEFAULT_FONT_RATIO = (7.0f / 360.0f);  // 21px @ 1080p, 28px @ 1440p, 42px @ 4K
-		static constexpr float MIN_FONT_SIZE = 16.0f;            // ~1.5% @ 1080px height
-		static constexpr float MAX_FONT_SIZE = 108.0f;           // 5.0% @ 2160px height
+		static constexpr float MIN_FONT_SIZE = 16.0f;                 // ~1.5% @ 1080px height
+		static constexpr float MAX_FONT_SIZE = 108.0f;                // 5.0% @ 2160px height
 		static constexpr float DEFAULT_FONT_SIZE = 27.0f;
 
 		// Global scale constants

--- a/src/Menu/ThemeManager.h
+++ b/src/Menu/ThemeManager.h
@@ -146,7 +146,7 @@ public:
 	{
 		// Font size constants
 		static constexpr float DEFAULT_SCREEN_HEIGHT = 1080.0f;  // Default screen resolution to use for subsequent calculations
-		static constexpr float DEFAULT_FONT_RATIO = 0.025f;      // Default 2.5% of screen height
+		static constexpr float DEFAULT_FONT_RATIO = (7.0f / 360.0f);  // 21px @ 1080p, 28px @ 1440p, 42px @ 4K
 		static constexpr float MIN_FONT_SIZE = 16.0f;            // ~1.5% @ 1080px height
 		static constexpr float MAX_FONT_SIZE = 108.0f;           // 5.0% @ 2160px height
 		static constexpr float DEFAULT_FONT_SIZE = 27.0f;


### PR DESCRIPTION
Fixes scaling of resolution based font and enables it by default.

1080p:
<img width="1920" height="1080" alt="Skyrim Special Edition 2_18_2026 10_55_50 AM" src="https://github.com/user-attachments/assets/51a07ecf-05f7-492e-bded-b058b66437f4" />

1440p:
<img width="2560" height="1440" alt="Skyrim Special Edition 2_18_2026 10_57_32 AM" src="https://github.com/user-attachments/assets/ad33d11f-b51b-4f35-9f85-c3524ceb4e6e" />

4K:
<img width="3840" height="2160" alt="Skyrim Special Edition 2_18_2026 10_59_03 AM" src="https://github.com/user-attachments/assets/fd96b356-d719-4213-be63-d6046fcf0318" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed font sizing calculations across all UI themes to ensure consistent and properly-scaled text rendering
  * Recalibrated default font scaling metrics for improved display consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->