### PR TITLE
test(shader): fallback to warp on invalidarg

### DIFF
--- a/tests/shaders/runtime_test_discovery.h
+++ b/tests/shaders/runtime_test_discovery.h
@@ -15,13 +15,6 @@
 
 namespace HLSLTestDiscovery
 {
-	enum class EPreferredDevice
-	{
-		Undecided,
-		Hardware,
-		Software
-	};
-
 	struct TestFunction
 	{
 		std::string name;
@@ -201,8 +194,6 @@ namespace HLSLTestDiscovery
 	inline bool runTest(const TestFunction& test, std::string& errorMsg)
 	{
 		try {
-			static EPreferredDevice preferredDevice = EPreferredDevice::Undecided;
-
 			auto runWithDevice = [&test, &errorMsg](const stf::GPUDevice::EDeviceType deviceType) {
 				stf::ShaderTestFixture fixture(ShaderTest::GetFixtureDesc(deviceType));
 				auto shaderDir = (ShaderTest::GetExecutableDirectory() / "Shaders").wstring();
@@ -229,23 +220,19 @@ namespace HLSLTestDiscovery
 				return true;
 			};
 
-			if (preferredDevice == EPreferredDevice::Hardware) {
-				return runWithDevice(stf::GPUDevice::EDeviceType::Hardware);
-			}
-
-			if (preferredDevice == EPreferredDevice::Software) {
+			if (ShaderTest::GetPreferredDevice() == ShaderTest::EPreferredDevice::Software) {
 				return runWithDevice(stf::GPUDevice::EDeviceType::Software);
 			}
 
 			try {
 				const bool hardwareResult = runWithDevice(stf::GPUDevice::EDeviceType::Hardware);
-				preferredDevice = EPreferredDevice::Hardware;
+				ShaderTest::SetPreferredDevice(ShaderTest::EPreferredDevice::Hardware);
 				return hardwareResult;
 			} catch (const stf::HrException& e) {
 				if (e.Error() == E_INVALIDARG) {
 					std::cout << "\n[ShaderTests] Hardware D3D12 path returned E_INVALIDARG; retrying with software WARP device.\n";
 					const bool softwareResult = runWithDevice(stf::GPUDevice::EDeviceType::Software);
-					preferredDevice = EPreferredDevice::Software;
+					ShaderTest::SetPreferredDevice(ShaderTest::EPreferredDevice::Software);
 					return softwareResult;
 				}
 				throw;

--- a/tests/shaders/runtime_test_discovery.h
+++ b/tests/shaders/runtime_test_discovery.h
@@ -15,6 +15,13 @@
 
 namespace HLSLTestDiscovery
 {
+	enum class EPreferredDevice
+	{
+		Undecided,
+		Hardware,
+		Software
+	};
+
 	struct TestFunction
 	{
 		std::string name;
@@ -194,28 +201,55 @@ namespace HLSLTestDiscovery
 	inline bool runTest(const TestFunction& test, std::string& errorMsg)
 	{
 		try {
-			stf::ShaderTestFixture fixture(ShaderTest::GetFixtureDesc());
-			auto shaderDir = (ShaderTest::GetExecutableDirectory() / "Shaders").wstring();
+			static EPreferredDevice preferredDevice = EPreferredDevice::Undecided;
 
-			auto result = fixture.RunTest(stf::ShaderTestFixture::RuntimeTestDesc{
-				.CompilationEnv{ .Source = std::filesystem::path(test.filePath),
-					.CompilationFlags = { L"-I", shaderDir } },
-				.TestName = test.name,
-				.ThreadGroupCount{ 1, 1, 1 } });
+			auto runWithDevice = [&test, &errorMsg](const stf::GPUDevice::EDeviceType deviceType) {
+				stf::ShaderTestFixture fixture(ShaderTest::GetFixtureDesc(deviceType));
+				auto shaderDir = (ShaderTest::GetExecutableDirectory() / "Shaders").wstring();
 
-			if (!result) {
-				// Extract detailed error information from the result
-				// This includes line numbers, thread IDs, and actual/expected values
-				std::ostringstream oss;
-				oss << result;
-				errorMsg = oss.str();
+				auto result = fixture.RunTest(stf::ShaderTestFixture::RuntimeTestDesc{
+					.CompilationEnv{ .Source = std::filesystem::path(test.filePath),
+						.CompilationFlags = { L"-I", shaderDir } },
+					.TestName = test.name,
+					.ThreadGroupCount{ 1, 1, 1 } });
 
-				// Also print to stdout for immediate visibility during test runs
-				std::cout << "\n"
-						  << errorMsg << "\n";
-				return false;
+				if (!result) {
+					// Extract detailed error information from the result
+					// This includes line numbers, thread IDs, and actual/expected values
+					std::ostringstream oss;
+					oss << result;
+					errorMsg = oss.str();
+
+					// Also print to stdout for immediate visibility during test runs
+					std::cout << "\n"
+							  << errorMsg << "\n";
+					return false;
+				}
+
+				return true;
+			};
+
+			if (preferredDevice == EPreferredDevice::Hardware) {
+				return runWithDevice(stf::GPUDevice::EDeviceType::Hardware);
 			}
-			return true;
+
+			if (preferredDevice == EPreferredDevice::Software) {
+				return runWithDevice(stf::GPUDevice::EDeviceType::Software);
+			}
+
+			try {
+				const bool hardwareResult = runWithDevice(stf::GPUDevice::EDeviceType::Hardware);
+				preferredDevice = EPreferredDevice::Hardware;
+				return hardwareResult;
+			} catch (const stf::HrException& e) {
+				if (e.Error() == E_INVALIDARG) {
+					std::cout << "\n[ShaderTests] Hardware D3D12 path returned E_INVALIDARG; retrying with software WARP device.\n";
+					const bool softwareResult = runWithDevice(stf::GPUDevice::EDeviceType::Software);
+					preferredDevice = EPreferredDevice::Software;
+					return softwareResult;
+				}
+				throw;
+			}
 		} catch (const std::exception& e) {
 			errorMsg = e.what();
 			std::cout << "\nException: " << errorMsg << "\n";

--- a/tests/shaders/runtime_test_discovery.h
+++ b/tests/shaders/runtime_test_discovery.h
@@ -220,6 +220,10 @@ namespace HLSLTestDiscovery
 				return true;
 			};
 
+			if (ShaderTest::GetPreferredDevice() == ShaderTest::EPreferredDevice::Hardware) {
+				return runWithDevice(stf::GPUDevice::EDeviceType::Hardware);
+			}
+
 			if (ShaderTest::GetPreferredDevice() == ShaderTest::EPreferredDevice::Software) {
 				return runWithDevice(stf::GPUDevice::EDeviceType::Software);
 			}
@@ -234,8 +238,9 @@ namespace HLSLTestDiscovery
 					const bool softwareResult = runWithDevice(stf::GPUDevice::EDeviceType::Software);
 					ShaderTest::SetPreferredDevice(ShaderTest::EPreferredDevice::Software);
 					return softwareResult;
+				} else {
+					throw;
 				}
-				throw;
 			}
 		} catch (const std::exception& e) {
 			errorMsg = e.what();

--- a/tests/shaders/test_common.h
+++ b/tests/shaders/test_common.h
@@ -53,13 +53,14 @@ namespace ShaderTest
 	}
 
 	/// Get standard fixture description for hardware testing
-	inline stf::ShaderTestFixture::FixtureDesc GetFixtureDesc()
+	inline stf::ShaderTestFixture::FixtureDesc GetFixtureDesc(
+		const stf::GPUDevice::EDeviceType deviceType = stf::GPUDevice::EDeviceType::Hardware)
 	{
 		return stf::ShaderTestFixture::FixtureDesc{
 			.Mappings = GetShaderDirectoryMappings(),
 			.GPUDeviceParams{
 				.DebugLevel = stf::GPUDevice::EDebugLevel::Off,       // Disable debug layer (may conflict with some drivers)
-				.DeviceType = stf::GPUDevice::EDeviceType::Hardware,  // Use real GPU instead of WARP
+				.DeviceType = deviceType,
 				.EnableGPUCapture = false }
 		};
 	}

--- a/tests/shaders/test_common.h
+++ b/tests/shaders/test_common.h
@@ -10,6 +10,43 @@
 
 namespace ShaderTest
 {
+	enum class EPreferredDevice
+	{
+		Undecided,
+		Hardware,
+		Software
+	};
+
+	inline EPreferredDevice& GetPreferredDeviceState()
+	{
+		static EPreferredDevice preferredDevice = EPreferredDevice::Undecided;
+		return preferredDevice;
+	}
+
+	inline void SetPreferredDevice(const EPreferredDevice preferredDevice)
+	{
+		GetPreferredDeviceState() = preferredDevice;
+	}
+
+	inline EPreferredDevice GetPreferredDevice()
+	{
+		return GetPreferredDeviceState();
+	}
+
+	inline stf::GPUDevice::EDeviceType ToGPUDeviceType(const EPreferredDevice preferredDevice)
+	{
+		if (preferredDevice == EPreferredDevice::Software) {
+			return stf::GPUDevice::EDeviceType::Software;
+		}
+
+		return stf::GPUDevice::EDeviceType::Hardware;
+	}
+
+	inline stf::GPUDevice::EDeviceType GetPreferredGPUDeviceType()
+	{
+		return ToGPUDeviceType(GetPreferredDevice());
+	}
+
 	/// Get the directory containing the test executable
 	/// This is portable across different working directories and drive letters
 	inline std::filesystem::path GetExecutableDirectory()
@@ -52,9 +89,8 @@ namespace ShaderTest
 		};
 	}
 
-	/// Get standard fixture description for hardware testing
-	inline stf::ShaderTestFixture::FixtureDesc GetFixtureDesc(
-		const stf::GPUDevice::EDeviceType deviceType = stf::GPUDevice::EDeviceType::Hardware)
+	/// Get fixture description for an explicitly selected GPU device type
+	inline stf::ShaderTestFixture::FixtureDesc GetFixtureDesc(const stf::GPUDevice::EDeviceType deviceType)
 	{
 		return stf::ShaderTestFixture::FixtureDesc{
 			.Mappings = GetShaderDirectoryMappings(),
@@ -63,5 +99,11 @@ namespace ShaderTest
 				.DeviceType = deviceType,
 				.EnableGPUCapture = false }
 		};
+	}
+
+	/// Get fixture description using the shared preferred device selection
+	inline stf::ShaderTestFixture::FixtureDesc GetFixtureDesc()
+	{
+		return GetFixtureDesc(GetPreferredGPUDeviceType());
 	}
 }

--- a/tests/shaders/test_common.h
+++ b/tests/shaders/test_common.h
@@ -59,7 +59,7 @@ namespace ShaderTest
 		return stf::ShaderTestFixture::FixtureDesc{
 			.Mappings = GetShaderDirectoryMappings(),
 			.GPUDeviceParams{
-				.DebugLevel = stf::GPUDevice::EDebugLevel::Off,       // Disable debug layer (may conflict with some drivers)
+				.DebugLevel = stf::GPUDevice::EDebugLevel::Off,  // Disable debug layer (may conflict with some drivers)
 				.DeviceType = deviceType,
 				.EnableGPUCapture = false }
 		};

--- a/tests/shaders/test_common.h
+++ b/tests/shaders/test_common.h
@@ -3,6 +3,8 @@
 
 #include <Framework/ShaderTestFixture.h>
 #include <filesystem>
+#include <stdexcept>
+#include <vector>
 
 #ifdef _WIN32
 #	include <windows.h>
@@ -44,7 +46,14 @@ namespace ShaderTest
 
 	inline stf::GPUDevice::EDeviceType GetPreferredGPUDeviceType()
 	{
-		return ToGPUDeviceType(GetPreferredDevice());
+		const EPreferredDevice preferredDevice = GetPreferredDevice();
+		if (preferredDevice == EPreferredDevice::Undecided) {
+			throw std::logic_error(
+				"Preferred GPU device is undecided. Call ShaderTest::SetPreferredDevice(...) "
+				"or use ShaderTest::GetFixtureDesc(deviceType) with an explicit device.");
+		}
+
+		return ToGPUDeviceType(preferredDevice);
 	}
 
 	/// Get the directory containing the test executable

--- a/tests/shaders/test_helpers_unified.h
+++ b/tests/shaders/test_helpers_unified.h
@@ -29,7 +29,7 @@
 	TEST_CASE(test_name, tags)                                                         \
 	{                                                                                  \
 		stf::ShaderTestFixture fixture(                                                \
-			ShaderTest::GetFixtureDesc(stf::GPUDevice::EDeviceType::Hardware));         \
+			ShaderTest::GetFixtureDesc(stf::GPUDevice::EDeviceType::Hardware));        \
 		auto shaderDir = (ShaderTest::GetExecutableDirectory() / "Shaders").wstring(); \
 		auto result = fixture.RunTest(stf::ShaderTestFixture::RuntimeTestDesc{         \
 			.CompilationEnv{ .Source = std::filesystem::path(shader_path),             \

--- a/tests/shaders/test_helpers_unified.h
+++ b/tests/shaders/test_helpers_unified.h
@@ -28,7 +28,8 @@
 #define SHADER_TEST(test_name, tags, shader_path, hlsl_function, x, y, z)              \
 	TEST_CASE(test_name, tags)                                                         \
 	{                                                                                  \
-		stf::ShaderTestFixture fixture(ShaderTest::GetFixtureDesc());                  \
+		stf::ShaderTestFixture fixture(                                                \
+			ShaderTest::GetFixtureDesc(stf::GPUDevice::EDeviceType::Hardware));         \
 		auto shaderDir = (ShaderTest::GetExecutableDirectory() / "Shaders").wstring(); \
 		auto result = fixture.RunTest(stf::ShaderTestFixture::RuntimeTestDesc{         \
 			.CompilationEnv{ .Source = std::filesystem::path(shader_path),             \
@@ -87,7 +88,7 @@ inline void GenerateShaderTests(const char* shaderPath, const ShaderTestEntry (&
 	for (const auto& entry : entries) {
 		DYNAMIC_SECTION(entry.testName)
 		{
-			stf::ShaderTestFixture fixture(ShaderTest::GetFixtureDesc());
+			stf::ShaderTestFixture fixture(ShaderTest::GetFixtureDesc(stf::GPUDevice::EDeviceType::Hardware));
 			auto result = fixture.RunTest(stf::ShaderTestFixture::RuntimeTestDesc{
 				.CompilationEnv{ .Source = std::filesystem::path(shaderPath),
 					.CompilationFlags = { L"-I", shaderDir } },


### PR DESCRIPTION
## Summary
- Add a robust fallback path in shader runtime test discovery for systems where hardware D3D12 initialization fails with `HRESULT 0x80070057 (E_INVALIDARG)`.
- Preserve hardware execution as the primary path, but automatically retry with software WARP when the specific initialization failure is encountered.
- Keep test output semantics unchanged while reducing environment-specific false negatives.

## What changed
### `tests/shaders/test_common.h`
- Updated `GetFixtureDesc(...)` to accept an explicit `stf::GPUDevice::EDeviceType` parameter.
- Kept current behavior intact by defaulting to `Hardware`.

### `tests/shaders/runtime_test_discovery.h`
- Added a preferred-device state machine (`Undecided`, `Hardware`, `Software`).
- Introduced a local execution helper that runs a test using a selected device type.
- Implemented one-time probing logic:
  1. Try hardware first.
  2. If initialization throws `stf::HrException` with `E_INVALIDARG`, retry using software WARP.
  3. Cache the successful path for remaining discovered tests in the same process.
- Preserved existing failure-detail extraction and reporting behavior.

## Why this change
The previous harness always initialized hardware for every discovered test. On systems with incompatible D3D12 hardware/runtime combinations, this can fail before shader assertions run, causing repeated suite failures that do not reflect shader correctness. This update keeps the fast path when available and introduces a deterministic, minimal fallback when hardware initialization is invalid.

## Validation
- Built and ran `run_shader_tests`.
- Observed expected fallback behavior:
  - hardware path reports `E_INVALIDARG`
  - fallback to software WARP is engaged
- Final result: `All tests passed (164 assertions in 1 test case)`.

## Scope
- Change is intentionally localized to shader test harness plumbing only.
- No production shader runtime path or gameplay runtime logic changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-facing preferred-device setting to remember and expose Hardware vs. Software GPU choice.
  * Added ability to request test fixtures for a specific GPU device type.

* **Tests**
  * Implemented device-aware test execution with intelligent fallback: try preferred device, default to Hardware, and retry with Software on specific failures; logs and preserves error details.
  * Generated shader tests now explicitly target Hardware by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->