### PR TITLE
feat(UI): open log file button

### DIFF
--- a/src/FeatureIssues.cpp
+++ b/src/FeatureIssues.cpp
@@ -435,6 +435,17 @@ namespace FeatureIssues
 			ImGui::Text("Opens the main Shaders directory to view individual feature shader folders.");
 		}
 
+		std::filesystem::path logPath = Util::PathHelpers::GetLogPath();
+		if (!logPath.empty()) {
+			ImGui::SameLine();
+			if (ImGui::Button("Open Logs")) {
+				ShellExecuteA(NULL, "open", logPath.string().c_str(), NULL, NULL, SW_SHOWNORMAL);
+			}
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text("Opens the CommunityShaders.log file for manual review.");
+			}
+		}
+
 		ImGui::SameLine();
 		if (ImGui::Button("Clear Issue List")) {
 			ClearFeatureIssues();
@@ -451,6 +462,7 @@ namespace FeatureIssues
 		ImGui::TextColored(theme.Palette.Text, "General Actions:");
 		ImGui::BulletText("Use 'Open Features Folder' to manually review INI files");
 		ImGui::BulletText("Use 'Open Shaders Directory' to check for orphaned shader folders");
+		ImGui::BulletText("Use 'Open Logs' to manually review the logs");
 		ImGui::BulletText("Use 'Clear Issue List' to refresh after manual cleanup");
 	}
 

--- a/src/Menu/AdvancedSettingsRenderer.cpp
+++ b/src/Menu/AdvancedSettingsRenderer.cpp
@@ -5,7 +5,6 @@
 #include <imgui.h>
 #include <imgui_stdlib.h>
 #include <thread>
-#include <windows.h>
 
 #include "FeatureIssues.h"
 #include "Features/PerformanceOverlay/ABTesting/ABTesting.h"

--- a/src/Menu/AdvancedSettingsRenderer.cpp
+++ b/src/Menu/AdvancedSettingsRenderer.cpp
@@ -5,6 +5,7 @@
 #include <imgui.h>
 #include <imgui_stdlib.h>
 #include <thread>
+#include <windows.h>
 
 #include "FeatureIssues.h"
 #include "Features/PerformanceOverlay/ABTesting/ABTesting.h"
@@ -137,10 +138,22 @@ void AdvancedSettingsRenderer::RenderLoggingSection()
 			"The more threads the faster compilation will finish but may make the system unresponsive. ");
 	}
 
+	ImGui::Columns(2, nullptr, false);
+
 	// Dump Ini Settings button
 	if (ImGui::Button("Dump Ini Settings", { -1, 0 })) {
 		Util::DumpSettingsOptions();
 	}
+
+	ImGui::NextColumn();
+
+	// Open Logs button
+	std::filesystem::path logPath = Util::PathHelpers::GetLogPath();
+	if (!logPath.empty() && ImGui::Button("Open Logs", { -1, 0 })) {
+		ShellExecuteA(NULL, "open", logPath.string().c_str(), NULL, NULL, SW_SHOWNORMAL);
+	}
+
+	ImGui::Columns(1);
 }
 
 void AdvancedSettingsRenderer::RenderShaderDebugSection()

--- a/src/Utils/FileSystem.cpp
+++ b/src/Utils/FileSystem.cpp
@@ -169,6 +169,16 @@ namespace Util
 		{
 			return GetFeaturesPath() / featureName;
 		}
+
+		std::filesystem::path GetLogPath()
+		{
+			auto path = logger::log_directory();
+			if (!path) {
+				return {};
+			}
+			*path /= std::format("{}.log", std::string(Plugin::NAME));
+			return *path;
+		}
 	}
 
 	// File system utilities implementation

--- a/src/Utils/FileSystem.h
+++ b/src/Utils/FileSystem.h
@@ -177,6 +177,12 @@ namespace Util
 		 */
 		std::filesystem::path GetFeaturesRealPath();
 
+		/**
+		 * Returns the path to the Community Shaders log file in the default SKSE logging folder.
+		 * @return Documents / "My Games" / "Skyrim..." / "SKSE" / "CommunityShaders.log"
+		 */
+		std::filesystem::path GetLogPath();
+
 	}
 
 	/**


### PR DESCRIPTION
Adds button in two locations
- Feature issues
- Advanced > Logging

<img width="963" height="287" alt="image" src="https://github.com/user-attachments/assets/8ac75923-2587-41b2-92be-07d73b37d05c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Open Logs" button to Cleanup Actions and Advanced Settings so users can open log files directly from the UI.
  * Added descriptive tooltips for the new Open Logs action.
  * Updated Advanced Settings layout to present related actions side-by-side for clearer access.
* **Chores**
  * App now resolves the plugin log file location automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->