### PR TITLE
fix(pbr): use GTSO, remove ao^2 mult with direct lighting

### DIFF
--- a/package/Shaders/Common/PBR.hlsli
+++ b/package/Shaders/Common/PBR.hlsli
@@ -268,7 +268,7 @@ namespace PBR
 		// Apply ambient occlusion with multi-bounce approximation
 		lobeWeights.diffuse *= MultiBounceAO(material.BaseColor, material.AO);
 		float alpha = material.Roughness * material.Roughness;
-		lobeWeights.specular *= SpecularOcclusion(NdotV, alpha, material.AO);
+		lobeWeights.specular *= SpecularOcclusionGTSO(NdotV, material.AO);
 	}
 }
 

--- a/package/Shaders/Common/Shading.hlsli
+++ b/package/Shaders/Common/Shading.hlsli
@@ -13,8 +13,8 @@ float3 MultiBounceAO(float3 baseColor, float ao)
 // [Jimenez et al. 2016, "Practical Realtime Strategies for Accurate Indirect Occlusion"]
 float SpecularOcclusionGTSO(float NdotV, float ao)
 {
-    float d = NdotV + ao;
-    return saturate(d * d - 1.0 + ao);
+	float d = NdotV + ao;
+	return saturate(d * d - 1.0 + ao);
 }
 
 // [Lagarde et al. 2014, "Moving Frostbite to Physically Based Rendering 3.0"]

--- a/package/Shaders/Common/Shading.hlsli
+++ b/package/Shaders/Common/Shading.hlsli
@@ -10,6 +10,13 @@ float3 MultiBounceAO(float3 baseColor, float ao)
 	return max(ao, ((ao * a + b) * ao + c) * ao);
 }
 
+// [Jimenez et al. 2016, "Practical Realtime Strategies for Accurate Indirect Occlusion"]
+float SpecularOcclusionGTSO(float NdotV, float ao)
+{
+    float d = NdotV + ao;
+    return saturate(d * d - 1.0 + ao);
+}
+
 // [Lagarde et al. 2014, "Moving Frostbite to Physically Based Rendering 3.0"]
 float SpecularAOLagarde(float NdotV, float ao, float roughness)
 {

--- a/package/Shaders/DeferredCompositeCS.hlsl
+++ b/package/Shaders/DeferredCompositeCS.hlsl
@@ -55,8 +55,7 @@ void SampleSSGI(uint2 pixCoord, float3 normalWS, out float ao, out float3 il)
 void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, inout float ao, out float3 il, in float3 normal, in float3 view, in float roughness)
 {
 	float NdotV = dot(normal, view);
-	float alpha = roughness * roughness;
-	ao = SpecularOcclusion(saturate(NdotV), alpha, ao);
+	ao = SpecularOcclusionGTSO(saturate(NdotV), ao);
 
 	float4 ssgiIlYSh = SsgiYTexture[pixCoord];
 	float ssgiIlY = SphericalHarmonics::FuncProductIntegral(ssgiIlYSh, lobe);
@@ -144,8 +143,6 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, inout float ao, out float3 il,
 	float3 linAlbedo = Color::IrradianceToLinear(albedo / Color::PBRLightingScale);
 
 	float3 multiBounceSSGIAo = MultiBounceAO(linAlbedo, ssgiAo);
-
-	linDiffuseColor *= sqrt(multiBounceSSGIAo);
 
 	diffuseColor = Color::IrradianceToGamma(linDiffuseColor);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated specular occlusion calculations in shader rendering pipeline.
  * Simplified diffuse lighting calculations for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->