### PR TITLE
fix(UI): feature description text wrapping

### DIFF
--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -183,12 +183,14 @@ namespace
 			ImGui::SetCursorScreenPos(ImVec2(startPos.x, startPos.y + titleSize.y + 2.0f));
 		}
 
-		// Draw description if provided (single line, truncated)
+		// Draw description if provided (wrapped to content width)
 		if (!description.empty()) {
 			MenuFonts::FontRoleGuard subtextGuard(Menu::FontRole::Subtext);
 			ImVec4 descColor = palette.Text;
 			descColor.w *= 0.7f;  // Slightly dimmed
-			ImGui::TextColored(descColor, "%s", description.c_str());
+			ImGui::PushStyleColor(ImGuiCol_Text, descColor);
+			ImGui::TextWrapped("%s", description.c_str());
+			ImGui::PopStyleColor();
 		}
 
 		// Draw plain separator below


### PR DESCRIPTION
Feature descriptions are single-line so they often don't fit. It causes overflow in the container which requires horizontal scrolling.

This PR makes it wrap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced description rendering to support multi-line text wrapping, improving readability of longer descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->