### PR TITLE
fix: upscaling monitor detection fixes

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -311,7 +311,7 @@ void Upscaling::DrawSettings()
 			if (!d3d12SwapChainActive)
 				ImGui::EndDisabled();
 
-			ImGui::Text("Allows frame generation to function on low refresh rate monitors");
+			ImGui::TextWrapped("Allows frame generation to function on low refresh rate monitors. Detected: %.2f Hz", refreshRate);
 			ImGui::SliderInt("Force Enable Frame Generation", (int*)&settings.frameGenerationForceEnable, 0, 1, std::format("{}", toggleModes[settings.frameGenerationForceEnable]).c_str());
 
 			ImGui::TreePop();
@@ -1370,7 +1370,7 @@ double Upscaling::GetRefreshRate(HWND a_window)
 					sourceName.header.size = sizeof(sourceName);
 					sourceName.header.adapterId = p.sourceInfo.adapterId;
 					sourceName.header.id = p.sourceInfo.id;
-					if (DisplayConfigGetDeviceInfo(&sourceName.header) == ERROR_SUCCESS) {
+					if (DisplayConfigGetDeviceInfo(&sourceName.header) == ERROR_SUCCESS && wcscmp(info.szDevice, sourceName.viewGdiDeviceName) == 0) {
 						// find the matched device which is associated with current device
 						// there may be the possibility that display may be duplicated and windows may be one of them in such scenario
 						// there may be two callback because source is same target will be different


### PR DESCRIPTION
The source for `Upscaling::GetRefreshRate` is from Streamline. But it looks like we forgot to port over one extra check (check that the device we're iterating over matches the one for the swap chain).

As a sanity check, look at `extern\Streamline-DX12\source\platforms\sl.chi\d3d12.cpp`. The fix seems correct assuming that NVIDIA is not writing junk code that doesn't work.

Without this check, it will match on the first device, regardless of whether it's correct or not.
This PR also adds a small UI change to show the currently detected refresh rate. I can move it whereever based on feedback.

Fixes https://github.com/doodlum/skyrim-community-shaders/issues/1962