### PR TITLE
fix(VR): exponential height fog stereo mismatch

### DIFF
--- a/package/Shaders/ISSAOComposite.hlsl
+++ b/package/Shaders/ISSAOComposite.hlsl
@@ -187,7 +187,8 @@ PS_OUTPUT main(PS_INPUT input)
 #		endif
 #		if defined(EXP_HEIGHT_FOG)
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(input.TexCoord.xy);
-	float4 positionWS = float4(2 * float2(input.TexCoord.x, -input.TexCoord.y + 1) - 1, depth, 1);
+	float2 monoUV = Stereo::ConvertFromStereoUV(input.TexCoord.xy, eyeIndex);
+	float4 positionWS = float4(2 * float2(monoUV.x, -monoUV.y + 1) - 1, depth, 1);
 	positionWS = mul(FrameBuffer::CameraViewProjInverse[eyeIndex], positionWS);
 	positionWS.xyz = positionWS.xyz / positionWS.w;
 	if (SharedData::exponentialHeightFogSettings.enabled) {


### PR DESCRIPTION
Used `Stereo::ConvertFromStereoUV` to fix left/right eye mismatch and ghosting when Exponential Height Fog is enabled in VR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stereo/VR rendering calculations to correctly handle per-eye view positioning, enhancing compatibility and accuracy for stereo displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->