### PR TITLE
feat(VR): add edge detection for stereo blending

### DIFF
--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/stereoSync.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/stereoSync.cs.hlsl
@@ -37,13 +37,16 @@ void Passthrough(uint2 dtid)
 
 // Samples four depth neighbors in a cross pattern (±step.x, ±step.y) around centerUV,
 // scaled by texScale to map from output UV space to texture sample coords.
-float4 SampleCrossDepths(float2 centerUV, float2 step, float2 texScale)
+// centerUV is clamped to eyeIndex's half of the stereo buffer before offsetting
+// to prevent neighbor reads from crossing the x=0.5 seam into the other eye.
+float4 SampleCrossDepths(float2 centerUV, float2 step, float2 texScale, uint eyeIndex)
 {
+	float2 uv = Stereo::ClampToEyeUV(centerUV, eyeIndex);
 	return float4(
-		srcDepth.SampleLevel(samplerPointClamp, (centerUV + float2(step.x, 0)) * texScale, RES_MIP),
-		srcDepth.SampleLevel(samplerPointClamp, (centerUV + float2(-step.x, 0)) * texScale, RES_MIP),
-		srcDepth.SampleLevel(samplerPointClamp, (centerUV + float2(0, step.y)) * texScale, RES_MIP),
-		srcDepth.SampleLevel(samplerPointClamp, (centerUV + float2(0, -step.y)) * texScale, RES_MIP));
+		srcDepth.SampleLevel(samplerPointClamp, (uv + float2(step.x, 0)) * texScale, RES_MIP),
+		srcDepth.SampleLevel(samplerPointClamp, (uv + float2(-step.x, 0)) * texScale, RES_MIP),
+		srcDepth.SampleLevel(samplerPointClamp, (uv + float2(0, step.y)) * texScale, RES_MIP),
+		srcDepth.SampleLevel(samplerPointClamp, (uv + float2(0, -step.y)) * texScale, RES_MIP));
 }
 
 [numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
@@ -69,7 +72,7 @@ float4 SampleCrossDepths(float2 centerUV, float2 step, float2 texScale)
 	// Placed before rawDepth conversion and reprojection to save VP matrix work
 	// for edge pixels.
 	float2 pixelStep = 1.0 / outFrameDim;
-	float4 srcNeighborDepths = SampleCrossDepths(uv, pixelStep, frameScale);
+	float4 srcNeighborDepths = SampleCrossDepths(uv, pixelStep, frameScale, eyeIndex);
 	if (Stereo::MaxDepthDiff(depth, srcNeighborDepths) / max(depth, 1.0) > kEdgeRelThreshold) {
 		Passthrough(dtid);
 		return;
@@ -98,7 +101,7 @@ float4 SampleCrossDepths(float2 centerUV, float2 step, float2 texScale)
 	// arm silhouette appears at a different screen position per eye, so the reprojection
 	// can cross a boundary invisible from this eye's perspective.
 	float2 marginStep = float(kEdgeMargin) / outFrameDim;
-	float4 otherNeighborDepths = SampleCrossDepths(r.otherStereoUV, marginStep, frameScale);
+	float4 otherNeighborDepths = SampleCrossDepths(r.otherStereoUV, marginStep, frameScale, 1 - eyeIndex);
 	if (any(otherNeighborDepths < kMaskDepth) ||
 		Stereo::MaxDepthDiff(otherLinearDepth, otherNeighborDepths) / max(otherLinearDepth, 1.0) > kEdgeRelThreshold) {
 		Passthrough(dtid);

--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/stereoSync.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/stereoSync.cs.hlsl
@@ -1,8 +1,7 @@
 // Stereo Sync - Bilateral blend of SSGI buffers between eyes
 //
 // Reprojects each pixel to the other eye and blends AO/IL based on depth
-// agreement with back-check validation. Runs after the SSGI blur to reduce
-// per-eye GI disparities.
+// agreement. Runs after the SSGI blur to reduce per-eye GI disparities.
 //
 // Based on: Shi, Billeter, Eisemann 2022, "Stereo-consistent screen-space
 // ambient occlusion" https://eprints.whiterose.ac.uk/id/eprint/187713/
@@ -22,9 +21,30 @@ RWTexture2D<float> outAo : register(u0);
 RWTexture2D<float4> outIlY : register(u1);
 RWTexture2D<float2> outIlCoCg : register(u2);
 
-static const float kDepthSigma = 0.01;
-static const float kMaxBlend = 0.5;
-static const float kBackCheckThreshold = 8.0;
+static const float kDepthSigma = 0.01;       // Bilateral depth tolerance (NDC): surfaces within this range are considered the same and blended
+static const float kMaxBlend = 0.5;          // Maximum stereo blend weight; 0.5 gives equal weighting between eyes
+static const float kEdgeRelThreshold = 0.5;  // Relative linear-depth difference above which a pixel is a depth discontinuity (50% change)
+static const float kMaskDepth = 0.01;        // Linear depth sentinel: values below this are outside the HMD lens area
+static const int kEdgeMargin = 2;            // Neighbor offset (pixels) for destination edge + mask boundary check
+
+// Writes all output channels from the source buffers (passthrough / no-blend path).
+void Passthrough(uint2 dtid)
+{
+	outAo[dtid] = srcAo[dtid];
+	outIlY[dtid] = srcIlY[dtid];
+	outIlCoCg[dtid] = srcIlCoCg[dtid];
+}
+
+// Samples four depth neighbors in a cross pattern (±step.x, ±step.y) around centerUV,
+// scaled by texScale to map from output UV space to texture sample coords.
+float4 SampleCrossDepths(float2 centerUV, float2 step, float2 texScale)
+{
+	return float4(
+		srcDepth.SampleLevel(samplerPointClamp, (centerUV + float2(step.x, 0)) * texScale, RES_MIP),
+		srcDepth.SampleLevel(samplerPointClamp, (centerUV + float2(-step.x, 0)) * texScale, RES_MIP),
+		srcDepth.SampleLevel(samplerPointClamp, (centerUV + float2(0, step.y)) * texScale, RES_MIP),
+		srcDepth.SampleLevel(samplerPointClamp, (centerUV + float2(0, -step.y)) * texScale, RES_MIP));
+}
 
 [numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
 	const float2 outFrameDim = OUT_FRAME_DIM;
@@ -40,9 +60,18 @@ static const float kBackCheckThreshold = 8.0;
 	// 0.0 = mask (outside lens area). FP_Z = first-person hands threshold (~18.0).
 	float depth = srcDepth.SampleLevel(samplerPointClamp, uv * frameScale, RES_MIP);
 	if (depth < FP_Z) {
-		outAo[dtid] = srcAo[dtid];
-		outIlY[dtid] = srcIlY[dtid];
-		outIlCoCg[dtid] = srcIlCoCg[dtid];
+		Passthrough(dtid);
+		return;
+	}
+
+	// Source edge detection: skip stereo sync at depth discontinuities.
+	// Uses a relative threshold since depth is linear view-space (not NDC).
+	// Placed before rawDepth conversion and reprojection to save VP matrix work
+	// for edge pixels.
+	float2 pixelStep = 1.0 / outFrameDim;
+	float4 srcNeighborDepths = SampleCrossDepths(uv, pixelStep, frameScale);
+	if (Stereo::MaxDepthDiff(depth, srcNeighborDepths) / max(depth, 1.0) > kEdgeRelThreshold) {
+		Passthrough(dtid);
 		return;
 	}
 
@@ -54,23 +83,33 @@ static const float kBackCheckThreshold = 8.0;
 	Stereo::StereoBilateralResult r = Stereo::ReprojectToOtherEye(uv, rawDepth, eyeIndex, outFrameDim);
 
 	if (!r.valid) {
-		outAo[dtid] = srcAo[dtid];
-		outIlY[dtid] = srcIlY[dtid];
-		outIlCoCg[dtid] = srcIlCoCg[dtid];
+		Passthrough(dtid);
 		return;
 	}
 
 	float otherLinearDepth = srcDepth.SampleLevel(samplerPointClamp, r.otherStereoUV * frameScale, RES_MIP);
 	if (otherLinearDepth < FP_Z) {
-		outAo[dtid] = srcAo[dtid];
-		outIlY[dtid] = srcIlY[dtid];
-		outIlCoCg[dtid] = srcIlCoCg[dtid];
+		Passthrough(dtid);
 		return;
 	}
+
+	// Destination edge detection: skip if the reprojected pixel is near the HMD mask
+	// boundary or at a depth discontinuity in the other eye. Due to VR parallax the
+	// arm silhouette appears at a different screen position per eye, so the reprojection
+	// can cross a boundary invisible from this eye's perspective.
+	float2 marginStep = float(kEdgeMargin) / outFrameDim;
+	float4 otherNeighborDepths = SampleCrossDepths(r.otherStereoUV, marginStep, frameScale);
+	if (any(otherNeighborDepths < kMaskDepth) ||
+		Stereo::MaxDepthDiff(otherLinearDepth, otherNeighborDepths) / max(otherLinearDepth, 1.0) > kEdgeRelThreshold) {
+		Passthrough(dtid);
+		return;
+	}
+
 	float otherRawDepth = (SharedData::CameraData.x - SharedData::CameraData.w / otherLinearDepth) / SharedData::CameraData.z;
 
-	// Use raw depth for back-check reprojection (required) and bilateral weight (consistent with StereoBlendCS)
-	Stereo::FinalizeStereoBlend(r, uv, rawDepth, otherRawDepth, eyeIndex, outFrameDim, kDepthSigma, kMaxBlend, kBackCheckThreshold);
+	// Back-check disabled: source + destination edge detection covers the occlusion
+	// boundary cases it was guarding, saving 2 VP matrix multiplies per blended pixel.
+	Stereo::FinalizeStereoBlend(r, uv, rawDepth, otherRawDepth, eyeIndex, outFrameDim, kDepthSigma, kMaxBlend, 0.0);
 
 	outAo[dtid] = lerp(srcAo[dtid], srcAo[r.otherPx], r.blendWeight);
 	outIlY[dtid] = lerp(srcIlY[dtid], srcIlY[r.otherPx], r.blendWeight);

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/StereoSyncCS.hlsl
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/StereoSyncCS.hlsl
@@ -71,14 +71,15 @@ float BlurShadow(int2 dtid, float centerDepth)
 	return weight > 0.0 ? shadow / weight : SrcShadowTexture[dtid];
 }
 
-// Samples four depth neighbors in a cross pattern (±offset pixels) around center.
-float4 SampleCrossDepths(int2 center, int offset)
+// Samples four depth neighbors in a cross pattern (±offset pixels) around center,
+// clamped to eyeIndex's half of the packed stereo buffer to avoid seam contamination.
+float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 {
 	return float4(
-		SrcDepthTexture[center + int2(offset, 0)],
-		SrcDepthTexture[center + int2(-offset, 0)],
-		SrcDepthTexture[center + int2(0, offset)],
-		SrcDepthTexture[center + int2(0, -offset)]);
+		SrcDepthTexture[Stereo::ClampToEyeBounds(center + int2(offset, 0), eyeIndex, FrameDim)],
+		SrcDepthTexture[Stereo::ClampToEyeBounds(center + int2(-offset, 0), eyeIndex, FrameDim)],
+		SrcDepthTexture[Stereo::ClampToEyeBounds(center + int2(0, offset), eyeIndex, FrameDim)],
+		SrcDepthTexture[Stereo::ClampToEyeBounds(center + int2(0, -offset), eyeIndex, FrameDim)]);
 }
 
 [numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
@@ -109,7 +110,7 @@ float4 SampleCrossDepths(int2 center, int offset)
 	// Skip stereo sync at depth discontinuities (arm/world silhouettes, object edges).
 	// Placed before the blur: the bilateral depth weighting zeroes out cross-edge
 	// samples, so the blur collapses to SrcShadowTexture[dtid] at these pixels anyway.
-	float4 edgeDepths = SampleCrossDepths(dtid, 1);
+	float4 edgeDepths = SampleCrossDepths(dtid, 1, eyeIndex);
 	if (Stereo::MaxDepthDiff(depth, edgeDepths) > kEdgeDepthThreshold) {
 		OutShadowTexture[dtid] = SrcShadowTexture[dtid];
 		return;
@@ -140,7 +141,7 @@ float4 SampleCrossDepths(int2 center, int offset)
 	// silhouette appears at a different screen position in each eye, so the
 	// reprojection can cross a boundary invisible from this eye's perspective.
 	// Reusing the same four neighbor reads covers both purposes at no extra cost.
-	float4 otherNeighbors = SampleCrossDepths(r.otherPx, kEdgeMargin);
+	float4 otherNeighbors = SampleCrossDepths(r.otherPx, kEdgeMargin, 1 - eyeIndex);
 	if (any(otherNeighbors < 1e-5) || Stereo::MaxDepthDiff(otherDepth, otherNeighbors) > kEdgeDepthThreshold) {
 		OutShadowTexture[dtid] = myShadow;
 		return;

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/StereoSyncCS.hlsl
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/StereoSyncCS.hlsl
@@ -26,12 +26,7 @@ cbuffer StereoSyncCB : register(b1)
 static const float kDepthSigma = 0.01;          // Bilateral depth tolerance (NDC): surfaces within this range are considered the same and blended
 static const float kMaxBlend = 1.0;             // Maximum stereo blend weight; reduce below 1.0 to soften the cross-eye contribution
 static const float kEdgeDepthThreshold = 0.05;  // NDC depth difference above which a pixel is considered a depth discontinuity and excluded from stereo sync
-
-float MaxDepthDiff(float center, float4 neighbors)
-{
-	return max(max(abs(center - neighbors.x), abs(center - neighbors.y)),
-		max(abs(center - neighbors.z), abs(center - neighbors.w)));
-}
+static const int kEdgeMargin = 2;               // Neighbor offset (pixels) for destination edge + mask boundary check
 
 // Depth-weighted 4-sample blur using a rotated Poisson disk.
 // Uses dtid hash for per-pixel rotation to break structured patterns.
@@ -76,6 +71,16 @@ float BlurShadow(int2 dtid, float centerDepth)
 	return weight > 0.0 ? shadow / weight : SrcShadowTexture[dtid];
 }
 
+// Samples four depth neighbors in a cross pattern (±offset pixels) around center.
+float4 SampleCrossDepths(int2 center, int offset)
+{
+	return float4(
+		SrcDepthTexture[center + int2(offset, 0)],
+		SrcDepthTexture[center + int2(-offset, 0)],
+		SrcDepthTexture[center + int2(0, offset)],
+		SrcDepthTexture[center + int2(0, -offset)]);
+}
+
 [numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
 	if (any(dtid >= uint2(FrameDim)))
 		return;
@@ -104,12 +109,8 @@ float BlurShadow(int2 dtid, float centerDepth)
 	// Skip stereo sync at depth discontinuities (arm/world silhouettes, object edges).
 	// Placed before the blur: the bilateral depth weighting zeroes out cross-edge
 	// samples, so the blur collapses to SrcShadowTexture[dtid] at these pixels anyway.
-	float4 edgeDepths = float4(
-		SrcDepthTexture[dtid + int2(1, 0)],
-		SrcDepthTexture[dtid + int2(-1, 0)],
-		SrcDepthTexture[dtid + int2(0, 1)],
-		SrcDepthTexture[dtid + int2(0, -1)]);
-	if (MaxDepthDiff(depth, edgeDepths) > kEdgeDepthThreshold) {
+	float4 edgeDepths = SampleCrossDepths(dtid, 1);
+	if (Stereo::MaxDepthDiff(depth, edgeDepths) > kEdgeDepthThreshold) {
 		OutShadowTexture[dtid] = SrcShadowTexture[dtid];
 		return;
 	}
@@ -139,13 +140,8 @@ float BlurShadow(int2 dtid, float centerDepth)
 	// silhouette appears at a different screen position in each eye, so the
 	// reprojection can cross a boundary invisible from this eye's perspective.
 	// Reusing the same four neighbor reads covers both purposes at no extra cost.
-	static const int kEdgeMargin = 2;
-	float4 otherNeighbors = float4(
-		SrcDepthTexture[r.otherPx + int2(-kEdgeMargin, 0)],
-		SrcDepthTexture[r.otherPx + int2(kEdgeMargin, 0)],
-		SrcDepthTexture[r.otherPx + int2(0, -kEdgeMargin)],
-		SrcDepthTexture[r.otherPx + int2(0, kEdgeMargin)]);
-	if (any(otherNeighbors < 1e-5) || MaxDepthDiff(otherDepth, otherNeighbors) > kEdgeDepthThreshold) {
+	float4 otherNeighbors = SampleCrossDepths(r.otherPx, kEdgeMargin);
+	if (any(otherNeighbors < 1e-5) || Stereo::MaxDepthDiff(otherDepth, otherNeighbors) > kEdgeDepthThreshold) {
 		OutShadowTexture[dtid] = myShadow;
 		return;
 	}

--- a/package/Shaders/Common/VR.hlsli
+++ b/package/Shaders/Common/VR.hlsli
@@ -172,6 +172,42 @@ namespace Stereo
 			max(abs(center - neighbors.z), abs(center - neighbors.w)));
 	}
 
+	/**
+	* @brief Clamps a stereo UV coordinate to the eye-local X range of the packed stereo buffer.
+	*
+	* Prevents cross-neighbor UV samples from crossing the x=0.5 seam into the other eye's
+	* region of the side-by-side stereo texture. Y is not clamped; sampler address modes
+	* handle vertical out-of-bounds.
+	*
+	* @param[in] uv        Stereo UV coordinate to clamp.
+	* @param[in] eyeIndex  Eye index (0 = left [0, 0.5], 1 = right [0.5, 1]).
+	* @return UV with x restricted to eyeIndex's half of the stereo buffer.
+	*/
+	float2 ClampToEyeUV(float2 uv, uint eyeIndex)
+	{
+		uv.x = clamp(uv.x, eyeIndex == 0 ? 0.0f : 0.5f, eyeIndex == 0 ? 0.5f : 1.0f);
+		return uv;
+	}
+
+	/**
+	* @brief Clamps a pixel coordinate to the eye-local X bounds of the packed stereo buffer.
+	*
+	* Prevents cross-neighbor pixel reads from crossing the half-width seam into the
+	* other eye's region of the side-by-side stereo texture.
+	*
+	* @param[in] px        Pixel coordinate to clamp.
+	* @param[in] eyeIndex  Eye index (0 = left, 1 = right).
+	* @param[in] frameDim  Full stereo buffer dimensions (width covers both eyes).
+	* @return Clamped pixel coordinate, restricted to eyeIndex's half of the buffer.
+	*/
+	int2 ClampToEyeBounds(int2 px, uint eyeIndex, float2 frameDim)
+	{
+		int halfWidth = (int)frameDim.x / 2;
+		px.x = clamp(px.x, eyeIndex == 0 ? 0 : halfWidth, eyeIndex == 0 ? (halfWidth - 1) : ((int)frameDim.x - 1));
+		px.y = clamp(px.y, 0, (int)frameDim.y - 1);
+		return px;
+	}
+
 #if defined(PSHADER) || defined(FRAMEBUFFER)
 	// These functions require the framebuffer which is typically provided with the PSHADER
 	/**

--- a/package/Shaders/Common/VR.hlsli
+++ b/package/Shaders/Common/VR.hlsli
@@ -155,6 +155,23 @@ namespace Stereo
 		return normalizedCoord;
 	}
 
+	/**
+	* @brief Returns the maximum absolute depth difference between a center depth and four neighbors.
+	*
+	* Used for depth-discontinuity edge detection in stereo sync passes.
+	* Works with both NDC depths (fixed absolute threshold) and linear view-space depths
+	* (relative threshold: divide result by max(center, 1.0)).
+	*
+	* @param[in] center    Depth at the pixel being tested.
+	* @param[in] neighbors Depths at four neighboring pixels (e.g. ±1 or ±2 cross pattern).
+	* @return Maximum of |center - neighbor| across all four samples.
+	*/
+	float MaxDepthDiff(float center, float4 neighbors)
+	{
+		return max(max(abs(center - neighbors.x), abs(center - neighbors.y)),
+			max(abs(center - neighbors.z), abs(center - neighbors.w)));
+	}
+
 #if defined(PSHADER) || defined(FRAMEBUFFER)
 	// These functions require the framebuffer which is typically provided with the PSHADER
 	/**

--- a/package/Shaders/Tests/TestVR.hlsl
+++ b/package/Shaders/Tests/TestVR.hlsl
@@ -158,14 +158,13 @@ static const float kEps = 0.0001f;
 }
 
 	/// @tags vr, stereo, depth, edge-detection
-	/// MaxDepthDiff: works with NDC arm/world case (arm ~0.75, world ~1.0 -> diff 0.25 > 0.05 threshold)
+	/// MaxDepthDiff: arm/world case returns exact diff (arm=0.75, world=1.0 -> 0.25)
 	[numthreads(1, 1, 1)] void TestMaxDepthDiffArmWorldCase()
 {
 	float armDepth = 0.75;
 	float worldDepth = 1.0;
 	float result = Stereo::MaxDepthDiff(armDepth, float4(worldDepth, armDepth, armDepth, armDepth));
-	ASSERT(IsTrue, result > 0.05);  // exceeds kEdgeDepthThreshold used in SSS
-	ASSERT(IsTrue, result < 0.5);   // not a false positive at some larger threshold
+	ASSERT(IsTrue, abs(result - abs(worldDepth - armDepth)) < kEps);
 }
 
 /// @tags vr, stereo, depth, edge-detection
@@ -183,6 +182,112 @@ static const float kEps = 0.0001f;
 {
 	float result = Stereo::MaxDepthDiff(0.0, float4(0.8, 0.0, 0.0, 0.0));
 	ASSERT(IsTrue, abs(result - 0.8) < kEps);
+}
+
+/// @tags vr, stereo, edge-detection
+/// ClampToEyeBounds: interior pixel is returned unchanged for both eyes
+[numthreads(1, 1, 1)] void TestClampToEyeBoundsInterior() {
+	float2 frameDim = float2(2048, 1024);
+	int2 left = Stereo::ClampToEyeBounds(int2(512, 512), 0, frameDim);
+	ASSERT(AreEqual, left.x, 512);
+	ASSERT(AreEqual, left.y, 512);
+
+	int2 right = Stereo::ClampToEyeBounds(int2(1536, 512), 1, frameDim);
+	ASSERT(AreEqual, right.x, 1536);
+	ASSERT(AreEqual, right.y, 512);
+}
+
+	/// @tags vr, stereo, edge-detection
+	/// ClampToEyeBounds: left eye x cannot cross the half-width seam
+	[numthreads(1, 1, 1)] void TestClampToEyeBoundsLeftEyeSeam()
+{
+	float2 frameDim = float2(2048, 1024);
+	// x past the seam clamps to halfWidth - 1 = 1023
+	int2 result = Stereo::ClampToEyeBounds(int2(1025, 512), 0, frameDim);
+	ASSERT(AreEqual, result.x, 1023);
+}
+
+/// @tags vr, stereo, edge-detection
+/// ClampToEyeBounds: right eye x cannot cross the half-width seam
+[numthreads(1, 1, 1)] void TestClampToEyeBoundsRightEyeSeam() {
+	float2 frameDim = float2(2048, 1024);
+	// x before the seam clamps to halfWidth = 1024
+	int2 result = Stereo::ClampToEyeBounds(int2(1022, 512), 1, frameDim);
+	ASSERT(AreEqual, result.x, 1024);
+}
+
+	/// @tags vr, stereo, edge-detection
+	/// ClampToEyeBounds: x clamped at outer borders (left eye left edge, right eye right edge)
+	[numthreads(1, 1, 1)] void TestClampToEyeBoundsOuterBorders()
+{
+	float2 frameDim = float2(2048, 1024);
+	int2 leftBorder = Stereo::ClampToEyeBounds(int2(-1, 512), 0, frameDim);
+	ASSERT(AreEqual, leftBorder.x, 0);
+
+	int2 rightBorder = Stereo::ClampToEyeBounds(int2(2049, 512), 1, frameDim);
+	ASSERT(AreEqual, rightBorder.x, 2047);
+}
+
+/// @tags vr, stereo, edge-detection
+/// ClampToEyeBounds: y is clamped to [0, frameDim.y - 1] independently of eye
+[numthreads(1, 1, 1)] void TestClampToEyeBoundsY() {
+	float2 frameDim = float2(2048, 1024);
+	int2 top = Stereo::ClampToEyeBounds(int2(512, -1), 0, frameDim);
+	ASSERT(AreEqual, top.y, 0);
+
+	int2 bottom = Stereo::ClampToEyeBounds(int2(512, 1025), 0, frameDim);
+	ASSERT(AreEqual, bottom.y, 1023);
+}
+
+	/// @tags vr, stereo, edge-detection
+	/// ClampToEyeUV: interior UV is returned unchanged for both eyes
+	[numthreads(1, 1, 1)] void TestClampToEyeUVInterior()
+{
+	float2 left = Stereo::ClampToEyeUV(float2(0.25, 0.5), 0);
+	ASSERT(IsTrue, abs(left.x - 0.25) < kEps);
+	ASSERT(IsTrue, abs(left.y - 0.5) < kEps);
+
+	float2 right = Stereo::ClampToEyeUV(float2(0.75, 0.5), 1);
+	ASSERT(IsTrue, abs(right.x - 0.75) < kEps);
+	ASSERT(IsTrue, abs(right.y - 0.5) < kEps);
+}
+
+/// @tags vr, stereo, edge-detection
+/// ClampToEyeUV: left eye x cannot cross the x=0.5 seam
+[numthreads(1, 1, 1)] void TestClampToEyeUVLeftEyeSeam() {
+	// x past the seam clamps to 0.5
+	float2 result = Stereo::ClampToEyeUV(float2(0.6, 0.5), 0);
+	ASSERT(IsTrue, abs(result.x - 0.5) < kEps);
+}
+
+	/// @tags vr, stereo, edge-detection
+	/// ClampToEyeUV: right eye x cannot cross the x=0.5 seam
+	[numthreads(1, 1, 1)] void TestClampToEyeUVRightEyeSeam()
+{
+	// x before the seam clamps to 0.5
+	float2 result = Stereo::ClampToEyeUV(float2(0.4, 0.5), 1);
+	ASSERT(IsTrue, abs(result.x - 0.5) < kEps);
+}
+
+/// @tags vr, stereo, edge-detection
+/// ClampToEyeUV: x clamped at outer borders (left eye at 0.0, right eye at 1.0)
+[numthreads(1, 1, 1)] void TestClampToEyeUVOuterBorders() {
+	float2 leftBorder = Stereo::ClampToEyeUV(float2(-0.1, 0.5), 0);
+	ASSERT(IsTrue, abs(leftBorder.x - 0.0) < kEps);
+
+	float2 rightBorder = Stereo::ClampToEyeUV(float2(1.1, 0.5), 1);
+	ASSERT(IsTrue, abs(rightBorder.x - 1.0) < kEps);
+}
+
+	/// @tags vr, stereo, edge-detection
+	/// ClampToEyeUV: y coordinate is not modified
+	[numthreads(1, 1, 1)] void TestClampToEyeUVYUnchanged()
+{
+	float2 result = Stereo::ClampToEyeUV(float2(0.25, 1.5), 0);
+	ASSERT(IsTrue, abs(result.y - 1.5) < kEps);
+
+	result = Stereo::ClampToEyeUV(float2(0.75, -0.5), 1);
+	ASSERT(IsTrue, abs(result.y - (-0.5)) < kEps);
 }
 
 /// @tags vr, stereo, uv

--- a/package/Shaders/Tests/TestVR.hlsl
+++ b/package/Shaders/Tests/TestVR.hlsl
@@ -134,6 +134,57 @@ static const float kEps = 0.0001f;
 	ASSERT(AreEqual, Stereo::GetEyeIndexFromTexCoord(stereoRight), 1u);
 }
 
+/// @tags vr, stereo, depth, edge-detection
+/// MaxDepthDiff: identical neighbors -> 0
+[numthreads(1, 1, 1)] void TestMaxDepthDiffAllSame() {
+	float result = Stereo::MaxDepthDiff(0.5, float4(0.5, 0.5, 0.5, 0.5));
+	ASSERT(IsTrue, abs(result) < kEps);
+}
+
+	/// @tags vr, stereo, depth, edge-detection
+	/// MaxDepthDiff: returns |center - neighbor| when one neighbor differs
+	[numthreads(1, 1, 1)] void TestMaxDepthDiffOneDiffers()
+{
+	// Only .z differs
+	float result = Stereo::MaxDepthDiff(0.5, float4(0.5, 0.5, 0.8, 0.5));
+	ASSERT(IsTrue, abs(result - 0.3) < kEps);
+}
+
+/// @tags vr, stereo, depth, edge-detection
+/// MaxDepthDiff: returns the largest difference across all four neighbors
+[numthreads(1, 1, 1)] void TestMaxDepthDiffPicksLargest() {
+	float result = Stereo::MaxDepthDiff(0.5, float4(0.55, 0.45, 0.9, 0.48));
+	ASSERT(IsTrue, abs(result - 0.4) < kEps);  // abs(0.5 - 0.9) = 0.4
+}
+
+	/// @tags vr, stereo, depth, edge-detection
+	/// MaxDepthDiff: works with NDC arm/world case (arm ~0.75, world ~1.0 -> diff 0.25 > 0.05 threshold)
+	[numthreads(1, 1, 1)] void TestMaxDepthDiffArmWorldCase()
+{
+	float armDepth = 0.75;
+	float worldDepth = 1.0;
+	float result = Stereo::MaxDepthDiff(armDepth, float4(worldDepth, armDepth, armDepth, armDepth));
+	ASSERT(IsTrue, result > 0.05);  // exceeds kEdgeDepthThreshold used in SSS
+	ASSERT(IsTrue, result < 0.5);   // not a false positive at some larger threshold
+}
+
+/// @tags vr, stereo, depth, edge-detection
+/// MaxDepthDiff: symmetric - diff(a,b) == diff(b,a)
+[numthreads(1, 1, 1)] void TestMaxDepthDiffSymmetry() {
+	float a = 0.3, b = 0.7;
+	float fwd = Stereo::MaxDepthDiff(a, float4(b, a, a, a));
+	float rev = Stereo::MaxDepthDiff(b, float4(a, b, b, b));
+	ASSERT(IsTrue, abs(fwd - rev) < kEps);
+}
+
+	/// @tags vr, stereo, depth, edge-detection
+	/// MaxDepthDiff: center == 0 (mask pixel) against world neighbor
+	[numthreads(1, 1, 1)] void TestMaxDepthDiffMaskCenter()
+{
+	float result = Stereo::MaxDepthDiff(0.0, float4(0.8, 0.0, 0.0, 0.0));
+	ASSERT(IsTrue, abs(result - 0.8) < kEps);
+}
+
 /// @tags vr, stereo, uv
 /// ConvertToStereoUV clamps input x to [0,1] via saturate
 [numthreads(1, 1, 1)] void TestConvertToStereoUVClamping() {

--- a/package/Shaders/VR/StereoBlendCS.hlsl
+++ b/package/Shaders/VR/StereoBlendCS.hlsl
@@ -31,14 +31,15 @@ cbuffer StereoBlendCB : register(b1)
 static const float kEdgeDepthThreshold = 0.05;  // NDC depth difference above which a pixel is considered a depth discontinuity and excluded from stereo blend
 static const int kEdgeMargin = 2;               // Neighbor offset (pixels) for destination edge + mask boundary check
 
-// Samples four depth neighbors in a cross pattern (±offset pixels) around center.
-float4 SampleCrossDepths(int2 center, int offset)
+// Samples four depth neighbors in a cross pattern (±offset pixels) around center,
+// clamped to eyeIndex's half of the packed stereo buffer to avoid seam contamination.
+float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 {
 	return float4(
-		DepthTexture[center + int2(offset, 0)],
-		DepthTexture[center + int2(-offset, 0)],
-		DepthTexture[center + int2(0, offset)],
-		DepthTexture[center + int2(0, -offset)]);
+		DepthTexture[Stereo::ClampToEyeBounds(center + int2(offset, 0), eyeIndex, FrameDim)],
+		DepthTexture[Stereo::ClampToEyeBounds(center + int2(-offset, 0), eyeIndex, FrameDim)],
+		DepthTexture[Stereo::ClampToEyeBounds(center + int2(0, offset), eyeIndex, FrameDim)],
+		DepthTexture[Stereo::ClampToEyeBounds(center + int2(0, -offset), eyeIndex, FrameDim)]);
 }
 
 [numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
@@ -69,7 +70,7 @@ float4 SampleCrossDepths(int2 center, int offset)
 	if (!isSkipPixel) {
 		// Source edge detection: skip at depth discontinuities (arm/world silhouettes,
 		// object edges). Saves VP reprojection work and prevents halo artifacts.
-		float4 srcEdgeDepths = SampleCrossDepths(dtid, 1);
+		float4 srcEdgeDepths = SampleCrossDepths(dtid, 1, eyeIndex);
 		if (Stereo::MaxDepthDiff(centerDepth, srcEdgeDepths) > kEdgeDepthThreshold) {
 			debugState = 1;
 		} else {
@@ -81,7 +82,7 @@ float4 SampleCrossDepths(int2 center, int offset)
 				// mask boundary or at a depth discontinuity in the other eye. Due to VR
 				// parallax the arm silhouette appears at a different screen position per eye,
 				// so the reprojection can cross a boundary invisible from this eye.
-				float4 dstEdgeDepths = SampleCrossDepths(r.otherPx, kEdgeMargin);
+				float4 dstEdgeDepths = SampleCrossDepths(r.otherPx, kEdgeMargin, 1 - eyeIndex);
 				if (any(dstEdgeDepths < 1e-5) || Stereo::MaxDepthDiff(otherDepth, dstEdgeDepths) > kEdgeDepthThreshold) {
 					debugState = 2;
 				} else {

--- a/package/Shaders/VR/StereoBlendCS.hlsl
+++ b/package/Shaders/VR/StereoBlendCS.hlsl
@@ -2,8 +2,8 @@
 //
 // Full-image depth-aware bilateral blend with back-check validation that
 // reprojects each pixel to the other eye and blends based on depth agreement.
-// No spatial cutoff -- the blend weight comes entirely from depth confidence
-// and round-trip reprojection validation, so there's no visible seam.
+// Source and destination edge detection guard silhouette boundaries before
+// reprojection; the back-check provides a second layer of validation.
 //
 // Based on the stereo-aware bilateral filter from:
 // Shi, Billeter, Eisemann 2022, "Stereo-consistent screen-space ambient occlusion"
@@ -28,6 +28,19 @@ cbuffer StereoBlendCB : register(b1)
 	float pad;
 };
 
+static const float kEdgeDepthThreshold = 0.05;  // NDC depth difference above which a pixel is considered a depth discontinuity and excluded from stereo blend
+static const int kEdgeMargin = 2;               // Neighbor offset (pixels) for destination edge + mask boundary check
+
+// Samples four depth neighbors in a cross pattern (±offset pixels) around center.
+float4 SampleCrossDepths(int2 center, int offset)
+{
+	return float4(
+		DepthTexture[center + int2(offset, 0)],
+		DepthTexture[center + int2(-offset, 0)],
+		DepthTexture[center + int2(0, offset)],
+		DepthTexture[center + int2(0, -offset)]);
+}
+
 [numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
 	if (any(dtid >= uint2(FrameDim)))
 		return;
@@ -38,10 +51,13 @@ cbuffer StereoBlendCB : register(b1)
 	float4 centerColor = ColorTexture[dtid];
 	float centerDepth = DepthTexture[dtid];
 
-	// State 0 = HMD mask (depth==0) or sky (depth==1): no reprojection attempted
-	// State 1 = reprojected, out of other eye's bounds
-	// State 2 = reprojected, back-check passed
-	// State 3 = reprojected, back-check failed (occlusion edge)
+	// Debug states:
+	//   0 = mask/sky: skipped (depth == 0 or 1)
+	//   1 = source edge: depth discontinuity at this pixel
+	//   2 = destination edge: depth discontinuity at reprojected pixel
+	//   3 = out of bounds: reprojection left the other eye's frame
+	//   4 = blended, back-check passed: surfaces match in both eyes
+	//   5 = blended, back-check failed: blend penalized (occlusion edge)
 	uint debugState = 0;
 
 	Stereo::StereoBilateralResult r = (Stereo::StereoBilateralResult)0;
@@ -51,38 +67,59 @@ cbuffer StereoBlendCB : register(b1)
 	// depth == 1.0: sky/far plane (no real geometry, bilateral reprojection not meaningful)
 	bool isSkipPixel = centerDepth < 1e-5 || centerDepth >= 1.0;
 	if (!isSkipPixel) {
-		r = Stereo::ReprojectToOtherEye(uv, centerDepth, eyeIndex, FrameDim);
-		if (r.valid) {
-			float4 otherColor = ColorTexture[r.otherPx];
-			float otherDepth = DepthTexture[r.otherPx];
-			Stereo::FinalizeStereoBlend(r, uv, centerDepth, otherDepth, eyeIndex, FrameDim, DepthSigma, MaxBlendFactor);
-
-			// Only blend where the two eyes actually disagree (screen-space effect
-			// inconsistency). Luminance difference below the threshold means both
-			// eyes computed the same result and blending would only destroy parallax.
-			float colorDiff = abs(dot(centerColor.rgb, float3(0.2126, 0.7152, 0.0722)) -
-								  dot(otherColor.rgb, float3(0.2126, 0.7152, 0.0722)));
-			float colorGate = smoothstep(ColorDiffThreshold * 0.5, ColorDiffThreshold * 2.0, colorDiff);
-			r.blendWeight *= colorGate;
-
-			blendedColor = lerp(centerColor, otherColor, r.blendWeight);
-			debugState = r.backCheckPassed ? 2 : 3;
-		} else {
+		// Source edge detection: skip at depth discontinuities (arm/world silhouettes,
+		// object edges). Saves VP reprojection work and prevents halo artifacts.
+		float4 srcEdgeDepths = SampleCrossDepths(dtid, 1);
+		if (Stereo::MaxDepthDiff(centerDepth, srcEdgeDepths) > kEdgeDepthThreshold) {
 			debugState = 1;
+		} else {
+			r = Stereo::ReprojectToOtherEye(uv, centerDepth, eyeIndex, FrameDim);
+			if (r.valid) {
+				float otherDepth = DepthTexture[r.otherPx];
+
+				// Destination edge detection: skip if the reprojected pixel is near the HMD
+				// mask boundary or at a depth discontinuity in the other eye. Due to VR
+				// parallax the arm silhouette appears at a different screen position per eye,
+				// so the reprojection can cross a boundary invisible from this eye.
+				float4 dstEdgeDepths = SampleCrossDepths(r.otherPx, kEdgeMargin);
+				if (any(dstEdgeDepths < 1e-5) || Stereo::MaxDepthDiff(otherDepth, dstEdgeDepths) > kEdgeDepthThreshold) {
+					debugState = 2;
+				} else {
+					float4 otherColor = ColorTexture[r.otherPx];
+					Stereo::FinalizeStereoBlend(r, uv, centerDepth, otherDepth, eyeIndex, FrameDim, DepthSigma, MaxBlendFactor);
+
+					// Only blend where the two eyes actually disagree (screen-space effect
+					// inconsistency). Luminance difference below the threshold means both
+					// eyes computed the same result and blending would only destroy parallax.
+					float colorDiff = abs(dot(centerColor.rgb, float3(0.2126, 0.7152, 0.0722)) -
+										  dot(otherColor.rgb, float3(0.2126, 0.7152, 0.0722)));
+					float colorGate = smoothstep(ColorDiffThreshold * 0.5, ColorDiffThreshold * 2.0, colorDiff);
+					r.blendWeight *= colorGate;
+
+					blendedColor = lerp(centerColor, otherColor, r.blendWeight);
+					debugState = r.backCheckPassed ? 4 : 5;
+				}
+			} else {
+				debugState = 3;
+			}
 		}
 	}
 
 #ifdef DEBUG_BACKCHECK
-	// Debug visualization:
-	//   Blue  = HMD mask (depth==0) or sky (depth==1): skipped
-	//   Grey  = reprojection out of bounds (other eye can't see this point)
-	//   Green = back-check passed (surfaces match in both eyes)
-	//   Red   = back-check failed (occlusion edge, surfaces disagree)
-	float3 debugColors[4] = {
+	// Debug visualization (6 states):
+	//   Blue   = mask/sky: skipped
+	//   Yellow = source edge: depth discontinuity at this pixel
+	//   Orange = destination edge: depth discontinuity at reprojected pixel
+	//   Grey   = out of bounds: other eye can't see this point
+	//   Green  = back-check passed: surfaces match in both eyes
+	//   Red    = back-check failed: blend penalized (occlusion edge)
+	float3 debugColors[6] = {
 		float3(0.1, 0.1, 0.5),  // 0: mask/sky - blue
-		float3(0.3, 0.3, 0.3),  // 1: out of bounds - grey
-		float3(0.0, 0.5, 0.0),  // 2: back-check passed - green
-		float3(0.5, 0.0, 0.0)   // 3: back-check failed - red
+		float3(0.8, 0.8, 0.0),  // 1: source edge - yellow
+		float3(0.8, 0.4, 0.0),  // 2: destination edge - orange
+		float3(0.3, 0.3, 0.3),  // 3: out of bounds - grey
+		float3(0.0, 0.5, 0.0),  // 4: back-check passed - green
+		float3(0.5, 0.0, 0.0)   // 5: back-check failed - red
 	};
 	OutputRW[dtid] = float4(lerp(centerColor.rgb, debugColors[debugState], 0.7), centerColor.a);
 #elif defined(DEBUG_BLEND_WEIGHT)
@@ -94,6 +131,18 @@ cbuffer StereoBlendCB : register(b1)
 		OutputRW[dtid] = float4(lerp(centerColor.rgb, saturate(heatmap), 0.8), centerColor.a);
 	} else {
 		OutputRW[dtid] = centerColor;
+	}
+#elif defined(DEBUG_EDGE_DETECTION)
+	// Edge detection visualizer: highlights pixels excluded by depth discontinuity checks.
+	// Non-edge pixels show the normal blended output for scene context.
+	//   Bright yellow = source edge: discontinuity at this pixel
+	//   Bright orange = destination edge: discontinuity at reprojected pixel
+	if (debugState == 1) {
+		OutputRW[dtid] = float4(lerp(centerColor.rgb, float3(1.0, 1.0, 0.0), 0.8), centerColor.a);
+	} else if (debugState == 2) {
+		OutputRW[dtid] = float4(lerp(centerColor.rgb, float3(1.0, 0.5, 0.0), 0.8), centerColor.a);
+	} else {
+		OutputRW[dtid] = blendedColor;
 	}
 #else
 	OutputRW[dtid] = blendedColor;

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -84,6 +84,11 @@ void VR::SetupResources()
 	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", blendWeightDefines, "cs_5_0")))
 		stereoBlendDebugBlendWeightCS.attach(rawPtr);
 
+	auto edgeDetectionDefines = defines;
+	edgeDetectionDefines.push_back({ "DEBUG_EDGE_DETECTION", "" });
+	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", edgeDetectionDefines, "cs_5_0")))
+		stereoBlendDebugEdgeDetectionCS.attach(rawPtr);
+
 	auto renderer = globals::game::renderer;
 	auto mainTex = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];
 	D3D11_TEXTURE2D_DESC mainDesc;

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -164,7 +164,7 @@ public:
 		float StereoBlendDepthSigma = 0.01f;      ///< Depth sensitivity for bilateral weight (lower = stricter)
 		float StereoBlendMaxFactor = 0.1f;        ///< Maximum blend factor; keep low to preserve stereo parallax
 		float StereoBlendColorThreshold = 0.02f;  ///< Minimum color difference to trigger blending (luminance)
-		int StereoBlendDebugMode = 0;             ///< 0=off, 1=back-check, 2=blend weight
+		int StereoBlendDebugMode = 0;             ///< 0=off, 1=back-check, 2=blend weight, 3=edge detection
 
 		// VR Menu Overlay positioning settings
 		float VRMenuScale = Config::kDefaultMenuScale;  ///< Scale factor for overlay UI (0.5-2.0)
@@ -261,7 +261,7 @@ public:
 			StereoBlendDepthSigma = std::clamp(StereoBlendDepthSigma, 0.001f, 0.1f);
 			StereoBlendMaxFactor = std::clamp(StereoBlendMaxFactor, 0.0f, 0.5f);
 			StereoBlendColorThreshold = std::clamp(StereoBlendColorThreshold, 0.0f, 0.2f);
-			StereoBlendDebugMode = std::clamp(StereoBlendDebugMode, 0, 2);
+			StereoBlendDebugMode = std::clamp(StereoBlendDebugMode, 0, 3);
 		}
 	};
 
@@ -358,6 +358,7 @@ public:
 	winrt::com_ptr<ID3D11ComputeShader> stereoBlendCS;
 	winrt::com_ptr<ID3D11ComputeShader> stereoBlendDebugBackCheckCS;
 	winrt::com_ptr<ID3D11ComputeShader> stereoBlendDebugBlendWeightCS;
+	winrt::com_ptr<ID3D11ComputeShader> stereoBlendDebugEdgeDetectionCS;
 	eastl::unique_ptr<Texture2D> stereoBlendCopyTex;
 	eastl::unique_ptr<ConstantBuffer> stereoBlendCB;
 

--- a/src/Features/VR/SettingsUI.cpp
+++ b/src/Features/VR/SettingsUI.cpp
@@ -323,19 +323,25 @@ namespace
 
 		ImGui::Separator();
 
-		const char* debugModes[] = { "Off", "Back-Check", "Blend Weight" };
+		const char* debugModes[] = { "Off", "Back-Check", "Blend Weight", "Edge Detection" };
 		ImGui::Combo("Debug View", &settings.StereoBlendDebugMode, debugModes, IM_ARRAYSIZE(debugModes));
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Off: Normal rendering.\n\n"
-				"Back-Check: Visualize reprojection validation.\n"
-				"  Blue  = sky or HMD mask (skipped).\n"
-				"  Grey  = other eye can't see this point (out of bounds).\n"
-				"  Green = back-check passed (surfaces match in both eyes).\n"
-				"  Red   = back-check failed (occlusion edge).\n\n"
-				"Blend Weight: Grayscale intensity of the stereo blend.\n"
-				"  Black = no blending, White = maximum blending.\n"
-				"  Shows where the two eyes disagree and correction is applied.");
+				"Back-Check: Visualize reprojection outcomes.\n"
+				"  Blue   = sky or HMD mask (skipped).\n"
+				"  Yellow = source edge rejected (depth discontinuity at this pixel).\n"
+				"  Orange = destination edge rejected (discontinuity at reprojected pixel).\n"
+				"  Grey   = other eye can't see this point (out of bounds).\n"
+				"  Green  = back-check passed (surfaces match in both eyes).\n"
+				"  Red    = back-check failed (occlusion edge, blend penalized).\n\n"
+				"Blend Weight: Heatmap of stereo blend strength.\n"
+				"  Cool/black = no blending. Hot/white = maximum blending.\n"
+				"  Shows where the two eyes disagree and correction is applied.\n\n"
+				"Edge Detection: Highlights pixels excluded by depth discontinuity checks.\n"
+				"  Yellow = source edge (discontinuity at this pixel).\n"
+				"  Orange = destination edge (discontinuity at reprojected pixel).\n"
+				"  Scene  = all other pixels shown with normal blending.");
 		}
 
 		ImGui::EndDisabled();

--- a/src/Features/VR/StereoBlend.cpp
+++ b/src/Features/VR/StereoBlend.cpp
@@ -10,6 +10,7 @@ void VR::ClearShaderCache()
 	stereoBlendCS = nullptr;
 	stereoBlendDebugBackCheckCS = nullptr;
 	stereoBlendDebugBlendWeightCS = nullptr;
+	stereoBlendDebugEdgeDetectionCS = nullptr;
 }
 
 bool VR::AnyScreenSpaceEffectLoaded()
@@ -65,6 +66,8 @@ void VR::DrawStereoBlend()
 		activeCS = stereoBlendDebugBackCheckCS.get();
 	else if (settings.StereoBlendDebugMode == 2 && stereoBlendDebugBlendWeightCS)
 		activeCS = stereoBlendDebugBlendWeightCS.get();
+	else if (settings.StereoBlendDebugMode == 3 && stereoBlendDebugEdgeDetectionCS)
+		activeCS = stereoBlendDebugEdgeDetectionCS.get();
 
 	context->CSSetConstantBuffers(1, 1, &cbPtr);
 	context->CSSetShaderResources(0, 2, srvs);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Edge Detection" debug visualization mode for stereo blending.
  * Edge-aware stereo handling: skip synchronization/blending near depth discontinuities to reduce incorrect cross-eye artifacts.

* **Tests**
  * Added extensive unit tests for depth-difference calculations and stereo clamping/UV behavior.

* **Documentation**
  * Updated stereo debug tooltips to describe new edge-detection and refined back-check/blend visualizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->