### PR TITLE
feat(UI): delete theme button

### DIFF
--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -564,11 +564,9 @@ void SettingsTabRenderer::RenderThemesTab()
 
 		if (!isPreset && currentThemeInfo && !currentThemeInfo->filePath.empty()) {
 			ImGui::SameLine();
-			{
-				auto _style = Util::ErrorButtonStyle();
-				if (Util::ButtonWithFlash("Delete")) {
-					showDeleteThemePopup = true;
-				}
+			auto _style = Util::ErrorButtonStyle();
+			if (Util::ButtonWithFlash("Delete")) {
+				showDeleteThemePopup = true;
 			}
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Delete the theme file for '%s'. This cannot be undone.",
@@ -725,7 +723,7 @@ void SettingsTabRenderer::RenderThemesTab()
 			}
 		}
 
-		if (ImGui::BeginPopupModal("Delete Theme", &showDeleteThemePopup, ImGuiWindowFlags_AlwaysAutoResize) && currentThemeInfo && !currentThemeInfo->filePath.empty()) {
+		if (ImGui::BeginPopupModal("Delete Theme", &showDeleteThemePopup, ImGuiWindowFlags_AlwaysAutoResize)) {
 			ImGui::Text("Are you sure you want to delete the theme ");
 			ImGui::SameLine(0, 0);
 			ImGui::TextColored(themeSettings.StatusPalette.InfoColor, "%s",
@@ -744,7 +742,7 @@ void SettingsTabRenderer::RenderThemesTab()
 			ImGui::SameLine();
 
 			auto _style = Util::ErrorButtonStyle();
-			if (ImGui::Button("Delete")) {
+			if (ImGui::Button("Delete") && currentThemeInfo && !currentThemeInfo->filePath.empty()) {
 				auto result = Util::FileHelpers::SafeDelete(currentThemeInfo->filePath, "Theme '" + currentThemePreset + "'");
 				if (result.success) {
 					themeManager->RefreshThemes();

--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -743,21 +743,20 @@ void SettingsTabRenderer::RenderThemesTab()
 
 			ImGui::SameLine();
 
-			{
-				auto _style = Util::ErrorButtonStyle();
-				if (ImGui::Button("Delete")) {
-					auto result = Util::FileHelpers::SafeDelete(currentThemeInfo->filePath, "Theme '" + currentThemePreset + "'");
-					if (result.success) {
-						themeManager->RefreshThemes();
-						globals::menu->LoadThemePreset("Default");
-						currentThemePreset = "Default";
-					} else {
-						logger::warn("Failed to delete theme '{}': {}", currentThemePreset, result.errorMessage);
-					}
-					showDeleteThemePopup = false;
-					ImGui::CloseCurrentPopup();
+			auto _style = Util::ErrorButtonStyle();
+			if (ImGui::Button("Delete")) {
+				auto result = Util::FileHelpers::SafeDelete(currentThemeInfo->filePath, "Theme '" + currentThemePreset + "'");
+				if (result.success) {
+					themeManager->RefreshThemes();
+					globals::menu->LoadThemePreset("Default");
+					currentThemePreset = "Default";
+				} else {
+					logger::warn("Failed to delete theme '{}': {}", currentThemePreset, result.errorMessage);
 				}
+				showDeleteThemePopup = false;
+				ImGui::CloseCurrentPopup();
 			}
+
 			ImGui::EndPopup();
 		}
 

--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -364,8 +364,8 @@ void SettingsTabRenderer::RenderThemesTab()
 		auto& themeSettings = globals::menu->GetSettings().Theme;
 
 		// Static variables for popup state and new theme creation
+		static Util::ConfirmationPopup deleteThemePopup("Delete Theme", "", "Delete", "Cancel");
 		static bool showCreateThemePopup = false;
-		static bool showDeleteThemePopup = false;
 		static char newThemeName[128] = "";
 		static char newThemeDisplayName[128] = "";
 		static char newThemeDescription[256] = "";
@@ -566,7 +566,11 @@ void SettingsTabRenderer::RenderThemesTab()
 			ImGui::SameLine();
 			auto _style = Util::ErrorButtonStyle();
 			if (Util::ButtonWithFlash("Delete")) {
-				showDeleteThemePopup = true;
+				deleteThemePopup.message =
+					"Are you sure you want to delete the theme '" +
+					(currentThemeInfo->displayName.empty() ? currentThemePreset : currentThemeInfo->displayName) +
+					"'?\n\nThis will permanently remove the theme file. This cannot be undone.";
+				deleteThemePopup.Request();
 			}
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("Delete the theme file for '%s'. This cannot be undone.",
@@ -714,48 +718,15 @@ void SettingsTabRenderer::RenderThemesTab()
 			ImGui::EndPopup();
 		}
 
-		// Delete theme confirmation modal
-		if (showDeleteThemePopup) {
-			if (currentThemeInfo && !currentThemeInfo->filePath.empty()) {
-				ImGui::OpenPopup("Delete Theme");
+		if (deleteThemePopup.Draw() && currentThemeInfo && !currentThemeInfo->filePath.empty()) {
+			auto result = Util::FileHelpers::SafeDelete(currentThemeInfo->filePath, "Theme '" + currentThemePreset + "'");
+			if (result.success) {
+				themeManager->RefreshThemes();
+				globals::menu->LoadThemePreset("Default");
+				currentThemePreset = "Default";
 			} else {
-				showDeleteThemePopup = false;
+				logger::warn("Failed to delete theme '{}': {}", currentThemePreset, result.errorMessage);
 			}
-		}
-
-		if (ImGui::BeginPopupModal("Delete Theme", &showDeleteThemePopup, ImGuiWindowFlags_AlwaysAutoResize)) {
-			ImGui::Text("Are you sure you want to delete the theme ");
-			ImGui::SameLine(0, 0);
-			ImGui::TextColored(themeSettings.StatusPalette.InfoColor, "%s",
-				(currentThemeInfo && !currentThemeInfo->displayName.empty() ? currentThemeInfo->displayName : currentThemePreset).c_str());
-			ImGui::SameLine(0, 0);
-			ImGui::Text("?");
-			ImGui::Text("This will permanently remove the theme file. This cannot be undone.");
-
-			ImGui::Separator();
-
-			if (ImGui::Button("Cancel")) {
-				showDeleteThemePopup = false;
-				ImGui::CloseCurrentPopup();
-			}
-
-			ImGui::SameLine();
-
-			auto _style = Util::ErrorButtonStyle();
-			if (ImGui::Button("Delete") && currentThemeInfo && !currentThemeInfo->filePath.empty()) {
-				auto result = Util::FileHelpers::SafeDelete(currentThemeInfo->filePath, "Theme '" + currentThemePreset + "'");
-				if (result.success) {
-					themeManager->RefreshThemes();
-					globals::menu->LoadThemePreset("Default");
-					currentThemePreset = "Default";
-				} else {
-					logger::warn("Failed to delete theme '{}': {}", currentThemePreset, result.errorMessage);
-				}
-				showDeleteThemePopup = false;
-				ImGui::CloseCurrentPopup();
-			}
-
-			ImGui::EndPopup();
 		}
 
 		ImGui::EndTabItem();

--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -365,6 +365,7 @@ void SettingsTabRenderer::RenderThemesTab()
 
 		// Static variables for popup state and new theme creation
 		static bool showCreateThemePopup = false;
+		static bool showDeleteThemePopup = false;
 		static char newThemeName[128] = "";
 		static char newThemeDisplayName[128] = "";
 		static char newThemeDescription[256] = "";
@@ -476,7 +477,7 @@ void SettingsTabRenderer::RenderThemesTab()
 			ImGui::Spacing();
 			const auto& selectedTheme = themes[currentItem];
 			ImGui::Text("Selected Theme: ");
-			ImGui::SameLine();
+			ImGui::SameLine(0, 0);
 			ImGui::TextColored(themeSettings.StatusPalette.InfoColor, "%s", selectedTheme.displayName.c_str());
 			if (!selectedTheme.description.empty()) {
 				ImGui::TextWrapped("%s", selectedTheme.description.c_str());
@@ -485,10 +486,10 @@ void SettingsTabRenderer::RenderThemesTab()
 		ImGui::Spacing();
 
 		const bool isPreset = IsPresetThemeSelected();
+		const auto* currentThemeInfo = themeManager->GetThemeInfo(currentThemePreset);
 
 		if (!isPreset) {
 			if (Util::ButtonWithFlash("Save")) {
-				const auto* currentThemeInfo = themeManager->GetThemeInfo(currentThemePreset);
 				if (currentThemeInfo) {
 					// Get current settings
 					json currentThemeJson;
@@ -559,6 +560,20 @@ void SettingsTabRenderer::RenderThemesTab()
 			memset(newThemeDisplayName, 0, sizeof(newThemeDisplayName));
 			memset(newThemeDescription, 0, sizeof(newThemeDescription));
 			showValidationError = false;
+		}
+
+		if (!isPreset && currentThemeInfo && !currentThemeInfo->filePath.empty()) {
+			ImGui::SameLine();
+			{
+				auto _style = Util::ErrorButtonStyle();
+				if (Util::ButtonWithFlash("Delete")) {
+					showDeleteThemePopup = true;
+				}
+			}
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text("Delete the theme file for '%s'. This cannot be undone.",
+					(currentThemeInfo->displayName.empty() ? currentThemePreset : currentThemeInfo->displayName).c_str());
+			}
 		}
 
 		// Display update feedback below the buttons
@@ -698,6 +713,51 @@ void SettingsTabRenderer::RenderThemesTab()
 				ImGui::CloseCurrentPopup();
 			}
 
+			ImGui::EndPopup();
+		}
+
+		// Delete theme confirmation modal
+		if (showDeleteThemePopup) {
+			if (currentThemeInfo && !currentThemeInfo->filePath.empty()) {
+				ImGui::OpenPopup("Delete Theme");
+			} else {
+				showDeleteThemePopup = false;
+			}
+		}
+
+		if (ImGui::BeginPopupModal("Delete Theme", &showDeleteThemePopup, ImGuiWindowFlags_AlwaysAutoResize) && currentThemeInfo && !currentThemeInfo->filePath.empty()) {
+			ImGui::Text("Are you sure you want to delete the theme ");
+			ImGui::SameLine(0, 0);
+			ImGui::TextColored(themeSettings.StatusPalette.InfoColor, "%s",
+				(currentThemeInfo && !currentThemeInfo->displayName.empty() ? currentThemeInfo->displayName : currentThemePreset).c_str());
+			ImGui::SameLine(0, 0);
+			ImGui::Text("?");
+			ImGui::Text("This will permanently remove the theme file. This cannot be undone.");
+
+			ImGui::Separator();
+
+			if (ImGui::Button("Cancel")) {
+				showDeleteThemePopup = false;
+				ImGui::CloseCurrentPopup();
+			}
+
+			ImGui::SameLine();
+
+			{
+				auto _style = Util::ErrorButtonStyle();
+				if (ImGui::Button("Delete")) {
+					auto result = Util::FileHelpers::SafeDelete(currentThemeInfo->filePath, "Theme '" + currentThemePreset + "'");
+					if (result.success) {
+						themeManager->RefreshThemes();
+						globals::menu->LoadThemePreset("Default");
+						currentThemePreset = "Default";
+					} else {
+						logger::warn("Failed to delete theme '{}': {}", currentThemePreset, result.errorMessage);
+					}
+					showDeleteThemePopup = false;
+					ImGui::CloseCurrentPopup();
+				}
+			}
 			ImGui::EndPopup();
 		}
 


### PR DESCRIPTION
Now that we can detect shipped versus user presets, we can show a delete button.

<img width="874" height="347" alt="image" src="https://github.com/user-attachments/assets/a1ae0135-ad7d-4447-a5e1-81a4fb2005af" />
<img width="591" height="183" alt="image" src="https://github.com/user-attachments/assets/74e902ce-565f-44af-b60d-dd9f865bef93" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can delete custom themes via a confirmed "Delete Theme" dialog to prevent accidental removal.
  * Deletion is available from both the theme list and the "Create New Theme" popup.
  * After deletion the app reloads themes and switches back to the default preset automatically; canceling closes the dialog.
  * Improved confirmation messaging and consistent tooltip feedback for delete actions.

* **Style**
  * Improved spacing and inline placement of action buttons for a cleaner theme settings layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->