### PR TITLE
fix(skysync): remove sunlight fade and volumetric lighting overrides

### DIFF
--- a/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
+++ b/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
@@ -114,14 +114,16 @@ cbuffer PerTechnique : register(b0)
 
 	float shadowContribution = noShadow;
 
-#	if defined(TERRAIN_SHADOWS)
-	if (!SharedData::InInterior)
-		shadowContribution *= TerrainShadows::GetTerrainShadow(positionWS.xyz + PosAdjust[eyeIndex], LinearSampler);
-#	endif
-
-#	if defined(CLOUD_SHADOWS)
-	if (!SharedData::InInterior)
-		shadowContribution *= sqrt(CloudShadows::GetCloudShadowMult(positionWS.xyz + PosAdjust[eyeIndex], LinearSampler));
+#	if defined(TERRAIN_SHADOWS) || defined(CLOUD_SHADOWS)
+	if (!SharedData::InInterior) {
+		float3 worldPos = positionWS.xyz + PosAdjust[eyeIndex];
+#		if defined(TERRAIN_SHADOWS)
+		shadowContribution *= TerrainShadows::GetTerrainShadow(worldPos, LinearSampler);
+#		endif
+#		if defined(CLOUD_SHADOWS)
+		shadowContribution *= sqrt(CloudShadows::GetCloudShadowMult(worldPos, LinearSampler));
+#		endif
+	}
 #	endif
 
 	float vl = shadowContribution * densityContribution * phaseContribution;

--- a/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
+++ b/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
@@ -115,15 +115,7 @@ cbuffer PerTechnique : register(b0)
 	float shadowContribution = noShadow;
 
 #	if defined(TERRAIN_SHADOWS) || defined(CLOUD_SHADOWS)
-	if (!SharedData::InInterior) {
-		float3 worldPos = positionWS.xyz + PosAdjust[eyeIndex];
-#		if defined(TERRAIN_SHADOWS)
-		shadowContribution *= TerrainShadows::GetTerrainShadow(worldPos, LinearSampler);
-#		endif
-#		if defined(CLOUD_SHADOWS)
-		shadowContribution *= sqrt(CloudShadows::GetCloudShadowMult(worldPos, LinearSampler));
-#		endif
-	}
+	shadowContribution *= sqrt(ShadowSampling::GetWorldShadow(positionWS.xyz, PosAdjust[eyeIndex], eyeIndex));
 #	endif
 
 	float vl = shadowContribution * densityContribution * phaseContribution;

--- a/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
+++ b/package/Shaders/ISVolumetricLightingGenerateCS.hlsl
@@ -113,6 +113,17 @@ cbuffer PerTechnique : register(b0)
 	float phaseContribution = lerp(1, phaseFactor, PhaseContribution);
 
 	float shadowContribution = noShadow;
+
+#	if defined(TERRAIN_SHADOWS)
+	if (!SharedData::InInterior)
+		shadowContribution *= TerrainShadows::GetTerrainShadow(positionWS.xyz + PosAdjust[eyeIndex], LinearSampler);
+#	endif
+
+#	if defined(CLOUD_SHADOWS)
+	if (!SharedData::InInterior)
+		shadowContribution *= sqrt(CloudShadows::GetCloudShadowMult(positionWS.xyz + PosAdjust[eyeIndex], LinearSampler));
+#	endif
+
 	float vl = shadowContribution * densityContribution * phaseContribution;
 
 	DensityRW[dispatchID.xyz] = vl;

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -85,7 +85,6 @@ void SkySync::PostPostLoad()
 	stl::detour_thunk<Moon_Update>(REL::RelocationID(25626, 26169));
 	stl::detour_thunk<Sky_Update>(REL::RelocationID(25682, 26229));
 	stl::detour_thunk<Sky_OnNewClimate>(REL::RelocationID(25695, 26242));
-	stl::write_thunk_call<ApplyVolumetricLighting_VolumetricLightingDescriptor_Get>(REL::RelocationID(100475, 107193).address() + 0x354);
 
 	gSunPosition = reinterpret_cast<RE::NiPoint3*>(REL::RelocationID(527924, 414871).address());
 	gSunGlareSize = reinterpret_cast<float*>(REL::RelocationID(502611, 370235).address());
@@ -415,7 +414,6 @@ void SkySync::ShadowFader::SetLighting(const RE::Sun* sun, RE::NiPoint3 dir, flo
 	sun->light->Update(updateData);
 
 	intensity = std::clamp(intensity, 0.0f, 1.0f);
-	volumetricLightingIntensityFactor = intensity;
 }
 
 inline void SkySync::ShadowFader::ClampDirection(RE::NiPoint3& dir)
@@ -434,14 +432,6 @@ inline void SkySync::ShadowFader::ClampDirection(RE::NiPoint3& dir)
 	dir.x = cosElev * cosHeading;
 	dir.y = cosElev * sinHeading;
 	dir.z = sinElev;
-}
-
-SkySync::VolumetricLightingDescriptor* SkySync::ApplyVolumetricLighting_VolumetricLightingDescriptor_Get::thunk()
-{
-	const auto volumetricLightingDescriptor = func();
-	if (globals::features::skySync.settings.Enabled)
-		volumetricLightingDescriptor->lightingIntensity *= volumetricLightingIntensityFactor;
-	return volumetricLightingDescriptor;
 }
 
 void SkySync::ClimateTimings::Update(const RE::TESClimate* climate)

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -69,19 +69,6 @@ public:
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
-	struct VolumetricLightingDescriptor
-	{
-		float lightingIntensity;
-	};
-
-	struct ApplyVolumetricLighting_VolumetricLightingDescriptor_Get
-	{
-		static VolumetricLightingDescriptor* thunk();
-		static inline REL::Relocation<decltype(thunk)> func;
-	};
-
-	inline static float volumetricLightingIntensityFactor = 1.0f;
-
 private:
 	enum class MoonLightSource : uint8_t
 	{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed Features**
  * Volumetric lighting effects and the separate sky-driven intensity adjustment have been removed.

* **New Features**
  * Outdoor scenes now apply conditional terrain and cloud shadow multipliers for more nuanced shadow blending.

* **Other**
  * No other sky behavior changes; overall lighting flow and phase/density calculations remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->