### PR TITLE
refactor: move TurboColormap into Color.hlsli

### DIFF
--- a/features/Light Limit Fix/Shaders/Features/LightLimitFix.ini
+++ b/features/Light Limit Fix/Shaders/Features/LightLimitFix.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 3-0-1
+Version = 3-0-2

--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -37,35 +37,6 @@ namespace LightLimitFix
 		return true;
 	}
 
-	// Copyright 2019 Google LLC.
-	// SPDX-License-Identifier: Apache-2.0
-
-	// Polynomial approximation in GLSL for the Turbo colormap
-	// Original LUT: https://gist.github.com/mikhailov-work/ee72ba4191942acecc03fe6da94fc73f
-
-	// Authors:
-	//   Colormap Design: Anton Mikhailov (mikhailov@google.com)
-	//   GLSL Approximation: Ruofei Du (ruofei@google.com)
-
-	// See also: https://ai.googleblog.com/2019/08/turbo-improved-rainbow-colormap-for.html
-
-	float3 TurboColormap(float x)
-	{
-		const float4 kRedVec4 = float4(0.13572138, 4.61539260, -42.66032258, 132.13108234);
-		const float4 kGreenVec4 = float4(0.09140261, 2.19418839, 4.84296658, -14.18503333);
-		const float4 kBlueVec4 = float4(0.10667330, 12.64194608, -60.58204836, 110.36276771);
-		const float2 kRedVec2 = float2(-152.94239396, 59.28637943);
-		const float2 kGreenVec2 = float2(4.27729857, 2.82956604);
-		const float2 kBlueVec2 = float2(-89.90310912, 27.34824973);
-
-		x = saturate(x);
-		float4 v4 = float4(1.0, x, x * x, x * x * x);
-		float2 v2 = v4.zw * v4.z;
-		return float3(
-			dot(v4, kRedVec4) + dot(v2, kRedVec2),
-			dot(v4, kGreenVec4) + dot(v2, kGreenVec2),
-			dot(v4, kBlueVec4) + dot(v2, kBlueVec2));
-	}
 
 	bool IsLightIgnored(Light light)
 	{

--- a/package/Shaders/Common/Color.hlsli
+++ b/package/Shaders/Common/Color.hlsli
@@ -18,6 +18,30 @@ namespace Color
 {
 	static float GammaCorrectionValue = 2.2;
 
+	// Copyright 2019 Google LLC.
+	// SPDX-License-Identifier: Apache-2.0
+	// Polynomial approximation in GLSL for the Turbo colormap
+	// Original LUT: https://gist.github.com/mikhailov-work/ee72ba4191942acecc03fe6da94fc73f
+	// Authors: Anton Mikhailov (mikhailov@google.com), Ruofei Du (ruofei@google.com)
+	// https://ai.googleblog.com/2019/08/turbo-improved-rainbow-colormap-for.html
+	float3 TurboColormap(float x)
+	{
+		const float4 kRedVec4 = float4(0.13572138, 4.61539260, -42.66032258, 132.13108234);
+		const float4 kGreenVec4 = float4(0.09140261, 2.19418839, 4.84296658, -14.18503333);
+		const float4 kBlueVec4 = float4(0.10667330, 12.64194608, -60.58204836, 110.36276771);
+		const float2 kRedVec2 = float2(-152.94239396, 59.28637943);
+		const float2 kGreenVec2 = float2(4.27729857, 2.82956604);
+		const float2 kBlueVec2 = float2(-89.90310912, 27.34824973);
+
+		x = saturate(x);
+		float4 v4 = float4(1.0, x, x * x, x * x * x);
+		float2 v2 = v4.zw * v4.z;
+		return float3(
+			dot(v4, kRedVec4) + dot(v2, kRedVec2),
+			dot(v4, kGreenVec4) + dot(v2, kGreenVec2),
+			dot(v4, kBlueVec4) + dot(v2, kBlueVec2));
+	}
+
 	// [Jimenez et al. 2016, "Practical Realtime Strategies for Accurate Indirect Occlusion"]
 	float3 MultiBounceAO(float3 baseColor, float ao)
 	{

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -882,11 +882,11 @@ PS_OUTPUT main(PS_INPUT input)
 #	if defined(LIGHTING) && defined(LIGHT_LIMIT_FIX) && defined(LLFDEBUG)
 	if (SharedData::lightLimitFixSettings.EnableLightsVisualisation) {
 		if (SharedData::lightLimitFixSettings.LightsVisualisationMode == 0) {
-			psout.Diffuse.xyz = LightLimitFix::TurboColormap(0.0);
+			psout.Diffuse.xyz = Color::TurboColormap(0.0);
 		} else if (SharedData::lightLimitFixSettings.LightsVisualisationMode == 1) {
-			psout.Diffuse.xyz = LightLimitFix::TurboColormap(0.0);
+			psout.Diffuse.xyz = Color::TurboColormap(0.0);
 		} else {
-			psout.Diffuse.xyz = LightLimitFix::TurboColormap((float)lightCount / MAX_CLUSTER_LIGHTS);
+			psout.Diffuse.xyz = Color::TurboColormap((float)lightCount / MAX_CLUSTER_LIGHTS);
 		}
 	}
 #	endif

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -3162,11 +3162,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #	if defined(LIGHT_LIMIT_FIX) && defined(LLFDEBUG)
 	if (SharedData::lightLimitFixSettings.EnableLightsVisualisation) {
 		if (SharedData::lightLimitFixSettings.LightsVisualisationMode == 0) {
-			psout.Diffuse.xyz = LightLimitFix::TurboColormap(LightLimitFix::NumStrictLights >= 7.0);
+			psout.Diffuse.xyz = Color::TurboColormap(LightLimitFix::NumStrictLights >= 7.0);
 		} else if (SharedData::lightLimitFixSettings.LightsVisualisationMode == 1) {
-			psout.Diffuse.xyz = LightLimitFix::TurboColormap((float)LightLimitFix::NumStrictLights / 15.0);
+			psout.Diffuse.xyz = Color::TurboColormap((float)LightLimitFix::NumStrictLights / 15.0);
 		} else if (SharedData::lightLimitFixSettings.LightsVisualisationMode == 2) {
-			psout.Diffuse.xyz = LightLimitFix::TurboColormap((float)numClusteredLights / MAX_CLUSTER_LIGHTS);
+			psout.Diffuse.xyz = Color::TurboColormap((float)numClusteredLights / MAX_CLUSTER_LIGHTS);
 		} else {
 			psout.Diffuse.xyz = shadowColor.xyz;
 		}

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -828,11 +828,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			if defined(LIGHT_LIMIT_FIX) && defined(LLFDEBUG)
 	if (SharedData::lightLimitFixSettings.EnableLightsVisualisation) {
 		if (SharedData::lightLimitFixSettings.LightsVisualisationMode == 0) {
-			diffuseColor.xyz = LightLimitFix::TurboColormap(0);
+			diffuseColor.xyz = Color::TurboColormap(0);
 		} else if (SharedData::lightLimitFixSettings.LightsVisualisationMode == 1) {
-			diffuseColor.xyz = LightLimitFix::TurboColormap(0);
+			diffuseColor.xyz = Color::TurboColormap(0);
 		} else {
-			diffuseColor.xyz = LightLimitFix::TurboColormap((float)lightCount / MAX_CLUSTER_LIGHTS);
+			diffuseColor.xyz = Color::TurboColormap((float)lightCount / MAX_CLUSTER_LIGHTS);
 		}
 	} else {
 		psout.Diffuse = float4(diffuseColor, 1);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added bounds validation to prevent out-of-range cluster index errors in light-related calculations.

* **Refactor**
  * Centralized the color mapping used for light visualizations into a shared color utility and updated renderers to use it for consistent visuals.

* **Chores**
  * Bumped light-limit feature version to 3-0-2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->