### PR TITLE
fix(ssgi): guard VR only compilation

### DIFF
--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/stereoSync.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/stereoSync.cs.hlsl
@@ -11,6 +11,8 @@
 #include "Common/VR.hlsli"
 #include "ScreenSpaceGI/common.hlsli"
 
+#ifdef VR
+
 Texture2D<float> srcDepth : register(t0);
 Texture2D<float> srcAo : register(t1);
 Texture2D<float4> srcIlY : register(t2);
@@ -75,3 +77,5 @@ static const float kBackCheckThreshold = 8.0;
 	outIlY[dtid] = lerp(srcIlY[dtid], srcIlY[r.otherPx], r.blendWeight);
 	outIlCoCg[dtid] = lerp(srcIlCoCg[dtid], srcIlCoCg[r.otherPx], r.blendWeight);
 }
+
+#endif  // VR

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -585,9 +585,11 @@ void ScreenSpaceGI::CompileComputeShaders()
 			{ &radianceDisoccCompute, "radianceDisocc.cs.hlsl", {} },
 			{ &giCompute, "gi.cs.hlsl", {} },
 			{ &blurCompute, "blur.cs.hlsl", {} },
-			{ &stereoSyncCompute, "stereoSync.cs.hlsl", { { "FRAMEBUFFER", "" } } },
 			{ &upsampleCompute, "upsample.cs.hlsl", {} },
 		};
+
+	if (REL::Module::IsVR())
+		shaderInfos.push_back({ &stereoSyncCompute, "stereoSync.cs.hlsl", { { "FRAMEBUFFER", "" } } });
 	for (auto& info : shaderInfos) {
 		if (REL::Module::IsVR())
 			info.defines.push_back({ "VR", "" });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Screen Space GI VR shaders now properly compile conditionally when VR mode is active, ensuring correct behavior and improved efficiency across different rendering configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->