### PR TITLE
fix(UI): first-time dialog fade affects all overlays

### DIFF
--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -382,14 +382,12 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 	io.WantCaptureKeyboard = true;
 	io.MouseDrawCursor = true;  // Show ImGui cursor
 
-	// Draw semi-transparent dark overlay behind the dialog for depth
-	Util::DrawModalBackground();
-
 	// Center the window properly with rounded corners and thin border
 	ImVec2 center = ImVec2(io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f);
 	ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
 	// Set a minimum width for better layout, but allow auto-sizing for height
 	ImGui::SetNextWindowSizeConstraints(ImVec2(500, 0), ImVec2(600, FLT_MAX));
+	ImGui::SetNextWindowFocus();
 
 	// Style for rounded window with thin border
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 8.0f);
@@ -404,6 +402,13 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 		ImGui::End();
 		return;
 	}
+
+	// Draw fullscreen fade on the dialog's own draw list (renders at dialog's z-position,
+	// covering all windows beneath, with dialog content drawn on top)
+	auto* drawList = ImGui::GetWindowDrawList();
+	drawList->PushClipRectFullScreen();
+	drawList->AddRectFilled(ImVec2(0, 0), io.DisplaySize, IM_COL32(0, 0, 0, MODAL_OVERLAY_ALPHA));
+	drawList->PopClipRect();
 
 	// Set absolute font size for better readability in this welcome dialog
 	float targetFontSize = 27.0f;

--- a/src/Menu/HomePageRenderer.h
+++ b/src/Menu/HomePageRenderer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 class HomePageRenderer

--- a/src/Menu/HomePageRenderer.h
+++ b/src/Menu/HomePageRenderer.h
@@ -14,6 +14,7 @@ public:
 	static constexpr float HELP_TEXT_SCALE = 1.35f;
 	static constexpr float QUICK_LINKS_BUTTON_WIDTH = 180.0f;
 	static constexpr float LOGO_WATERMARK_HEIGHT = 200.0f;
+	static constexpr uint8_t MODAL_OVERLAY_ALPHA = 160;
 
 	// Discord banner scaling constants
 	static constexpr float DISCORD_BANNER_TARGET_WIDTH_RATIO = 0.85f;  // 25% of window width

--- a/src/Menu/OverlayRenderer.cpp
+++ b/src/Menu/OverlayRenderer.cpp
@@ -50,7 +50,6 @@ void OverlayRenderer::RenderOverlay(
 
 	RenderShaderCompilationStatus(keyIdToString);
 	RenderShaderBlockingStatus();
-	RenderFirstTimeSetupOverlay();
 
 	// Draw weather editor independently of main menu state
 	// Auto-close editor if player leaves valid game space (e.g., loading screen)
@@ -72,6 +71,7 @@ void OverlayRenderer::RenderOverlay(
 	}
 
 	RenderFeatureOverlays();
+	RenderFirstTimeSetupOverlay();
 	HandleABTesting();
 	FinalizeImGuiFrame();
 }


### PR DESCRIPTION
First-time dialog box background fade now appears over shader compilation window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a fullscreen modal overlay to the first-time setup dialog for improved visual prominence.
  * Ensured the setup dialog receives focus reliably for smoother interaction.
  * Reordered overlay rendering to improve dialog visibility and UI layering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->