### PR TITLE
fix(skysync): effect mesh blackout during shadow caster transitions

### DIFF
--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -415,7 +415,6 @@ void SkySync::ShadowFader::SetLighting(const RE::Sun* sun, RE::NiPoint3 dir, flo
 	sun->light->Update(updateData);
 
 	intensity = std::clamp(intensity, 0.0f, 1.0f);
-	sun->light->GetLightRuntimeData().fade = intensity;
 	volumetricLightingIntensityFactor = intensity;
 }
 

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -80,6 +80,8 @@ public:
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
+	inline static float volumetricLightingIntensityFactor = 1.0f;
+
 private:
 	enum class MoonLightSource : uint8_t
 	{
@@ -166,8 +168,6 @@ private:
 	inline static float* gSunGlareSize = nullptr;
 	inline static uint32_t* gMasserSize = nullptr;
 	inline static uint32_t* gSecundaSize = nullptr;
-
-	inline static float volumetricLightingIntensityFactor = 1.0f;
 
 	bool moonAndStarsLoaded = false;
 	RE::TESObjectCELL* currentCell = nullptr;


### PR DESCRIPTION
Effect meshes with lightingInfluence set to 255 go completely black at dawn/dusk when SkySync is enabled. 

SkySync's shadow fader zeroed at sunset, which the game multiplied into effect mesh lighting causing blackout. Volumetric lighting works well through its own intensity factor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal lighting system architecture to streamline intensity factor management without altering end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->