### PR TITLE
chore(UI): add subsurface scattering to Interior Only

### DIFF
--- a/src/SceneSettingsManager.cpp
+++ b/src/SceneSettingsManager.cpp
@@ -40,6 +40,7 @@ std::vector<std::string> SceneSettingsManager::GetInteriorRelevantFeatureNames()
 	static const std::unordered_set<std::string> interiorRelevantFeatures = {
 		"ScreenSpaceGI",
 		"ScreenSpaceShadows",
+		"SubsurfaceScattering",
 		"LinearLighting",
 		"ImageBasedLighting",
 		"PostProcessing",


### PR DESCRIPTION
Adds subsurface scattering to Interior Only by request from community member.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded interior rendering to include subsurface scattering support for interior overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->