### PR TITLE
ci: fix wiki deletion with buffer update

### DIFF
--- a/.github/workflows/update-buffers-wiki.yaml
+++ b/.github/workflows/update-buffers-wiki.yaml
@@ -34,7 +34,13 @@ jobs:
 
             - name: Checkout existing wiki
               run: |
-                  git clone --depth=1 "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git" wiki-content || mkdir -p wiki-content
+                  WIKI_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git"
+                  if git ls-remote --exit-code "$WIKI_URL" &>/dev/null; then
+                      git clone --depth=1 "$WIKI_URL" wiki-content
+                  else
+                      echo "Wiki does not exist yet; initializing empty wiki-content directory."
+                      mkdir -p wiki-content
+                  fi
               shell: bash
 
             - name: Scan buffer usage

--- a/.github/workflows/update-buffers-wiki.yaml
+++ b/.github/workflows/update-buffers-wiki.yaml
@@ -32,8 +32,9 @@ jobs:
             - name: Prepare shaders
               uses: ./.github/actions/prepare-shaders
 
-            - name: Create wiki content directory
-              run: mkdir -p wiki-content
+            - name: Checkout existing wiki
+              run: |
+                  git clone --depth=1 "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git" wiki-content || mkdir -p wiki-content
               shell: bash
 
             - name: Scan buffer usage


### PR DESCRIPTION
Andrew-Chen-Wang/github-wiki-action@v5.0.4 fixed deletions not propagating and introduced correct behavior of only keeping what was in the wiki directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated wiki update workflow to attempt cloning existing wiki content before creating a new directory.
  * Falls back to initializing an empty wiki directory and logs an informational message if no wiki is found.
  * Improves resilience and reduces unnecessary empty directory creation during wiki preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->