### PR TITLE
fix(skylighting): remove redundant albedo mult

### DIFF
--- a/features/Skylighting/Shaders/Skylighting/Skylighting.hlsli
+++ b/features/Skylighting/Shaders/Skylighting/Skylighting.hlsli
@@ -49,7 +49,7 @@ namespace Skylighting
 
 		diffuseColor = max(0.0, diffuseColor - directionalAmbientColor);
 
-		directionalAmbientColor = Color::IrradianceToGamma(Color::IrradianceToLinear(directionalAmbientColor) * Color::IrradianceToLinear(albedo / Color::PBRLightingScale) * skylightingDiffuse);
+		directionalAmbientColor = Color::IrradianceToGamma(Color::IrradianceToLinear(directionalAmbientColor) * skylightingDiffuse);
 
 		diffuseColor += directionalAmbientColor;
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined skylighting calculations by simplifying ambient color computations and eliminating redundant color scaling operations. This optimization significantly improves rendering accuracy and ensures consistent visual quality in environmental lighting contributions across diverse rendering scenarios. The refinement enhances overall image fidelity without affecting system performance or compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->