### PR TITLE
fix(pbr): use scrap heap allocation

### DIFF
--- a/src/TruePBR/BSLightingShaderMaterialPBR.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBR.cpp
@@ -9,7 +9,13 @@ BSLightingShaderMaterialPBR::~BSLightingShaderMaterialPBR()
 
 BSLightingShaderMaterialPBR* BSLightingShaderMaterialPBR::Make()
 {
-	return new BSLightingShaderMaterialPBR;
+	auto* scrapHeap = globals::game::memoryManager->GetThreadScrapHeap();
+	auto* material = static_cast<BSLightingShaderMaterialPBR*>(scrapHeap->Allocate(sizeof(BSLightingShaderMaterialPBR), 8));
+	if (material) {
+		std::memset(material, 0, sizeof(BSLightingShaderMaterialPBR));
+		std::construct_at(material);
+	}
+	return material;
 }
 
 RE::BSShaderMaterial* BSLightingShaderMaterialPBR::Create()

--- a/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
@@ -15,7 +15,13 @@ BSLightingShaderMaterialPBRLandscape::~BSLightingShaderMaterialPBRLandscape()
 
 BSLightingShaderMaterialPBRLandscape* BSLightingShaderMaterialPBRLandscape::Make()
 {
-	return new BSLightingShaderMaterialPBRLandscape;
+	auto* scrapHeap = globals::game::memoryManager->GetThreadScrapHeap();
+	auto* material = static_cast<BSLightingShaderMaterialPBRLandscape*>(scrapHeap->Allocate(sizeof(BSLightingShaderMaterialPBRLandscape), 8));
+	if (material) {
+		std::memset(material, 0, sizeof(BSLightingShaderMaterialPBRLandscape));
+		std::construct_at(material);
+	}
+	return material;
 }
 
 RE::BSShaderMaterial* BSLightingShaderMaterialPBRLandscape::Create()


### PR DESCRIPTION
PBR material Make() was using operator new (via TES_HEAP_REDEFINE_NEW), which allocates from the global heap with RE::malloc. The game expects materials to be allocated from the Thread ScrapHeap with align=8. This mismatch causes heap corruption when materials are later freed via scrap heap deallocation paths.

Switch to scrapHeap->Allocate + std::construct_at, matching the pattern used by CommonLib's BSLightingShaderMaterialBase::CreateMaterial

Ref: #1895,
closes #1654

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized memory allocation and initialization for shader materials, improving runtime memory efficiency, stability, and startup reliability for rendering. Creation paths unified to reduce inconsistencies, which can result in fewer rendering glitches and more consistent performance across scenes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->