### PR TITLE
feat(vr): VR stereo reprojection quality improvements

### DIFF
--- a/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
+++ b/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
@@ -325,6 +325,7 @@ namespace ExtendedMaterials
 	float2 GetParallaxCoords(float distance, float2 coords, float mipLevel, float3 viewDir, float3x3 tbn, float noise, Texture2D<float4> tex, SamplerState texSampler, uint channel, DisplacementParams params, out float pixelOffset)
 #endif
 	{
+		pixelOffset = 0;
 		float3 viewDirTS = normalize(mul(tbn, viewDir));
 #if defined(LANDSCAPE)
 		viewDirTS.xy /= viewDirTS.z * 0.7 + 0.3 + params[0].FlattenAmount;  // Fix for objects at extreme viewing angles
@@ -496,7 +497,7 @@ namespace ExtendedMaterials
 #endif
 				nearBlendToFar *= nearBlendToFar;
 			float offset = (1.0 - parallaxAmount) * -maxHeight + minHeight;
-			pixelOffset = lerp(parallaxAmount * scale, 0, nearBlendToFar);
+			pixelOffset = lerp(parallaxAmount, 0.5, nearBlendToFar);
 			return lerp(viewDirTS.xy * offset + coords.xy, coords, nearBlendToFar);
 		}
 

--- a/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
+++ b/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
@@ -497,7 +497,7 @@ namespace ExtendedMaterials
 #endif
 				nearBlendToFar *= nearBlendToFar;
 			float offset = (1.0 - parallaxAmount) * -maxHeight + minHeight;
-			pixelOffset = lerp(parallaxAmount, 0.5, nearBlendToFar);
+			pixelOffset = saturate(lerp(parallaxAmount, 0.5, nearBlendToFar));
 			return lerp(viewDirTS.xy * offset + coords.xy, coords, nearBlendToFar);
 		}
 

--- a/features/VR Stereo Optimizations/Shaders/Features/VRStereoOptimizations.ini
+++ b/features/VR Stereo Optimizations/Shaders/Features/VRStereoOptimizations.ini
@@ -1,0 +1,2 @@
+[Info]
+Version = 1-0-0

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -57,7 +57,7 @@ namespace SharedData
 		bool EnableShadows;
 		bool ExtendShadows;
 		bool EnableParallaxWarpingFix;
-		float1 pad0;
+		bool pad0;
 	};
 
 	struct CubemapCreatorSettings

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -20,15 +20,15 @@ namespace SharedData
 		float Timer;
 		uint FrameCount;
 		uint FrameCountAlwaysActive;
-		bool InInterior;  // If the area lacks a directional shadow light e.g. the sun or moon
-		bool InMapMenu;   // If the world/local map is open (note that the renderer is still deferred here)
-		bool HideSky;     // HideSky flag in WorldSpace, e.g. Blackreach
-		float MipBias;              // Offset to mip level for TAA sharpness
-		float VRMipBias;            // Additional negative MIP bias for VR foliage sharpening (depth-scaled)
-		float VRMipBiasNearDist;    // Game units: no VR MIP bias closer than this
-		float VRMipBiasFarDist;     // Game units: full VR MIP bias beyond this
-		uint VRMipBiasMode;         // 0=Off, 1=All Textures, 2=Distant Trees (TREE_ANIM) only
-		float VRAlphaTestThreshold; // Alpha test threshold for VR TREE_ANIM (0 = disabled)
+		bool InInterior;             // If the area lacks a directional shadow light e.g. the sun or moon
+		bool InMapMenu;              // If the world/local map is open (note that the renderer is still deferred here)
+		bool HideSky;                // HideSky flag in WorldSpace, e.g. Blackreach
+		float MipBias;               // Offset to mip level for TAA sharpness
+		float VRMipBias;             // Additional negative MIP bias for VR foliage sharpening (depth-scaled)
+		float VRMipBiasNearDist;     // Game units: no VR MIP bias closer than this
+		float VRMipBiasFarDist;      // Game units: full VR MIP bias beyond this
+		uint VRMipBiasMode;          // 0=Off, 1=All Textures, 2=Distant Trees (TREE_ANIM) only
+		float VRAlphaTestThreshold;  // Alpha test threshold for VR TREE_ANIM (0 = disabled)
 		float2 pad0;
 		float4 AmbientSHR;
 		float4 AmbientSHG;

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -23,8 +23,13 @@ namespace SharedData
 		bool InInterior;  // If the area lacks a directional shadow light e.g. the sun or moon
 		bool InMapMenu;   // If the world/local map is open (note that the renderer is still deferred here)
 		bool HideSky;     // HideSky flag in WorldSpace, e.g. Blackreach
-		float MipBias;    // Offset to mip level for TAA sharpness#
-		float pad0;
+		float MipBias;              // Offset to mip level for TAA sharpness
+		float VRMipBias;            // Additional negative MIP bias for VR foliage sharpening (depth-scaled)
+		float VRMipBiasNearDist;    // Game units: no VR MIP bias closer than this
+		float VRMipBiasFarDist;     // Game units: full VR MIP bias beyond this
+		uint VRMipBiasMode;         // 0=Off, 1=All Textures, 2=Distant Trees (TREE_ANIM) only
+		float VRAlphaTestThreshold; // Alpha test threshold for VR TREE_ANIM (0 = disabled)
+		float2 pad0;
 		float4 AmbientSHR;
 		float4 AmbientSHG;
 		float4 AmbientSHB;

--- a/package/Shaders/Common/VR.hlsli
+++ b/package/Shaders/Common/VR.hlsli
@@ -627,13 +627,17 @@ namespace Stereo
 		vsout.VRPosition.z = clipPos.z;
 		vsout.VRPosition.w = clipPos.w;
 
-		// Hardcoded ~0.75px diagonal jitter for Eye 1 stereo edge supersampling.
-		// Larger offset increases chance of different alpha test outcomes between eyes
-		// (tree branches vs sky). NDC for 6304x3088 SBS reference; scales with resolution.
+		// Sub-pixel diagonal jitter for Eye 1 stereo edge supersampling.
+		// Shifts Eye 1 rasterization by ~0.75px so alpha-tested edges (tree branches,
+		// fences) sample at slightly different positions than Eye 0, giving StereoBlend
+		// reprojection better edge detail to work with.
+		// Hardcoded NDC values: FrameBuffer/SharedData cbuffers are not reliably
+		// available in all vertex shader contexts (VSHADER section only includes
+		// FrameBuffer.hlsli, and BufferDim lives in SharedData). These constants
+		// give ~0.75px offset at the 6304x3088 SBS reference resolution and scale
+		// proportionally at other resolutions since NDC is resolution-relative.
 		if (a_eyeIndex == 1) {
-			// ~0.75px diagonal jitter for Eye 1 stereo edge supersampling.
-			// Scales with resolution: 0.53/halfWidth horizontal, 1.06/height vertical.
-			float2 kJitterNDC = float2(0.53 / (FrameBuffer::BufferDim.x * 0.5), -1.06 / FrameBuffer::BufferDim.y);
+			static const float2 kJitterNDC = float2(1.68e-4, -3.44e-4);
 			vsout.VRPosition.xy += kJitterNDC * vsout.VRPosition.w;
 		}
 

--- a/package/Shaders/Common/VR.hlsli
+++ b/package/Shaders/Common/VR.hlsli
@@ -631,7 +631,9 @@ namespace Stereo
 		// Larger offset increases chance of different alpha test outcomes between eyes
 		// (tree branches vs sky). NDC for 6304x3088 SBS reference; scales with resolution.
 		if (a_eyeIndex == 1) {
-			static const float2 kJitterNDC = float2(1.68e-4, -3.44e-4);
+			// ~0.75px diagonal jitter for Eye 1 stereo edge supersampling.
+			// Scales with resolution: 0.53/halfWidth horizontal, 1.06/height vertical.
+			float2 kJitterNDC = float2(0.53 / (FrameBuffer::BufferDim.x * 0.5), -1.06 / FrameBuffer::BufferDim.y);
 			vsout.VRPosition.xy += kJitterNDC * vsout.VRPosition.w;
 		}
 

--- a/package/Shaders/Common/VR.hlsli
+++ b/package/Shaders/Common/VR.hlsli
@@ -21,6 +21,7 @@ cbuffer VRValues : register(b13)
 	float2 EyeOffsetScale : packoffset(c0.z);
 	float4 EyeClipEdge[2] : packoffset(c1);
 }
+
 #endif
 
 namespace Stereo
@@ -625,6 +626,14 @@ namespace Stereo
 		vsout.VRPosition.y = clipPos.y;
 		vsout.VRPosition.z = clipPos.z;
 		vsout.VRPosition.w = clipPos.w;
+
+		// Hardcoded ~0.75px diagonal jitter for Eye 1 stereo edge supersampling.
+		// Larger offset increases chance of different alpha test outcomes between eyes
+		// (tree branches vs sky). NDC for 6304x3088 SBS reference; scales with resolution.
+		if (a_eyeIndex == 1) {
+			static const float2 kJitterNDC = float2(1.68e-4, -3.44e-4);
+			vsout.VRPosition.xy += kJitterNDC * vsout.VRPosition.w;
+		}
 
 		vsout.ClipDistance = clipEdges.y;
 		vsout.CullDistance = clipEdges.x;

--- a/package/Shaders/DeferredCompositeCS.hlsl
+++ b/package/Shaders/DeferredCompositeCS.hlsl
@@ -100,7 +100,7 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, inout float ao, out float3 il,
 #if defined(VR_STEREO_OPT)
 	if (eyeIndex == 1) {
 		uint mode = StereoOptModeTexture[uint2(dispatchID.xy)];
-		if (mode == 2 || mode == 1) {  // MODE_MAIN or MODE_EDGE — stencil-culled, no valid G-buffer
+		if (mode == 2) {  // MODE_MAIN — stencil-culled, no valid G-buffer
 			return;
 		}
 	}

--- a/package/Shaders/DeferredCompositeCS.hlsl
+++ b/package/Shaders/DeferredCompositeCS.hlsl
@@ -19,6 +19,10 @@ RWTexture2D<float4> NormalTAAMaskSpecularMaskRW : register(u1);
 RWTexture2D<float2> MotionVectorsRW : register(u2);
 Texture2D<float> DepthTexture : register(t4);
 
+#if defined(VR_STEREO_OPT)
+Texture2D<uint> StereoOptModeTexture : register(t16);
+#endif
+
 #if defined(DYNAMIC_CUBEMAPS)
 Texture2D<float3> ReflectanceTexture : register(t5);
 TextureCube<float3> EnvTexture : register(t6);
@@ -92,6 +96,16 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, inout float ao, out float3 il,
 	uv *= FrameBuffer::DynamicResolutionParams2.xy;  // adjust for dynamic res
 
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
+
+#if defined(VR_STEREO_OPT)
+	if (eyeIndex == 1) {
+		uint mode = StereoOptModeTexture[uint2(dispatchID.xy)];
+		if (mode == 2 || mode == 1) {  // MODE_MAIN or MODE_EDGE — stencil-culled, no valid G-buffer
+			return;
+		}
+	}
+#endif
+
 	uv = Stereo::ConvertFromStereoUV(uv, eyeIndex);
 
 	float3 normalGlossiness = NormalRoughnessTexture[dispatchID.xy];

--- a/package/Shaders/DistantTree.hlsl
+++ b/package/Shaders/DistantTree.hlsl
@@ -203,8 +203,14 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float alpha = TexDiffuse.SampleBias(SampDiffuse, input.TexCoord.xy, SharedData::MipBias).w;
 
-	if ((alpha - AlphaTestRefRS) < 0) {
-		discard;
+	{
+		float alphaRef = AlphaTestRefRS;
+#if defined(VR)
+		alphaRef -= eyeIndex * 0.1;
+#endif
+		if ((alpha - alphaRef) < 0) {
+			discard;
+		}
 	}
 
 	psout.Diffuse.xyz = input.Depth.xxx / input.Depth.yyy;
@@ -213,8 +219,14 @@ PS_OUTPUT main(PS_INPUT input)
 	float4 baseColor = TexDiffuse.SampleBias(SampDiffuse, input.TexCoord.xy, SharedData::MipBias);
 	baseColor.xyz = Color::Diffuse(baseColor.xyz);
 
-	if ((baseColor.w - AlphaTestRefRS) < 0) {
-		discard;
+	{
+		float alphaRef = AlphaTestRefRS;
+#if defined(VR)
+		alphaRef -= eyeIndex * 0.1;
+#endif
+		if ((baseColor.w - alphaRef) < 0) {
+			discard;
+		}
 	}
 
 #		if defined(DEFERRED)

--- a/package/Shaders/DistantTree.hlsl
+++ b/package/Shaders/DistantTree.hlsl
@@ -205,9 +205,9 @@ PS_OUTPUT main(PS_INPUT input)
 
 	{
 		float alphaRef = AlphaTestRefRS;
-#if defined(VR)
+#		if defined(VR)
 		alphaRef -= eyeIndex * 0.1;
-#endif
+#		endif
 		if ((alpha - alphaRef) < 0) {
 			discard;
 		}
@@ -221,9 +221,9 @@ PS_OUTPUT main(PS_INPUT input)
 
 	{
 		float alphaRef = AlphaTestRefRS;
-#if defined(VR)
+#		if defined(VR)
 		alphaRef -= eyeIndex * 0.1;
-#endif
+#		endif
 		if ((baseColor.w - alphaRef) < 0) {
 			discard;
 		}

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -3198,7 +3198,12 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	}
 #		endif
 
-	psout.Reflectance = float4(indirectLobeWeights.specular, psout.Diffuse.w);
+#		if defined(EMAT) && (defined(PARALLAX) || defined(LANDSCAPE))
+	psout.Reflectance = float4(indirectLobeWeights.specular,
+		(pixelOffset > 0.0) ? saturate(pixelOffset) : 0.0);
+#		else
+	psout.Reflectance = float4(indirectLobeWeights.specular, 0.0);
+#		endif
 	psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), saturate(1.0 - material.Roughness), psout.Diffuse.w);
 
 #		if defined(SNOW)

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -3197,7 +3197,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	}
 #		endif
 
-#		if defined(EMAT) && (defined(PARALLAX) || defined(LANDSCAPE))
+#		if (defined(EMAT) || defined(TRUE_PBR)) && (defined(PARALLAX) || defined(LANDSCAPE))
 	psout.Reflectance = float4(indirectLobeWeights.specular,
 		(pixelOffset > 0.0) ? saturate(pixelOffset) : 0.0);
 #		else

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1783,11 +1783,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	// VR MIP bias: depth-gated sharpening for distant textures
 	// Mode 1 = All Textures, Mode 2 = Distant Trees (TREE_ANIM) only
 	float vrFoliageBias = 0;
-#	if defined(TREE_ANIM)
+#		if defined(TREE_ANIM)
 	if (SharedData::VRMipBias < 0) {
-#	else
+#		else
 	if (SharedData::VRMipBias < 0 && SharedData::VRMipBiasMode == 1) {
-#	endif
+#		endif
 		float linDepth = SharedData::GetScreenDepth(input.Position.z);
 		float t = saturate((linDepth - SharedData::VRMipBiasNearDist) / max(SharedData::VRMipBiasFarDist - SharedData::VRMipBiasNearDist, 1.0));
 		vrFoliageBias = SharedData::VRMipBias * t;
@@ -3109,7 +3109,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	}
 #			endif  // TREE_ANIM
 #		endif      // DO_ALPHA_TEST
-
 
 #		if defined(ANISOTROPIC_ALPHA)
 	// Uniform alpha material settings

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1780,7 +1780,19 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	rawRMAOS = blendedRMAOS;
 #		endif
 #	else  // Non-landscape code
-	float4 rawBaseColor = TexColorSampler.SampleBias(SampColorSampler, diffuseUv, SharedData::MipBias);
+	// VR MIP bias: depth-gated sharpening for distant textures
+	// Mode 1 = All Textures, Mode 2 = Distant Trees (TREE_ANIM) only
+	float vrFoliageBias = 0;
+#	if defined(TREE_ANIM)
+	if (SharedData::VRMipBias < 0) {
+#	else
+	if (SharedData::VRMipBias < 0 && SharedData::VRMipBiasMode == 1) {
+#	endif
+		float linDepth = SharedData::GetScreenDepth(input.Position.z);
+		float t = saturate((linDepth - SharedData::VRMipBiasNearDist) / max(SharedData::VRMipBiasFarDist - SharedData::VRMipBiasNearDist, 1.0));
+		vrFoliageBias = SharedData::VRMipBias * t;
+	}
+	float4 rawBaseColor = TexColorSampler.SampleBias(SampColorSampler, diffuseUv, SharedData::MipBias + vrFoliageBias);
 	baseColor = float4(Color::Diffuse(rawBaseColor.rgb), rawBaseColor.a);
 	float4 normalColor = TexNormalSampler.SampleBias(SampNormalSampler, uv, SharedData::MipBias);
 	normal = normalColor;
@@ -3021,11 +3033,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float alpha = baseColor.w;
 #		if defined(EMAT) && !defined(LANDSCAPE)
 #			if defined(PARALLAX)
-	alpha = TexColorSampler.SampleBias(SampColorSampler, uvOriginal, SharedData::MipBias).w;
+	alpha = TexColorSampler.SampleBias(SampColorSampler, uvOriginal, SharedData::MipBias + vrFoliageBias).w;
 #			elif defined(TRUE_PBR)
 	[branch] if (PBRParallax)
 	{
-		alpha = TexColorSampler.SampleBias(SampColorSampler, uvOriginal, SharedData::MipBias).w;
+		alpha = TexColorSampler.SampleBias(SampColorSampler, uvOriginal, SharedData::MipBias + vrFoliageBias).w;
 	}
 #			endif
 #		endif
@@ -3074,10 +3086,30 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	}
 	alpha = saturate(1.05 * alpha);
 #			endif  // DEPTH_WRITE_DECALS
+#			if defined(TREE_ANIM)
+	// Fixed alpha floor — catch zombie texels with near-zero alpha
+	if (alpha < 0.1) {
+		discard;
+	}
 	if (alpha - AlphaTestRefRS < 0) {
 		discard;
 	}
+	// Suppress RGB fringe contamination from negative MIP bias.
+	// Low-alpha texels near the foliage boundary have bright padding bleeding into RGB.
+	// Alpha is a direct proxy for contamination — low alpha = more padding contribution.
+	// Scale correction by bias strength so close-range (no bias) textures are untouched.
+	if (vrFoliageBias < 0) {
+		float biasStrength = saturate(vrFoliageBias / min(SharedData::VRMipBias, -0.001));
+		float fringeScale = 5.0;  // higher = more aggressive fringe suppression
+		baseColor.rgb *= saturate(alpha * lerp(1.0, fringeScale, biasStrength));
+	}
+#			else
+	if (alpha - AlphaTestRefRS < 0) {
+		discard;
+	}
+#			endif  // TREE_ANIM
 #		endif      // DO_ALPHA_TEST
+
 
 #		if defined(ANISOTROPIC_ALPHA)
 	// Uniform alpha material settings

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -504,10 +504,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float diffuseAlpha = input.VertexColor.w * baseColor.w;
 	{
 		float alphaRef = AlphaTestRefRS;
-#if defined(VR)
+#			if defined(VR)
 		uint convergenceEyeIndex = Stereo::GetEyeIndexPS(input.HPosition, VPOSOffset);
 		alphaRef -= convergenceEyeIndex * 0.1;
-#endif
+#			endif
 		if ((diffuseAlpha - alphaRef) < 0) {
 			discard;
 		}
@@ -875,10 +875,10 @@ PS_OUTPUT main(PS_INPUT input)
 	float diffuseAlpha = input.VertexColor.w * baseColor.w;
 	{
 		float alphaRef = AlphaTestRefRS;
-#if defined(VR)
+#			if defined(VR)
 		uint convergenceEyeIndex = Stereo::GetEyeIndexPS(input.HPosition, VPOSOffset);
 		alphaRef -= convergenceEyeIndex * 0.1;
-#endif
+#			endif
 		if ((diffuseAlpha - alphaRef) < 0) {
 			discard;
 		}

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -480,22 +480,37 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	bool complex = abs(complexLength - 1.0) < SharedData::grassLightingSettings.ComplexGrassThreshold;
 #		endif  // !TRUE_PBR
 
+	// VR MIP bias: depth-gated sharpening for distant textures
+	float vrGrassBias = 0;
+	if (SharedData::VRMipBias < 0 && SharedData::VRMipBiasMode == 1) {
+		float linDepth = SharedData::GetScreenDepth(input.HPosition.z);
+		float t = saturate((linDepth - SharedData::VRMipBiasNearDist) / max(SharedData::VRMipBiasFarDist - SharedData::VRMipBiasNearDist, 1.0));
+		vrGrassBias = SharedData::VRMipBias * t;
+	}
+
 	float4 baseColor;
 #		if !defined(TRUE_PBR)
 	if (complex) {
-		baseColor = TexBaseSampler.SampleBias(SampBaseSampler, float2(input.TexCoord.x, input.TexCoord.y * 0.5), SharedData::MipBias);
+		baseColor = TexBaseSampler.SampleBias(SampBaseSampler, float2(input.TexCoord.x, input.TexCoord.y * 0.5), SharedData::MipBias + vrGrassBias);
 	} else
 #		endif  // !TRUE_PBR
 	{
-		baseColor = TexBaseSampler.SampleBias(SampBaseSampler, input.TexCoord.xy, SharedData::MipBias);
+		baseColor = TexBaseSampler.SampleBias(SampBaseSampler, input.TexCoord.xy, SharedData::MipBias + vrGrassBias);
 	}
 
 	baseColor.xyz = Color::Diffuse(baseColor.xyz);
 
 #		if defined(RENDER_DEPTH)
 	float diffuseAlpha = input.VertexColor.w * baseColor.w;
-	if ((diffuseAlpha - AlphaTestRefRS) < 0) {
-		discard;
+	{
+		float alphaRef = AlphaTestRefRS;
+#if defined(VR)
+		uint convergenceEyeIndex = Stereo::GetEyeIndexPS(input.HPosition, VPOSOffset);
+		alphaRef -= convergenceEyeIndex * 0.1;
+#endif
+		if ((diffuseAlpha - alphaRef) < 0) {
+			discard;
+		}
 	}
 #		endif  // RENDER_DEPTH || DO_ALPHA_TEST
 
@@ -505,9 +520,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	psout.PS.w = diffuseAlpha;
 #		else
 #			if !defined(TRUE_PBR)
-	float4 specColor = complex ? TexBaseSampler.SampleBias(SampBaseSampler, float2(input.TexCoord.x, 0.5 + input.TexCoord.y * 0.5), SharedData::MipBias) : 1;
+	float4 specColor = complex ? TexBaseSampler.SampleBias(SampBaseSampler, float2(input.TexCoord.x, 0.5 + input.TexCoord.y * 0.5), SharedData::MipBias + vrGrassBias) : 1;
 #			else
-	float4 specColor = TexNormalSampler.SampleBias(SampNormalSampler, input.TexCoord.xy, SharedData::MipBias);
+	float4 specColor = TexNormalSampler.SampleBias(SampNormalSampler, input.TexCoord.xy, SharedData::MipBias + vrGrassBias);
 #			endif
 
 	uint eyeIndex = Stereo::GetEyeIndexPS(input.HPosition, VPOSOffset);
@@ -548,7 +563,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			endif  // !TRUE_PBR
 
 #			if defined(TRUE_PBR)
-	float4 rawRMAOS = TexRMAOSSampler.SampleBias(SampRMAOSSampler, input.TexCoord.xy, SharedData::MipBias) * float4(PBRParams1.x, 1, 1, PBRParams1.y);
+	float4 rawRMAOS = TexRMAOSSampler.SampleBias(SampRMAOSSampler, input.TexCoord.xy, SharedData::MipBias + vrGrassBias) * float4(PBRParams1.x, 1, 1, PBRParams1.y);
 
 	PBR::SurfaceProperties pbrSurfaceProperties = PBR::InitSurfaceProperties();
 
@@ -846,13 +861,27 @@ PS_OUTPUT main(PS_INPUT input)
 {
 	PS_OUTPUT psout;
 
-	float4 baseColor = TexBaseSampler.SampleBias(SampBaseSampler, input.TexCoord.xy, SharedData::MipBias);
+	// VR MIP bias: depth-gated sharpening for distant textures
+	float vrGrassBias = 0;
+	if (SharedData::VRMipBias < 0 && SharedData::VRMipBiasMode == 1) {
+		float linDepth = SharedData::GetScreenDepth(input.HPosition.z);
+		float t = saturate((linDepth - SharedData::VRMipBiasNearDist) / max(SharedData::VRMipBiasFarDist - SharedData::VRMipBiasNearDist, 1.0));
+		vrGrassBias = SharedData::VRMipBias * t;
+	}
+
+	float4 baseColor = TexBaseSampler.SampleBias(SampBaseSampler, input.TexCoord.xy, SharedData::MipBias + vrGrassBias);
 
 #		if defined(RENDER_DEPTH)
 	float diffuseAlpha = input.VertexColor.w * baseColor.w;
-
-	if ((diffuseAlpha - AlphaTestRefRS) < 0) {
-		discard;
+	{
+		float alphaRef = AlphaTestRefRS;
+#if defined(VR)
+		uint convergenceEyeIndex = Stereo::GetEyeIndexPS(input.HPosition, VPOSOffset);
+		alphaRef -= convergenceEyeIndex * 0.1;
+#endif
+		if ((diffuseAlpha - alphaRef) < 0) {
+			discard;
+		}
 	}
 #		endif  // RENDER_DEPTH || DO_ALPHA_TEST
 

--- a/package/Shaders/VR/CASCS.hlsl
+++ b/package/Shaders/VR/CASCS.hlsl
@@ -57,7 +57,7 @@ RWTexture2D<float4> Dest : register(u0);
 	mxRGB += mxRGB2;
 
 	// Adaptive sharpening amount
-	float3 ampRGB = saturate(min(mnRGB, 2.0 - mxRGB) * rcp(mxRGB));
+	float3 ampRGB = saturate(min(mnRGB, 2.0 - mxRGB) * rcp(max(mxRGB, 1e-4)));
 	ampRGB = rsqrt(ampRGB);
 
 	// Peak controls sharpening strength:

--- a/package/Shaders/VR/CASCS.hlsl
+++ b/package/Shaders/VR/CASCS.hlsl
@@ -1,0 +1,74 @@
+// AMD Contrast Adaptive Sharpening (CAS) - Sharpen-only for VR
+// Based on AMD FidelityFX CAS (sharpen-only path)
+// Reference: https://gpuopen.com/fidelityfx-cas/
+//
+// Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// CASParams[0] = sharpness (0.0 = no sharpening, 1.0 = maximum sharpening)
+StructuredBuffer<float> CASParams : register(t1);
+
+Texture2D<float4> Source : register(t0);
+RWTexture2D<float4> Dest : register(u0);
+
+[numthreads(8, 8, 1)] void main(uint3 DTid : SV_DispatchThreadID) {
+	uint2 texDim;
+	Dest.GetDimensions(texDim.x, texDim.y);
+
+	if (DTid.x >= texDim.x || DTid.y >= texDim.y)
+		return;
+
+	float sharpness = CASParams[0];
+
+	// Fetch 3x3 neighborhood
+	int2 sp = int2(DTid.xy);
+	float3 a = Source.Load(int3(sp + int2(-1, -1), 0)).rgb;
+	float3 b = Source.Load(int3(sp + int2(0, -1), 0)).rgb;
+	float3 c = Source.Load(int3(sp + int2(1, -1), 0)).rgb;
+	float3 d = Source.Load(int3(sp + int2(-1, 0), 0)).rgb;
+	float3 e = Source.Load(int3(sp, 0)).rgb;
+	float3 f = Source.Load(int3(sp + int2(1, 0), 0)).rgb;
+	float3 g = Source.Load(int3(sp + int2(-1, 1), 0)).rgb;
+	float3 h = Source.Load(int3(sp + int2(0, 1), 0)).rgb;
+	float3 i = Source.Load(int3(sp + int2(1, 1), 0)).rgb;
+
+	// Soft min/max of cross neighborhood
+	float3 mnRGB = min(min(min(d, e), min(f, b)), h);
+	float3 mxRGB = max(max(max(d, e), max(f, b)), h);
+
+	// Expand with diagonal neighbors for soft min/max
+	float3 mnRGB2 = min(min(a, c), min(g, i));
+	float3 mxRGB2 = max(max(a, c), max(g, i));
+	mnRGB += mnRGB2;
+	mxRGB += mxRGB2;
+
+	// Adaptive sharpening amount
+	float3 ampRGB = saturate(min(mnRGB, 2.0 - mxRGB) * rcp(mxRGB));
+	ampRGB = rsqrt(ampRGB);
+
+	// Peak controls sharpening strength:
+	//   sharpness 0.0 -> peak 8.0 (no sharpening)
+	//   sharpness 1.0 -> peak 5.0 (maximum sharpening)
+	float peak = -3.0 * sharpness + 8.0;
+	float3 wRGB = -rcp(ampRGB * peak);
+	float3 rcpWeightRGB = rcp(4.0 * wRGB + 1.0);
+
+	// Apply sharpening filter
+	float3 outColor = saturate(((b + d) + (f + h)) * wRGB + e) * rcpWeightRGB;
+
+	Dest[DTid.xy] = float4(outColor, 1.0);
+}

--- a/package/Shaders/VR/StereoBlendCS.hlsl
+++ b/package/Shaders/VR/StereoBlendCS.hlsl
@@ -162,7 +162,7 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 		if (pomOffsetFB > 1e-2 && POMDepthScale > 0) {
 			float linDepthFB = SharedData::GetScreenDepth(centerDepth);
 			float depthCorrectionFB = (0.5 - pomOffsetFB) * POMDepthScale;
-			float newLinDepthFB = linDepthFB + depthCorrectionFB;
+			float newLinDepthFB = max(linDepthFB + depthCorrectionFB, 1e-4);
 			reprojDepthFB = (SharedData::CameraData.x - SharedData::CameraData.w / newLinDepthFB) / SharedData::CameraData.z;
 		}
 
@@ -227,7 +227,7 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 		// Re-reproject with POM-adjusted depth centered at geometry plane
 		float linearDepth = SharedData::GetScreenDepth(centerDepth);
 		float depthCorrection = (0.5 - pomOffset) * POMDepthScale;
-		float newLinearDepth = linearDepth + depthCorrection;
+		float newLinearDepth = max(linearDepth + depthCorrection, 1e-4);
 		reprojDepth = (SharedData::CameraData.x - SharedData::CameraData.w / newLinearDepth) / SharedData::CameraData.z;
 		r = Stereo::ReprojectToOtherEye(uv, reprojDepth, eyeIndex, FrameDim);
 		if (!r.valid)

--- a/package/Shaders/VR/StereoBlendCS.hlsl
+++ b/package/Shaders/VR/StereoBlendCS.hlsl
@@ -27,11 +27,11 @@ SamplerState LinearSampler : register(s0);
 
 // Mode constants matching VRStereoOptimizations/cbuffers.hlsli
 // (can't include directly — its cbuffer on b1 conflicts with StereoBlendCB)
-#define MODE_DISOCCLUDED     0
-#define MODE_EDGE            1
-#define MODE_MAIN            2
-#define MODE_EDGE_NEIGHBOUR  3
-#define MODE_FULL_BLEND      4
+#	define MODE_DISOCCLUDED 0
+#	define MODE_EDGE 1
+#	define MODE_MAIN 2
+#	define MODE_EDGE_NEIGHBOUR 3
+#	define MODE_FULL_BLEND 4
 
 // Hardware bilinear color sample from reprojected pixel coordinates.
 // Converts integer pixel coords to proper full-texture UV for SampleLevel,
@@ -59,13 +59,13 @@ cbuffer StereoBlendCB : register(b1)
 	float MaxBlendFactor;
 	float ColorDiffThreshold;
 	float DebugEdgeTint;
-	uint DebugMode;       // 0 = normal, 1 = depth map diagnostic, 2 = full blend depth visualizer, 3 = POM depth heatmap
+	uint DebugMode;  // 0 = normal, 1 = depth map diagnostic, 2 = full blend depth visualizer, 3 = POM depth heatmap
 	float FullBlendDistance;
 	float POMDepthScale;
 	float _pad;
 };
 
-static const float kEdgeDepthThreshold = 0.05;       // NDC depth difference above which a pixel is considered a depth discontinuity and excluded from stereo blend
+static const float kEdgeDepthThreshold = 0.05;        // NDC depth difference above which a pixel is considered a depth discontinuity and excluded from stereo blend
 static const int kEdgeMargin = 2;                     // Neighbor offset (pixels) for destination edge + mask boundary check
 static const float kDepthAgreementThreshold = 0.015;  // Relative depth difference threshold for overwrite mode disocclusion rejection
 
@@ -246,12 +246,12 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 
 #else  // Normal bilateral blend path
 
-#ifdef EYE0_ONLY
+#	ifdef EYE0_ONLY
 	// Only process Eye 0 (left half) - Eye 1 left untouched
 	float2 uvCheck = (dtid + 0.5) * RcpFrameDim;
 	if (Stereo::GetEyeIndexFromTexCoord(uvCheck) == 1)
 		return;
-#endif
+#	endif
 
 	float2 uv = (dtid + 0.5) * RcpFrameDim;
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
@@ -305,7 +305,7 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 		}
 	}
 
-#ifdef DEBUG_BACKCHECK
+#	ifdef DEBUG_BACKCHECK
 	// Debug visualization (6 states):
 	//   Blue   = mask/sky: skipped
 	//   Yellow = source edge: depth discontinuity at this pixel
@@ -322,7 +322,7 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 		float3(0.5, 0.0, 0.0)   // 5: back-check failed - red
 	};
 	OutputRW[dtid] = float4(lerp(centerColor.rgb, debugColors[debugState], 0.7), centerColor.a);
-#elif defined(DEBUG_BLEND_WEIGHT)
+#	elif defined(DEBUG_BLEND_WEIGHT)
 	// Blend weight heatmap: only pixels with actual blend activity are colorized.
 	// Untouched pixels pass through unmodified.
 	float w = saturate(r.blendWeight / max(MaxBlendFactor, 1e-5));
@@ -332,7 +332,7 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 	} else {
 		OutputRW[dtid] = centerColor;
 	}
-#elif defined(DEBUG_EDGE_DETECTION)
+#	elif defined(DEBUG_EDGE_DETECTION)
 	// Edge detection visualizer: highlights pixels excluded by depth discontinuity checks.
 	// Non-edge pixels show the normal blended output for scene context.
 	//   Bright yellow = source edge: discontinuity at this pixel
@@ -344,9 +344,9 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 	} else {
 		OutputRW[dtid] = blendedColor;
 	}
-#else
+#	else
 	OutputRW[dtid] = blendedColor;
-#endif
+#	endif
 
 #endif  // STEREO_OVERWRITE
 }

--- a/package/Shaders/VR/StereoBlendCS.hlsl
+++ b/package/Shaders/VR/StereoBlendCS.hlsl
@@ -11,12 +11,26 @@
 
 #include "Common/Color.hlsli"
 #include "Common/FrameBuffer.hlsli"
+#include "Common/SharedData.hlsli"
 #include "Common/VR.hlsli"
 
 Texture2D<float4> ColorTexture : register(t0);
 Texture2D<float> DepthTexture : register(t1);
 
 RWTexture2D<float4> OutputRW : register(u0);
+
+#ifdef STEREO_OVERWRITE
+RWTexture2D<float2> MotionRW : register(u1);
+Texture2D<uint> ModeTexture : register(t2);
+
+// Mode constants matching VRStereoOptimizations/cbuffers.hlsli
+// (can't include directly — its cbuffer on b1 conflicts with StereoBlendCB)
+#define MODE_DISOCCLUDED     0
+#define MODE_EDGE            1
+#define MODE_MAIN            2
+#define MODE_EDGE_NEIGHBOUR  3
+#define MODE_FULL_BLEND      4
+#endif
 
 cbuffer StereoBlendCB : register(b1)
 {
@@ -25,11 +39,15 @@ cbuffer StereoBlendCB : register(b1)
 	float DepthSigma;
 	float MaxBlendFactor;
 	float ColorDiffThreshold;
-	float pad;
+	float DebugEdgeTint;
+	uint DebugMode;       // 0 = normal, 1 = depth map diagnostic, 2 = full blend depth visualizer
+	float FullBlendDistance;
+	float2 _pad;
 };
 
-static const float kEdgeDepthThreshold = 0.05;  // NDC depth difference above which a pixel is considered a depth discontinuity and excluded from stereo blend
-static const int kEdgeMargin = 2;               // Neighbor offset (pixels) for destination edge + mask boundary check
+static const float kEdgeDepthThreshold = 0.05;       // NDC depth difference above which a pixel is considered a depth discontinuity and excluded from stereo blend
+static const int kEdgeMargin = 2;                     // Neighbor offset (pixels) for destination edge + mask boundary check
+static const float kDepthAgreementThreshold = 0.015;  // Relative depth difference threshold for overwrite mode disocclusion rejection
 
 // Samples four depth neighbors in a cross pattern (±offset pixels) around center,
 // clamped to eyeIndex's half of the packed stereo buffer to avoid seam contamination.
@@ -45,6 +63,125 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 [numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
 	if (any(dtid >= uint2(FrameDim)))
 		return;
+
+#ifdef STEREO_OVERWRITE
+	// =========================================================================
+	// Mode-driven stereo merge: reads per-pixel classification from StencilCS
+	// and applies appropriate action per mode and eye.
+	// Mode texture is full SBS resolution — ModeTexture[dtid] maps directly.
+	// =========================================================================
+
+	float2 uv = (dtid + 0.5) * RcpFrameDim;
+	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
+
+	float centerDepth = DepthTexture[dtid];
+
+	// HMD mask pixels (depth >= 1.0 in reversed-Z) — always skip
+	if (centerDepth >= 1.0)
+		return;
+
+	uint pixelMode = ModeTexture[dtid];
+
+	// Debug mode 1: depth map diagnostic — show mode texture as solid colors (all pixels)
+	if (DebugMode == 1) {
+		float4 c = ColorTexture[dtid];
+		if (pixelMode == MODE_EDGE)
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(0, 1, 0), 0.5), c.a);
+		else if (pixelMode == MODE_EDGE_NEIGHBOUR)
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(1, 0, 1), 0.5), c.a);
+		else if (pixelMode == MODE_DISOCCLUDED)
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(0, 0.5, 1), 0.3), c.a);
+		else if (pixelMode == MODE_FULL_BLEND)
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(1, 0.5, 0), 0.5), c.a);
+		return;
+	}
+
+	// Debug mode 2: full blend depth visualizer — cyan tint based on proximity to FullBlendDistance
+	if (DebugMode == 2) {
+		if (centerDepth < 1e-5 || centerDepth >= 1.0)
+			return;
+		float linDepth = SharedData::GetScreenDepth(centerDepth);
+		if (linDepth < FullBlendDistance) {
+			float4 c = ColorTexture[dtid];
+			float proximity = saturate(1.0 - linDepth / max(FullBlendDistance, 1.0));
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(0, 1, 1), proximity * 0.4), c.a);
+		}
+		return;
+	}
+
+	// MODE_DISOCCLUDED: fully shaded, leave untouched
+	if (pixelMode == MODE_DISOCCLUDED)
+		return;
+
+	// MODE_FULL_BLEND: bilateral blend for 2x supersampling
+	if (pixelMode == MODE_FULL_BLEND) {
+		float4 center = ColorTexture[dtid];
+
+		// Reproject to the other eye
+		Stereo::StereoBilateralResult r = Stereo::ReprojectToOtherEye(uv, centerDepth, eyeIndex, FrameDim);
+		if (!r.valid) {
+			// Debug tint for failed reprojection
+			if (DebugEdgeTint > 0)
+				OutputRW[dtid] = float4(lerp(center.rgb, float3(1, 0.5, 0), DebugEdgeTint), center.a);
+			return;
+		}
+
+		// Only blend with pixels that have valid composited data in both eyes
+		uint otherMode = ModeTexture[r.otherPx];
+		if (otherMode != MODE_FULL_BLEND && otherMode != MODE_DISOCCLUDED)
+			return;
+
+		float4 otherColor = ColorTexture[r.otherPx];
+		float otherDepth = DepthTexture[r.otherPx];
+
+		// Depth-weighted bilateral blend
+		float maxDepth = max(max(centerDepth, otherDepth), 1e-5);
+		float depthAgreement = 1.0 - saturate(abs(centerDepth - otherDepth) / maxDepth / 0.02);
+		float blendWeight = 0.5 * depthAgreement;
+
+		float4 result = lerp(center, otherColor, blendWeight);
+
+		if (DebugEdgeTint > 0)
+			result.rgb = lerp(result.rgb, float3(0, 1, 1), DebugEdgeTint);
+
+		OutputRW[dtid] = result;
+		return;
+	}
+
+	if (eyeIndex == 0) {
+		// Eye 0: fully shaded for all modes — only apply debug tint to edge pixels
+		if (DebugEdgeTint > 0 && pixelMode == MODE_EDGE) {
+			float4 c = ColorTexture[dtid];
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(0, 1, 0), DebugEdgeTint), c.a);
+		}
+		return;
+	}
+
+	// Eye 1: reproject all non-disoccluded, non-full-blend pixels (MAIN, EDGE) from Eye 0.
+	// StencilCS already performed the authoritative disocclusion check with the correct
+	// depth buffer state — no redundant depth agreement check here.
+	Stereo::StereoBilateralResult r = Stereo::ReprojectToOtherEye(uv, centerDepth, eyeIndex, FrameDim);
+	if (!r.valid)
+		return;
+
+	// Skip if the Eye 0 source pixel is sky/unrendered (depth at clear value).
+	// At DeferredPasses time, sky hasn't rendered yet — source would have clear color.
+	// Let the sky/water pass fill these pixels later instead.
+	float sourceDepth = DepthTexture[r.otherPx];
+	if (sourceDepth >= 1.0 || sourceDepth < 1e-5)
+		return;
+
+	OutputRW[dtid] = ColorTexture[r.otherPx];
+	MotionRW[dtid] = MotionRW[r.otherPx];
+
+#else  // Normal bilateral blend path
+
+#ifdef EYE0_ONLY
+	// Only process Eye 0 (left half) - Eye 1 left untouched
+	float2 uvCheck = (dtid + 0.5) * RcpFrameDim;
+	if (Stereo::GetEyeIndexFromTexCoord(uvCheck) == 1)
+		return;
+#endif
 
 	float2 uv = (dtid + 0.5) * RcpFrameDim;
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
@@ -68,8 +205,7 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 	// depth == 1.0: sky/far plane (no real geometry, bilateral reprojection not meaningful)
 	bool isSkipPixel = centerDepth < 1e-5 || centerDepth >= 1.0;
 	if (!isSkipPixel) {
-		// Source edge detection: skip at depth discontinuities (arm/world silhouettes,
-		// object edges). Saves VP reprojection work and prevents halo artifacts.
+		// Normal bilateral blend path
 		float4 srcEdgeDepths = SampleCrossDepths(dtid, 1, eyeIndex);
 		if (Stereo::MaxDepthDiff(centerDepth, srcEdgeDepths) > kEdgeDepthThreshold) {
 			debugState = 1;
@@ -78,10 +214,6 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 			if (r.valid) {
 				float otherDepth = DepthTexture[r.otherPx];
 
-				// Destination edge detection: skip if the reprojected pixel is near the HMD
-				// mask boundary or at a depth discontinuity in the other eye. Due to VR
-				// parallax the arm silhouette appears at a different screen position per eye,
-				// so the reprojection can cross a boundary invisible from this eye.
 				float4 dstEdgeDepths = SampleCrossDepths(r.otherPx, kEdgeMargin, 1 - eyeIndex);
 				if (any(dstEdgeDepths < 1e-5) || Stereo::MaxDepthDiff(otherDepth, dstEdgeDepths) > kEdgeDepthThreshold) {
 					debugState = 2;
@@ -89,9 +221,6 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 					float4 otherColor = ColorTexture[r.otherPx];
 					Stereo::FinalizeStereoBlend(r, uv, centerDepth, otherDepth, eyeIndex, FrameDim, DepthSigma, MaxBlendFactor);
 
-					// Only blend where the two eyes actually disagree (screen-space effect
-					// inconsistency). Luminance difference below the threshold means both
-					// eyes computed the same result and blending would only destroy parallax.
 					float colorDiff = abs(dot(centerColor.rgb, float3(0.2126, 0.7152, 0.0722)) -
 										  dot(otherColor.rgb, float3(0.2126, 0.7152, 0.0722)));
 					float colorGate = smoothstep(ColorDiffThreshold * 0.5, ColorDiffThreshold * 2.0, colorDiff);
@@ -148,4 +277,6 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 #else
 	OutputRW[dtid] = blendedColor;
 #endif
+
+#endif  // STEREO_OVERWRITE
 }

--- a/package/Shaders/VR/StereoBlendCS.hlsl
+++ b/package/Shaders/VR/StereoBlendCS.hlsl
@@ -22,6 +22,8 @@ RWTexture2D<float4> OutputRW : register(u0);
 #ifdef STEREO_OVERWRITE
 RWTexture2D<float2> MotionRW : register(u1);
 Texture2D<uint> ModeTexture : register(t2);
+Texture2D<float4> ReflectanceTexture : register(t3);  // .w = POM pixelOffset from Lighting pass
+SamplerState LinearSampler : register(s0);
 
 // Mode constants matching VRStereoOptimizations/cbuffers.hlsli
 // (can't include directly — its cbuffer on b1 conflicts with StereoBlendCB)
@@ -30,6 +32,23 @@ Texture2D<uint> ModeTexture : register(t2);
 #define MODE_MAIN            2
 #define MODE_EDGE_NEIGHBOUR  3
 #define MODE_FULL_BLEND      4
+
+// Hardware bilinear color sample from reprojected pixel coordinates.
+// Converts integer pixel coords to proper full-texture UV for SampleLevel,
+// clamped to the active DRS viewport to prevent sampling stale data.
+// Motion vectors stay as integer Load() — filtering them breaks DLSS.
+float4 SampleReprojectedColor(int2 reprojPx, float2 frameDim)
+{
+	uint texW, texH;
+	ColorTexture.GetDimensions(texW, texH);
+	float2 texSize = float2(texW, texH);
+	float2 sampleUV = (float2(reprojPx) + 0.5) / texSize;
+	// Clamp to active DRS viewport bounds (half-texel inset to keep bilinear inside valid region)
+	float2 minUV = 0.5 / texSize;
+	float2 maxUV = (frameDim - 0.5) / texSize;
+	sampleUV = clamp(sampleUV, minUV, maxUV);
+	return ColorTexture.SampleLevel(LinearSampler, sampleUV, 0);
+}
 #endif
 
 cbuffer StereoBlendCB : register(b1)
@@ -40,9 +59,10 @@ cbuffer StereoBlendCB : register(b1)
 	float MaxBlendFactor;
 	float ColorDiffThreshold;
 	float DebugEdgeTint;
-	uint DebugMode;       // 0 = normal, 1 = depth map diagnostic, 2 = full blend depth visualizer
+	uint DebugMode;       // 0 = normal, 1 = depth map diagnostic, 2 = full blend depth visualizer, 3 = POM depth heatmap
 	float FullBlendDistance;
-	float2 _pad;
+	float POMDepthScale;
+	float _pad;
 };
 
 static const float kEdgeDepthThreshold = 0.05;       // NDC depth difference above which a pixel is considered a depth discontinuity and excluded from stereo blend
@@ -109,6 +129,20 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 		return;
 	}
 
+	// Debug mode 3: POM depth data visualizer — show Reflectance.w as color
+	if (DebugMode == 3) {
+		float pomVal = ReflectanceTexture[dtid].w;
+		float4 c = ColorTexture[dtid];
+		if (pomVal > 1e-2) {
+			// POM pixel: red-to-green gradient based on parallaxAmount
+			// Red = peak (high pomVal, closer to camera), Green = valley (low pomVal, farther), Yellow = geometry plane
+			float3 pomColor = float3(pomVal, 1.0 - pomVal, 0);
+			OutputRW[dtid] = float4(lerp(c.rgb, pomColor, 0.7), c.a);
+		}
+		// Non-POM pixels (pomVal ~ 0) left untouched
+		return;
+	}
+
 	// MODE_DISOCCLUDED: fully shaded, leave untouched
 	if (pixelMode == MODE_DISOCCLUDED)
 		return;
@@ -117,8 +151,23 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 	if (pixelMode == MODE_FULL_BLEND) {
 		float4 center = ColorTexture[dtid];
 
+		// Check for POM depth offset at this pixel
+		// pixelOffset = parallaxAmount (0-1) from ExtendedMaterials, 0.5 = geometry plane.
+		// Values > 0.5 are peaks (closer to camera), < 0.5 are valleys (farther from camera).
+		// Correction: high pomVal should push depth closer (smaller linear depth),
+		// so we use (0.5 - pomOffset) to get a negative correction for peaks.
+		// Non-POM pixels store 0.0, so threshold > 1e-2 distinguishes them.
+		float reprojDepthFB = centerDepth;
+		float pomOffsetFB = ReflectanceTexture[dtid].w;
+		if (pomOffsetFB > 1e-2 && POMDepthScale > 0) {
+			float linDepthFB = SharedData::GetScreenDepth(centerDepth);
+			float depthCorrectionFB = (0.5 - pomOffsetFB) * POMDepthScale;
+			float newLinDepthFB = linDepthFB + depthCorrectionFB;
+			reprojDepthFB = (SharedData::CameraData.x - SharedData::CameraData.w / newLinDepthFB) / SharedData::CameraData.z;
+		}
+
 		// Reproject to the other eye
-		Stereo::StereoBilateralResult r = Stereo::ReprojectToOtherEye(uv, centerDepth, eyeIndex, FrameDim);
+		Stereo::StereoBilateralResult r = Stereo::ReprojectToOtherEye(uv, reprojDepthFB, eyeIndex, FrameDim);
 		if (!r.valid) {
 			// Debug tint for failed reprojection
 			if (DebugEdgeTint > 0)
@@ -131,7 +180,7 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 		if (otherMode != MODE_FULL_BLEND && otherMode != MODE_DISOCCLUDED)
 			return;
 
-		float4 otherColor = ColorTexture[r.otherPx];
+		float4 otherColor = SampleReprojectedColor(r.otherPx, FrameDim);
 		float otherDepth = DepthTexture[r.otherPx];
 
 		// Depth-weighted bilateral blend
@@ -160,9 +209,30 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 	// Eye 1: reproject all non-disoccluded, non-full-blend pixels (MAIN, EDGE) from Eye 0.
 	// StencilCS already performed the authoritative disocclusion check with the correct
 	// depth buffer state — no redundant depth agreement check here.
-	Stereo::StereoBilateralResult r = Stereo::ReprojectToOtherEye(uv, centerDepth, eyeIndex, FrameDim);
+	float reprojDepth = centerDepth;
+
+	// First-pass reprojection to find Eye 0 source pixel
+	Stereo::StereoBilateralResult r = Stereo::ReprojectToOtherEye(uv, reprojDepth, eyeIndex, FrameDim);
 	if (!r.valid)
 		return;
+
+	// Read POM offset from Eye 0 source's reflectance.w
+	// pixelOffset = parallaxAmount (0-1) from ExtendedMaterials, 0.5 = geometry plane.
+	// Values > 0.5 are peaks (closer to camera), < 0.5 are valleys (farther from camera).
+	// Correction: high pomVal should push depth closer (smaller linear depth),
+	// so we use (0.5 - pomOffset) to get a negative correction for peaks.
+	// Non-POM pixels store 0.0, so threshold > 1e-2 distinguishes them.
+	float pomOffset = ReflectanceTexture[r.otherPx].w;
+	if (pomOffset > 1e-2) {
+		// Re-reproject with POM-adjusted depth centered at geometry plane
+		float linearDepth = SharedData::GetScreenDepth(centerDepth);
+		float depthCorrection = (0.5 - pomOffset) * POMDepthScale;
+		float newLinearDepth = linearDepth + depthCorrection;
+		reprojDepth = (SharedData::CameraData.x - SharedData::CameraData.w / newLinearDepth) / SharedData::CameraData.z;
+		r = Stereo::ReprojectToOtherEye(uv, reprojDepth, eyeIndex, FrameDim);
+		if (!r.valid)
+			return;
+	}
 
 	// Skip if the Eye 0 source pixel is sky/unrendered (depth at clear value).
 	// At DeferredPasses time, sky hasn't rendered yet — source would have clear color.
@@ -171,7 +241,7 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 	if (sourceDepth >= 1.0 || sourceDepth < 1e-5)
 		return;
 
-	OutputRW[dtid] = ColorTexture[r.otherPx];
+	OutputRW[dtid] = SampleReprojectedColor(r.otherPx, FrameDim);
 	MotionRW[dtid] = MotionRW[r.otherPx];
 
 #else  // Normal bilateral blend path

--- a/package/Shaders/VR/VRPostProcessCS.hlsl
+++ b/package/Shaders/VR/VRPostProcessCS.hlsl
@@ -20,20 +20,19 @@ cbuffer VRPostProcessCB : register(b1)
 {
 	float2 FrameDim;
 	float2 RcpFrameDim;
-	float DebugEdgeTint;  // 0 = off, >0 = debug visualization strength
-	uint DebugMode;       // 0 = normal, 1 = depth map diagnostic, 2 = full blend depth visualizer
+	float DebugEdgeTint;      // 0 = off, >0 = debug visualization strength
+	uint DebugMode;           // 0 = normal, 1 = depth map diagnostic, 2 = full blend depth visualizer
 	float FullBlendDistance;  // Linearized depth threshold for full blend zone visualization
-	float _pad;              // Pad to 16-byte alignment
+	float _pad;               // Pad to 16-byte alignment
 };
 
-#define MODE_DISOCCLUDED    0
-#define MODE_EDGE           1
-#define MODE_MAIN           2
+#define MODE_DISOCCLUDED 0
+#define MODE_EDGE 1
+#define MODE_MAIN 2
 #define MODE_EDGE_NEIGHBOUR 3
-#define MODE_FULL_BLEND     4
+#define MODE_FULL_BLEND 4
 
-[numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID)
-{
+[numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
 	if (any(dtid >= uint2(FrameDim)))
 		return;
 

--- a/package/Shaders/VR/VRPostProcessCS.hlsl
+++ b/package/Shaders/VR/VRPostProcessCS.hlsl
@@ -1,0 +1,114 @@
+// VR Post-Process - Bilateral blend for near-camera 2x supersampling
+//
+// Runs after all compositing and stereo blending is complete.
+// Reads per-pixel classification from StencilCS and applies:
+//   - MODE_FULL_BLEND: bilateral depth-weighted blend for 2x supersampling
+//
+// Only MODE_FULL_BLEND pixels are processed. All others pass through untouched.
+
+#include "Common/FrameBuffer.hlsli"
+#include "Common/SharedData.hlsli"
+#include "Common/VR.hlsli"
+
+Texture2D<float4> ColorTexture : register(t0);  // Copy of final composited image
+Texture2D<uint> ModeTexture : register(t1);
+Texture2D<float> DepthTexture : register(t2);
+
+RWTexture2D<float4> OutputRW : register(u0);
+
+cbuffer VRPostProcessCB : register(b1)
+{
+	float2 FrameDim;
+	float2 RcpFrameDim;
+	float DebugEdgeTint;  // 0 = off, >0 = debug visualization strength
+	uint DebugMode;       // 0 = normal, 1 = depth map diagnostic, 2 = full blend depth visualizer
+	float FullBlendDistance;  // Linearized depth threshold for full blend zone visualization
+	float _pad;              // Pad to 16-byte alignment
+};
+
+#define MODE_DISOCCLUDED    0
+#define MODE_EDGE           1
+#define MODE_MAIN           2
+#define MODE_EDGE_NEIGHBOUR 3
+#define MODE_FULL_BLEND     4
+
+[numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID)
+{
+	if (any(dtid >= uint2(FrameDim)))
+		return;
+
+	uint pixelMode = ModeTexture[dtid];
+
+	// Depth map diagnostic: show mode texture contents as solid colors
+	if (DebugMode == 1) {
+		float4 c = ColorTexture[dtid];
+		if (pixelMode == MODE_EDGE)
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(0, 1, 0), 0.5), c.a);
+		else if (pixelMode == MODE_EDGE_NEIGHBOUR)
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(1, 0, 1), 0.5), c.a);
+		else if (pixelMode == MODE_DISOCCLUDED)
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(0, 0.5, 1), 0.3), c.a);
+		else if (pixelMode == MODE_FULL_BLEND)
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(1, 0.5, 0), 0.5), c.a);  // Orange = full blend zone
+		return;
+	}
+
+	// Full blend depth visualizer: shows the depth boundary as a cyan tint
+	if (DebugMode == 2) {
+		float2 uvDb = (dtid + 0.5) * RcpFrameDim;
+		float depthDb = DepthTexture[dtid];
+		if (depthDb < 1e-5 || depthDb >= 1.0)
+			return;
+		float linDepth = SharedData::GetScreenDepth(depthDb);
+		if (linDepth < FullBlendDistance) {
+			float4 c = ColorTexture[dtid];
+			float proximity = saturate(1.0 - linDepth / max(FullBlendDistance, 1.0));
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(0, 1, 1), proximity * 0.4), c.a);
+		}
+		return;
+	}
+
+	// Only process full blend pixels
+	if (pixelMode != MODE_FULL_BLEND)
+		return;
+
+	float2 uv = (dtid + 0.5) * RcpFrameDim;
+	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
+
+	float4 result = ColorTexture[dtid];
+
+	// === MODE_FULL_BLEND: bilateral blend for 2x supersampling ===
+	{
+		float4 center = result;
+		float centerDepth = DepthTexture[dtid];
+
+		// Reproject to the other eye
+		Stereo::StereoBilateralResult r = Stereo::ReprojectToOtherEye(uv, centerDepth, eyeIndex, FrameDim);
+		if (!r.valid) {
+			// Debug tint for failed reprojection
+			if (DebugEdgeTint > 0)
+				OutputRW[dtid] = float4(lerp(center.rgb, float3(1, 0.5, 0), DebugEdgeTint), center.a);
+			return;
+		}
+
+		// Only blend with pixels that have valid composited data in both eyes.
+		uint otherMode = ModeTexture[r.otherPx];
+		if (otherMode != MODE_FULL_BLEND && otherMode != MODE_DISOCCLUDED)
+			return;
+
+		float4 otherColor = ColorTexture[r.otherPx];
+		float otherDepth = DepthTexture[r.otherPx];
+
+		// Depth-weighted bilateral blend
+		float maxDepth = max(max(centerDepth, otherDepth), 1e-5);
+		float depthAgreement = 1.0 - saturate(abs(centerDepth - otherDepth) / maxDepth / 0.02);
+		float blendWeight = 0.5 * depthAgreement;
+
+		result = lerp(center, otherColor, blendWeight);
+
+		if (DebugEdgeTint > 0)
+			result.rgb = lerp(result.rgb, float3(0, 1, 1), DebugEdgeTint);
+	}
+
+	OutputRW[dtid] = result;
+}

--- a/package/Shaders/VRStereoOptimizations/ReprojectionCS.hlsl
+++ b/package/Shaders/VRStereoOptimizations/ReprojectionCS.hlsl
@@ -1,0 +1,55 @@
+// VR Stereo Optimizations - Reprojection Compute Shader
+//
+// Fills Eye 1 pixels that were stencil-culled during rendering by reprojecting
+// color data from Eye 0. Only operates on pixels classified as MODE_MAIN.
+//
+// Reads Eye 0 color directly from the OutputRW UAV (left half) and writes to
+// Eye 1 (right half). No read-write conflict because reads and writes target
+// strictly different halves of the texture.
+//
+// Input:
+//   t0 = Depth buffer
+//   t1 = Per-pixel mode classification texture
+// Output:
+//   u0 = Main render target UAV (reads Eye 0, writes Eye 1)
+
+#include "Common/VR.hlsli"
+#include "VRStereoOptimizations/cbuffers.hlsli"
+
+Texture2D<float> DepthTexture : register(t0);
+Texture2D<uint> ModeTexture : register(t1);
+
+RWTexture2D<float4> OutputRW : register(u0);
+
+[numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
+	uint eyeWidth = (uint)FrameDim.x / 2;
+	uint eyeHeight = (uint)FrameDim.y;
+
+	if (any(dtid >= uint2(eyeWidth, eyeHeight)))
+		return;
+
+	// dtid is in Eye 1 local coords; convert to stereo buffer coords
+	uint2 stereoCoord = uint2(dtid.x + eyeWidth, dtid.y);
+
+	// Only fill pixels that were marked for reprojection
+	// Mode texture is full SBS resolution, so use stereoCoord for Eye 1
+	uint mode = ModeTexture[stereoCoord];
+	if (mode != MODE_MAIN)
+		return;
+
+	float depth = DepthTexture[stereoCoord];
+
+	// Compute mono UV for this Eye 1 pixel
+	float2 stereoUV = (float2(stereoCoord) + 0.5) * RcpFrameDim;
+	float2 monoUV = Stereo::ConvertFromStereoUV(stereoUV, 1);
+
+	// Reproject to Eye 0 and sample color
+	float3 otherEyeUV = Stereo::ConvertMonoUVToOtherEye(float3(monoUV, depth), 1);
+	float2 eye0StereoUV = Stereo::ConvertToStereoUV(otherEyeUV.xy, 0);
+	int2 eye0Px = clamp(int2(eye0StereoUV * FrameDim), int2(0, 0), int2(FrameDim) - 1);
+
+	float4 reprojectedColor = OutputRW[eye0Px];
+
+	// Write to Eye 1 in the main render target
+	OutputRW[stereoCoord] = reprojectedColor;
+}

--- a/package/Shaders/VRStereoOptimizations/StencilCS.hlsl
+++ b/package/Shaders/VRStereoOptimizations/StencilCS.hlsl
@@ -1,0 +1,151 @@
+// VR Stereo Optimizations - Stencil Classification Compute Shader
+//
+// Classifies BOTH eyes over the full SBS buffer. Each pixel is tagged as:
+//   MODE_DISOCCLUDED    - Must be fully shaded (sky, HMD mask, parallax-occluded)
+//   MODE_EDGE           - Depth edge boundary (dist 1) or inner/foreground band; fully shaded + bilateral blend
+//   MODE_MAIN           - Standard pixel eligible for reprojection / bilateral blend
+//   MODE_FULL_BLEND     - Near-camera geometry: both eyes fully shaded for 2x supersampling
+//
+// Dispatched over full SBS resolution (FrameDim.x x FrameDim.y).
+
+#include "Common/VR.hlsli"
+#include "Common/SharedData.hlsli"
+#include "VRStereoOptimizations/cbuffers.hlsli"
+
+Texture2D<float> DepthTexture : register(t0);
+
+RWTexture2D<uint> ModeTextureRW : register(u0);
+
+static const float kDisocclusionThreshold = 0.015;
+
+[numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
+	if (any(dtid >= uint2(FrameDim)))
+		return;
+
+	// Determine which eye this pixel belongs to
+	float2 uv = (float2(dtid) + 0.5) / FrameDim;
+	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
+
+	// Read depth directly in SBS coords
+	float centerDepth = DepthTexture[dtid];
+
+#ifdef DEBUG_DEPTH_MAP
+	// DIAGNOSTIC: Visualize what depth values StencilCS sees.
+	// Green (MODE_EDGE) = depth >= 1.0 (HMD mask threshold)
+	// Magenta (MODE_EDGE_NEIGHBOUR) = depth < 1e-5 (sky threshold)
+	// No tint (MODE_MAIN) = normal geometry with valid depth
+	if (centerDepth >= 1.0) {
+		ModeTextureRW[dtid] = MODE_EDGE;
+		return;
+	}
+	if (centerDepth < 1e-5) {
+		ModeTextureRW[dtid] = MODE_EDGE_NEIGHBOUR;
+		return;
+	}
+	ModeTextureRW[dtid] = MODE_MAIN;
+	return;
+#endif
+
+	// Sky/unrendered pixels (depth >= 1.0 at z-prepass time = depth buffer clear value)
+	// and HMD mask pixels both have depth >= 1.0 here. Treat them the same as sky:
+	// let edge detection run so geometry-vs-sky boundaries get classified.
+	// HMD mask pixels are in lens corners with no nearby geometry, so they'll
+	// fall through to MODE_DISOCCLUDED at the end.
+	bool isSky = (centerDepth < 1e-5) || (centerDepth >= 1.0);
+	float linCenter = isSky ? 999999.0 : SharedData::GetScreenDepth(centerDepth);
+
+	// Near-camera supersampling: geometry closer than FullBlendDistance gets full
+	// shading in both eyes for bilateral blend (2x supersampling in VRPostProcess).
+	if (!isSky && linCenter < FullBlendDistance) {
+		ModeTextureRW[dtid] = MODE_FULL_BLEND;
+		return;
+	}
+
+	// --- Disocclusion detection via reprojection (runs for all non-sky pixels) ---
+	// Early return: disoccluded pixels are always MODE_DISOCCLUDED regardless of edge proximity.
+	// This ensures MinEdgeDistance never affects disocclusion classification.
+	if (!isSky) {
+		Stereo::StereoBilateralResult reproj = Stereo::ReprojectToOtherEye(
+			uv,
+			centerDepth,
+			eyeIndex,
+			FrameDim);
+
+		bool isDisoccluded = false;
+		if (!reproj.valid) {
+			isDisoccluded = true;
+		} else {
+			float otherDepth = DepthTexture[reproj.otherPx];
+			float maxDepth = max(max(centerDepth, otherDepth), 1e-5);
+			float relativeDepthDiff = abs(centerDepth - otherDepth) / maxDepth;
+			isDisoccluded = (relativeDepthDiff > kDisocclusionThreshold);
+		}
+
+		if (isDisoccluded) {
+			ModeTextureRW[dtid] = MODE_DISOCCLUDED;
+			return;
+		}
+	}
+
+	// Depth gate: skip edge detection for nearby geometry (saves perf, distant AA matters more)
+	// Sky pixels always run edge detection — they need to expand the edge band outward.
+	// Disocclusion detection (above) is independent of this gate and always runs.
+	bool skipEdgeDetection = !isSky && (linCenter < MinEdgeDistance);
+
+	// --- Edge detection with two-tier classification ---
+	// MODE_EDGE:           immediate neighbor (distance 1) has depth discontinuity, OR
+	//                      inner/foreground band (distance <= kInnerWidth).
+	static const uint kInnerWidth = 2;
+	int2 offsets[4] = { int2(-1, 0), int2(1, 0), int2(0, -1), int2(0, 1) };
+
+	uint nearestEdgeDist = 0xFFFFFFFF;  // nearest distance at which a discontinuity was found
+	bool nearestWeAreOuter = false;     // whether we are on the background side at that nearest hit
+
+	// Use the larger of inner/outer widths for the search
+	uint maxWidth = kInnerWidth;
+
+	if (!skipEdgeDetection) {
+	[loop]
+	for (uint d = 1; d <= maxWidth; d++) {
+		[unroll]
+		for (int i = 0; i < 4; i++) {
+			int2 rawNeighbor = int2(dtid) + offsets[i] * (int)d;
+			uint2 neighborCoord = Stereo::ClampToEyeBounds(rawNeighbor, eyeIndex, FrameDim);
+
+			float neighborDepth = DepthTexture[neighborCoord];
+			bool neighborIsSky = (neighborDepth < 1e-5) || (neighborDepth >= 1.0);
+			float linNeighbor = neighborIsSky ? 999999.0 : SharedData::GetScreenDepth(neighborDepth);
+			float maxLin = max(max(linCenter, linNeighbor), 1e-5);
+			float relDepthDiff = abs(linCenter - linNeighbor) / maxLin;
+
+			if (relDepthDiff > EdgeDepthThreshold && d < nearestEdgeDist) {
+				nearestEdgeDist = d;
+				nearestWeAreOuter = (linNeighbor < linCenter);  // neighbor closer to camera = we are background
+			}
+		}
+	}
+
+	}  // !skipEdgeDetection
+
+	if (nearestEdgeDist != 0xFFFFFFFF) {
+		// Classify based on distance and side
+		if (nearestEdgeDist == 1) {
+			// Immediate neighbor discontinuity: always MODE_EDGE regardless of side
+			ModeTextureRW[dtid] = MODE_EDGE;
+			return;
+		} else if (!nearestWeAreOuter && nearestEdgeDist <= kInnerWidth) {
+			// Inner/foreground band beyond distance 1
+			ModeTextureRW[dtid] = MODE_EDGE;
+			return;
+		}
+	}
+
+	// Sky pixels that aren't near edges -> disoccluded (reprojection is meaningless for sky)
+	if (isSky) {
+		ModeTextureRW[dtid] = MODE_DISOCCLUDED;
+		return;
+	}
+
+	// Standard pixel
+	ModeTextureRW[dtid] = MODE_MAIN;
+}

--- a/package/Shaders/VRStereoOptimizations/StencilCS.hlsl
+++ b/package/Shaders/VRStereoOptimizations/StencilCS.hlsl
@@ -16,8 +16,6 @@ Texture2D<float> DepthTexture : register(t0);
 
 RWTexture2D<uint> ModeTextureRW : register(u0);
 
-static const float kDisocclusionThreshold = 0.015;
-
 [numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
 	if (any(dtid >= uint2(FrameDim)))
 		return;
@@ -78,7 +76,7 @@ static const float kDisocclusionThreshold = 0.015;
 			float otherDepth = DepthTexture[reproj.otherPx];
 			float maxDepth = max(max(centerDepth, otherDepth), 1e-5);
 			float relativeDepthDiff = abs(centerDepth - otherDepth) / maxDepth;
-			isDisoccluded = (relativeDepthDiff > kDisocclusionThreshold);
+			isDisoccluded = (relativeDepthDiff > DisocclusionThreshold);
 		}
 
 		if (isDisoccluded) {

--- a/package/Shaders/VRStereoOptimizations/StencilCS.hlsl
+++ b/package/Shaders/VRStereoOptimizations/StencilCS.hlsl
@@ -8,8 +8,8 @@
 //
 // Dispatched over full SBS resolution (FrameDim.x x FrameDim.y).
 
-#include "Common/VR.hlsli"
 #include "Common/SharedData.hlsli"
+#include "Common/VR.hlsli"
 #include "VRStereoOptimizations/cbuffers.hlsli"
 
 Texture2D<float> DepthTexture : register(t0);
@@ -105,25 +105,25 @@ static const float kDisocclusionThreshold = 0.015;
 	uint maxWidth = kInnerWidth;
 
 	if (!skipEdgeDetection) {
-	[loop]
-	for (uint d = 1; d <= maxWidth; d++) {
-		[unroll]
-		for (int i = 0; i < 4; i++) {
-			int2 rawNeighbor = int2(dtid) + offsets[i] * (int)d;
-			uint2 neighborCoord = Stereo::ClampToEyeBounds(rawNeighbor, eyeIndex, FrameDim);
+		[loop] for (uint d = 1; d <= maxWidth; d++)
+		{
+			[unroll] for (int i = 0; i < 4; i++)
+			{
+				int2 rawNeighbor = int2(dtid) + offsets[i] * (int)d;
+				uint2 neighborCoord = Stereo::ClampToEyeBounds(rawNeighbor, eyeIndex, FrameDim);
 
-			float neighborDepth = DepthTexture[neighborCoord];
-			bool neighborIsSky = (neighborDepth < 1e-5) || (neighborDepth >= 1.0);
-			float linNeighbor = neighborIsSky ? 999999.0 : SharedData::GetScreenDepth(neighborDepth);
-			float maxLin = max(max(linCenter, linNeighbor), 1e-5);
-			float relDepthDiff = abs(linCenter - linNeighbor) / maxLin;
+				float neighborDepth = DepthTexture[neighborCoord];
+				bool neighborIsSky = (neighborDepth < 1e-5) || (neighborDepth >= 1.0);
+				float linNeighbor = neighborIsSky ? 999999.0 : SharedData::GetScreenDepth(neighborDepth);
+				float maxLin = max(max(linCenter, linNeighbor), 1e-5);
+				float relDepthDiff = abs(linCenter - linNeighbor) / maxLin;
 
-			if (relDepthDiff > EdgeDepthThreshold && d < nearestEdgeDist) {
-				nearestEdgeDist = d;
-				nearestWeAreOuter = (linNeighbor < linCenter);  // neighbor closer to camera = we are background
+				if (relDepthDiff > EdgeDepthThreshold && d < nearestEdgeDist) {
+					nearestEdgeDist = d;
+					nearestWeAreOuter = (linNeighbor < linCenter);  // neighbor closer to camera = we are background
+				}
 			}
 		}
-	}
 
 	}  // !skipEdgeDetection
 

--- a/package/Shaders/VRStereoOptimizations/StencilWritePS.hlsl
+++ b/package/Shaders/VRStereoOptimizations/StencilWritePS.hlsl
@@ -1,0 +1,54 @@
+// VR Stereo Optimizations - Stencil Write Pixel Shader
+//
+// Reads from the per-pixel mode classification texture and depth texture.
+// Discards pixels that should NOT be stencil-culled:
+//   - MODE_DISOCCLUDED (0) = fully shaded in Eye 1, no reprojection needed
+//   - MODE_FULL_BLEND (4) = near-camera pixels fully shaded in both eyes for supersampling
+//   - Sky/HMD-mask pixels (depth >= 1.0 or depth < 1e-5) = need normal rendering
+//     in the sky pass; they keep their MODE_EDGE tag in
+//     the mode texture for VRPostProcess but must not be stencil-culled.
+//
+// Only geometry MODE_MAIN/MODE_EDGE pixels survive and get stencil ref=1 written.
+//
+// Mode texture is full SBS resolution (same as render target).
+// The DSS is configured with StencilFunc=ALWAYS, StencilPassOp=REPLACE, ref=1.
+// Pixels that survive (not discarded) get stencil=1 written.
+
+#include "VRStereoOptimizations/cbuffers.hlsli"
+
+Texture2D<uint> ModeTexture : register(t0);
+Texture2D<float> DepthTexture : register(t1);
+
+struct PS_INPUT
+{
+	float4 Position : SV_Position;
+	float2 TexCoord : TEXCOORD0;
+};
+
+void main(PS_INPUT input)
+{
+	// Mode texture is full SBS resolution — SV_Position maps directly
+	// (viewport is Eye 1 half, so SV_Position.x starts at eyeWidth)
+	int2 modeCoord = int2(input.Position.xy);
+
+	uint mode = ModeTexture[modeCoord];
+
+	// MODE_MAIN and MODE_EDGE in Eye 1 write stencil ref=1 (reprojectable).
+	// These are reprojected from Eye 0; MODE_DISOCCLUDED and MODE_FULL_BLEND are fully shaded in Eye 1.
+	if (mode == MODE_DISOCCLUDED)
+		discard;
+
+	// Sky/HMD-mask pixels must not be stencil-culled regardless of edge classification.
+	// They keep their MODE_EDGE tag in the mode texture for VRPostProcess,
+	// but must render normally in the sky pass (which runs after stencil culling).
+	float depth = DepthTexture[modeCoord];
+	if (depth >= 1.0 || depth < 1e-5)
+		discard;
+
+	// MODE_FULL_BLEND: near-camera pixels fully shaded in both eyes for supersampling
+	if (mode == MODE_FULL_BLEND)
+		discard;
+
+	// Pixel survives: DSS writes stencil ref=1
+	// No color output (no RTV bound)
+}

--- a/package/Shaders/VRStereoOptimizations/StencilWritePS.hlsl
+++ b/package/Shaders/VRStereoOptimizations/StencilWritePS.hlsl
@@ -21,8 +21,8 @@ Texture2D<float> DepthTexture : register(t1);
 
 struct PS_INPUT
 {
-	float4 Position : SV_Position;
-	float2 TexCoord : TEXCOORD0;
+	float4 Position: SV_Position;
+	float2 TexCoord: TEXCOORD0;
 };
 
 void main(PS_INPUT input)

--- a/package/Shaders/VRStereoOptimizations/StencilWriteVS.hlsl
+++ b/package/Shaders/VRStereoOptimizations/StencilWriteVS.hlsl
@@ -7,8 +7,8 @@
 
 struct VS_OUTPUT
 {
-	float4 Position : SV_Position;
-	float2 TexCoord : TEXCOORD0;
+	float4 Position: SV_Position;
+	float2 TexCoord: TEXCOORD0;
 };
 
 VS_OUTPUT main(uint vertexID : SV_VertexID)

--- a/package/Shaders/VRStereoOptimizations/StencilWriteVS.hlsl
+++ b/package/Shaders/VRStereoOptimizations/StencilWriteVS.hlsl
@@ -1,0 +1,24 @@
+// VR Stereo Optimizations - Stencil Write Vertex Shader
+//
+// Procedural fullscreen triangle covering Eye 1 (right half of SBS buffer).
+// No vertex buffer needed — vertex positions are generated from SV_VertexID.
+// The viewport is set to Eye 1 by the C++ code, so we just emit a standard
+// fullscreen triangle in clip space.
+
+struct VS_OUTPUT
+{
+	float4 Position : SV_Position;
+	float2 TexCoord : TEXCOORD0;
+};
+
+VS_OUTPUT main(uint vertexID : SV_VertexID)
+{
+	VS_OUTPUT output;
+
+	// Fullscreen triangle: 3 vertices covering [-1,1] clip space
+	float2 uv = float2((vertexID << 1) & 2, vertexID & 2);
+	output.Position = float4(uv * float2(2, -2) + float2(-1, 1), 0, 1);
+	output.TexCoord = uv;
+
+	return output;
+}

--- a/package/Shaders/VRStereoOptimizations/cbuffers.hlsli
+++ b/package/Shaders/VRStereoOptimizations/cbuffers.hlsli
@@ -6,30 +6,30 @@
 
 cbuffer VRStereoOptParams : register(b1)
 {
-	float2 FrameDim;               // Full stereo buffer dimensions (both eyes)
-	float2 RcpFrameDim;            // 1.0 / FrameDim
+	float2 FrameDim;     // Full stereo buffer dimensions (both eyes)
+	float2 RcpFrameDim;  // 1.0 / FrameDim
 
-	uint StereoModeValue;          // 0=Off, 1=Enable
-	float DisocclusionThreshold;   // Depth difference threshold for disocclusion detection
-	float EdgeDepthThreshold;   // Relative depth difference threshold for edge detection
-	uint EdgeWidth;            // Half-width of edge detection band in pixels
+	uint StereoModeValue;         // 0=Off, 1=Enable
+	float DisocclusionThreshold;  // Depth difference threshold for disocclusion detection
+	float EdgeDepthThreshold;     // Relative depth difference threshold for edge detection
+	uint EdgeWidth;               // Half-width of edge detection band in pixels
 
-	float2 QualityJitter;          // Sub-pixel jitter offset (Quality mode)
-	float FoveatedRadius;          // Radius of foveal region in UV space
+	float2 QualityJitter;  // Sub-pixel jitter offset (Quality mode)
+	float FoveatedRadius;  // Radius of foveal region in UV space
 	float pad2;
 
-	float2 FoveatedCenter;         // Center of foveal region in UV space
+	float2 FoveatedCenter;  // Center of foveal region in UV space
 	float MinEdgeDistance;
-	float FullBlendDistance;   // Linearized depth below which pixels get MODE_FULL_BLEND (game units)
+	float FullBlendDistance;  // Linearized depth below which pixels get MODE_FULL_BLEND (game units)
 };
 
-#define STEREO_MODE_OFF    0
+#define STEREO_MODE_OFF 0
 #define STEREO_MODE_ENABLE 1
 
-#define MODE_DISOCCLUDED    0  // Fully shaded, no reprojection, no blend (sky, HMD mask, parallax-occluded)
-#define MODE_EDGE           1  // Depth edge boundary (distance 1) or inner/foreground band; fully shaded + bilateral blend
-#define MODE_MAIN           2  // Eye 0: no reproject (Perf) / bilateral (Quality). Eye 1: overwrite reproject (Perf) / bilateral (Quality)
+#define MODE_DISOCCLUDED 0     // Fully shaded, no reprojection, no blend (sky, HMD mask, parallax-occluded)
+#define MODE_EDGE 1            // Depth edge boundary (distance 1) or inner/foreground band; fully shaded + bilateral blend
+#define MODE_MAIN 2            // Eye 0: no reproject (Perf) / bilateral (Quality). Eye 1: overwrite reproject (Perf) / bilateral (Quality)
 #define MODE_EDGE_NEIGHBOUR 3  // (Legacy, unused) Outer/background band — now classified as MODE_MAIN
-#define MODE_FULL_BLEND     4  // Near-camera geometry: both eyes fully shaded + bilateral blend for 2x supersampling
+#define MODE_FULL_BLEND 4      // Near-camera geometry: both eyes fully shaded + bilateral blend for 2x supersampling
 
 #endif

--- a/package/Shaders/VRStereoOptimizations/cbuffers.hlsli
+++ b/package/Shaders/VRStereoOptimizations/cbuffers.hlsli
@@ -1,0 +1,35 @@
+// VR Stereo Optimizations - Shared constant buffer layout
+// Must match VRStereoOptParams in VRStereoOptimizations.h exactly
+
+#ifndef __VR_STEREO_OPT_CBUFFERS_HLSLI__
+#define __VR_STEREO_OPT_CBUFFERS_HLSLI__
+
+cbuffer VRStereoOptParams : register(b1)
+{
+	float2 FrameDim;               // Full stereo buffer dimensions (both eyes)
+	float2 RcpFrameDim;            // 1.0 / FrameDim
+
+	uint StereoModeValue;          // 0=Off, 1=Enable
+	float DisocclusionThreshold;   // Depth difference threshold for disocclusion detection
+	float EdgeDepthThreshold;   // Relative depth difference threshold for edge detection
+	uint EdgeWidth;            // Half-width of edge detection band in pixels
+
+	float2 QualityJitter;          // Sub-pixel jitter offset (Quality mode)
+	float FoveatedRadius;          // Radius of foveal region in UV space
+	float pad2;
+
+	float2 FoveatedCenter;         // Center of foveal region in UV space
+	float MinEdgeDistance;
+	float FullBlendDistance;   // Linearized depth below which pixels get MODE_FULL_BLEND (game units)
+};
+
+#define STEREO_MODE_OFF    0
+#define STEREO_MODE_ENABLE 1
+
+#define MODE_DISOCCLUDED    0  // Fully shaded, no reprojection, no blend (sky, HMD mask, parallax-occluded)
+#define MODE_EDGE           1  // Depth edge boundary (distance 1) or inner/foreground band; fully shaded + bilateral blend
+#define MODE_MAIN           2  // Eye 0: no reproject (Perf) / bilateral (Quality). Eye 1: overwrite reproject (Perf) / bilateral (Quality)
+#define MODE_EDGE_NEIGHBOUR 3  // (Legacy, unused) Outer/background band — now classified as MODE_MAIN
+#define MODE_FULL_BLEND     4  // Near-camera geometry: both eyes fully shaded + bilateral blend for 2x supersampling
+
+#endif

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -14,6 +14,7 @@
 #include "Features/TerrainBlending.h"
 #include "Features/Upscaling.h"
 #include "Features/VR.h"
+#include "Features/VRStereoOptimizations.h"
 #include "Features/WeatherEditor.h"
 
 #include "Hooks.h"
@@ -275,6 +276,11 @@ void Deferred::StartDeferred()
 	PrepassPasses();
 
 	OverrideBlendStates();
+
+	// VR: Classify Eye 1 pixels and write hardware stencil marks before geometry rendering
+	if (globals::game::isVR) {
+		globals::features::vrStereoOptimizations.DispatchStencil();
+	}
 }
 
 void Deferred::DeferredPasses()
@@ -363,6 +369,14 @@ void Deferred::DeferredPasses()
 
 		context->CSSetShaderResources(0, ARRAYSIZE(srvs), srvs);
 
+		// Bind VRStereoOptimizations mode texture for Eye 1 skip
+		auto& vrStereoOpt = globals::features::vrStereoOptimizations;
+		if (REL::Module::IsVR() && vrStereoOpt.loaded && vrStereoOpt.settings.stereoMode != VRStereoOptimizations::StereoMode::Off) {
+			ID3D11ShaderResourceView* modeSRV = vrStereoOpt.GetModeTextureSRV();
+			if (modeSRV)
+				context->CSSetShaderResources(16, 1, &modeSRV);
+		}
+
 		ID3D11UnorderedAccessView* uavs[3]{ main.UAV, normals.UAV, motionVectors.UAV };
 		context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
 
@@ -370,13 +384,28 @@ void Deferred::DeferredPasses()
 		context->CSSetShader(shader, nullptr, 0);
 
 		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
+
+		// Unbind mode texture SRV
+		if (REL::Module::IsVR() && vrStereoOpt.loaded && vrStereoOpt.settings.stereoMode != VRStereoOptimizations::StereoMode::Off) {
+			ID3D11ShaderResourceView* nullSRV = nullptr;
+			context->CSSetShaderResources(16, 1, &nullSRV);
+		}
 	}
 
-	// VR stereo consistency blend - depth-aware bilateral blend at the eye seam
-	// Runs after composite as a general safety net for all screen-space effects.
-	// Must run before clearing b12/b13 -- needs FrameBuffer matrices for reprojection.
-	if (globals::game::isVR)
+	// VR: Deactivate stencil culling now that geometry rendering is complete.
+	// Must happen before StereoBlend so the blend pass itself isn't stencil-blocked.
+	if (globals::game::isVR) {
+		auto& stereoOpt = globals::features::vrStereoOptimizations;
+		if (stereoOpt.IsStencilActive()) {
+			stereoOpt.DeactivateStencil();
+		}
+	}
+
+	// VR: Stereo reprojection fills Eye 1 holes here (after DeferredComposite, before SSR/water/sky)
+	// so that ISReflectionsRayTracing sees valid pixels in both eyes.
+	if (globals::game::isVR) {
 		globals::features::vr.DrawStereoBlend();
+	}
 
 	// Clear
 	{
@@ -551,6 +580,9 @@ ID3D11ComputeShader* Deferred::GetComputeMainComposite()
 		if (REL::Module::IsVR())
 			defines.push_back({ "FRAMEBUFFER", nullptr });
 
+		if (REL::Module::IsVR() && globals::features::vrStereoOptimizations.loaded)
+			defines.push_back({ "VR_STEREO_OPT", nullptr });
+
 		mainCompositeCS = static_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\DeferredCompositeCS.hlsl", defines, "cs_5_0"));
 	}
 	return mainCompositeCS;
@@ -576,6 +608,9 @@ ID3D11ComputeShader* Deferred::GetComputeMainCompositeInterior()
 		if (REL::Module::IsVR())
 			defines.push_back({ "FRAMEBUFFER", nullptr });
 
+		if (REL::Module::IsVR() && globals::features::vrStereoOptimizations.loaded)
+			defines.push_back({ "VR_STEREO_OPT", nullptr });
+
 		mainCompositeInteriorCS = static_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\DeferredCompositeCS.hlsl", defines, "cs_5_0"));
 	}
 	return mainCompositeInteriorCS;
@@ -593,6 +628,7 @@ void Deferred::Hooks::Main_RenderWorld::thunk(bool a1)
 	state->permutationData.ExtraShaderDescriptor |= static_cast<uint32_t>(State::ExtraShaderDescriptors::InWorld);
 	state->inWorld = true;
 	func(a1);
+
 	state->inWorld = false;
 	state->permutationData.ExtraShaderDescriptor &= ~static_cast<uint32_t>(State::ExtraShaderDescriptors::InWorld);
 };

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -504,6 +504,10 @@ void Deferred::OverrideBlendStates()
 								blendDesc.RenderTarget[i].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
 							}
 
+							// RT[5] = REFLECTANCE: enable alpha writes for POM depth data
+							// stored in Reflectance.w, used by StereoBlendCS for depth-aware reprojection
+							blendDesc.RenderTarget[5].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+
 							DX::ThrowIfFailed(device->CreateBlendState(&blendDesc, &deferredBlendStates[a][b][c][d]));
 						} else {
 							deferredBlendStates[a][b][c][d] = nullptr;

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -30,6 +30,7 @@
 #include "Features/UnifiedWater.h"
 #include "Features/Upscaling.h"
 #include "Features/VR.h"
+#include "Features/VRStereoOptimizations.h"
 #include "Features/VolumetricLighting.h"
 #include "Features/VolumetricShadows.h"
 #include "Features/WaterEffects.h"
@@ -247,6 +248,7 @@ const std::vector<Feature*>& Feature::GetFeatureList()
 		static auto BuildVRList = []() -> std::vector<Feature*> {
 			auto v = features;
 			v.push_back(&globals::features::vr);
+			v.push_back(&globals::features::vrStereoOptimizations);
 
 			// In developer mode, keep all features for testing
 			// In production mode, filter to VR-compatible only

--- a/src/Features/ExtendedMaterials.h
+++ b/src/Features/ExtendedMaterials.h
@@ -36,7 +36,7 @@ struct ExtendedMaterials : Feature
 		uint ExtendShadows = 1;
 		uint EnableParallaxWarpingFix = 1;
 
-		float pad[1];
+		uint pad0 = 0;
 	};
 	STATIC_ASSERT_ALIGNAS_16(Settings);
 

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -3,8 +3,8 @@
 #include "Deferred.h"
 #include "Features/VRStereoOptimizations.h"
 #include "Hooks.h"
-#include "TAAReorder.h"
 #include "State.h"
+#include "TAAReorder.h"
 #include "Upscaling/DX12SwapChain.h"
 #include "Upscaling/FidelityFX.h"
 #include "Upscaling/Streamline.h"
@@ -984,16 +984,16 @@ void Upscaling::PreparePerEyeInputs(ID3D11Resource* colorSrc, ID3D11Resource* de
 			D3D11_TEXTURE2D_DESC srcDesc;
 			((ID3D11Texture2D*)colorSrc)->GetDesc(&srcDesc);
 			needsRecreate = (vrIntermediateColorIn[0]->desc.Width != eyeWidthIn ||
-			                 vrIntermediateColorIn[0]->desc.Height != eyeHeightIn ||
-			                 vrIntermediateColorIn[0]->desc.Format != srcDesc.Format ||
-			                 vrCropColorIn[0]->desc.Width != cropWidthIn ||
-			                 vrCropColorIn[0]->desc.Height != cropHeightIn ||
-			                 vrIntermediateDepth[0]->desc.Width != cropWidthIn ||
-			                 vrIntermediateDepth[0]->desc.Height != cropHeightIn ||
-			                 vrIntermediateColorOut[0]->desc.Width != cropWidthOut ||
-			                 vrIntermediateColorOut[0]->desc.Height != cropHeightOut ||
-			                 vrFinalOutput[0]->desc.Width != eyeWidthOut ||
-			                 vrFinalOutput[0]->desc.Height != eyeHeightOut);
+							 vrIntermediateColorIn[0]->desc.Height != eyeHeightIn ||
+							 vrIntermediateColorIn[0]->desc.Format != srcDesc.Format ||
+							 vrCropColorIn[0]->desc.Width != cropWidthIn ||
+							 vrCropColorIn[0]->desc.Height != cropHeightIn ||
+							 vrIntermediateDepth[0]->desc.Width != cropWidthIn ||
+							 vrIntermediateDepth[0]->desc.Height != cropHeightIn ||
+							 vrIntermediateColorOut[0]->desc.Width != cropWidthOut ||
+							 vrIntermediateColorOut[0]->desc.Height != cropHeightOut ||
+							 vrFinalOutput[0]->desc.Width != eyeWidthOut ||
+							 vrFinalOutput[0]->desc.Height != eyeHeightOut);
 		}
 
 		if (needsRecreate) {
@@ -1076,7 +1076,7 @@ void Upscaling::PreparePerEyeInputs(ID3D11Resource* colorSrc, ID3D11Resource* de
 
 			// Crop depth/mvec/reactive/transparency directly from stereo buffers
 			D3D11_BOX stereoCropBox = { offsetXIn + cropOffsetX, cropOffsetY, 0,
-			                            offsetXIn + cropOffsetX + cropWidthIn, cropOffsetY + cropHeightIn, 1 };
+				offsetXIn + cropOffsetX + cropWidthIn, cropOffsetY + cropHeightIn, 1 };
 			context->CopySubresourceRegion(vrIntermediateDepth[i]->resource.get(), 0, 0, 0, 0,
 				depthSrc, 0, &stereoCropBox);
 			context->CopySubresourceRegion(vrIntermediateMotionVectors[i]->resource.get(), 0, 0, 0, 0,
@@ -1100,10 +1100,10 @@ void Upscaling::PreparePerEyeInputs(ID3D11Resource* colorSrc, ID3D11Resource* de
 			D3D11_TEXTURE2D_DESC srcDesc;
 			((ID3D11Texture2D*)colorSrc)->GetDesc(&srcDesc);
 			needsRecreate = (vrIntermediateColorIn[0]->desc.Width != eyeWidthIn ||
-			                 vrIntermediateColorIn[0]->desc.Height != eyeHeightIn ||
-			                 vrIntermediateColorIn[0]->desc.Format != srcDesc.Format ||
-			                 vrIntermediateColorOut[0]->desc.Width != eyeWidthOut ||
-			                 vrIntermediateColorOut[0]->desc.Height != eyeHeightOut);
+							 vrIntermediateColorIn[0]->desc.Height != eyeHeightIn ||
+							 vrIntermediateColorIn[0]->desc.Format != srcDesc.Format ||
+							 vrIntermediateColorOut[0]->desc.Width != eyeWidthOut ||
+							 vrIntermediateColorOut[0]->desc.Height != eyeHeightOut);
 		}
 		if (needsRecreate) {
 			logger::info("[Upscaling] (Re)creating VR intermediates: per-eye in {}x{}, out {}x{}",
@@ -1758,7 +1758,6 @@ std::vector<FeatureConstraints::Constraint> Upscaling::GetActiveConstraints() co
 	return constraints;
 }
 
-
 /**
  * @brief Retrieves the current frame time for frame generation.
  *
@@ -1932,9 +1931,7 @@ void Upscaling::Upscale(ID3D11Texture2D* colorSourceOverride)
 		state->BeginPerfEvent("Upscaling");
 
 		// Use color source override if provided (e.g., post-PP intermediate for periphery TAA)
-		ID3D11Resource* colorSrc = colorSourceOverride
-			? static_cast<ID3D11Resource*>(colorSourceOverride)
-			: static_cast<ID3D11Resource*>(main.texture);
+		ID3D11Resource* colorSrc = colorSourceOverride ? static_cast<ID3D11Resource*>(colorSourceOverride) : static_cast<ID3D11Resource*>(main.texture);
 
 		if (upscaleMethod == UpscaleMethod::kDLSS) {
 			streamline.Upscale(colorSrc, reactiveMaskTexture->resource.get(), transparencyCompositionMaskTexture->resource.get(), motionVectorCopyTexture->resource.get());

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -147,7 +147,10 @@ HRESULT WINAPI hk_D3D11CreateDeviceAndSwapChainUpscaling(
 		ppImmediateContext);
 
 	if (upscaling.IsBackendInitialized()) {
-		// Skip interface wrapping for VR - it can affect frame pacing with VR compositor
+		// Skip Streamline interface wrapping for VR — slUpgradeInterface wraps the D3D
+		// device and swap chain with Streamline proxy objects, which disrupts VR compositor
+		// frame pacing (causes judder/stuttering). DLSS still functions without wrapped
+		// interfaces; only frame generation requires them (and that's already VR-gated above).
 		if (!globals::game::isVR) {
 			upscaling.UpgradeBackendInterface((void**)&(*ppDevice));
 			upscaling.UpgradeBackendInterface((void**)&(*ppSwapChain));

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1,10 +1,8 @@
 #include "Upscaling.h"
 
 #include "Deferred.h"
-#include "Features/VRStereoOptimizations.h"
 #include "Hooks.h"
 #include "State.h"
-#include "TAAReorder.h"
 #include "Upscaling/DX12SwapChain.h"
 #include "Upscaling/FidelityFX.h"
 #include "Upscaling/Streamline.h"
@@ -27,9 +25,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	sharpnessFSR,
 	sharpnessDLSS,
 	presetDLSS,
-	useGatherWideKernel,
-	vrDlssViewportScale,
-	vrPeripheryTAA);
+	useGatherWideKernel);
 
 decltype(&D3D11CreateDeviceAndSwapChain) ptrD3D11CreateDeviceAndSwapChainUpscaling;
 
@@ -65,9 +61,7 @@ HRESULT WINAPI hk_D3D11CreateDeviceAndSwapChainUpscaling(
 		upscaling.CheckBackendFeatures(pAdapter);
 
 	// Use better swap effect to prevent tearing and improve performance
-	// But don't change it for VR as it can affect frame pacing with the VR compositor
-	if (!globals::game::isVR)
-		pSwapChainDesc->SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	pSwapChainDesc->SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
 
 	bool shouldProxy = !globals::game::isVR;
 	if (shouldProxy)
@@ -147,14 +141,8 @@ HRESULT WINAPI hk_D3D11CreateDeviceAndSwapChainUpscaling(
 		ppImmediateContext);
 
 	if (upscaling.IsBackendInitialized()) {
-		// Skip Streamline interface wrapping for VR — slUpgradeInterface wraps the D3D
-		// device and swap chain with Streamline proxy objects, which disrupts VR compositor
-		// frame pacing (causes judder/stuttering). DLSS still functions without wrapped
-		// interfaces; only frame generation requires them (and that's already VR-gated above).
-		if (!globals::game::isVR) {
-			upscaling.UpgradeBackendInterface((void**)&(*ppDevice));
-			upscaling.UpgradeBackendInterface((void**)&(*ppSwapChain));
-		}
+		upscaling.UpgradeBackendInterface((void**)&(*ppDevice));
+		upscaling.UpgradeBackendInterface((void**)&(*ppSwapChain));
 		upscaling.SetBackendD3DDevice(*ppDevice);
 		upscaling.PostBackendDevice();
 	}
@@ -249,30 +237,6 @@ void Upscaling::DrawSettings()
 				ImGui::Text("Each model offers different visual quality, performance, and motion stability.");
 				ImGui::Text("Set to 'Default' for automatic selection based on your Upscale Preset and hardware.");
 				ImGui::Text("Changing this setting requires a restart to take effect.");
-			}
-
-			if (globals::game::isVR) {
-				if (ImGui::TreeNodeEx("VR Viewport Scaling", ImGuiTreeNodeFlags_DefaultOpen)) {
-					ImGui::SliderFloat("DLSS Viewport Scale", &settings.vrDlssViewportScale, 0.5f, 1.0f, "%.2f");
-					if (auto _tt = Util::HoverTooltipWrapper()) {
-						ImGui::Text("Controls the fraction of each eye's view that DLSS processes.");
-						ImGui::Text("Lower values = better performance, less visible area upscaled by DLSS.");
-						ImGui::Text("The VR lens hides the periphery, so 0.7-0.85 is recommended.");
-						ImGui::Text("The periphery outside the DLSS region is filled with a bilinear upscale.");
-					}
-
-					if (settings.vrDlssViewportScale < 1.0f) {
-						bool peripheryTAA = settings.vrPeripheryTAA != 0;
-						if (ImGui::Checkbox("Periphery TAA", &peripheryTAA))
-							settings.vrPeripheryTAA = peripheryTAA ? 1 : 0;
-						if (auto _tt = Util::HoverTooltipWrapper()) {
-							ImGui::Text("Applies temporal anti-aliasing to the bilinear-upscaled periphery.");
-							ImGui::Text("Reduces shimmer and improves peripheral quality.");
-							ImGui::Text("The DLSS center region passes through unchanged.");
-						}
-					}
-					ImGui::TreePop();
-				}
 			}
 		}
 
@@ -496,7 +460,6 @@ void Upscaling::LoadSettings(json& o_json)
 		logger::warn("[Upscaling] Loaded useGatherWideKernel {} out of range, clamping to 1", settings.useGatherWideKernel);
 		settings.useGatherWideKernel = 1;
 	}
-	settings.vrDlssViewportScale = std::clamp(settings.vrDlssViewportScale, 0.5f, 1.0f);
 	auto iniSettingCollection = globals::game::iniPrefSettingCollection;
 	if (iniSettingCollection) {
 		auto setting = iniSettingCollection->GetSetting("bUseTAA:Display");
@@ -524,10 +487,6 @@ void Upscaling::DataLoaded()
 void Upscaling::Load()
 {
 	*(uintptr_t*)&ptrD3D11CreateDeviceAndSwapChainUpscaling = SKSE::PatchIAT(hk_D3D11CreateDeviceAndSwapChainUpscaling, "d3d11.dll", "D3D11CreateDeviceAndSwapChain");
-
-	// Install depth/stencil registration hook early (before renderer creates targets)
-	if (globals::game::isVR)
-		TAAReorder::InitEarly();
 }
 
 struct BSImageSpace_Init_FXAA
@@ -571,10 +530,6 @@ void Upscaling::PostPostLoad()
 	stl::detour_thunk<BSImageSpace_Init_FXAA>(REL::RelocationID(98974, 105626));
 
 	logger::info("[Upscaling] Installed hooks");
-
-	// Install TAA reordering hooks for VR periphery TAA
-	if (globals::game::isVR)
-		TAAReorder::Init();
 }
 
 Upscaling::UpscaleMethod Upscaling::GetUpscaleMethod() const
@@ -684,13 +639,6 @@ void Upscaling::DestroyUpscalingTextureResources(UpscaleMethod a_upscalemethod)
 		}
 	}
 
-	// VR periphery TAA textures - only needed for DLSS with viewport scaling
-	if (a_upscalemethod != UpscaleMethod::kDLSS) {
-		vrPreTAACopy = nullptr;
-		for (int i = 0; i < 2; i++)
-			vrTAAdPerEye[i].reset();
-	}
-
 	// Motion vector copy texture is only needed for DLSS - destroy when switching away from DLSS
 	if (a_upscalemethod != UpscaleMethod::kDLSS) {
 		if (motionVectorCopyTexture) {
@@ -744,8 +692,6 @@ void Upscaling::CheckResources(UpscaleMethod a_upscalemethod)
 						vrIntermediateMotionVectors[i].reset();
 						vrIntermediateReactiveMask[i].reset();
 						vrIntermediateTransparencyMask[i].reset();
-						vrFinalOutput[i].reset();
-						vrCropColorIn[i].reset();
 					}
 				}
 			}
@@ -798,8 +744,6 @@ ID3D11PixelShader* Upscaling::GetDepthRefractionUpscalePS()
 	if (!depthRefractionUpscalePS) {
 		logger::debug("Compiling DepthRefractionUpscalePS.hlsl");
 		std::vector<std::pair<const char*, const char*>> defines = { { "PSHADER", "" } };
-		if (globals::game::isVR)
-			defines.push_back({ "VR", "" });
 		depthRefractionUpscalePS.attach((ID3D11PixelShader*)Util::CompileShader(L"Data/Shaders/Upscaling/DepthRefractionUpscalePS.hlsl", defines, "ps_5_0"));
 	}
 
@@ -825,37 +769,6 @@ ID3D11VertexShader* Upscaling::GetUpscaleVS()
 	}
 
 	return upscaleVS.get();
-}
-
-ID3D11PixelShader* Upscaling::GetDlssCompositePS()
-{
-	if (!vrDlssCompositePS) {
-		logger::debug("Compiling DLSSCompositePS.hlsl");
-		vrDlssCompositePS.attach((ID3D11PixelShader*)Util::CompileShader(L"Data/Shaders/Upscaling/DLSSCompositePS.hlsl", { { "PSHADER", "" } }, "ps_5_0"));
-	}
-
-	return vrDlssCompositePS.get();
-}
-
-ID3D11PixelShader* Upscaling::GetDlssUpscalePS()
-{
-	if (!vrDlssUpscalePS) {
-		logger::debug("Compiling DLSSCompositePS.hlsl (BILINEAR_UPSCALE)");
-		vrDlssUpscalePS.attach((ID3D11PixelShader*)Util::CompileShader(
-			L"Data/Shaders/Upscaling/DLSSCompositePS.hlsl",
-			{ { "PSHADER", "" }, { "BILINEAR_UPSCALE", "" } }, "ps_5_0"));
-	}
-
-	if (!vrDlssUpscaleCB) {
-		D3D11_BUFFER_DESC cbDesc = {};
-		cbDesc.ByteWidth = sizeof(DlssCompositeCB);
-		cbDesc.Usage = D3D11_USAGE_DYNAMIC;
-		cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
-		cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
-		DX::ThrowIfFailed(globals::d3d::device->CreateBuffer(&cbDesc, nullptr, vrDlssUpscaleCB.put()));
-	}
-
-	return vrDlssUpscalePS.get();
 }
 
 eastl::unique_ptr<Texture2D> Upscaling::CreateTextureFromSource(ID3D11Resource* src, uint32_t width, uint32_t height,
@@ -907,7 +820,7 @@ void Upscaling::CreateVRIntermediateTextures(uint32_t inWidth, uint32_t inHeight
 		std::string suffix = (i == 0) ? "Left" : "Right";
 
 		vrIntermediateColorIn[i] = CreateTextureFromSource(colorSrc, inWidth, inHeight, false, true, true, ("Upscale_ColorIn_" + suffix).c_str());
-		vrIntermediateColorOut[i] = CreateTextureFromSource(colorSrc, outWidth, outHeight, false, true, true, ("Upscale_ColorOut_" + suffix).c_str());
+		vrIntermediateColorOut[i] = CreateTextureFromSource(colorSrc, outWidth, outHeight, false, true, false, ("Upscale_ColorOut_" + suffix).c_str());
 
 		// Depth: R32_TYPELESS base (matches kMAIN), with R32_FLOAT SRV for ClearHMDMaskCS.
 		// CopySubresourceRegion requires matching typeless formats; SRV reinterprets as R32_FLOAT.
@@ -960,185 +873,41 @@ void Upscaling::PreparePerEyeInputs(ID3D11Resource* colorSrc, ID3D11Resource* de
 	uint32_t eyeWidthIn = (uint32_t)(renderSize.x / 2);
 	uint32_t eyeHeightIn = (uint32_t)renderSize.y;
 
-	float vpScale = settings.vrDlssViewportScale;
-	auto upscaleMethod = GetUpscaleMethod();
-	bool viewportScaling = (vpScale < 1.0f) && (upscaleMethod == UpscaleMethod::kDLSS);
+	bool needsRecreate = !vrIntermediateColorIn[0] || !vrIntermediateColorOut[0];
+	if (!needsRecreate) {
+		needsRecreate = (vrIntermediateColorIn[0]->desc.Width != eyeWidthIn ||
+						 vrIntermediateColorIn[0]->desc.Height != eyeHeightIn ||
+						 vrIntermediateColorOut[0]->desc.Width != eyeWidthOut ||
+						 vrIntermediateColorOut[0]->desc.Height != eyeHeightOut);
+	}
+	if (needsRecreate) {
+		logger::info("[Upscaling] (Re)creating VR intermediates: per-eye in {}x{}, out {}x{}",
+			eyeWidthIn, eyeHeightIn, eyeWidthOut, eyeHeightOut);
+		CreateVRIntermediateTextures(eyeWidthIn, eyeHeightIn, eyeWidthOut, eyeHeightOut,
+			colorSrc, mvecSrc, reactiveSrc, transparencySrc);
+	}
 
-	if (viewportScaling) {
-		// Viewport scaling: physically crop all DLSS inputs to eliminate non-zero subrect offsets.
-		// vrIntermediateColorIn stays at FULL render-res (for ClearHMDMask + FillPeriphery).
-		// All other DLSS inputs (depth, mvec, masks) are CROP-sized.
-		// vrCropColorIn is CROP-sized (DLSS color input, extracted from masked full color).
-		// This ensures DLSS sees all inputs at {0,0} with no subrect base offsets,
-		// which is critical for correct temporal reprojection during camera motion.
-		uint32_t cropWidthIn = (uint32_t)(eyeWidthIn * vpScale);
-		uint32_t cropHeightIn = (uint32_t)(eyeHeightIn * vpScale);
-		uint32_t cropWidthOut = (uint32_t)(eyeWidthOut * vpScale);
-		uint32_t cropHeightOut = (uint32_t)(eyeHeightOut * vpScale);
+	// Extract both eyes' inputs from combined stereo buffers
+	for (uint32_t i = 0; i < 2; ++i) {
+		uint32_t offsetXIn = (i == 1) ? eyeWidthIn : 0;
+		D3D11_BOX srcBox = { offsetXIn, 0, 0, offsetXIn + eyeWidthIn, eyeHeightIn, 1 };
 
-		bool needsRecreate = !vrIntermediateColorIn[0] || !vrCropColorIn[0] || !vrIntermediateDepth[0] ||
-		                     !vrIntermediateColorOut[0] || !vrFinalOutput[0];
-		if (!needsRecreate) {
-			// Check format too — periphery TAA feeds R8G8B8A8 post-PP intermediate,
-			// while normal DLSS feeds R11G11B10 kMAIN. Must recreate on format change.
-			D3D11_TEXTURE2D_DESC srcDesc;
-			((ID3D11Texture2D*)colorSrc)->GetDesc(&srcDesc);
-			needsRecreate = (vrIntermediateColorIn[0]->desc.Width != eyeWidthIn ||
-							 vrIntermediateColorIn[0]->desc.Height != eyeHeightIn ||
-							 vrIntermediateColorIn[0]->desc.Format != srcDesc.Format ||
-							 vrCropColorIn[0]->desc.Width != cropWidthIn ||
-							 vrCropColorIn[0]->desc.Height != cropHeightIn ||
-							 vrIntermediateDepth[0]->desc.Width != cropWidthIn ||
-							 vrIntermediateDepth[0]->desc.Height != cropHeightIn ||
-							 vrIntermediateColorOut[0]->desc.Width != cropWidthOut ||
-							 vrIntermediateColorOut[0]->desc.Height != cropHeightOut ||
-							 vrFinalOutput[0]->desc.Width != eyeWidthOut ||
-							 vrFinalOutput[0]->desc.Height != eyeHeightOut);
-		}
+		context->CopySubresourceRegion(vrIntermediateColorIn[i]->resource.get(), 0, 0, 0, 0, colorSrc, 0, &srcBox);
+		context->CopySubresourceRegion(vrIntermediateDepth[i]->resource.get(), 0, 0, 0, 0, depthSrc, 0, &srcBox);
+		context->CopySubresourceRegion(vrIntermediateMotionVectors[i]->resource.get(), 0, 0, 0, 0, mvecSrc, 0, &srcBox);
+		context->CopySubresourceRegion(vrIntermediateTransparencyMask[i]->resource.get(), 0, 0, 0, 0, transparencySrc, 0, &srcBox);
+		context->CopySubresourceRegion(vrIntermediateReactiveMask[i]->resource.get(), 0, 0, 0, 0, reactiveSrc, 0, &srcBox);
+	}
 
-		if (needsRecreate) {
-			logger::info("[Upscaling] (Re)creating VR viewport-scaled intermediates: full {}x{}, crop in {}x{}, crop out {}x{}",
-				eyeWidthIn, eyeHeightIn, cropWidthIn, cropHeightIn, cropWidthOut, cropHeightOut);
+	// Zero color where depth == 0 (HMD hidden area) in each per-eye buffer.
+	// Depth is read from the combined stereo SRV at the per-eye offset; color is written
+	// to the isolated per-eye UAV (ColorOffsetX = 0).
+	auto& depthTexture = globals::game::renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
 
-			for (int i = 0; i < 2; i++) {
-				std::string suffix = (i == 0) ? "Left" : "Right";
-
-				// Full-size color for ClearHMDMask + FillPeriphery
-				vrIntermediateColorIn[i] = CreateTextureFromSource(colorSrc, eyeWidthIn, eyeHeightIn,
-					false, true, true, ("Upscale_ColorIn_" + suffix).c_str());
-
-				// Crop-sized DLSS color input (needs UAV for ClearHMDMask)
-				vrCropColorIn[i] = CreateTextureFromSource(colorSrc, cropWidthIn, cropHeightIn,
-					false, true, true, ("Upscale_CropColorIn_" + suffix).c_str());
-
-				// Crop-sized DLSS output
-				vrIntermediateColorOut[i] = CreateTextureFromSource(colorSrc, cropWidthOut, cropHeightOut,
-					false, true, true, ("Upscale_ColorOut_" + suffix).c_str());
-
-				// Crop-sized depth (R32_TYPELESS with R32_FLOAT SRV)
-				{
-					D3D11_TEXTURE2D_DESC depthDesc = {};
-					depthDesc.Width = cropWidthIn;
-					depthDesc.Height = cropHeightIn;
-					depthDesc.MipLevels = 1;
-					depthDesc.ArraySize = 1;
-					depthDesc.Format = DXGI_FORMAT_R32_TYPELESS;
-					depthDesc.SampleDesc.Count = 1;
-					depthDesc.Usage = D3D11_USAGE_DEFAULT;
-					depthDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
-					vrIntermediateDepth[i] = eastl::make_unique<Texture2D>(depthDesc);
-					Util::SetResourceName(vrIntermediateDepth[i]->resource.get(), ("Upscale_Depth_" + suffix).c_str());
-
-					D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-					srvDesc.Format = DXGI_FORMAT_R32_FLOAT;
-					srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-					srvDesc.Texture2D.MipLevels = 1;
-					vrIntermediateDepth[i]->CreateSRV(srvDesc);
-				}
-
-				// Crop-sized motion vectors, reactive mask, transparency mask
-				vrIntermediateMotionVectors[i] = CreateTextureFromSource(mvecSrc, cropWidthIn, cropHeightIn,
-					false, true, false, ("Upscale_MVec_" + suffix).c_str());
-				vrIntermediateReactiveMask[i] = CreateTextureFromSource(reactiveSrc, cropWidthIn, cropHeightIn,
-					false, true, false, ("Upscale_Reactive_" + suffix).c_str());
-				vrIntermediateTransparencyMask[i] = CreateTextureFromSource(transparencySrc, cropWidthIn, cropHeightIn,
-					false, true, false, ("Upscale_Transparency_" + suffix).c_str());
-
-				// Full display-res composition target
-				vrFinalOutput[i] = CreateTextureFromSource(colorSrc, eyeWidthOut, eyeHeightOut,
-					false, true, true, ("Upscale_FinalOutput_" + suffix).c_str());
-			}
-		}
-
-		// Copy full eye to full-size vrIntermediateColorIn (raw render-res, no HMD mask yet)
-		for (uint32_t i = 0; i < 2; ++i) {
-			uint32_t offsetXIn = (i == 1) ? eyeWidthIn : 0;
-			D3D11_BOX srcBox = { offsetXIn, 0, 0, offsetXIn + eyeWidthIn, eyeHeightIn, 1 };
-			context->CopySubresourceRegion(vrIntermediateColorIn[i]->resource.get(), 0, 0, 0, 0, colorSrc, 0, &srcBox);
-		}
-
-		uint32_t cropOffsetX = (eyeWidthIn - cropWidthIn) / 2;
-		uint32_t cropOffsetY = (eyeHeightIn - cropHeightIn) / 2;
-		auto& depthTexture = globals::game::renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
-
-		// Extract DLSS crop from raw buffer (before TAA or HMD mask), then mask the crop directly.
-		for (uint32_t i = 0; i < 2; ++i) {
-			uint32_t offsetXIn = (i == 1) ? eyeWidthIn : 0;
-
-			// Crop color from raw (unmasked, non-TAA'd) full-size buffer
-			D3D11_BOX cropBox = { cropOffsetX, cropOffsetY, 0, cropOffsetX + cropWidthIn, cropOffsetY + cropHeightIn, 1 };
-			context->CopySubresourceRegion(vrCropColorIn[i]->resource.get(), 0, 0, 0, 0,
-				vrIntermediateColorIn[i]->resource.get(), 0, &cropBox);
-
-			// ClearHMDMask directly on the crop (depth offset accounts for eye + crop position in stereo buffer)
-			ClearHMDMask(vrCropColorIn[i]->uav.get(), depthTexture.depthSRV,
-				cropWidthIn, cropHeightIn, offsetXIn + cropOffsetX, 0, cropOffsetY);
-
-			// Crop depth/mvec/reactive/transparency directly from stereo buffers
-			D3D11_BOX stereoCropBox = { offsetXIn + cropOffsetX, cropOffsetY, 0,
-				offsetXIn + cropOffsetX + cropWidthIn, cropOffsetY + cropHeightIn, 1 };
-			context->CopySubresourceRegion(vrIntermediateDepth[i]->resource.get(), 0, 0, 0, 0,
-				depthSrc, 0, &stereoCropBox);
-			context->CopySubresourceRegion(vrIntermediateMotionVectors[i]->resource.get(), 0, 0, 0, 0,
-				mvecSrc, 0, &stereoCropBox);
-			context->CopySubresourceRegion(vrIntermediateReactiveMask[i]->resource.get(), 0, 0, 0, 0,
-				reactiveSrc, 0, &stereoCropBox);
-			context->CopySubresourceRegion(vrIntermediateTransparencyMask[i]->resource.get(), 0, 0, 0, 0,
-				transparencySrc, 0, &stereoCropBox);
-		}
-
-		// ClearHMDMask on full-size buffer (for FillPeriphery)
-		for (uint32_t i = 0; i < 2; ++i) {
-			uint32_t depthOffset = (i == 1) ? eyeWidthIn : 0;
-			ClearHMDMask(vrIntermediateColorIn[i]->uav.get(), depthTexture.depthSRV,
-				eyeWidthIn, eyeHeightIn, depthOffset, 0);
-		}
-	} else {
-		// Non-viewport-scaling path: all textures at full per-eye dimensions
-		bool needsRecreate = !vrIntermediateColorIn[0] || !vrIntermediateColorOut[0];
-		if (!needsRecreate) {
-			D3D11_TEXTURE2D_DESC srcDesc;
-			((ID3D11Texture2D*)colorSrc)->GetDesc(&srcDesc);
-			needsRecreate = (vrIntermediateColorIn[0]->desc.Width != eyeWidthIn ||
-							 vrIntermediateColorIn[0]->desc.Height != eyeHeightIn ||
-							 vrIntermediateColorIn[0]->desc.Format != srcDesc.Format ||
-							 vrIntermediateColorOut[0]->desc.Width != eyeWidthOut ||
-							 vrIntermediateColorOut[0]->desc.Height != eyeHeightOut);
-		}
-		if (needsRecreate) {
-			logger::info("[Upscaling] (Re)creating VR intermediates: per-eye in {}x{}, out {}x{}",
-				eyeWidthIn, eyeHeightIn, eyeWidthOut, eyeHeightOut);
-			CreateVRIntermediateTextures(eyeWidthIn, eyeHeightIn, eyeWidthOut, eyeHeightOut,
-				colorSrc, mvecSrc, reactiveSrc, transparencySrc);
-		}
-
-		// Release viewport-scaling-specific textures
-		for (int i = 0; i < 2; i++) {
-			vrCropColorIn[i].reset();
-			vrFinalOutput[i].reset();
-			vrTAAdPerEye[i].reset();
-		}
-		vrPreTAACopy = nullptr;
-
-		// Copy full eye to per-eye intermediates
-		for (uint32_t i = 0; i < 2; ++i) {
-			uint32_t offsetXIn = (i == 1) ? eyeWidthIn : 0;
-			D3D11_BOX srcBox = { offsetXIn, 0, 0, offsetXIn + eyeWidthIn, eyeHeightIn, 1 };
-
-			context->CopySubresourceRegion(vrIntermediateColorIn[i]->resource.get(), 0, 0, 0, 0, colorSrc, 0, &srcBox);
-			context->CopySubresourceRegion(vrIntermediateDepth[i]->resource.get(), 0, 0, 0, 0, depthSrc, 0, &srcBox);
-			context->CopySubresourceRegion(vrIntermediateMotionVectors[i]->resource.get(), 0, 0, 0, 0, mvecSrc, 0, &srcBox);
-			context->CopySubresourceRegion(vrIntermediateTransparencyMask[i]->resource.get(), 0, 0, 0, 0, transparencySrc, 0, &srcBox);
-			context->CopySubresourceRegion(vrIntermediateReactiveMask[i]->resource.get(), 0, 0, 0, 0, reactiveSrc, 0, &srcBox);
-		}
-
-		// Zero color where depth == 0 (HMD hidden area) in each per-eye buffer
-		auto& depthTexture = globals::game::renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
-		for (uint32_t i = 0; i < 2; ++i) {
-			uint32_t depthOffset = (i == 1) ? eyeWidthIn : 0;
-			ClearHMDMask(vrIntermediateColorIn[i]->uav.get(), depthTexture.depthSRV,
-				eyeWidthIn, eyeHeightIn, depthOffset, 0);
-		}
+	for (uint32_t i = 0; i < 2; ++i) {
+		uint32_t depthOffset = (i == 1) ? eyeWidthIn : 0;
+		ClearHMDMask(vrIntermediateColorIn[i]->uav.get(), depthTexture.depthSRV,
+			eyeWidthIn, eyeHeightIn, depthOffset, 0);
 	}
 
 	if (state->frameAnnotations)
@@ -1160,34 +929,11 @@ void Upscaling::FinalizePerEyeOutputs(ID3D11Resource* colorDst)
 	uint32_t eyeWidthOut = (uint32_t)(screenSize.x / 2);
 	uint32_t eyeHeightOut = (uint32_t)screenSize.y;
 
-	float vpScale = settings.vrDlssViewportScale;
-	auto upscaleMethod = GetUpscaleMethod();
-	bool viewportScaling = (vpScale < 1.0f) && (upscaleMethod == UpscaleMethod::kDLSS);
-
+	// Write upscaled outputs back
 	for (uint32_t i = 0; i < 2; ++i) {
 		uint32_t offsetXOut = (i == 1) ? eyeWidthOut : 0;
-
-		if (viewportScaling && vrFinalOutput[i]) {
-			// Paste crop-sized DLSS output into center of full-size composition target
-			uint32_t dlssWidthOut = vrIntermediateColorOut[i]->desc.Width;
-			uint32_t dlssHeightOut = vrIntermediateColorOut[i]->desc.Height;
-			uint32_t pasteX = (eyeWidthOut - dlssWidthOut) / 2;
-			uint32_t pasteY = (eyeHeightOut - dlssHeightOut) / 2;
-
-			D3D11_BOX dlssBox = { 0, 0, 0, dlssWidthOut, dlssHeightOut, 1 };
-			context->CopySubresourceRegion(vrFinalOutput[i]->resource.get(), 0, pasteX, pasteY, 0,
-				vrIntermediateColorOut[i]->resource.get(), 0, &dlssBox);
-
-			// Copy composition target to stereo buffer
-			D3D11_BOX outBox = { 0, 0, 0, eyeWidthOut, eyeHeightOut, 1 };
-			context->CopySubresourceRegion(colorDst, 0, offsetXOut, 0, 0,
-				vrFinalOutput[i]->resource.get(), 0, &outBox);
-		} else {
-			// Direct copy DLSS output to stereo buffer
-			D3D11_BOX outBox = { 0, 0, 0, eyeWidthOut, eyeHeightOut, 1 };
-			context->CopySubresourceRegion(colorDst, 0, offsetXOut, 0, 0,
-				vrIntermediateColorOut[i]->resource.get(), 0, &outBox);
-		}
+		D3D11_BOX outBox = { 0, 0, 0, eyeWidthOut, eyeHeightOut, 1 };
+		context->CopySubresourceRegion(colorDst, 0, offsetXOut, 0, 0, vrIntermediateColorOut[i]->resource.get(), 0, &outBox);
 	}
 
 	if (state->frameAnnotations)
@@ -1195,11 +941,7 @@ void Upscaling::FinalizePerEyeOutputs(ID3D11Resource* colorDst)
 }
 
 void Upscaling::ClearHMDMask(ID3D11UnorderedAccessView* colorUAV, ID3D11ShaderResourceView* depthSRV,
-	uint32_t eyeWidth, uint32_t eyeHeight, uint32_t depthOffsetX, uint32_t colorOffsetX,
-	uint32_t depthOffsetY,
-	uint32_t depthWidth, uint32_t depthHeight,
-	uint32_t colorWidth, uint32_t colorHeight,
-	ID3D11ShaderResourceView* fallbackSRV, uint32_t fallbackOffsetX)
+	uint32_t eyeWidth, uint32_t eyeHeight, uint32_t depthOffsetX, uint32_t colorOffsetX)
 {
 	if (!globals::game::isVR)
 		return;
@@ -1210,7 +952,7 @@ void Upscaling::ClearHMDMask(ID3D11UnorderedAccessView* colorUAV, ID3D11ShaderRe
 		vrClearHMDMaskCS.attach((ID3D11ComputeShader*)Util::CompileShader(L"Data/Shaders/Upscaling/ClearHMDMaskCS.hlsl", {}, "cs_5_0"));
 
 		D3D11_BUFFER_DESC cbDesc = {};
-		cbDesc.ByteWidth = 32;  // 8 uints (offsets + optional scaling dimensions)
+		cbDesc.ByteWidth = 16;  // 4 uints
 		cbDesc.Usage = D3D11_USAGE_DYNAMIC;
 		cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
 		cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
@@ -1223,9 +965,8 @@ void Upscaling::ClearHMDMask(ID3D11UnorderedAccessView* colorUAV, ID3D11ShaderRe
 
 		context->CSSetShader(vrClearHMDMaskCS.get(), nullptr, 0);
 
-		// t0 = depth, t1 = fallback (nullptr → unbound → reads return (0,0,0,0) → black)
-		ID3D11ShaderResourceView* srvs[2] = { depthSRV, fallbackSRV };
-		context->CSSetShaderResources(0, 2, srvs);
+		ID3D11ShaderResourceView* srvs[1] = { depthSRV };
+		context->CSSetShaderResources(0, 1, srvs);
 
 		ID3D11UnorderedAccessView* uavs[1] = { colorUAV };
 		context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
@@ -1233,10 +974,9 @@ void Upscaling::ClearHMDMask(ID3D11UnorderedAccessView* colorUAV, ID3D11ShaderRe
 		D3D11_MAPPED_SUBRESOURCE mapped{};
 		context->Map(vrClearHMDMaskCB.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
 
-		uint32_t cbData[8] = { depthOffsetX, colorOffsetX, depthOffsetY, fallbackOffsetX,
-			depthWidth, depthHeight, colorWidth, colorHeight };
+		uint32_t offsets[4] = { depthOffsetX, colorOffsetX, 0, 0 };
 
-		memcpy(mapped.pData, cbData, sizeof(cbData));
+		memcpy(mapped.pData, offsets, sizeof(offsets));
 		context->Unmap(vrClearHMDMaskCB.get(), 0);
 
 		ID3D11Buffer* cbs[1] = { vrClearHMDMaskCB.get() };
@@ -1245,80 +985,12 @@ void Upscaling::ClearHMDMask(ID3D11UnorderedAccessView* colorUAV, ID3D11ShaderRe
 		context->Dispatch(dispatchX, dispatchY, 1);
 
 		// Unbind
-		ID3D11ShaderResourceView* nullSRVs[2] = { nullptr, nullptr };
-		ID3D11UnorderedAccessView* nullUAV[1] = { nullptr };
-		ID3D11Buffer* nullCB[1] = { nullptr };
-		context->CSSetShaderResources(0, 2, nullSRVs);
-		context->CSSetUnorderedAccessViews(0, 1, nullUAV, nullptr);
-		context->CSSetConstantBuffers(0, 1, nullCB);
-		context->CSSetShader(nullptr, nullptr, 0);
-	}
-}
-
-void Upscaling::FillPeriphery(uint32_t eyeIndex, uint32_t srcWidth, uint32_t srcHeight,
-	uint32_t dstWidth, uint32_t dstHeight, ID3D11ShaderResourceView* overrideSRV)
-{
-	if (!globals::game::isVR || !vrFinalOutput[eyeIndex])
-		return;
-	if (!overrideSRV && !vrIntermediateColorIn[eyeIndex])
-		return;
-
-	auto context = globals::d3d::context;
-
-	if (!vrPeripheryFillCS) {
-		vrPeripheryFillCS.attach((ID3D11ComputeShader*)Util::CompileShader(L"Data/Shaders/Upscaling/VRPeripheryFillCS.hlsl", {}, "cs_5_0"));
-
-		D3D11_BUFFER_DESC cbDesc = {};
-		cbDesc.ByteWidth = 16;  // 4 uints
-		cbDesc.Usage = D3D11_USAGE_DYNAMIC;
-		cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
-		cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
-		DX::ThrowIfFailed(globals::d3d::device->CreateBuffer(&cbDesc, nullptr, vrPeripheryFillCB.put()));
-
-		D3D11_SAMPLER_DESC samplerDesc = {};
-		samplerDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
-		samplerDesc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
-		samplerDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
-		samplerDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
-		DX::ThrowIfFailed(globals::d3d::device->CreateSamplerState(&samplerDesc, vrLinearSampler.put()));
-	}
-
-	if (vrPeripheryFillCS) {
-		auto dispatchX = (dstWidth + 7) / 8;
-		auto dispatchY = (dstHeight + 7) / 8;
-
-		context->CSSetShader(vrPeripheryFillCS.get(), nullptr, 0);
-
-		// Read from overrideSRV (e.g. TAA texture) or default render-res per-eye input.
-		ID3D11ShaderResourceView* srvs[1] = { overrideSRV ? overrideSRV : vrIntermediateColorIn[eyeIndex]->srv.get() };
-		context->CSSetShaderResources(0, 1, srvs);
-
-		ID3D11UnorderedAccessView* uavs[1] = { vrFinalOutput[eyeIndex]->uav.get() };
-		context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
-
-		ID3D11SamplerState* samplers[1] = { vrLinearSampler.get() };
-		context->CSSetSamplers(0, 1, samplers);
-
-		D3D11_MAPPED_SUBRESOURCE mapped{};
-		context->Map(vrPeripheryFillCB.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
-		uint32_t cbData[4] = { srcWidth, srcHeight, dstWidth, dstHeight };
-		memcpy(mapped.pData, cbData, sizeof(cbData));
-		context->Unmap(vrPeripheryFillCB.get(), 0);
-
-		ID3D11Buffer* cbs[1] = { vrPeripheryFillCB.get() };
-		context->CSSetConstantBuffers(0, 1, cbs);
-
-		context->Dispatch(dispatchX, dispatchY, 1);
-
-		// Unbind
 		ID3D11ShaderResourceView* nullSRV[1] = { nullptr };
 		ID3D11UnorderedAccessView* nullUAV[1] = { nullptr };
 		ID3D11Buffer* nullCB[1] = { nullptr };
-		ID3D11SamplerState* nullSampler[1] = { nullptr };
 		context->CSSetShaderResources(0, 1, nullSRV);
 		context->CSSetUnorderedAccessViews(0, 1, nullUAV, nullptr);
 		context->CSSetConstantBuffers(0, 1, nullCB);
-		context->CSSetSamplers(0, 1, nullSampler);
 		context->CSSetShader(nullptr, nullptr, 0);
 	}
 }
@@ -1429,10 +1101,6 @@ void Upscaling::ConfigureUpscaling(RE::BSGraphics::State* a_viewport)
 	// Disable dynamic resolution unless the game explicitly enables it
 	if (!globals::game::isVR)
 		runtimeData.dynamicResolutionLock = 1;
-
-	// VR depth buffer culling is now compatible with upscaling thanks to depth buffer upscaling.
-	// No longer need to force-disable culling when upscaling is active.
-	// The depth buffer is upscaled in UpscaleDepth() before OBBOcclusionTesting runs.
 }
 
 void Upscaling::SetupResources()
@@ -1477,7 +1145,6 @@ void Upscaling::SetupResources()
 		depthStencilDesc.BackFace.StencilDepthFailOp = depthStencilDesc.FrontFace.StencilDepthFailOp;
 		depthStencilDesc.BackFace.StencilPassOp = depthStencilDesc.FrontFace.StencilPassOp;
 		depthStencilDesc.BackFace.StencilFunc = depthStencilDesc.FrontFace.StencilFunc;
-
 	} else {
 		depthStencilDesc.StencilEnable = false;  // Disable stencil testing
 	}
@@ -1531,12 +1198,6 @@ void Upscaling::ClearShaderCache()
 	depthRefractionUpscalePS = nullptr;  // com_ptr automatically releases
 	underwaterMaskUpscalePS = nullptr;   // com_ptr automatically releases
 	upscaleVS = nullptr;                 // com_ptr automatically releases
-	vrClearHMDMaskCS = nullptr;
-	vrPeripheryFillCS = nullptr;
-	vrPeripheryFillCB = nullptr;
-	vrDlssCompositePS = nullptr;
-	vrDlssUpscalePS = nullptr;
-	vrDlssUpscaleCB = nullptr;
 }
 
 void Upscaling::CopySharedD3D12Resources()
@@ -1747,17 +1408,6 @@ bool Upscaling::IsUpscalingActive() const
 	return resolutionScale.x < .99f;
 }
 
-std::vector<FeatureConstraints::Constraint> Upscaling::GetActiveConstraints() const
-{
-	std::vector<FeatureConstraints::Constraint> constraints;
-
-	// VR depth buffer culling is now compatible with upscaling thanks to depth buffer upscaling.
-	// The depth buffer is upscaled in UpscaleDepth() before OBBOcclusionTesting runs,
-	// so we no longer need to constrain depth buffer culling when upscaling is active.
-
-	return constraints;
-}
-
 /**
  * @brief Retrieves the current frame time for frame generation.
  *
@@ -1869,7 +1519,7 @@ Upscaling::BlurResources Upscaling::GetBlurResources() const
 	return {};
 }
 
-void Upscaling::Upscale(ID3D11Texture2D* colorSourceOverride)
+void Upscaling::Upscale()
 {
 	auto upscaleMethod = GetUpscaleMethod();
 
@@ -1930,11 +1580,8 @@ void Upscaling::Upscale(ID3D11Texture2D* colorSourceOverride)
 	{
 		state->BeginPerfEvent("Upscaling");
 
-		// Use color source override if provided (e.g., post-PP intermediate for periphery TAA)
-		ID3D11Resource* colorSrc = colorSourceOverride ? static_cast<ID3D11Resource*>(colorSourceOverride) : static_cast<ID3D11Resource*>(main.texture);
-
 		if (upscaleMethod == UpscaleMethod::kDLSS) {
-			streamline.Upscale(colorSrc, reactiveMaskTexture->resource.get(), transparencyCompositionMaskTexture->resource.get(), motionVectorCopyTexture->resource.get());
+			streamline.Upscale(main.texture, reactiveMaskTexture->resource.get(), transparencyCompositionMaskTexture->resource.get(), motionVectorCopyTexture->resource.get());
 		} else if (upscaleMethod == UpscaleMethod::kFSR) {
 			fidelityFX.Upscale(main.texture, reactiveMaskTexture->resource.get(), transparencyCompositionMaskTexture->resource.get(), motionVector.texture, settings.sharpnessFSR);
 		}
@@ -2174,73 +1821,20 @@ void Upscaling::Main_PostProcessing::thunk(RE::ImageSpaceManager* a_this, uint32
 	if (upscaling.d3d12SwapChainActive && upscaling.settings.frameGenerationMode)
 		upscaling.CopySharedD3D12Resources();
 
-	// Increment diagnostic counter (rate-limits TAAReorder logging)
-	if (TAAReorder::g_initialized) {
-		TAAReorder::g_diagCounter = (TAAReorder::g_diagCounter + 1) % TAAReorder::DIAG_INTERVAL;
-		if (TAAReorder::g_diagCounter == 0) {
-			TAAReorder::g_frameSeqCounter = 0;
-			logger::info("[SEQ] Main_PostProcessing START seq={}", TAAReorder::g_frameSeqCounter++);
-		}
-	}
+	if (upscaleMethod != UpscaleMethod::kNONE && upscaleMethod != UpscaleMethod::kTAA)
+		upscaling.PerformUpscaling();
 
-	bool peripheryTAA = TAAReorder::ShouldReorderTAA();
+	if (upscaleMethod == UpscaleMethod::kDLSS)
+		upscaling.ApplySharpening();
 
-	if (peripheryTAA) {
-		// ─── Periphery TAA with post-conductor DLSS (PureDark's approach) ───
-		// func() with TAA enabled → conductor runs all passes unimpeded:
-		//   Phase 2A: ExecutePassHook captures post-PP intermediate to g_postPPCopy
-		//   Phase 5: TAA + DRS → submit texture
-		// After conductor: ConductorCallHook evaluates DLSS on g_postPPCopy,
-		// then pastes DLSS center onto submit texture
+	auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
+	GET_INSTANCE_MEMBER(BSImagespaceShaderISTemporalAA, imageSpaceManager);
 
-		auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
-		GET_INSTANCE_MEMBER(BSImagespaceShaderISTemporalAA, imageSpaceManager);
+	BSImagespaceShaderISTemporalAA->taaEnabled = upscaleMethod == UpscaleMethod::kTAA;
 
-		// Reset per-frame flags
-		TAAReorder::g_postPPReady = false;
-		TAAReorder::g_dlssReady = false;
-		TAAReorder::g_dlssPasteComplete = false;
-		TAAReorder::g_phase5Complete = false;
-		TAAReorder::g_bsHookCallCount = 0;
+	func(a_this, a3, a_target, a_4, a_5);
 
-		if (TAAReorder::g_diagCounter == 0)
-			logger::info("[TAAReorder] peripheryTAA: running func() with TAA enabled...");
-
-		// func() with TAA ENABLED — DLSS eval + paste in ConductorCallHook (post-conductor)
-		BSImagespaceShaderISTemporalAA->taaEnabled = true;
-		func(a_this, a3, a_target, a_4, a_5);
-
-		// Lock DRS + update camera (after conductor completes)
-		auto& runtimeData = globals::game::graphicsState->GetRuntimeData();
-		runtimeData.dynamicResolutionLock = 1;
-		UpdateCameraData();
-
-		// Disable TAA for remainder of frame
-		BSImagespaceShaderISTemporalAA->taaEnabled = false;
-	} else {
-		// ─── Normal flow (no periphery TAA) ───
-		if (upscaleMethod != UpscaleMethod::kNONE && upscaleMethod != UpscaleMethod::kTAA)
-			upscaling.PerformUpscaling();
-
-		if (upscaleMethod == UpscaleMethod::kDLSS)
-			upscaling.ApplySharpening();
-
-		auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
-		GET_INSTANCE_MEMBER(BSImagespaceShaderISTemporalAA, imageSpaceManager);
-
-		BSImagespaceShaderISTemporalAA->taaEnabled = (upscaleMethod == UpscaleMethod::kTAA);
-
-		if (TAAReorder::g_diagCounter == 0 && TAAReorder::g_initialized)
-			logger::info("[DIAG] Normal DLSS flow: taaEnabled={}, running func()...", BSImagespaceShaderISTemporalAA->taaEnabled);
-
-		func(a_this, a3, a_target, a_4, a_5);
-
-		BSImagespaceShaderISTemporalAA->taaEnabled = false;
-	}
-
-	// VR CAS sharpening (after TAA)
-	if (REL::Module::IsVR() && globals::features::vrStereoOptimizations.loaded)
-		globals::features::vrStereoOptimizations.ApplyCAS(a_target);
+	BSImagespaceShaderISTemporalAA->taaEnabled = false;
 }
 
 void Upscaling::SetScissorRect::thunk(RE::BSGraphics::Renderer* This, int a_left, int a_top, int a_right, int a_bottom)

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1,7 +1,9 @@
 #include "Upscaling.h"
 
 #include "Deferred.h"
+#include "Features/VRStereoOptimizations.h"
 #include "Hooks.h"
+#include "TAAReorder.h"
 #include "State.h"
 #include "Upscaling/DX12SwapChain.h"
 #include "Upscaling/FidelityFX.h"
@@ -25,7 +27,9 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	sharpnessFSR,
 	sharpnessDLSS,
 	presetDLSS,
-	useGatherWideKernel);
+	useGatherWideKernel,
+	vrDlssViewportScale,
+	vrPeripheryTAA);
 
 decltype(&D3D11CreateDeviceAndSwapChain) ptrD3D11CreateDeviceAndSwapChainUpscaling;
 
@@ -61,7 +65,9 @@ HRESULT WINAPI hk_D3D11CreateDeviceAndSwapChainUpscaling(
 		upscaling.CheckBackendFeatures(pAdapter);
 
 	// Use better swap effect to prevent tearing and improve performance
-	pSwapChainDesc->SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+	// But don't change it for VR as it can affect frame pacing with the VR compositor
+	if (!globals::game::isVR)
+		pSwapChainDesc->SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
 
 	bool shouldProxy = !globals::game::isVR;
 	if (shouldProxy)
@@ -141,8 +147,11 @@ HRESULT WINAPI hk_D3D11CreateDeviceAndSwapChainUpscaling(
 		ppImmediateContext);
 
 	if (upscaling.IsBackendInitialized()) {
-		upscaling.UpgradeBackendInterface((void**)&(*ppDevice));
-		upscaling.UpgradeBackendInterface((void**)&(*ppSwapChain));
+		// Skip interface wrapping for VR - it can affect frame pacing with VR compositor
+		if (!globals::game::isVR) {
+			upscaling.UpgradeBackendInterface((void**)&(*ppDevice));
+			upscaling.UpgradeBackendInterface((void**)&(*ppSwapChain));
+		}
 		upscaling.SetBackendD3DDevice(*ppDevice);
 		upscaling.PostBackendDevice();
 	}
@@ -237,6 +246,30 @@ void Upscaling::DrawSettings()
 				ImGui::Text("Each model offers different visual quality, performance, and motion stability.");
 				ImGui::Text("Set to 'Default' for automatic selection based on your Upscale Preset and hardware.");
 				ImGui::Text("Changing this setting requires a restart to take effect.");
+			}
+
+			if (globals::game::isVR) {
+				if (ImGui::TreeNodeEx("VR Viewport Scaling", ImGuiTreeNodeFlags_DefaultOpen)) {
+					ImGui::SliderFloat("DLSS Viewport Scale", &settings.vrDlssViewportScale, 0.5f, 1.0f, "%.2f");
+					if (auto _tt = Util::HoverTooltipWrapper()) {
+						ImGui::Text("Controls the fraction of each eye's view that DLSS processes.");
+						ImGui::Text("Lower values = better performance, less visible area upscaled by DLSS.");
+						ImGui::Text("The VR lens hides the periphery, so 0.7-0.85 is recommended.");
+						ImGui::Text("The periphery outside the DLSS region is filled with a bilinear upscale.");
+					}
+
+					if (settings.vrDlssViewportScale < 1.0f) {
+						bool peripheryTAA = settings.vrPeripheryTAA != 0;
+						if (ImGui::Checkbox("Periphery TAA", &peripheryTAA))
+							settings.vrPeripheryTAA = peripheryTAA ? 1 : 0;
+						if (auto _tt = Util::HoverTooltipWrapper()) {
+							ImGui::Text("Applies temporal anti-aliasing to the bilinear-upscaled periphery.");
+							ImGui::Text("Reduces shimmer and improves peripheral quality.");
+							ImGui::Text("The DLSS center region passes through unchanged.");
+						}
+					}
+					ImGui::TreePop();
+				}
 			}
 		}
 
@@ -460,6 +493,7 @@ void Upscaling::LoadSettings(json& o_json)
 		logger::warn("[Upscaling] Loaded useGatherWideKernel {} out of range, clamping to 1", settings.useGatherWideKernel);
 		settings.useGatherWideKernel = 1;
 	}
+	settings.vrDlssViewportScale = std::clamp(settings.vrDlssViewportScale, 0.5f, 1.0f);
 	auto iniSettingCollection = globals::game::iniPrefSettingCollection;
 	if (iniSettingCollection) {
 		auto setting = iniSettingCollection->GetSetting("bUseTAA:Display");
@@ -487,6 +521,10 @@ void Upscaling::DataLoaded()
 void Upscaling::Load()
 {
 	*(uintptr_t*)&ptrD3D11CreateDeviceAndSwapChainUpscaling = SKSE::PatchIAT(hk_D3D11CreateDeviceAndSwapChainUpscaling, "d3d11.dll", "D3D11CreateDeviceAndSwapChain");
+
+	// Install depth/stencil registration hook early (before renderer creates targets)
+	if (globals::game::isVR)
+		TAAReorder::InitEarly();
 }
 
 struct BSImageSpace_Init_FXAA
@@ -530,6 +568,10 @@ void Upscaling::PostPostLoad()
 	stl::detour_thunk<BSImageSpace_Init_FXAA>(REL::RelocationID(98974, 105626));
 
 	logger::info("[Upscaling] Installed hooks");
+
+	// Install TAA reordering hooks for VR periphery TAA
+	if (globals::game::isVR)
+		TAAReorder::Init();
 }
 
 Upscaling::UpscaleMethod Upscaling::GetUpscaleMethod() const
@@ -639,6 +681,13 @@ void Upscaling::DestroyUpscalingTextureResources(UpscaleMethod a_upscalemethod)
 		}
 	}
 
+	// VR periphery TAA textures - only needed for DLSS with viewport scaling
+	if (a_upscalemethod != UpscaleMethod::kDLSS) {
+		vrPreTAACopy = nullptr;
+		for (int i = 0; i < 2; i++)
+			vrTAAdPerEye[i].reset();
+	}
+
 	// Motion vector copy texture is only needed for DLSS - destroy when switching away from DLSS
 	if (a_upscalemethod != UpscaleMethod::kDLSS) {
 		if (motionVectorCopyTexture) {
@@ -692,6 +741,8 @@ void Upscaling::CheckResources(UpscaleMethod a_upscalemethod)
 						vrIntermediateMotionVectors[i].reset();
 						vrIntermediateReactiveMask[i].reset();
 						vrIntermediateTransparencyMask[i].reset();
+						vrFinalOutput[i].reset();
+						vrCropColorIn[i].reset();
 					}
 				}
 			}
@@ -744,6 +795,8 @@ ID3D11PixelShader* Upscaling::GetDepthRefractionUpscalePS()
 	if (!depthRefractionUpscalePS) {
 		logger::debug("Compiling DepthRefractionUpscalePS.hlsl");
 		std::vector<std::pair<const char*, const char*>> defines = { { "PSHADER", "" } };
+		if (globals::game::isVR)
+			defines.push_back({ "VR", "" });
 		depthRefractionUpscalePS.attach((ID3D11PixelShader*)Util::CompileShader(L"Data/Shaders/Upscaling/DepthRefractionUpscalePS.hlsl", defines, "ps_5_0"));
 	}
 
@@ -769,6 +822,37 @@ ID3D11VertexShader* Upscaling::GetUpscaleVS()
 	}
 
 	return upscaleVS.get();
+}
+
+ID3D11PixelShader* Upscaling::GetDlssCompositePS()
+{
+	if (!vrDlssCompositePS) {
+		logger::debug("Compiling DLSSCompositePS.hlsl");
+		vrDlssCompositePS.attach((ID3D11PixelShader*)Util::CompileShader(L"Data/Shaders/Upscaling/DLSSCompositePS.hlsl", { { "PSHADER", "" } }, "ps_5_0"));
+	}
+
+	return vrDlssCompositePS.get();
+}
+
+ID3D11PixelShader* Upscaling::GetDlssUpscalePS()
+{
+	if (!vrDlssUpscalePS) {
+		logger::debug("Compiling DLSSCompositePS.hlsl (BILINEAR_UPSCALE)");
+		vrDlssUpscalePS.attach((ID3D11PixelShader*)Util::CompileShader(
+			L"Data/Shaders/Upscaling/DLSSCompositePS.hlsl",
+			{ { "PSHADER", "" }, { "BILINEAR_UPSCALE", "" } }, "ps_5_0"));
+	}
+
+	if (!vrDlssUpscaleCB) {
+		D3D11_BUFFER_DESC cbDesc = {};
+		cbDesc.ByteWidth = sizeof(DlssCompositeCB);
+		cbDesc.Usage = D3D11_USAGE_DYNAMIC;
+		cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+		cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+		DX::ThrowIfFailed(globals::d3d::device->CreateBuffer(&cbDesc, nullptr, vrDlssUpscaleCB.put()));
+	}
+
+	return vrDlssUpscalePS.get();
 }
 
 eastl::unique_ptr<Texture2D> Upscaling::CreateTextureFromSource(ID3D11Resource* src, uint32_t width, uint32_t height,
@@ -820,7 +904,7 @@ void Upscaling::CreateVRIntermediateTextures(uint32_t inWidth, uint32_t inHeight
 		std::string suffix = (i == 0) ? "Left" : "Right";
 
 		vrIntermediateColorIn[i] = CreateTextureFromSource(colorSrc, inWidth, inHeight, false, true, true, ("Upscale_ColorIn_" + suffix).c_str());
-		vrIntermediateColorOut[i] = CreateTextureFromSource(colorSrc, outWidth, outHeight, false, true, false, ("Upscale_ColorOut_" + suffix).c_str());
+		vrIntermediateColorOut[i] = CreateTextureFromSource(colorSrc, outWidth, outHeight, false, true, true, ("Upscale_ColorOut_" + suffix).c_str());
 
 		// Depth: R32_TYPELESS base (matches kMAIN), with R32_FLOAT SRV for ClearHMDMaskCS.
 		// CopySubresourceRegion requires matching typeless formats; SRV reinterprets as R32_FLOAT.
@@ -873,41 +957,185 @@ void Upscaling::PreparePerEyeInputs(ID3D11Resource* colorSrc, ID3D11Resource* de
 	uint32_t eyeWidthIn = (uint32_t)(renderSize.x / 2);
 	uint32_t eyeHeightIn = (uint32_t)renderSize.y;
 
-	bool needsRecreate = !vrIntermediateColorIn[0] || !vrIntermediateColorOut[0];
-	if (!needsRecreate) {
-		needsRecreate = (vrIntermediateColorIn[0]->desc.Width != eyeWidthIn ||
-						 vrIntermediateColorIn[0]->desc.Height != eyeHeightIn ||
-						 vrIntermediateColorOut[0]->desc.Width != eyeWidthOut ||
-						 vrIntermediateColorOut[0]->desc.Height != eyeHeightOut);
-	}
-	if (needsRecreate) {
-		logger::info("[Upscaling] (Re)creating VR intermediates: per-eye in {}x{}, out {}x{}",
-			eyeWidthIn, eyeHeightIn, eyeWidthOut, eyeHeightOut);
-		CreateVRIntermediateTextures(eyeWidthIn, eyeHeightIn, eyeWidthOut, eyeHeightOut,
-			colorSrc, mvecSrc, reactiveSrc, transparencySrc);
-	}
+	float vpScale = settings.vrDlssViewportScale;
+	auto upscaleMethod = GetUpscaleMethod();
+	bool viewportScaling = (vpScale < 1.0f) && (upscaleMethod == UpscaleMethod::kDLSS);
 
-	// Extract both eyes' inputs from combined stereo buffers
-	for (uint32_t i = 0; i < 2; ++i) {
-		uint32_t offsetXIn = (i == 1) ? eyeWidthIn : 0;
-		D3D11_BOX srcBox = { offsetXIn, 0, 0, offsetXIn + eyeWidthIn, eyeHeightIn, 1 };
+	if (viewportScaling) {
+		// Viewport scaling: physically crop all DLSS inputs to eliminate non-zero subrect offsets.
+		// vrIntermediateColorIn stays at FULL render-res (for ClearHMDMask + FillPeriphery).
+		// All other DLSS inputs (depth, mvec, masks) are CROP-sized.
+		// vrCropColorIn is CROP-sized (DLSS color input, extracted from masked full color).
+		// This ensures DLSS sees all inputs at {0,0} with no subrect base offsets,
+		// which is critical for correct temporal reprojection during camera motion.
+		uint32_t cropWidthIn = (uint32_t)(eyeWidthIn * vpScale);
+		uint32_t cropHeightIn = (uint32_t)(eyeHeightIn * vpScale);
+		uint32_t cropWidthOut = (uint32_t)(eyeWidthOut * vpScale);
+		uint32_t cropHeightOut = (uint32_t)(eyeHeightOut * vpScale);
 
-		context->CopySubresourceRegion(vrIntermediateColorIn[i]->resource.get(), 0, 0, 0, 0, colorSrc, 0, &srcBox);
-		context->CopySubresourceRegion(vrIntermediateDepth[i]->resource.get(), 0, 0, 0, 0, depthSrc, 0, &srcBox);
-		context->CopySubresourceRegion(vrIntermediateMotionVectors[i]->resource.get(), 0, 0, 0, 0, mvecSrc, 0, &srcBox);
-		context->CopySubresourceRegion(vrIntermediateTransparencyMask[i]->resource.get(), 0, 0, 0, 0, transparencySrc, 0, &srcBox);
-		context->CopySubresourceRegion(vrIntermediateReactiveMask[i]->resource.get(), 0, 0, 0, 0, reactiveSrc, 0, &srcBox);
-	}
+		bool needsRecreate = !vrIntermediateColorIn[0] || !vrCropColorIn[0] || !vrIntermediateDepth[0] ||
+		                     !vrIntermediateColorOut[0] || !vrFinalOutput[0];
+		if (!needsRecreate) {
+			// Check format too — periphery TAA feeds R8G8B8A8 post-PP intermediate,
+			// while normal DLSS feeds R11G11B10 kMAIN. Must recreate on format change.
+			D3D11_TEXTURE2D_DESC srcDesc;
+			((ID3D11Texture2D*)colorSrc)->GetDesc(&srcDesc);
+			needsRecreate = (vrIntermediateColorIn[0]->desc.Width != eyeWidthIn ||
+			                 vrIntermediateColorIn[0]->desc.Height != eyeHeightIn ||
+			                 vrIntermediateColorIn[0]->desc.Format != srcDesc.Format ||
+			                 vrCropColorIn[0]->desc.Width != cropWidthIn ||
+			                 vrCropColorIn[0]->desc.Height != cropHeightIn ||
+			                 vrIntermediateDepth[0]->desc.Width != cropWidthIn ||
+			                 vrIntermediateDepth[0]->desc.Height != cropHeightIn ||
+			                 vrIntermediateColorOut[0]->desc.Width != cropWidthOut ||
+			                 vrIntermediateColorOut[0]->desc.Height != cropHeightOut ||
+			                 vrFinalOutput[0]->desc.Width != eyeWidthOut ||
+			                 vrFinalOutput[0]->desc.Height != eyeHeightOut);
+		}
 
-	// Zero color where depth == 0 (HMD hidden area) in each per-eye buffer.
-	// Depth is read from the combined stereo SRV at the per-eye offset; color is written
-	// to the isolated per-eye UAV (ColorOffsetX = 0).
-	auto& depthTexture = globals::game::renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
+		if (needsRecreate) {
+			logger::info("[Upscaling] (Re)creating VR viewport-scaled intermediates: full {}x{}, crop in {}x{}, crop out {}x{}",
+				eyeWidthIn, eyeHeightIn, cropWidthIn, cropHeightIn, cropWidthOut, cropHeightOut);
 
-	for (uint32_t i = 0; i < 2; ++i) {
-		uint32_t depthOffset = (i == 1) ? eyeWidthIn : 0;
-		ClearHMDMask(vrIntermediateColorIn[i]->uav.get(), depthTexture.depthSRV,
-			eyeWidthIn, eyeHeightIn, depthOffset, 0);
+			for (int i = 0; i < 2; i++) {
+				std::string suffix = (i == 0) ? "Left" : "Right";
+
+				// Full-size color for ClearHMDMask + FillPeriphery
+				vrIntermediateColorIn[i] = CreateTextureFromSource(colorSrc, eyeWidthIn, eyeHeightIn,
+					false, true, true, ("Upscale_ColorIn_" + suffix).c_str());
+
+				// Crop-sized DLSS color input (needs UAV for ClearHMDMask)
+				vrCropColorIn[i] = CreateTextureFromSource(colorSrc, cropWidthIn, cropHeightIn,
+					false, true, true, ("Upscale_CropColorIn_" + suffix).c_str());
+
+				// Crop-sized DLSS output
+				vrIntermediateColorOut[i] = CreateTextureFromSource(colorSrc, cropWidthOut, cropHeightOut,
+					false, true, true, ("Upscale_ColorOut_" + suffix).c_str());
+
+				// Crop-sized depth (R32_TYPELESS with R32_FLOAT SRV)
+				{
+					D3D11_TEXTURE2D_DESC depthDesc = {};
+					depthDesc.Width = cropWidthIn;
+					depthDesc.Height = cropHeightIn;
+					depthDesc.MipLevels = 1;
+					depthDesc.ArraySize = 1;
+					depthDesc.Format = DXGI_FORMAT_R32_TYPELESS;
+					depthDesc.SampleDesc.Count = 1;
+					depthDesc.Usage = D3D11_USAGE_DEFAULT;
+					depthDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+					vrIntermediateDepth[i] = eastl::make_unique<Texture2D>(depthDesc);
+					Util::SetResourceName(vrIntermediateDepth[i]->resource.get(), ("Upscale_Depth_" + suffix).c_str());
+
+					D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+					srvDesc.Format = DXGI_FORMAT_R32_FLOAT;
+					srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+					srvDesc.Texture2D.MipLevels = 1;
+					vrIntermediateDepth[i]->CreateSRV(srvDesc);
+				}
+
+				// Crop-sized motion vectors, reactive mask, transparency mask
+				vrIntermediateMotionVectors[i] = CreateTextureFromSource(mvecSrc, cropWidthIn, cropHeightIn,
+					false, true, false, ("Upscale_MVec_" + suffix).c_str());
+				vrIntermediateReactiveMask[i] = CreateTextureFromSource(reactiveSrc, cropWidthIn, cropHeightIn,
+					false, true, false, ("Upscale_Reactive_" + suffix).c_str());
+				vrIntermediateTransparencyMask[i] = CreateTextureFromSource(transparencySrc, cropWidthIn, cropHeightIn,
+					false, true, false, ("Upscale_Transparency_" + suffix).c_str());
+
+				// Full display-res composition target
+				vrFinalOutput[i] = CreateTextureFromSource(colorSrc, eyeWidthOut, eyeHeightOut,
+					false, true, true, ("Upscale_FinalOutput_" + suffix).c_str());
+			}
+		}
+
+		// Copy full eye to full-size vrIntermediateColorIn (raw render-res, no HMD mask yet)
+		for (uint32_t i = 0; i < 2; ++i) {
+			uint32_t offsetXIn = (i == 1) ? eyeWidthIn : 0;
+			D3D11_BOX srcBox = { offsetXIn, 0, 0, offsetXIn + eyeWidthIn, eyeHeightIn, 1 };
+			context->CopySubresourceRegion(vrIntermediateColorIn[i]->resource.get(), 0, 0, 0, 0, colorSrc, 0, &srcBox);
+		}
+
+		uint32_t cropOffsetX = (eyeWidthIn - cropWidthIn) / 2;
+		uint32_t cropOffsetY = (eyeHeightIn - cropHeightIn) / 2;
+		auto& depthTexture = globals::game::renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
+
+		// Extract DLSS crop from raw buffer (before TAA or HMD mask), then mask the crop directly.
+		for (uint32_t i = 0; i < 2; ++i) {
+			uint32_t offsetXIn = (i == 1) ? eyeWidthIn : 0;
+
+			// Crop color from raw (unmasked, non-TAA'd) full-size buffer
+			D3D11_BOX cropBox = { cropOffsetX, cropOffsetY, 0, cropOffsetX + cropWidthIn, cropOffsetY + cropHeightIn, 1 };
+			context->CopySubresourceRegion(vrCropColorIn[i]->resource.get(), 0, 0, 0, 0,
+				vrIntermediateColorIn[i]->resource.get(), 0, &cropBox);
+
+			// ClearHMDMask directly on the crop (depth offset accounts for eye + crop position in stereo buffer)
+			ClearHMDMask(vrCropColorIn[i]->uav.get(), depthTexture.depthSRV,
+				cropWidthIn, cropHeightIn, offsetXIn + cropOffsetX, 0, cropOffsetY);
+
+			// Crop depth/mvec/reactive/transparency directly from stereo buffers
+			D3D11_BOX stereoCropBox = { offsetXIn + cropOffsetX, cropOffsetY, 0,
+			                            offsetXIn + cropOffsetX + cropWidthIn, cropOffsetY + cropHeightIn, 1 };
+			context->CopySubresourceRegion(vrIntermediateDepth[i]->resource.get(), 0, 0, 0, 0,
+				depthSrc, 0, &stereoCropBox);
+			context->CopySubresourceRegion(vrIntermediateMotionVectors[i]->resource.get(), 0, 0, 0, 0,
+				mvecSrc, 0, &stereoCropBox);
+			context->CopySubresourceRegion(vrIntermediateReactiveMask[i]->resource.get(), 0, 0, 0, 0,
+				reactiveSrc, 0, &stereoCropBox);
+			context->CopySubresourceRegion(vrIntermediateTransparencyMask[i]->resource.get(), 0, 0, 0, 0,
+				transparencySrc, 0, &stereoCropBox);
+		}
+
+		// ClearHMDMask on full-size buffer (for FillPeriphery)
+		for (uint32_t i = 0; i < 2; ++i) {
+			uint32_t depthOffset = (i == 1) ? eyeWidthIn : 0;
+			ClearHMDMask(vrIntermediateColorIn[i]->uav.get(), depthTexture.depthSRV,
+				eyeWidthIn, eyeHeightIn, depthOffset, 0);
+		}
+	} else {
+		// Non-viewport-scaling path: all textures at full per-eye dimensions
+		bool needsRecreate = !vrIntermediateColorIn[0] || !vrIntermediateColorOut[0];
+		if (!needsRecreate) {
+			D3D11_TEXTURE2D_DESC srcDesc;
+			((ID3D11Texture2D*)colorSrc)->GetDesc(&srcDesc);
+			needsRecreate = (vrIntermediateColorIn[0]->desc.Width != eyeWidthIn ||
+			                 vrIntermediateColorIn[0]->desc.Height != eyeHeightIn ||
+			                 vrIntermediateColorIn[0]->desc.Format != srcDesc.Format ||
+			                 vrIntermediateColorOut[0]->desc.Width != eyeWidthOut ||
+			                 vrIntermediateColorOut[0]->desc.Height != eyeHeightOut);
+		}
+		if (needsRecreate) {
+			logger::info("[Upscaling] (Re)creating VR intermediates: per-eye in {}x{}, out {}x{}",
+				eyeWidthIn, eyeHeightIn, eyeWidthOut, eyeHeightOut);
+			CreateVRIntermediateTextures(eyeWidthIn, eyeHeightIn, eyeWidthOut, eyeHeightOut,
+				colorSrc, mvecSrc, reactiveSrc, transparencySrc);
+		}
+
+		// Release viewport-scaling-specific textures
+		for (int i = 0; i < 2; i++) {
+			vrCropColorIn[i].reset();
+			vrFinalOutput[i].reset();
+			vrTAAdPerEye[i].reset();
+		}
+		vrPreTAACopy = nullptr;
+
+		// Copy full eye to per-eye intermediates
+		for (uint32_t i = 0; i < 2; ++i) {
+			uint32_t offsetXIn = (i == 1) ? eyeWidthIn : 0;
+			D3D11_BOX srcBox = { offsetXIn, 0, 0, offsetXIn + eyeWidthIn, eyeHeightIn, 1 };
+
+			context->CopySubresourceRegion(vrIntermediateColorIn[i]->resource.get(), 0, 0, 0, 0, colorSrc, 0, &srcBox);
+			context->CopySubresourceRegion(vrIntermediateDepth[i]->resource.get(), 0, 0, 0, 0, depthSrc, 0, &srcBox);
+			context->CopySubresourceRegion(vrIntermediateMotionVectors[i]->resource.get(), 0, 0, 0, 0, mvecSrc, 0, &srcBox);
+			context->CopySubresourceRegion(vrIntermediateTransparencyMask[i]->resource.get(), 0, 0, 0, 0, transparencySrc, 0, &srcBox);
+			context->CopySubresourceRegion(vrIntermediateReactiveMask[i]->resource.get(), 0, 0, 0, 0, reactiveSrc, 0, &srcBox);
+		}
+
+		// Zero color where depth == 0 (HMD hidden area) in each per-eye buffer
+		auto& depthTexture = globals::game::renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
+		for (uint32_t i = 0; i < 2; ++i) {
+			uint32_t depthOffset = (i == 1) ? eyeWidthIn : 0;
+			ClearHMDMask(vrIntermediateColorIn[i]->uav.get(), depthTexture.depthSRV,
+				eyeWidthIn, eyeHeightIn, depthOffset, 0);
+		}
 	}
 
 	if (state->frameAnnotations)
@@ -929,11 +1157,34 @@ void Upscaling::FinalizePerEyeOutputs(ID3D11Resource* colorDst)
 	uint32_t eyeWidthOut = (uint32_t)(screenSize.x / 2);
 	uint32_t eyeHeightOut = (uint32_t)screenSize.y;
 
-	// Write upscaled outputs back
+	float vpScale = settings.vrDlssViewportScale;
+	auto upscaleMethod = GetUpscaleMethod();
+	bool viewportScaling = (vpScale < 1.0f) && (upscaleMethod == UpscaleMethod::kDLSS);
+
 	for (uint32_t i = 0; i < 2; ++i) {
 		uint32_t offsetXOut = (i == 1) ? eyeWidthOut : 0;
-		D3D11_BOX outBox = { 0, 0, 0, eyeWidthOut, eyeHeightOut, 1 };
-		context->CopySubresourceRegion(colorDst, 0, offsetXOut, 0, 0, vrIntermediateColorOut[i]->resource.get(), 0, &outBox);
+
+		if (viewportScaling && vrFinalOutput[i]) {
+			// Paste crop-sized DLSS output into center of full-size composition target
+			uint32_t dlssWidthOut = vrIntermediateColorOut[i]->desc.Width;
+			uint32_t dlssHeightOut = vrIntermediateColorOut[i]->desc.Height;
+			uint32_t pasteX = (eyeWidthOut - dlssWidthOut) / 2;
+			uint32_t pasteY = (eyeHeightOut - dlssHeightOut) / 2;
+
+			D3D11_BOX dlssBox = { 0, 0, 0, dlssWidthOut, dlssHeightOut, 1 };
+			context->CopySubresourceRegion(vrFinalOutput[i]->resource.get(), 0, pasteX, pasteY, 0,
+				vrIntermediateColorOut[i]->resource.get(), 0, &dlssBox);
+
+			// Copy composition target to stereo buffer
+			D3D11_BOX outBox = { 0, 0, 0, eyeWidthOut, eyeHeightOut, 1 };
+			context->CopySubresourceRegion(colorDst, 0, offsetXOut, 0, 0,
+				vrFinalOutput[i]->resource.get(), 0, &outBox);
+		} else {
+			// Direct copy DLSS output to stereo buffer
+			D3D11_BOX outBox = { 0, 0, 0, eyeWidthOut, eyeHeightOut, 1 };
+			context->CopySubresourceRegion(colorDst, 0, offsetXOut, 0, 0,
+				vrIntermediateColorOut[i]->resource.get(), 0, &outBox);
+		}
 	}
 
 	if (state->frameAnnotations)
@@ -941,7 +1192,11 @@ void Upscaling::FinalizePerEyeOutputs(ID3D11Resource* colorDst)
 }
 
 void Upscaling::ClearHMDMask(ID3D11UnorderedAccessView* colorUAV, ID3D11ShaderResourceView* depthSRV,
-	uint32_t eyeWidth, uint32_t eyeHeight, uint32_t depthOffsetX, uint32_t colorOffsetX)
+	uint32_t eyeWidth, uint32_t eyeHeight, uint32_t depthOffsetX, uint32_t colorOffsetX,
+	uint32_t depthOffsetY,
+	uint32_t depthWidth, uint32_t depthHeight,
+	uint32_t colorWidth, uint32_t colorHeight,
+	ID3D11ShaderResourceView* fallbackSRV, uint32_t fallbackOffsetX)
 {
 	if (!globals::game::isVR)
 		return;
@@ -952,7 +1207,7 @@ void Upscaling::ClearHMDMask(ID3D11UnorderedAccessView* colorUAV, ID3D11ShaderRe
 		vrClearHMDMaskCS.attach((ID3D11ComputeShader*)Util::CompileShader(L"Data/Shaders/Upscaling/ClearHMDMaskCS.hlsl", {}, "cs_5_0"));
 
 		D3D11_BUFFER_DESC cbDesc = {};
-		cbDesc.ByteWidth = 16;  // 4 uints
+		cbDesc.ByteWidth = 32;  // 8 uints (offsets + optional scaling dimensions)
 		cbDesc.Usage = D3D11_USAGE_DYNAMIC;
 		cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
 		cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
@@ -965,8 +1220,9 @@ void Upscaling::ClearHMDMask(ID3D11UnorderedAccessView* colorUAV, ID3D11ShaderRe
 
 		context->CSSetShader(vrClearHMDMaskCS.get(), nullptr, 0);
 
-		ID3D11ShaderResourceView* srvs[1] = { depthSRV };
-		context->CSSetShaderResources(0, 1, srvs);
+		// t0 = depth, t1 = fallback (nullptr → unbound → reads return (0,0,0,0) → black)
+		ID3D11ShaderResourceView* srvs[2] = { depthSRV, fallbackSRV };
+		context->CSSetShaderResources(0, 2, srvs);
 
 		ID3D11UnorderedAccessView* uavs[1] = { colorUAV };
 		context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
@@ -974,9 +1230,10 @@ void Upscaling::ClearHMDMask(ID3D11UnorderedAccessView* colorUAV, ID3D11ShaderRe
 		D3D11_MAPPED_SUBRESOURCE mapped{};
 		context->Map(vrClearHMDMaskCB.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
 
-		uint32_t offsets[4] = { depthOffsetX, colorOffsetX, 0, 0 };
+		uint32_t cbData[8] = { depthOffsetX, colorOffsetX, depthOffsetY, fallbackOffsetX,
+			depthWidth, depthHeight, colorWidth, colorHeight };
 
-		memcpy(mapped.pData, offsets, sizeof(offsets));
+		memcpy(mapped.pData, cbData, sizeof(cbData));
 		context->Unmap(vrClearHMDMaskCB.get(), 0);
 
 		ID3D11Buffer* cbs[1] = { vrClearHMDMaskCB.get() };
@@ -985,12 +1242,80 @@ void Upscaling::ClearHMDMask(ID3D11UnorderedAccessView* colorUAV, ID3D11ShaderRe
 		context->Dispatch(dispatchX, dispatchY, 1);
 
 		// Unbind
+		ID3D11ShaderResourceView* nullSRVs[2] = { nullptr, nullptr };
+		ID3D11UnorderedAccessView* nullUAV[1] = { nullptr };
+		ID3D11Buffer* nullCB[1] = { nullptr };
+		context->CSSetShaderResources(0, 2, nullSRVs);
+		context->CSSetUnorderedAccessViews(0, 1, nullUAV, nullptr);
+		context->CSSetConstantBuffers(0, 1, nullCB);
+		context->CSSetShader(nullptr, nullptr, 0);
+	}
+}
+
+void Upscaling::FillPeriphery(uint32_t eyeIndex, uint32_t srcWidth, uint32_t srcHeight,
+	uint32_t dstWidth, uint32_t dstHeight, ID3D11ShaderResourceView* overrideSRV)
+{
+	if (!globals::game::isVR || !vrFinalOutput[eyeIndex])
+		return;
+	if (!overrideSRV && !vrIntermediateColorIn[eyeIndex])
+		return;
+
+	auto context = globals::d3d::context;
+
+	if (!vrPeripheryFillCS) {
+		vrPeripheryFillCS.attach((ID3D11ComputeShader*)Util::CompileShader(L"Data/Shaders/Upscaling/VRPeripheryFillCS.hlsl", {}, "cs_5_0"));
+
+		D3D11_BUFFER_DESC cbDesc = {};
+		cbDesc.ByteWidth = 16;  // 4 uints
+		cbDesc.Usage = D3D11_USAGE_DYNAMIC;
+		cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+		cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+		DX::ThrowIfFailed(globals::d3d::device->CreateBuffer(&cbDesc, nullptr, vrPeripheryFillCB.put()));
+
+		D3D11_SAMPLER_DESC samplerDesc = {};
+		samplerDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+		samplerDesc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+		samplerDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+		samplerDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+		DX::ThrowIfFailed(globals::d3d::device->CreateSamplerState(&samplerDesc, vrLinearSampler.put()));
+	}
+
+	if (vrPeripheryFillCS) {
+		auto dispatchX = (dstWidth + 7) / 8;
+		auto dispatchY = (dstHeight + 7) / 8;
+
+		context->CSSetShader(vrPeripheryFillCS.get(), nullptr, 0);
+
+		// Read from overrideSRV (e.g. TAA texture) or default render-res per-eye input.
+		ID3D11ShaderResourceView* srvs[1] = { overrideSRV ? overrideSRV : vrIntermediateColorIn[eyeIndex]->srv.get() };
+		context->CSSetShaderResources(0, 1, srvs);
+
+		ID3D11UnorderedAccessView* uavs[1] = { vrFinalOutput[eyeIndex]->uav.get() };
+		context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
+
+		ID3D11SamplerState* samplers[1] = { vrLinearSampler.get() };
+		context->CSSetSamplers(0, 1, samplers);
+
+		D3D11_MAPPED_SUBRESOURCE mapped{};
+		context->Map(vrPeripheryFillCB.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
+		uint32_t cbData[4] = { srcWidth, srcHeight, dstWidth, dstHeight };
+		memcpy(mapped.pData, cbData, sizeof(cbData));
+		context->Unmap(vrPeripheryFillCB.get(), 0);
+
+		ID3D11Buffer* cbs[1] = { vrPeripheryFillCB.get() };
+		context->CSSetConstantBuffers(0, 1, cbs);
+
+		context->Dispatch(dispatchX, dispatchY, 1);
+
+		// Unbind
 		ID3D11ShaderResourceView* nullSRV[1] = { nullptr };
 		ID3D11UnorderedAccessView* nullUAV[1] = { nullptr };
 		ID3D11Buffer* nullCB[1] = { nullptr };
+		ID3D11SamplerState* nullSampler[1] = { nullptr };
 		context->CSSetShaderResources(0, 1, nullSRV);
 		context->CSSetUnorderedAccessViews(0, 1, nullUAV, nullptr);
 		context->CSSetConstantBuffers(0, 1, nullCB);
+		context->CSSetSamplers(0, 1, nullSampler);
 		context->CSSetShader(nullptr, nullptr, 0);
 	}
 }
@@ -1101,6 +1426,10 @@ void Upscaling::ConfigureUpscaling(RE::BSGraphics::State* a_viewport)
 	// Disable dynamic resolution unless the game explicitly enables it
 	if (!globals::game::isVR)
 		runtimeData.dynamicResolutionLock = 1;
+
+	// VR depth buffer culling is now compatible with upscaling thanks to depth buffer upscaling.
+	// No longer need to force-disable culling when upscaling is active.
+	// The depth buffer is upscaled in UpscaleDepth() before OBBOcclusionTesting runs.
 }
 
 void Upscaling::SetupResources()
@@ -1145,6 +1474,7 @@ void Upscaling::SetupResources()
 		depthStencilDesc.BackFace.StencilDepthFailOp = depthStencilDesc.FrontFace.StencilDepthFailOp;
 		depthStencilDesc.BackFace.StencilPassOp = depthStencilDesc.FrontFace.StencilPassOp;
 		depthStencilDesc.BackFace.StencilFunc = depthStencilDesc.FrontFace.StencilFunc;
+
 	} else {
 		depthStencilDesc.StencilEnable = false;  // Disable stencil testing
 	}
@@ -1198,6 +1528,12 @@ void Upscaling::ClearShaderCache()
 	depthRefractionUpscalePS = nullptr;  // com_ptr automatically releases
 	underwaterMaskUpscalePS = nullptr;   // com_ptr automatically releases
 	upscaleVS = nullptr;                 // com_ptr automatically releases
+	vrClearHMDMaskCS = nullptr;
+	vrPeripheryFillCS = nullptr;
+	vrPeripheryFillCB = nullptr;
+	vrDlssCompositePS = nullptr;
+	vrDlssUpscalePS = nullptr;
+	vrDlssUpscaleCB = nullptr;
 }
 
 void Upscaling::CopySharedD3D12Resources()
@@ -1408,6 +1744,18 @@ bool Upscaling::IsUpscalingActive() const
 	return resolutionScale.x < .99f;
 }
 
+std::vector<FeatureConstraints::Constraint> Upscaling::GetActiveConstraints() const
+{
+	std::vector<FeatureConstraints::Constraint> constraints;
+
+	// VR depth buffer culling is now compatible with upscaling thanks to depth buffer upscaling.
+	// The depth buffer is upscaled in UpscaleDepth() before OBBOcclusionTesting runs,
+	// so we no longer need to constrain depth buffer culling when upscaling is active.
+
+	return constraints;
+}
+
+
 /**
  * @brief Retrieves the current frame time for frame generation.
  *
@@ -1519,7 +1867,7 @@ Upscaling::BlurResources Upscaling::GetBlurResources() const
 	return {};
 }
 
-void Upscaling::Upscale()
+void Upscaling::Upscale(ID3D11Texture2D* colorSourceOverride)
 {
 	auto upscaleMethod = GetUpscaleMethod();
 
@@ -1580,8 +1928,13 @@ void Upscaling::Upscale()
 	{
 		state->BeginPerfEvent("Upscaling");
 
+		// Use color source override if provided (e.g., post-PP intermediate for periphery TAA)
+		ID3D11Resource* colorSrc = colorSourceOverride
+			? static_cast<ID3D11Resource*>(colorSourceOverride)
+			: static_cast<ID3D11Resource*>(main.texture);
+
 		if (upscaleMethod == UpscaleMethod::kDLSS) {
-			streamline.Upscale(main.texture, reactiveMaskTexture->resource.get(), transparencyCompositionMaskTexture->resource.get(), motionVectorCopyTexture->resource.get());
+			streamline.Upscale(colorSrc, reactiveMaskTexture->resource.get(), transparencyCompositionMaskTexture->resource.get(), motionVectorCopyTexture->resource.get());
 		} else if (upscaleMethod == UpscaleMethod::kFSR) {
 			fidelityFX.Upscale(main.texture, reactiveMaskTexture->resource.get(), transparencyCompositionMaskTexture->resource.get(), motionVector.texture, settings.sharpnessFSR);
 		}
@@ -1821,20 +2174,73 @@ void Upscaling::Main_PostProcessing::thunk(RE::ImageSpaceManager* a_this, uint32
 	if (upscaling.d3d12SwapChainActive && upscaling.settings.frameGenerationMode)
 		upscaling.CopySharedD3D12Resources();
 
-	if (upscaleMethod != UpscaleMethod::kNONE && upscaleMethod != UpscaleMethod::kTAA)
-		upscaling.PerformUpscaling();
+	// Increment diagnostic counter (rate-limits TAAReorder logging)
+	if (TAAReorder::g_initialized) {
+		TAAReorder::g_diagCounter = (TAAReorder::g_diagCounter + 1) % TAAReorder::DIAG_INTERVAL;
+		if (TAAReorder::g_diagCounter == 0) {
+			TAAReorder::g_frameSeqCounter = 0;
+			logger::info("[SEQ] Main_PostProcessing START seq={}", TAAReorder::g_frameSeqCounter++);
+		}
+	}
 
-	if (upscaleMethod == UpscaleMethod::kDLSS)
-		upscaling.ApplySharpening();
+	bool peripheryTAA = TAAReorder::ShouldReorderTAA();
 
-	auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
-	GET_INSTANCE_MEMBER(BSImagespaceShaderISTemporalAA, imageSpaceManager);
+	if (peripheryTAA) {
+		// ─── Periphery TAA with post-conductor DLSS (PureDark's approach) ───
+		// func() with TAA enabled → conductor runs all passes unimpeded:
+		//   Phase 2A: ExecutePassHook captures post-PP intermediate to g_postPPCopy
+		//   Phase 5: TAA + DRS → submit texture
+		// After conductor: ConductorCallHook evaluates DLSS on g_postPPCopy,
+		// then pastes DLSS center onto submit texture
 
-	BSImagespaceShaderISTemporalAA->taaEnabled = upscaleMethod == UpscaleMethod::kTAA;
+		auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
+		GET_INSTANCE_MEMBER(BSImagespaceShaderISTemporalAA, imageSpaceManager);
 
-	func(a_this, a3, a_target, a_4, a_5);
+		// Reset per-frame flags
+		TAAReorder::g_postPPReady = false;
+		TAAReorder::g_dlssReady = false;
+		TAAReorder::g_dlssPasteComplete = false;
+		TAAReorder::g_phase5Complete = false;
+		TAAReorder::g_bsHookCallCount = 0;
 
-	BSImagespaceShaderISTemporalAA->taaEnabled = false;
+		if (TAAReorder::g_diagCounter == 0)
+			logger::info("[TAAReorder] peripheryTAA: running func() with TAA enabled...");
+
+		// func() with TAA ENABLED — DLSS eval + paste in ConductorCallHook (post-conductor)
+		BSImagespaceShaderISTemporalAA->taaEnabled = true;
+		func(a_this, a3, a_target, a_4, a_5);
+
+		// Lock DRS + update camera (after conductor completes)
+		auto& runtimeData = globals::game::graphicsState->GetRuntimeData();
+		runtimeData.dynamicResolutionLock = 1;
+		UpdateCameraData();
+
+		// Disable TAA for remainder of frame
+		BSImagespaceShaderISTemporalAA->taaEnabled = false;
+	} else {
+		// ─── Normal flow (no periphery TAA) ───
+		if (upscaleMethod != UpscaleMethod::kNONE && upscaleMethod != UpscaleMethod::kTAA)
+			upscaling.PerformUpscaling();
+
+		if (upscaleMethod == UpscaleMethod::kDLSS)
+			upscaling.ApplySharpening();
+
+		auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
+		GET_INSTANCE_MEMBER(BSImagespaceShaderISTemporalAA, imageSpaceManager);
+
+		BSImagespaceShaderISTemporalAA->taaEnabled = (upscaleMethod == UpscaleMethod::kTAA);
+
+		if (TAAReorder::g_diagCounter == 0 && TAAReorder::g_initialized)
+			logger::info("[DIAG] Normal DLSS flow: taaEnabled={}, running func()...", BSImagespaceShaderISTemporalAA->taaEnabled);
+
+		func(a_this, a3, a_target, a_4, a_5);
+
+		BSImagespaceShaderISTemporalAA->taaEnabled = false;
+	}
+
+	// VR CAS sharpening (after TAA)
+	if (REL::Module::IsVR() && globals::features::vrStereoOptimizations.loaded)
+		globals::features::vrStereoOptimizations.ApplyCAS(a_target);
 }
 
 void Upscaling::SetScissorRect::thunk(RE::BSGraphics::Renderer* This, int a_left, int a_top, int a_right, int a_bottom)

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -57,10 +57,10 @@ public:
 		uint streamlineLogLevel = 0;  // 0=Off, 1=Default, 2=Verbose
 		float sharpnessFSR = 0.0f;
 		float sharpnessDLSS = 0.0f;
-		uint presetDLSS = 0;           // 0=Default, 1=J, 2=K, 3=L, 4=M
-		uint useGatherWideKernel = 1;  // 0=Legacy 3x3, 1=Gather wide-kernel
+		uint presetDLSS = 0;               // 0=Default, 1=J, 2=K, 3=L, 4=M
+		uint useGatherWideKernel = 1;      // 0=Legacy 3x3, 1=Gather wide-kernel
 		float vrDlssViewportScale = 1.0f;  // 0.5 to 1.0, fraction of each eye that DLSS processes (VR only)
-		uint vrPeripheryTAA = 0;            // 0=off, 1=on - enable native TAA on periphery when viewport scaling active (VR only)
+		uint vrPeripheryTAA = 0;           // 0=off, 1=on - enable native TAA on periphery when viewport scaling active (VR only)
 	};
 
 	Settings settings;
@@ -159,8 +159,8 @@ public:
 	eastl::unique_ptr<Texture2D> vrCropColorIn[2];                   // crop-sized DLSS color input (VR viewport scaling only)
 
 	// Periphery TAA (conductor approach) — used by two-call func() flow
-	winrt::com_ptr<ID3D11Texture2D> vrPreTAACopy;                    // full stereo kMAIN copy (Phase 1 PP, pre-TAA)
-	eastl::unique_ptr<Texture2D> vrTAAdPerEye[2];                    // per-eye render-res TAA'd content (periphery source)
+	winrt::com_ptr<ID3D11Texture2D> vrPreTAACopy;  // full stereo kMAIN copy (Phase 1 PP, pre-TAA)
+	eastl::unique_ptr<Texture2D> vrTAAdPerEye[2];  // per-eye render-res TAA'd content (periphery source)
 
 	// Periphery fill compute shader (bilinear upscale render-res → display-res for VR viewport scaling)
 	winrt::com_ptr<ID3D11ComputeShader> vrPeripheryFillCS;
@@ -168,9 +168,9 @@ public:
 	winrt::com_ptr<ID3D11SamplerState> vrLinearSampler;
 
 	// DLSS composite pixel shaders (format-converting fullscreen copy for TAAReorder)
-	winrt::com_ptr<ID3D11PixelShader> vrDlssCompositePS;    // point-sample (same-res format conversion)
-	winrt::com_ptr<ID3D11PixelShader> vrDlssUpscalePS;      // bilinear upscale (render-res → display-res)
-	winrt::com_ptr<ID3D11Buffer> vrDlssUpscaleCB;           // constant buffer for upscale params
+	winrt::com_ptr<ID3D11PixelShader> vrDlssCompositePS;  // point-sample (same-res format conversion)
+	winrt::com_ptr<ID3D11PixelShader> vrDlssUpscalePS;    // bilinear upscale (render-res → display-res)
+	winrt::com_ptr<ID3D11Buffer> vrDlssUpscaleCB;         // constant buffer for upscale params
 	ID3D11PixelShader* GetDlssCompositePS();
 	ID3D11PixelShader* GetDlssUpscalePS();
 

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -59,6 +59,8 @@ public:
 		float sharpnessDLSS = 0.0f;
 		uint presetDLSS = 0;           // 0=Default, 1=J, 2=K, 3=L, 4=M
 		uint useGatherWideKernel = 1;  // 0=Legacy 3x3, 1=Gather wide-kernel
+		float vrDlssViewportScale = 1.0f;  // 0.5 to 1.0, fraction of each eye that DLSS processes (VR only)
+		uint vrPeripheryTAA = 0;            // 0=off, 1=on - enable native TAA on periphery when viewport scaling active (VR only)
 	};
 
 	Settings settings;
@@ -110,6 +112,7 @@ public:
 	virtual void Load() override;
 	virtual void PostPostLoad() override;
 	virtual void SetupResources() override;
+	virtual std::vector<FeatureConstraints::Constraint> GetActiveConstraints() const override;
 
 	UpscaleMethod GetUpscaleMethod() const;
 
@@ -138,7 +141,11 @@ public:
 	winrt::com_ptr<ID3D11Buffer> vrClearHMDMaskCB;
 	// Helper to dispatch mask clearing for a single eye region
 	void ClearHMDMask(ID3D11UnorderedAccessView* colorUAV, ID3D11ShaderResourceView* depthSRV,
-		uint32_t eyeWidth, uint32_t eyeHeight, uint32_t depthOffsetX, uint32_t colorOffsetX);
+		uint32_t eyeWidth, uint32_t eyeHeight, uint32_t depthOffsetX, uint32_t colorOffsetX,
+		uint32_t depthOffsetY = 0,
+		uint32_t depthWidth = 0, uint32_t depthHeight = 0,
+		uint32_t colorWidth = 0, uint32_t colorHeight = 0,
+		ID3D11ShaderResourceView* fallbackSRV = nullptr, uint32_t fallbackOffsetX = 0);
 
 	// Shared VR Per-Eye Intermediate Buffers
 	// Owned here so both Streamline (DLSS) and FidelityFX (FSR) can use them.
@@ -148,6 +155,34 @@ public:
 	eastl::unique_ptr<Texture2D> vrIntermediateMotionVectors[2];     // per-eye render resolution
 	eastl::unique_ptr<Texture2D> vrIntermediateReactiveMask[2];      // per-eye render resolution
 	eastl::unique_ptr<Texture2D> vrIntermediateTransparencyMask[2];  // per-eye render resolution
+	eastl::unique_ptr<Texture2D> vrFinalOutput[2];                   // per-eye display-res composition target (VR viewport scaling)
+	eastl::unique_ptr<Texture2D> vrCropColorIn[2];                   // crop-sized DLSS color input (VR viewport scaling only)
+
+	// Periphery TAA (conductor approach) — used by two-call func() flow
+	winrt::com_ptr<ID3D11Texture2D> vrPreTAACopy;                    // full stereo kMAIN copy (Phase 1 PP, pre-TAA)
+	eastl::unique_ptr<Texture2D> vrTAAdPerEye[2];                    // per-eye render-res TAA'd content (periphery source)
+
+	// Periphery fill compute shader (bilinear upscale render-res → display-res for VR viewport scaling)
+	winrt::com_ptr<ID3D11ComputeShader> vrPeripheryFillCS;
+	winrt::com_ptr<ID3D11Buffer> vrPeripheryFillCB;
+	winrt::com_ptr<ID3D11SamplerState> vrLinearSampler;
+
+	// DLSS composite pixel shaders (format-converting fullscreen copy for TAAReorder)
+	winrt::com_ptr<ID3D11PixelShader> vrDlssCompositePS;    // point-sample (same-res format conversion)
+	winrt::com_ptr<ID3D11PixelShader> vrDlssUpscalePS;      // bilinear upscale (render-res → display-res)
+	winrt::com_ptr<ID3D11Buffer> vrDlssUpscaleCB;           // constant buffer for upscale params
+	ID3D11PixelShader* GetDlssCompositePS();
+	ID3D11PixelShader* GetDlssUpscalePS();
+
+	struct DlssCompositeCB
+	{
+		float2 DynResScale;  // renderRes / displayRes per-eye
+		float2 EyeOffset;    // (i * eyeWidth, 0)
+		float2 SrcTexSize;   // full texture dimensions
+		float2 pad;
+	};
+	void FillPeriphery(uint32_t eyeIndex, uint32_t srcWidth, uint32_t srcHeight,
+		uint32_t dstWidth, uint32_t dstHeight, ID3D11ShaderResourceView* overrideSRV = nullptr);
 
 	// Helper to create/resize per-eye buffers matching source formats
 	void CreateVRIntermediateTextures(uint32_t inWidth, uint32_t inHeight, uint32_t outWidth, uint32_t outHeight,
@@ -164,7 +199,7 @@ public:
 
 	void ConfigureTAA();
 	void ConfigureUpscaling(RE::BSGraphics::State* a_state);
-	void Upscale();
+	void Upscale(ID3D11Texture2D* colorSourceOverride = nullptr);
 
 	// D3D11 textures
 	Texture2D* reactiveMaskTexture = nullptr;

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -57,10 +57,8 @@ public:
 		uint streamlineLogLevel = 0;  // 0=Off, 1=Default, 2=Verbose
 		float sharpnessFSR = 0.0f;
 		float sharpnessDLSS = 0.0f;
-		uint presetDLSS = 0;               // 0=Default, 1=J, 2=K, 3=L, 4=M
-		uint useGatherWideKernel = 1;      // 0=Legacy 3x3, 1=Gather wide-kernel
-		float vrDlssViewportScale = 1.0f;  // 0.5 to 1.0, fraction of each eye that DLSS processes (VR only)
-		uint vrPeripheryTAA = 0;           // 0=off, 1=on - enable native TAA on periphery when viewport scaling active (VR only)
+		uint presetDLSS = 0;           // 0=Default, 1=J, 2=K, 3=L, 4=M
+		uint useGatherWideKernel = 1;  // 0=Legacy 3x3, 1=Gather wide-kernel
 	};
 
 	Settings settings;
@@ -112,7 +110,6 @@ public:
 	virtual void Load() override;
 	virtual void PostPostLoad() override;
 	virtual void SetupResources() override;
-	virtual std::vector<FeatureConstraints::Constraint> GetActiveConstraints() const override;
 
 	UpscaleMethod GetUpscaleMethod() const;
 
@@ -141,11 +138,7 @@ public:
 	winrt::com_ptr<ID3D11Buffer> vrClearHMDMaskCB;
 	// Helper to dispatch mask clearing for a single eye region
 	void ClearHMDMask(ID3D11UnorderedAccessView* colorUAV, ID3D11ShaderResourceView* depthSRV,
-		uint32_t eyeWidth, uint32_t eyeHeight, uint32_t depthOffsetX, uint32_t colorOffsetX,
-		uint32_t depthOffsetY = 0,
-		uint32_t depthWidth = 0, uint32_t depthHeight = 0,
-		uint32_t colorWidth = 0, uint32_t colorHeight = 0,
-		ID3D11ShaderResourceView* fallbackSRV = nullptr, uint32_t fallbackOffsetX = 0);
+		uint32_t eyeWidth, uint32_t eyeHeight, uint32_t depthOffsetX, uint32_t colorOffsetX);
 
 	// Shared VR Per-Eye Intermediate Buffers
 	// Owned here so both Streamline (DLSS) and FidelityFX (FSR) can use them.
@@ -155,34 +148,6 @@ public:
 	eastl::unique_ptr<Texture2D> vrIntermediateMotionVectors[2];     // per-eye render resolution
 	eastl::unique_ptr<Texture2D> vrIntermediateReactiveMask[2];      // per-eye render resolution
 	eastl::unique_ptr<Texture2D> vrIntermediateTransparencyMask[2];  // per-eye render resolution
-	eastl::unique_ptr<Texture2D> vrFinalOutput[2];                   // per-eye display-res composition target (VR viewport scaling)
-	eastl::unique_ptr<Texture2D> vrCropColorIn[2];                   // crop-sized DLSS color input (VR viewport scaling only)
-
-	// Periphery TAA (conductor approach) — used by two-call func() flow
-	winrt::com_ptr<ID3D11Texture2D> vrPreTAACopy;  // full stereo kMAIN copy (Phase 1 PP, pre-TAA)
-	eastl::unique_ptr<Texture2D> vrTAAdPerEye[2];  // per-eye render-res TAA'd content (periphery source)
-
-	// Periphery fill compute shader (bilinear upscale render-res → display-res for VR viewport scaling)
-	winrt::com_ptr<ID3D11ComputeShader> vrPeripheryFillCS;
-	winrt::com_ptr<ID3D11Buffer> vrPeripheryFillCB;
-	winrt::com_ptr<ID3D11SamplerState> vrLinearSampler;
-
-	// DLSS composite pixel shaders (format-converting fullscreen copy for TAAReorder)
-	winrt::com_ptr<ID3D11PixelShader> vrDlssCompositePS;  // point-sample (same-res format conversion)
-	winrt::com_ptr<ID3D11PixelShader> vrDlssUpscalePS;    // bilinear upscale (render-res → display-res)
-	winrt::com_ptr<ID3D11Buffer> vrDlssUpscaleCB;         // constant buffer for upscale params
-	ID3D11PixelShader* GetDlssCompositePS();
-	ID3D11PixelShader* GetDlssUpscalePS();
-
-	struct DlssCompositeCB
-	{
-		float2 DynResScale;  // renderRes / displayRes per-eye
-		float2 EyeOffset;    // (i * eyeWidth, 0)
-		float2 SrcTexSize;   // full texture dimensions
-		float2 pad;
-	};
-	void FillPeriphery(uint32_t eyeIndex, uint32_t srcWidth, uint32_t srcHeight,
-		uint32_t dstWidth, uint32_t dstHeight, ID3D11ShaderResourceView* overrideSRV = nullptr);
 
 	// Helper to create/resize per-eye buffers matching source formats
 	void CreateVRIntermediateTextures(uint32_t inWidth, uint32_t inHeight, uint32_t outWidth, uint32_t outHeight,
@@ -199,7 +164,7 @@ public:
 
 	void ConfigureTAA();
 	void ConfigureUpscaling(RE::BSGraphics::State* a_state);
-	void Upscale(ID3D11Texture2D* colorSourceOverride = nullptr);
+	void Upscale();
 
 	// D3D11 textures
 	Texture2D* reactiveMaskTexture = nullptr;

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -88,6 +88,12 @@ void VR::SetupResources()
 	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", edgeDetectionDefines, "cs_5_0")))
 		stereoBlendDebugEdgeDetectionCS.attach(rawPtr);
 
+	// Overwrite mode: direct replacement instead of blend (for stencil culling)
+	auto overwriteDefines = defines;
+	overwriteDefines.push_back({ "STEREO_OVERWRITE", "" });
+	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", overwriteDefines, "cs_5_0")))
+		stereoBlendOverwriteCS.attach(rawPtr);
+
 	auto renderer = globals::game::renderer;
 	auto mainTex = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];
 	D3D11_TEXTURE2D_DESC mainDesc;

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -260,7 +260,7 @@ public:
 			StereoBlendDepthSigma = std::clamp(StereoBlendDepthSigma, 0.001f, 0.1f);
 			StereoBlendMaxFactor = std::clamp(StereoBlendMaxFactor, 0.0f, 0.5f);
 			StereoBlendColorThreshold = std::clamp(StereoBlendColorThreshold, 0.0f, 0.2f);
-			StereoBlendDebugMode = std::clamp(StereoBlendDebugMode, 0, 3);
+			StereoBlendDebugMode = std::clamp(StereoBlendDebugMode, 0, 5);
 		}
 	};
 
@@ -358,6 +358,7 @@ public:
 	winrt::com_ptr<ID3D11ComputeShader> stereoBlendDebugBackCheckCS;
 	winrt::com_ptr<ID3D11ComputeShader> stereoBlendDebugBlendWeightCS;
 	winrt::com_ptr<ID3D11ComputeShader> stereoBlendDebugEdgeDetectionCS;
+	winrt::com_ptr<ID3D11ComputeShader> stereoBlendOverwriteCS;
 	eastl::unique_ptr<Texture2D> stereoBlendCopyTex;
 	eastl::unique_ptr<ConstantBuffer> stereoBlendCB;
 
@@ -368,7 +369,10 @@ public:
 		float DepthSigma;
 		float MaxBlendFactor;
 		float ColorDiffThreshold;
-		float pad;
+		float DebugEdgeTint;
+		uint32_t DebugMode;
+		float FullBlendDistance;
+		float _pad[2];
 	};
 
 	// Engine hook integration points

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -361,6 +361,7 @@ public:
 	winrt::com_ptr<ID3D11ComputeShader> stereoBlendOverwriteCS;
 	eastl::unique_ptr<Texture2D> stereoBlendCopyTex;
 	eastl::unique_ptr<ConstantBuffer> stereoBlendCB;
+	winrt::com_ptr<ID3D11SamplerState> stereoBlendLinearSampler;
 
 	struct alignas(16) StereoBlendCB
 	{
@@ -372,7 +373,8 @@ public:
 		float DebugEdgeTint;
 		uint32_t DebugMode;
 		float FullBlendDistance;
-		float _pad[2];
+		float POMDepthScale;
+		float _pad;
 	};
 
 	// Engine hook integration points

--- a/src/Features/VR/SettingsUI.cpp
+++ b/src/Features/VR/SettingsUI.cpp
@@ -323,7 +323,7 @@ namespace
 
 		ImGui::Separator();
 
-		const char* debugModes[] = { "Off", "Back-Check", "Blend Weight", "Edge Detection" };
+		const char* debugModes[] = { "Off", "Back-Check", "Blend Weight", "Edge Detection", "Overwrite", "Overwrite Eye1" };
 		ImGui::Combo("Debug View", &settings.StereoBlendDebugMode, debugModes, IM_ARRAYSIZE(debugModes));
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(

--- a/src/Features/VR/StereoBlend.cpp
+++ b/src/Features/VR/StereoBlend.cpp
@@ -5,6 +5,7 @@
 #include "Features/ScreenSpaceShadows.h"
 #include "Features/VRStereoOptimizations.h"
 #include "State.h"
+#include "Deferred.h"
 
 void VR::ClearShaderCache()
 {
@@ -79,10 +80,13 @@ void VR::DrawStereoBlend()
 		cbData.DebugMode = 1u;
 	else if (vrStereoOptActive && globals::features::vrStereoOptimizations.settings.debugFullBlendDepth)
 		cbData.DebugMode = 2u;
+	else if (vrStereoOptActive && globals::features::vrStereoOptimizations.settings.debugPOMDepth)
+		cbData.DebugMode = 3u;
 	else
 		cbData.DebugMode = 0u;
 
 	cbData.FullBlendDistance = vrStereoOptActive ? globals::features::vrStereoOptimizations.settings.fullBlendDistance : 0.0f;
+	cbData.POMDepthScale = vrStereoOptActive ? globals::features::vrStereoOptimizations.settings.pomDepthScale : 1.0f;
 
 	stereoBlendCB->Update(cbData);
 	auto cbPtr = stereoBlendCB->CB();
@@ -125,6 +129,10 @@ void VR::DrawStereoBlend()
 		if (modeSRV)
 			context->CSSetShaderResources(2, 1, &modeSRV);
 
+		// Bind REFLECTANCE SRV for POM depth offset (stored in .w by Lighting pass)
+		auto& reflectanceRT = renderer->GetRuntimeData().renderTargets[REFLECTANCE];
+		context->CSSetShaderResources(3, 1, &reflectanceRT.SRV);
+
 		ID3D11UnorderedAccessView* uavs[2]{ main.UAV, motionVectors.UAV };
 		context->CSSetUnorderedAccessViews(0, 2, uavs, nullptr);
 	} else {
@@ -132,16 +140,34 @@ void VR::DrawStereoBlend()
 		context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
 	}
 
+	// Bind linear sampler for hardware bilinear color sampling in overwrite mode
+	if (isOverwriteMode) {
+		if (!stereoBlendLinearSampler) {
+			D3D11_SAMPLER_DESC sampDesc = {};
+			sampDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+			sampDesc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+			sampDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+			sampDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+			globals::d3d::device->CreateSamplerState(&sampDesc, stereoBlendLinearSampler.put());
+		}
+		ID3D11SamplerState* samplers[] = { stereoBlendLinearSampler.get() };
+		context->CSSetSamplers(0, 1, samplers);
+	}
+
 	context->CSSetShader(activeCS, nullptr, 0);
 	context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
 
 	// Cleanup
-	ID3D11ShaderResourceView* nullSRVs[3] = {};
-	context->CSSetShaderResources(0, isOverwriteMode ? 3 : 2, nullSRVs);
+	ID3D11ShaderResourceView* nullSRVs[4] = {};
+	context->CSSetShaderResources(0, isOverwriteMode ? 4 : 2, nullSRVs);
 	ID3D11UnorderedAccessView* nullUAVs[2] = {};
 	context->CSSetUnorderedAccessViews(0, isOverwriteMode ? 2 : 1, nullUAVs, nullptr);
 	ID3D11Buffer* nullCB = nullptr;
 	context->CSSetConstantBuffers(1, 1, &nullCB);
+	if (isOverwriteMode) {
+		ID3D11SamplerState* nullSampler[] = { nullptr };
+		context->CSSetSamplers(0, 1, nullSampler);
+	}
 	context->CSSetShader(nullptr, nullptr, 0);
 
 	// Restore DSV after CS dispatch in overwrite mode

--- a/src/Features/VR/StereoBlend.cpp
+++ b/src/Features/VR/StereoBlend.cpp
@@ -1,11 +1,11 @@
 #include "Features/VR.h"
 
+#include "Deferred.h"
 #include "Features/DynamicCubemaps.h"
 #include "Features/ScreenSpaceGI.h"
 #include "Features/ScreenSpaceShadows.h"
 #include "Features/VRStereoOptimizations.h"
 #include "State.h"
-#include "Deferred.h"
 
 void VR::ClearShaderCache()
 {
@@ -183,5 +183,4 @@ void VR::DrawStereoBlend()
 
 	if (globals::state->frameAnnotations)
 		globals::state->EndPerfEvent();
-
 }

--- a/src/Features/VR/StereoBlend.cpp
+++ b/src/Features/VR/StereoBlend.cpp
@@ -3,6 +3,7 @@
 #include "Features/DynamicCubemaps.h"
 #include "Features/ScreenSpaceGI.h"
 #include "Features/ScreenSpaceShadows.h"
+#include "Features/VRStereoOptimizations.h"
 #include "State.h"
 
 void VR::ClearShaderCache()
@@ -11,6 +12,7 @@ void VR::ClearShaderCache()
 	stereoBlendDebugBackCheckCS = nullptr;
 	stereoBlendDebugBlendWeightCS = nullptr;
 	stereoBlendDebugEdgeDetectionCS = nullptr;
+	stereoBlendOverwriteCS = nullptr;
 }
 
 bool VR::AnyScreenSpaceEffectLoaded()
@@ -22,10 +24,20 @@ bool VR::AnyScreenSpaceEffectLoaded()
 
 void VR::DrawStereoBlend()
 {
-	if (!REL::Module::IsVR() || !settings.EnableStereoBlend || !stereoBlendCS || !stereoBlendCopyTex || !stereoBlendCB)
+	bool vrStereoOptActive = globals::features::vrStereoOptimizations.loaded &&
+	                         globals::features::vrStereoOptimizations.settings.stereoMode != VRStereoOptimizations::StereoMode::Off &&
+	                         stereoBlendOverwriteCS;
+
+	if (!REL::Module::IsVR() || !stereoBlendCopyTex || !stereoBlendCB)
 		return;
 
-	if (!AnyScreenSpaceEffectLoaded() && !globals::state->IsDeveloperMode())
+	if (vrStereoOptActive && globals::features::vrStereoOptimizations.settings.debugSkipMerge)
+		return;
+
+	if (!vrStereoOptActive && (!settings.EnableStereoBlend || !stereoBlendCS))
+		return;
+
+	if (!vrStereoOptActive && !AnyScreenSpaceEffectLoaded() && !globals::state->IsDeveloperMode())
 		return;
 
 	ZoneScoped;
@@ -38,9 +50,10 @@ void VR::DrawStereoBlend()
 	auto renderer = globals::game::renderer;
 
 	auto& main = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];
-	auto* depthSRV = Util::GetCurrentSceneDepthSRV();
+	// Use live depth buffer (kMAIN) — at DeferredPasses time this has the correct
+	// opaque geometry depth matching the composited color buffer.
+	auto* depthSRV = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN].depthSRV;
 
-	// Copy main color to read-only texture to avoid read/write race between eyes
 	context->CopyResource(stereoBlendCopyTex->resource.get(), main.texture);
 
 	auto dispatchCount = Util::GetScreenDispatchCount(true);
@@ -55,37 +68,94 @@ void VR::DrawStereoBlend()
 	cbData.MaxBlendFactor = settings.StereoBlendMaxFactor;
 	cbData.ColorDiffThreshold = settings.StereoBlendColorThreshold;
 
+	// Pass debug edge tint from VRStereoOptimizations settings
+	if (vrStereoOptActive && globals::features::vrStereoOptimizations.settings.debugVisualization)
+		cbData.DebugEdgeTint = 0.3f;
+	else
+		cbData.DebugEdgeTint = 0.0f;
+
+	// Debug mode: 0=normal, 1=depth map diagnostic, 2=full blend depth visualizer
+	if (vrStereoOptActive && globals::features::vrStereoOptimizations.settings.debugDepthMap)
+		cbData.DebugMode = 1u;
+	else if (vrStereoOptActive && globals::features::vrStereoOptimizations.settings.debugFullBlendDepth)
+		cbData.DebugMode = 2u;
+	else
+		cbData.DebugMode = 0u;
+
+	cbData.FullBlendDistance = vrStereoOptActive ? globals::features::vrStereoOptimizations.settings.fullBlendDistance : 0.0f;
+
 	stereoBlendCB->Update(cbData);
 	auto cbPtr = stereoBlendCB->CB();
 
-	ID3D11ShaderResourceView* srvs[2]{ stereoBlendCopyTex->srv.get(), depthSRV };
-	ID3D11UnorderedAccessView* uavs[1]{ main.UAV };
+	auto& motionVectors = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMOTION_VECTOR];
+
+	bool isOverwriteMode = vrStereoOptActive;
 
 	ID3D11ComputeShader* activeCS = stereoBlendCS.get();
-	if (settings.StereoBlendDebugMode == 1 && stereoBlendDebugBackCheckCS)
-		activeCS = stereoBlendDebugBackCheckCS.get();
-	else if (settings.StereoBlendDebugMode == 2 && stereoBlendDebugBlendWeightCS)
-		activeCS = stereoBlendDebugBlendWeightCS.get();
-	else if (settings.StereoBlendDebugMode == 3 && stereoBlendDebugEdgeDetectionCS)
-		activeCS = stereoBlendDebugEdgeDetectionCS.get();
+	if (vrStereoOptActive) {
+		activeCS = stereoBlendOverwriteCS.get();
+	} else {
+		int effectiveMode = settings.StereoBlendDebugMode;
+		if (effectiveMode == 1 && stereoBlendDebugBackCheckCS)
+			activeCS = stereoBlendDebugBackCheckCS.get();
+		else if (effectiveMode == 2 && stereoBlendDebugBlendWeightCS)
+			activeCS = stereoBlendDebugBlendWeightCS.get();
+		else if (effectiveMode == 3 && stereoBlendDebugEdgeDetectionCS)
+			activeCS = stereoBlendDebugEdgeDetectionCS.get();
+	}
 
+	// Save and unbind DSV to avoid SRV/DSV conflict on depth buffer in overwrite mode
+	ID3D11RenderTargetView* savedRTVs[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT] = {};
+	ID3D11DepthStencilView* savedDSV = nullptr;
+	if (isOverwriteMode) {
+		context->OMGetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, savedRTVs, &savedDSV);
+		context->OMSetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, savedRTVs, nullptr);
+		for (auto& rtv : savedRTVs) {
+			if (rtv)
+				rtv->Release();
+		}
+	}
+
+	ID3D11ShaderResourceView* srvs[2]{ stereoBlendCopyTex->srv.get(), depthSRV };
 	context->CSSetConstantBuffers(1, 1, &cbPtr);
 	context->CSSetShaderResources(0, 2, srvs);
-	context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
-	context->CSSetShader(activeCS, nullptr, 0);
 
+	if (isOverwriteMode) {
+		ID3D11ShaderResourceView* modeSRV = globals::features::vrStereoOptimizations.GetModeTextureSRV();
+		if (modeSRV)
+			context->CSSetShaderResources(2, 1, &modeSRV);
+
+		ID3D11UnorderedAccessView* uavs[2]{ main.UAV, motionVectors.UAV };
+		context->CSSetUnorderedAccessViews(0, 2, uavs, nullptr);
+	} else {
+		ID3D11UnorderedAccessView* uavs[1]{ main.UAV };
+		context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
+	}
+
+	context->CSSetShader(activeCS, nullptr, 0);
 	context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
 
 	// Cleanup
-	srvs[0] = nullptr;
-	srvs[1] = nullptr;
-	uavs[0] = nullptr;
-	cbPtr = nullptr;
-	context->CSSetShaderResources(0, 2, srvs);
-	context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
-	context->CSSetConstantBuffers(1, 1, &cbPtr);
+	ID3D11ShaderResourceView* nullSRVs[3] = {};
+	context->CSSetShaderResources(0, isOverwriteMode ? 3 : 2, nullSRVs);
+	ID3D11UnorderedAccessView* nullUAVs[2] = {};
+	context->CSSetUnorderedAccessViews(0, isOverwriteMode ? 2 : 1, nullUAVs, nullptr);
+	ID3D11Buffer* nullCB = nullptr;
+	context->CSSetConstantBuffers(1, 1, &nullCB);
 	context->CSSetShader(nullptr, nullptr, 0);
+
+	// Restore DSV after CS dispatch in overwrite mode
+	if (isOverwriteMode && savedDSV) {
+		context->OMGetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, savedRTVs, nullptr);
+		context->OMSetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, savedRTVs, savedDSV);
+		for (auto& rtv : savedRTVs) {
+			if (rtv)
+				rtv->Release();
+		}
+		savedDSV->Release();
+	}
 
 	if (globals::state->frameAnnotations)
 		globals::state->EndPerfEvent();
+
 }

--- a/src/Features/VR/StereoBlend.cpp
+++ b/src/Features/VR/StereoBlend.cpp
@@ -6,6 +6,7 @@
 #include "Features/ScreenSpaceShadows.h"
 #include "Features/VRStereoOptimizations.h"
 #include "State.h"
+#include "Utils/D3D.h"
 
 void VR::ClearShaderCache()
 {
@@ -51,9 +52,7 @@ void VR::DrawStereoBlend()
 	auto renderer = globals::game::renderer;
 
 	auto& main = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];
-	// Use live depth buffer (kMAIN) — at DeferredPasses time this has the correct
-	// opaque geometry depth matching the composited color buffer.
-	auto* depthSRV = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN].depthSRV;
+	auto* depthSRV = Util::GetCurrentSceneDepthSRV();
 
 	context->CopyResource(stereoBlendCopyTex->resource.get(), main.texture);
 

--- a/src/Features/VRStereoOptimizations.cpp
+++ b/src/Features/VRStereoOptimizations.cpp
@@ -1,5 +1,6 @@
 #include "VRStereoOptimizations.h"
 
+#include "ExtendedMaterials.h"
 #include "Globals.h"
 #include "State.h"
 #include "Utils/D3D.h"
@@ -79,8 +80,10 @@ void VRStereoOptimizations::LoadSettings(json& o_json)
 		settings.mipBiasNearDist = o_json["MipBiasNearDist"].get<float>();
 	if (o_json.contains("MipBiasFarDist"))
 		settings.mipBiasFarDist = o_json["MipBiasFarDist"].get<float>();
-	if (o_json.contains("CASStrength"))
-		settings.casStrength = o_json["CASStrength"].get<float>();
+	// CAS disabled for now — ignore saved value
+	// if (o_json.contains("CASStrength"))
+	//	settings.casStrength = o_json["CASStrength"].get<float>();
+	settings.casStrength = 0.0f;
 	if (o_json.contains("AlphaTestThreshold"))
 		settings.alphaTestThreshold = o_json["AlphaTestThreshold"].get<float>();
 }
@@ -332,23 +335,29 @@ void VRStereoOptimizations::DrawSettings()
 	ImGui::Separator();
 
 
-	ImGui::SliderFloat("CAS Sharpening", &settings.casStrength, 0.0f, 1.0f, "%.2f");
-	if (ImGui::IsItemHovered())
-		ImGui::SetTooltip("Contrast Adaptive Sharpening (intended for use with TAA).\n0 = disabled, higher = sharper.");
-	ImGui::Separator();
+	// CAS slider hidden for now — forced to 0
+	// ImGui::SliderFloat("CAS Sharpening", &settings.casStrength, 0.0f, 1.0f, "%.2f");
+	// if (ImGui::IsItemHovered())
+	//	ImGui::SetTooltip("Contrast Adaptive Sharpening (intended for use with TAA).\n0 = disabled, higher = sharper.");
+	// ImGui::Separator();
 
 	if (settings.stereoMode == StereoMode::Off)
 		return;
 
 	ImGui::SliderFloat("Disocclusion Depth Threshold", &settings.disocclusionDepthThreshold, 0.001f, 0.1f, "%.4f");
-	ImGui::SliderFloat("Full Blend Distance", &settings.fullBlendDistance, 0.0f, 10000.0f, "%.0f");
-	if (ImGui::IsItemHovered())
-		ImGui::SetTooltip("Geometry closer than this distance (game units) is fully shaded in both eyes and bilaterally blended for 2x supersampling. 0 = disabled.");
 
 	if (globals::state->IsDeveloperMode()) {
 		if (ImGui::TreeNode("Debug")) {
+			ImGui::SliderFloat("Full Blend Distance", &settings.fullBlendDistance, 0.0f, 10000.0f, "%.0f");
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip("Geometry closer than this distance (game units) is fully shaded in both eyes and bilaterally blended for 2x supersampling. 0 = disabled.");
+
+			ImGui::SliderFloat("POM Depth Scale", &settings.pomDepthScale, 0.0f, 500.0f, "%.1f");
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip("Scale factor for POM depth correction in stereo reprojection.\n1.0 = physical scale. Increase for more visible POM stereo depth.");
 			ImGui::Checkbox("Skip Pixel Reprojection", &settings.debugSkipMerge);
 			ImGui::Checkbox("Full Blend Depth View", &settings.debugFullBlendDepth);
+			ImGui::Checkbox("Debug POM Depth", &settings.debugPOMDepth);
 			if (settings.debugFullBlendDepth)
 				ImGui::TextColored(ImVec4(0, 1, 1, 1), "  Cyan = full blend zone (closer = stronger tint)");
 			ImGui::Text("Stencil swaps this frame: %u", stencilSwapCount);

--- a/src/Features/VRStereoOptimizations.cpp
+++ b/src/Features/VRStereoOptimizations.cpp
@@ -421,6 +421,10 @@ void VRStereoOptimizations::DispatchStencil()
 	// StencilCS can correctly detect sky-vs-geometry edges in the current frame.
 	auto renderer = globals::game::renderer;
 	auto* depthSRV = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN].depthSRV;
+	if (!depthSRV) {
+		logger::warn("[VRStereoOptimizations] DispatchStencil: depthSRV is null, skipping");
+		return;
+	}
 
 	// Dispatch classification CS over Eye 1 region
 	// Input: t0 = depth, b1 = params CB
@@ -659,10 +663,14 @@ void VRStereoOptimizations::DispatchReprojection()
 		return;
 	if (settings.stereoMode == StereoMode::Off)
 		return;
-	if (!reprojectionCS || !texPerPixelMode || !paramsCB)
+	if (!reprojectionCS || !texPerPixelMode || !paramsCB) {
+		DeactivateStencil();
 		return;
-	if (settings.debugSkipMerge)
+	}
+	if (settings.debugSkipMerge) {
+		DeactivateStencil();
 		return;
+	}
 
 	ZoneScoped;
 	TracyD3D11Zone(globals::state->tracyCtx, "VR Stereo Opt - Reprojection");

--- a/src/Features/VRStereoOptimizations.cpp
+++ b/src/Features/VRStereoOptimizations.cpp
@@ -10,9 +10,9 @@
 
 // JSON enum serialization for StereoMode
 NLOHMANN_JSON_SERIALIZE_ENUM(VRStereoOptimizations::StereoMode, {
-	{ VRStereoOptimizations::StereoMode::Off, "Off" },
-	{ VRStereoOptimizations::StereoMode::Enable, "Enable" },
-})
+																	{ VRStereoOptimizations::StereoMode::Off, "Off" },
+																	{ VRStereoOptimizations::StereoMode::Enable, "Enable" },
+																})
 
 //=============================================================================
 // SETTINGS MANAGEMENT
@@ -333,7 +333,6 @@ void VRStereoOptimizations::DrawSettings()
 			ImGui::SetTooltip("Game units. Full MIP bias beyond this distance.\nSmooth ramp between near and far.");
 	}
 	ImGui::Separator();
-
 
 	// CAS slider hidden for now — forced to 0
 	// ImGui::SliderFloat("CAS Sharpening", &settings.casStrength, 0.0f, 1.0f, "%.2f");

--- a/src/Features/VRStereoOptimizations.cpp
+++ b/src/Features/VRStereoOptimizations.cpp
@@ -1,0 +1,812 @@
+#include "VRStereoOptimizations.h"
+
+#include "Globals.h"
+#include "State.h"
+#include "Utils/D3D.h"
+#include "Utils/Game.h"
+
+#include <imgui.h>
+
+// JSON enum serialization for StereoMode
+NLOHMANN_JSON_SERIALIZE_ENUM(VRStereoOptimizations::StereoMode, {
+	{ VRStereoOptimizations::StereoMode::Off, "Off" },
+	{ VRStereoOptimizations::StereoMode::Enable, "Enable" },
+})
+
+//=============================================================================
+// SETTINGS MANAGEMENT
+//=============================================================================
+
+void VRStereoOptimizations::SaveSettings(json& o_json)
+{
+	o_json["StereoMode"] = settings.stereoMode;
+	o_json["DisocclusionDepthThreshold"] = settings.disocclusionDepthThreshold;
+	o_json["FullBlendDistance"] = settings.fullBlendDistance;
+	o_json["QualityJitterOffset"] = settings.qualityJitterOffset;
+	o_json["FoveatedRegionRadius"] = settings.foveatedRegionRadius;
+	o_json["FoveatedRegionCenterX"] = settings.foveatedRegionCenterX;
+	o_json["FoveatedRegionCenterY"] = settings.foveatedRegionCenterY;
+	o_json["UseEyeTracking"] = settings.useEyeTracking;
+	o_json["DebugVisualization"] = settings.debugVisualization;
+	o_json["DebugSkipMerge"] = settings.debugSkipMerge;
+	o_json["DebugForceAllStencil"] = settings.debugForceAllStencil;
+	o_json["DebugForceAllReprojectCS"] = settings.debugForceAllReprojectCS;
+	o_json["DebugDepthMap"] = settings.debugDepthMap;
+	o_json["MipBiasMode"] = settings.mipBiasMode;
+	o_json["MipLodBias"] = settings.mipLodBias;
+	o_json["MipBiasNearDist"] = settings.mipBiasNearDist;
+	o_json["MipBiasFarDist"] = settings.mipBiasFarDist;
+	o_json["CASStrength"] = settings.casStrength;
+	o_json["AlphaTestThreshold"] = settings.alphaTestThreshold;
+}
+
+void VRStereoOptimizations::LoadSettings(json& o_json)
+{
+	if (o_json.contains("StereoMode"))
+		settings.stereoMode = o_json["StereoMode"].get<StereoMode>();
+	if (o_json.contains("DisocclusionDepthThreshold"))
+		settings.disocclusionDepthThreshold = o_json["DisocclusionDepthThreshold"].get<float>();
+	if (o_json.contains("QualityJitterOffset"))
+		settings.qualityJitterOffset = o_json["QualityJitterOffset"].get<float>();
+	if (o_json.contains("FoveatedRegionRadius"))
+		settings.foveatedRegionRadius = o_json["FoveatedRegionRadius"].get<float>();
+	if (o_json.contains("FoveatedRegionCenterX"))
+		settings.foveatedRegionCenterX = o_json["FoveatedRegionCenterX"].get<float>();
+	if (o_json.contains("FoveatedRegionCenterY"))
+		settings.foveatedRegionCenterY = o_json["FoveatedRegionCenterY"].get<float>();
+	if (o_json.contains("UseEyeTracking"))
+		settings.useEyeTracking = o_json["UseEyeTracking"].get<bool>();
+	if (o_json.contains("DebugVisualization"))
+		settings.debugVisualization = o_json["DebugVisualization"].get<bool>();
+	if (o_json.contains("DebugSkipMerge"))
+		settings.debugSkipMerge = o_json["DebugSkipMerge"].get<bool>();
+	if (o_json.contains("DebugForceAllStencil"))
+		settings.debugForceAllStencil = o_json["DebugForceAllStencil"].get<bool>();
+	if (o_json.contains("DebugForceAllReprojectCS"))
+		settings.debugForceAllReprojectCS = o_json["DebugForceAllReprojectCS"].get<bool>();
+	if (o_json.contains("DebugDepthMap"))
+		settings.debugDepthMap = o_json["DebugDepthMap"].get<bool>();
+	if (o_json.contains("FullBlendDistance"))
+		settings.fullBlendDistance = o_json["FullBlendDistance"].get<float>();
+	if (o_json.contains("MipBiasMode"))
+		settings.mipBiasMode = o_json["MipBiasMode"].get<int>();
+	// Backwards compat: old bool EnableMipBias -> mode 2 (Distant Trees)
+	else if (o_json.contains("EnableMipBias") && o_json["EnableMipBias"].get<bool>())
+		settings.mipBiasMode = 2;
+	if (o_json.contains("MipLodBias"))
+		settings.mipLodBias = o_json["MipLodBias"].get<float>();
+	if (o_json.contains("MipBiasNearDist"))
+		settings.mipBiasNearDist = o_json["MipBiasNearDist"].get<float>();
+	if (o_json.contains("MipBiasFarDist"))
+		settings.mipBiasFarDist = o_json["MipBiasFarDist"].get<float>();
+	if (o_json.contains("CASStrength"))
+		settings.casStrength = o_json["CASStrength"].get<float>();
+	if (o_json.contains("AlphaTestThreshold"))
+		settings.alphaTestThreshold = o_json["AlphaTestThreshold"].get<float>();
+}
+
+void VRStereoOptimizations::RestoreDefaultSettings()
+{
+	settings = {};
+}
+
+//=============================================================================
+// RESOURCE SETUP
+//=============================================================================
+
+void VRStereoOptimizations::SetupResources()
+{
+	if (!REL::Module::IsVR())
+		return;
+
+	auto device = globals::d3d::device;
+	auto renderer = globals::game::renderer;
+
+	// Constant buffers
+	paramsCB = eastl::make_unique<ConstantBuffer>(ConstantBufferDesc<VRStereoOptParams>());
+
+	// Get main RT dimensions for per-eye calculations
+	auto& main = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];
+	D3D11_TEXTURE2D_DESC mainDesc;
+	main.texture->GetDesc(&mainDesc);
+
+	// Per-pixel mode texture (R8_UINT, full SBS resolution = both eyes)
+	{
+		D3D11_TEXTURE2D_DESC modeDesc{};
+		modeDesc.Width = mainDesc.Width;
+		modeDesc.Height = mainDesc.Height;
+		modeDesc.MipLevels = 1;
+		modeDesc.ArraySize = 1;
+		modeDesc.Format = DXGI_FORMAT_R8_UINT;
+		modeDesc.SampleDesc.Count = 1;
+		modeDesc.SampleDesc.Quality = 0;
+		modeDesc.Usage = D3D11_USAGE_DEFAULT;
+		modeDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
+		modeDesc.CPUAccessFlags = 0;
+		modeDesc.MiscFlags = 0;
+
+		texPerPixelMode = eastl::make_unique<Texture2D>(modeDesc);
+		texPerPixelMode->CreateSRV(D3D11_SHADER_RESOURCE_VIEW_DESC{
+			.Format = DXGI_FORMAT_R8_UINT,
+			.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D,
+			.Texture2D = { .MostDetailedMip = 0, .MipLevels = 1 } });
+		texPerPixelMode->CreateUAV(D3D11_UNORDERED_ACCESS_VIEW_DESC{
+			.Format = DXGI_FORMAT_R8_UINT,
+			.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D,
+			.Texture2D = { .MipSlice = 0 } });
+	}
+
+	// Depth-stencil state for stencil write pass:
+	// Depth test OFF (not rendering geometry), stencil ALWAYS + REPLACE with ref=1
+	{
+		D3D11_DEPTH_STENCIL_DESC dssDesc{};
+		dssDesc.DepthEnable = FALSE;
+		dssDesc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ZERO;
+		dssDesc.StencilEnable = TRUE;
+		dssDesc.StencilReadMask = 0xFF;
+		dssDesc.StencilWriteMask = 0xFF;
+		dssDesc.FrontFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
+		dssDesc.FrontFace.StencilDepthFailOp = D3D11_STENCIL_OP_KEEP;
+		dssDesc.FrontFace.StencilPassOp = D3D11_STENCIL_OP_REPLACE;
+		dssDesc.FrontFace.StencilFunc = D3D11_COMPARISON_ALWAYS;
+		dssDesc.BackFace = dssDesc.FrontFace;
+
+		DX::ThrowIfFailed(device->CreateDepthStencilState(&dssDesc, stencilWriteDSS.put()));
+	}
+
+	// Rasterizer state for stencil write: no culling, no depth clip
+	{
+		D3D11_RASTERIZER_DESC rsDesc{};
+		rsDesc.FillMode = D3D11_FILL_SOLID;
+		rsDesc.CullMode = D3D11_CULL_NONE;
+		rsDesc.DepthClipEnable = FALSE;
+
+		DX::ThrowIfFailed(device->CreateRasterizerState(&rsDesc, stencilWriteRS.put()));
+	}
+
+	// Read-only depth DSV for stencil write pass: allows simultaneous depth SRV binding.
+	// We write stencil but never write depth, so D3D11_DSV_READ_ONLY_DEPTH is safe.
+	{
+		auto& depthData = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
+		if (depthData.views[0] && depthData.texture) {
+			D3D11_DEPTH_STENCIL_VIEW_DESC dsvDesc{};
+			depthData.views[0]->GetDesc(&dsvDesc);
+			dsvDesc.Flags = D3D11_DSV_READ_ONLY_DEPTH;
+
+			DX::ThrowIfFailed(device->CreateDepthStencilView(depthData.texture, &dsvDesc, stencilWriteReadOnlyDSV.put()));
+		} else {
+			logger::warn("[VRStereoOptimizations] Could not create read-only DSV: depth stencil data not available");
+		}
+	}
+
+	// CAS sharpness parameter buffer (structured buffer SRV to avoid cbuffer conflicts)
+	{
+		D3D11_BUFFER_DESC bufDesc{};
+		bufDesc.ByteWidth = sizeof(float);
+		bufDesc.Usage = D3D11_USAGE_DYNAMIC;
+		bufDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+		bufDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+		bufDesc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
+		bufDesc.StructureByteStride = sizeof(float);
+
+		float initSharpness = settings.casStrength;
+		D3D11_SUBRESOURCE_DATA initData{};
+		initData.pSysMem = &initSharpness;
+
+		DX::ThrowIfFailed(device->CreateBuffer(&bufDesc, &initData, casParamsBuf.put()));
+
+		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc{};
+		srvDesc.Format = DXGI_FORMAT_UNKNOWN;
+		srvDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
+		srvDesc.Buffer.FirstElement = 0;
+		srvDesc.Buffer.NumElements = 1;
+		DX::ThrowIfFailed(device->CreateShaderResourceView(casParamsBuf.get(), &srvDesc, casParamsSRV.put()));
+	}
+
+	// CAS output texture (same format as main RT, with UAV capability)
+	{
+		D3D11_TEXTURE2D_DESC casDesc{};
+		casDesc.Width = mainDesc.Width;
+		casDesc.Height = mainDesc.Height;
+		casDesc.MipLevels = 1;
+		casDesc.ArraySize = 1;
+		casDesc.Format = mainDesc.Format;
+		casDesc.SampleDesc.Count = 1;
+		casDesc.SampleDesc.Quality = 0;
+		casDesc.Usage = D3D11_USAGE_DEFAULT;
+		casDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
+		casDesc.CPUAccessFlags = 0;
+		casDesc.MiscFlags = 0;
+
+		casTex = eastl::make_unique<Texture2D>(casDesc);
+		casTex->CreateSRV(D3D11_SHADER_RESOURCE_VIEW_DESC{
+			.Format = mainDesc.Format,
+			.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D,
+			.Texture2D = { .MostDetailedMip = 0, .MipLevels = 1 } });
+		casTex->CreateUAV(D3D11_UNORDERED_ACCESS_VIEW_DESC{
+			.Format = mainDesc.Format,
+			.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D,
+			.Texture2D = { .MipSlice = 0 } });
+	}
+
+	CompileShaders();
+
+	logger::info("[VRStereoOptimizations] Resources created: mode tex {}x{} (full SBS)", mainDesc.Width, mainDesc.Height);
+}
+
+void VRStereoOptimizations::CompileShaders()
+{
+	std::vector<std::pair<const char*, const char*>> csDefines = {
+		{ "VR", nullptr },
+		{ "FRAMEBUFFER", nullptr }
+	};
+
+	std::vector<std::pair<const char*, const char*>> vspsDefines = {
+		{ "VR", nullptr }
+	};
+
+	if (auto* ptr = Util::CompileShader(L"Data\\Shaders\\VRStereoOptimizations\\StencilCS.hlsl", csDefines, "cs_5_0"))
+		stencilCS.attach(reinterpret_cast<ID3D11ComputeShader*>(ptr));
+	else
+		logger::error("[VRStereoOptimizations] Failed to compile StencilCS");
+
+	{
+		auto debugDefines = csDefines;
+		debugDefines.push_back({ "DEBUG_DEPTH_MAP", nullptr });
+		if (auto* ptr = Util::CompileShader(L"Data\\Shaders\\VRStereoOptimizations\\StencilCS.hlsl", debugDefines, "cs_5_0"))
+			stencilDebugDepthMapCS.attach(reinterpret_cast<ID3D11ComputeShader*>(ptr));
+		else
+			logger::error("[VRStereoOptimizations] Failed to compile StencilCS (DEBUG_DEPTH_MAP)");
+	}
+
+	if (auto* ptr = Util::CompileShader(L"Data\\Shaders\\VRStereoOptimizations\\StencilWriteVS.hlsl", vspsDefines, "vs_5_0"))
+		stencilWriteVS.attach(reinterpret_cast<ID3D11VertexShader*>(ptr));
+	else
+		logger::error("[VRStereoOptimizations] Failed to compile StencilWriteVS");
+
+	if (auto* ptr = Util::CompileShader(L"Data\\Shaders\\VRStereoOptimizations\\StencilWritePS.hlsl", vspsDefines, "ps_5_0"))
+		stencilWritePS.attach(reinterpret_cast<ID3D11PixelShader*>(ptr));
+	else
+		logger::error("[VRStereoOptimizations] Failed to compile StencilWritePS");
+
+	if (auto* ptr = Util::CompileShader(L"Data\\Shaders\\VRStereoOptimizations\\ReprojectionCS.hlsl", csDefines, "cs_5_0"))
+		reprojectionCS.attach(reinterpret_cast<ID3D11ComputeShader*>(ptr));
+	else
+		logger::error("[VRStereoOptimizations] Failed to compile ReprojectionCS");
+
+	{
+		std::vector<std::pair<const char*, const char*>> casDefines = {};
+		if (auto* ptr = Util::CompileShader(L"Data\\Shaders\\VR\\CASCS.hlsl", casDefines, "cs_5_0"))
+			casCS.attach(reinterpret_cast<ID3D11ComputeShader*>(ptr));
+		else
+			logger::error("[VRStereoOptimizations] Failed to compile CASCS");
+	}
+}
+
+void VRStereoOptimizations::ClearShaderCache()
+{
+	stencilCS = nullptr;
+	stencilDebugDepthMapCS = nullptr;
+	stencilWriteVS = nullptr;
+	stencilWritePS = nullptr;
+	reprojectionCS = nullptr;
+	casCS = nullptr;
+	dssCache.clear();
+}
+
+void VRStereoOptimizations::Reset()
+{
+	stencilActive = false;
+	stencilSwapCount = 0;
+}
+
+//=============================================================================
+// IMGUI SETTINGS
+//=============================================================================
+
+void VRStereoOptimizations::DrawSettings()
+{
+	const char* modeNames[] = { "Off", "Enable" };
+	int currentMode = static_cast<int>(settings.stereoMode);
+	if (ImGui::Combo("Feature Enable", &currentMode, modeNames, IM_ARRAYSIZE(modeNames)))
+		settings.stereoMode = static_cast<StereoMode>(currentMode);
+
+	// MIP LOD Bias section (always shown, independent of stereo mode)
+	ImGui::Separator();
+	const char* mipBiasModes[] = { "Off", "All Textures", "Distant Trees" };
+	ImGui::Combo("MIP LOD Bias", &settings.mipBiasMode, mipBiasModes, 3);
+	if (ImGui::IsItemHovered())
+		ImGui::SetTooltip("Off: No MIP bias\nAll Textures: Depth-gated sharpening for all textures\nDistant Trees: Depth-gated sharpening for foliage only");
+
+	if (settings.mipBiasMode > 0) {
+		ImGui::SliderFloat("MIP Bias Strength", &settings.mipLodBias, -3.0f, 0.0f, "%.2f");
+		if (ImGui::IsItemHovered())
+			ImGui::SetTooltip("Negative = sharper. -0.5 subtle, -1.0 moderate, -2.0 aggressive.");
+		ImGui::SliderFloat("MIP Near Distance", &settings.mipBiasNearDist, 0.0f, 10000.0f, "%.0f");
+		if (ImGui::IsItemHovered())
+			ImGui::SetTooltip("Game units. No MIP bias closer than this distance.");
+		ImGui::SliderFloat("MIP Far Distance", &settings.mipBiasFarDist, 0.0f, 20000.0f, "%.0f");
+		if (ImGui::IsItemHovered())
+			ImGui::SetTooltip("Game units. Full MIP bias beyond this distance.\nSmooth ramp between near and far.");
+	}
+	ImGui::Separator();
+
+
+	ImGui::SliderFloat("CAS Sharpening", &settings.casStrength, 0.0f, 1.0f, "%.2f");
+	if (ImGui::IsItemHovered())
+		ImGui::SetTooltip("Contrast Adaptive Sharpening (intended for use with TAA).\n0 = disabled, higher = sharper.");
+	ImGui::Separator();
+
+	if (settings.stereoMode == StereoMode::Off)
+		return;
+
+	ImGui::SliderFloat("Disocclusion Depth Threshold", &settings.disocclusionDepthThreshold, 0.001f, 0.1f, "%.4f");
+	ImGui::SliderFloat("Full Blend Distance", &settings.fullBlendDistance, 0.0f, 10000.0f, "%.0f");
+	if (ImGui::IsItemHovered())
+		ImGui::SetTooltip("Geometry closer than this distance (game units) is fully shaded in both eyes and bilaterally blended for 2x supersampling. 0 = disabled.");
+
+	if (globals::state->IsDeveloperMode()) {
+		if (ImGui::TreeNode("Debug")) {
+			ImGui::Checkbox("Skip Pixel Reprojection", &settings.debugSkipMerge);
+			ImGui::Checkbox("Full Blend Depth View", &settings.debugFullBlendDepth);
+			if (settings.debugFullBlendDepth)
+				ImGui::TextColored(ImVec4(0, 1, 1, 1), "  Cyan = full blend zone (closer = stronger tint)");
+			ImGui::Text("Stencil swaps this frame: %u", stencilSwapCount);
+			ImGui::TreePop();
+		}
+	}
+}
+
+//=============================================================================
+// CONSTANT BUFFER UPDATE
+//=============================================================================
+
+void VRStereoOptimizations::UpdateConstantBuffer()
+{
+	float2 resolution = Util::ConvertToDynamic(globals::state->screenSize);
+
+	VRStereoOptParams params{};
+	params.FrameDim[0] = resolution.x;
+	params.FrameDim[1] = resolution.y;
+	params.RcpFrameDim[0] = 1.0f / resolution.x;
+	params.RcpFrameDim[1] = 1.0f / resolution.y;
+	params.StereoModeValue = static_cast<uint32_t>(settings.stereoMode);
+	params.DisocclusionThreshold = settings.disocclusionDepthThreshold;
+	params.EdgeDepthThreshold = settings.edgeDepthThreshold;
+	params.EdgeWidth = static_cast<uint32_t>(settings.edgeWidth);
+	params.QualityJitter[0] = settings.qualityJitterOffset;
+	params.QualityJitter[1] = settings.qualityJitterOffset;
+	params.FoveatedRadius = settings.foveatedRegionRadius;
+	params.FoveatedCenter[0] = settings.foveatedRegionCenterX;
+	params.FoveatedCenter[1] = settings.foveatedRegionCenterY;
+	params.MinEdgeDistance = settings.minEdgeDistance;
+	params.FullBlendDistance = settings.fullBlendDistance;
+
+	paramsCB->Update(params);
+}
+
+//=============================================================================
+// PHASE 1: STENCIL CLASSIFICATION + WRITE
+//=============================================================================
+
+void VRStereoOptimizations::DispatchStencil()
+{
+	if (!REL::Module::IsVR())
+		return;
+	if (settings.stereoMode == StereoMode::Off)
+		return;
+	if (!stencilCS || !stencilWriteVS || !stencilWritePS || !texPerPixelMode || !paramsCB)
+		return;
+
+	ZoneScoped;
+	TracyD3D11Zone(globals::state->tracyCtx, "VR Stereo Opt - Stencil");
+
+	if (globals::state->frameAnnotations)
+		globals::state->BeginPerfEvent("VR Stereo Opt - Stencil");
+
+	auto context = globals::d3d::context;
+
+	UpdateConstantBuffer();
+	auto cbPtr = paramsCB->CB();
+	// Use live depth buffer (kMAIN) instead of kPOST_ZPREPASS_COPY — at StartDeferred time,
+	// kPOST_ZPREPASS_COPY is stale (previous frame). kMAIN has fresh z-prepass depth so
+	// StencilCS can correctly detect sky-vs-geometry edges in the current frame.
+	auto renderer = globals::game::renderer;
+	auto* depthSRV = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN].depthSRV;
+
+	// Dispatch classification CS over Eye 1 region
+	// Input: t0 = depth, b1 = params CB
+	// Output: u0 = per-pixel mode texture
+	{
+		ID3D11ShaderResourceView* srvs[1]{ depthSRV };
+		ID3D11UnorderedAccessView* uavs[1]{ texPerPixelMode->uav.get() };
+
+		context->CSSetConstantBuffers(1, 1, &cbPtr);
+		context->CSSetShaderResources(0, 1, srvs);
+		context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
+		auto* activeStencilCS = (settings.debugDepthMap && stencilDebugDepthMapCS) ? stencilDebugDepthMapCS.get() : stencilCS.get();
+		context->CSSetShader(activeStencilCS, nullptr, 0);
+
+		uint32_t fullWidth = texPerPixelMode->desc.Width;
+		uint32_t fullHeight = texPerPixelMode->desc.Height;
+		context->Dispatch((fullWidth + 7) / 8, (fullHeight + 7) / 8, 1);
+
+		// Cleanup CS bindings
+		ID3D11ShaderResourceView* nullSRV = nullptr;
+		ID3D11UnorderedAccessView* nullUAV = nullptr;
+		ID3D11Buffer* nullCB = nullptr;
+		context->CSSetShaderResources(0, 1, &nullSRV);
+		context->CSSetUnorderedAccessViews(0, 1, &nullUAV, nullptr);
+		context->CSSetConstantBuffers(1, 1, &nullCB);
+		context->CSSetShader(nullptr, nullptr, 0);
+	}
+
+	// Transfer classification to hardware stencil buffer
+	ExecuteStencilWritePass();
+
+	stencilActive = true;
+	stencilSwapCount = 0;
+
+	if (globals::state->frameAnnotations)
+		globals::state->EndPerfEvent();
+}
+
+void VRStereoOptimizations::ExecuteStencilWritePass()
+{
+	auto context = globals::d3d::context;
+	auto renderer = globals::game::renderer;
+
+	// ===== SAVE FULL D3D11 PIPELINE STATE =====
+
+	ID3D11RenderTargetView* savedRTVs[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT] = {};
+	ID3D11DepthStencilView* savedDSV = nullptr;
+	context->OMGetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, savedRTVs, &savedDSV);
+
+	ID3D11DepthStencilState* savedDSS = nullptr;
+	UINT savedStencilRef = 0;
+	context->OMGetDepthStencilState(&savedDSS, &savedStencilRef);
+
+	ID3D11BlendState* savedBlendState = nullptr;
+	FLOAT savedBlendFactor[4] = {};
+	UINT savedSampleMask = 0;
+	context->OMGetBlendState(&savedBlendState, savedBlendFactor, &savedSampleMask);
+
+	ID3D11RasterizerState* savedRS = nullptr;
+	context->RSGetState(&savedRS);
+
+	D3D11_VIEWPORT savedViewports[D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE] = {};
+	UINT numViewports = D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE;
+	context->RSGetViewports(&numViewports, savedViewports);
+
+	ID3D11VertexShader* savedVS = nullptr;
+	context->VSGetShader(&savedVS, nullptr, nullptr);
+
+	ID3D11PixelShader* savedPS = nullptr;
+	context->PSGetShader(&savedPS, nullptr, nullptr);
+
+	ID3D11GeometryShader* savedGS = nullptr;
+	context->GSGetShader(&savedGS, nullptr, nullptr);
+
+	ID3D11InputLayout* savedInputLayout = nullptr;
+	context->IAGetInputLayout(&savedInputLayout);
+
+	D3D11_PRIMITIVE_TOPOLOGY savedTopology = D3D11_PRIMITIVE_TOPOLOGY_UNDEFINED;
+	context->IAGetPrimitiveTopology(&savedTopology);
+
+	ID3D11ShaderResourceView* savedPSSRVs[2] = {};
+	context->PSGetShaderResources(0, 2, savedPSSRVs);
+
+	ID3D11Buffer* savedPSCB = nullptr;
+	context->PSGetConstantBuffers(1, 1, &savedPSCB);
+
+	// ===== SET UP STENCIL WRITE PASS =====
+
+	// Use our custom read-only-depth DSV to allow simultaneous depth SRV binding (t1).
+	// D3D11_DSV_READ_ONLY_DEPTH permits depth SRV + stencil write simultaneously.
+	// Using views[0] would cause D3D11 to silently NULL the depth SRV.
+	// depthData.readOnlyViews[0] has BOTH read-only flags and doesn't allow stencil writes.
+	context->OMSetRenderTargets(0, nullptr, stencilWriteReadOnlyDSV.get());
+	context->OMSetDepthStencilState(stencilWriteDSS.get(), 1);
+	context->RSSetState(stencilWriteRS.get());
+
+	// Eye 1 viewport (right half of SBS buffer)
+	{
+		D3D11_TEXTURE2D_DESC mainDesc;
+		renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN].texture->GetDesc(&mainDesc);
+
+		D3D11_VIEWPORT vp{};
+		vp.TopLeftX = static_cast<float>(mainDesc.Width / 2);
+		vp.TopLeftY = 0.0f;
+		vp.Width = static_cast<float>(mainDesc.Width / 2);
+		vp.Height = static_cast<float>(mainDesc.Height);
+		vp.MinDepth = 0.0f;
+		vp.MaxDepth = 1.0f;
+		context->RSSetViewports(1, &vp);
+	}
+
+	// Bind shaders and mode texture
+	context->VSSetShader(stencilWriteVS.get(), nullptr, 0);
+	context->PSSetShader(stencilWritePS.get(), nullptr, 0);
+	context->GSSetShader(nullptr, nullptr, 0);
+
+	ID3D11ShaderResourceView* modeSRV = texPerPixelMode->srv.get();
+	context->PSSetShaderResources(0, 1, &modeSRV);
+
+	auto* depthSRV = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN].depthSRV;
+	context->PSSetShaderResources(1, 1, &depthSRV);
+
+	// Bind params CB to pixel shader (CS and PS have separate CB bindings)
+	auto cbPtr = paramsCB->CB();
+	context->PSSetConstantBuffers(1, 1, &cbPtr);
+
+	// Fullscreen triangle: no VB/IB, procedurally generated in VS
+	context->IASetInputLayout(nullptr);
+	context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+	context->Draw(3, 0);
+
+	// ===== RESTORE FULL D3D11 PIPELINE STATE =====
+
+	ID3D11ShaderResourceView* nullSRVs[2] = {};
+	context->PSSetShaderResources(0, 2, nullSRVs);
+
+	context->PSSetConstantBuffers(1, 1, &savedPSCB);
+
+	context->OMSetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, savedRTVs, savedDSV);
+	context->OMSetDepthStencilState(savedDSS, savedStencilRef);
+	context->OMSetBlendState(savedBlendState, savedBlendFactor, savedSampleMask);
+	context->RSSetState(savedRS);
+	context->RSSetViewports(numViewports, savedViewports);
+	context->VSSetShader(savedVS, nullptr, 0);
+	context->PSSetShader(savedPS, nullptr, 0);
+	context->GSSetShader(savedGS, nullptr, 0);
+	context->IASetInputLayout(savedInputLayout);
+	context->IASetPrimitiveTopology(savedTopology);
+	context->PSSetShaderResources(0, 2, savedPSSRVs);
+
+	// Release COM references acquired by Get* calls
+	for (auto& rtv : savedRTVs) {
+		if (rtv)
+			rtv->Release();
+	}
+	if (savedDSV)
+		savedDSV->Release();
+	if (savedDSS)
+		savedDSS->Release();
+	if (savedBlendState)
+		savedBlendState->Release();
+	if (savedRS)
+		savedRS->Release();
+	if (savedVS)
+		savedVS->Release();
+	if (savedPS)
+		savedPS->Release();
+	if (savedGS)
+		savedGS->Release();
+	if (savedInputLayout)
+		savedInputLayout->Release();
+	if (savedPSSRVs[0])
+		savedPSSRVs[0]->Release();
+	if (savedPSSRVs[1])
+		savedPSSRVs[1]->Release();
+	if (savedPSCB)
+		savedPSCB->Release();
+}
+
+void VRStereoOptimizations::PerformLateStencilWrite()
+{
+	// Placeholder for future multi-pass stencil strategies
+}
+
+//=============================================================================
+// DSS CACHE: CLONE + STENCIL NOT_EQUAL ENFORCEMENT
+//=============================================================================
+
+ID3D11DepthStencilState* VRStereoOptimizations::GetOrCreateModifiedDSS(ID3D11DepthStencilState* originalDSS)
+{
+	if (!originalDSS || !stencilActive)
+		return originalDSS;
+
+	stencilSwapCount++;
+
+	auto it = dssCache.find(originalDSS);
+	if (it != dssCache.end())
+		return it->second.get();
+
+	// Clone original desc and add read-only stencil NOT_EQUAL test
+	D3D11_DEPTH_STENCIL_DESC desc{};
+	originalDSS->GetDesc(&desc);
+
+	desc.StencilEnable = TRUE;
+	desc.StencilReadMask = 0xFF;
+	desc.StencilWriteMask = 0x00;  // Read-only: game rendering must not modify our marks
+
+	// NOT_EQUAL with ref=1: skip pixels where stencil == 1 (MODE_MAIN)
+	desc.FrontFace.StencilFunc = D3D11_COMPARISON_NOT_EQUAL;
+	desc.FrontFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
+	desc.FrontFace.StencilDepthFailOp = D3D11_STENCIL_OP_KEEP;
+	desc.FrontFace.StencilPassOp = D3D11_STENCIL_OP_KEEP;
+	desc.BackFace = desc.FrontFace;
+
+	winrt::com_ptr<ID3D11DepthStencilState> modifiedDSS;
+	HRESULT hr = globals::d3d::device->CreateDepthStencilState(&desc, modifiedDSS.put());
+	if (FAILED(hr)) {
+		logger::warn("[VRStereoOptimizations] Failed to create modified DSS (HRESULT: {:#x})", static_cast<uint32_t>(hr));
+		return originalDSS;
+	}
+
+	auto* result = modifiedDSS.get();
+	dssCache[originalDSS] = std::move(modifiedDSS);
+
+	return result;
+}
+
+//=============================================================================
+// PHASE 3: REPROJECTION COMPUTE SHADER
+//=============================================================================
+
+void VRStereoOptimizations::DispatchReprojection()
+{
+	if (!REL::Module::IsVR())
+		return;
+	if (settings.stereoMode == StereoMode::Off)
+		return;
+	if (!reprojectionCS || !texPerPixelMode || !paramsCB)
+		return;
+	if (settings.debugSkipMerge)
+		return;
+
+	ZoneScoped;
+	TracyD3D11Zone(globals::state->tracyCtx, "VR Stereo Opt - Reprojection");
+
+	if (globals::state->frameAnnotations)
+		globals::state->BeginPerfEvent("VR Stereo Opt - Reprojection");
+
+	auto context = globals::d3d::context;
+	auto renderer = globals::game::renderer;
+	auto& main = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];
+
+	UpdateConstantBuffer();
+	auto cbPtr = paramsCB->CB();
+	auto* depthSRV = Util::GetCurrentSceneDepthSRV();
+
+	// Bind: t0 = depth, t1 = mode texture, u0 = main UAV, b1 = params
+	ID3D11ShaderResourceView* srvs[2]{
+		depthSRV,
+		texPerPixelMode->srv.get()
+	};
+	ID3D11UnorderedAccessView* uavs[1]{ main.UAV };
+
+	context->CSSetConstantBuffers(1, 1, &cbPtr);
+	context->CSSetShaderResources(0, 2, srvs);
+	context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
+	context->CSSetShader(reprojectionCS.get(), nullptr, 0);
+
+	// Dispatch over full SBS texture
+	uint32_t fullWidth = texPerPixelMode->desc.Width;
+	uint32_t fullHeight = texPerPixelMode->desc.Height;
+	context->Dispatch((fullWidth + 7) / 8, (fullHeight + 7) / 8, 1);
+
+	// Cleanup
+	ID3D11ShaderResourceView* nullSRVs[2] = {};
+	ID3D11UnorderedAccessView* nullUAV = nullptr;
+	ID3D11Buffer* nullCB = nullptr;
+	context->CSSetShaderResources(0, 2, nullSRVs);
+	context->CSSetUnorderedAccessViews(0, 1, &nullUAV, nullptr);
+	context->CSSetConstantBuffers(1, 1, &nullCB);
+	context->CSSetShader(nullptr, nullptr, 0);
+
+	// Stencil culling is done for this frame
+	logger::trace("[VRStereoOptimizations] Frame: stencilSwapCount={}", stencilSwapCount);
+	stencilActive = false;
+
+	if (globals::state->frameAnnotations)
+		globals::state->EndPerfEvent();
+}
+
+void VRStereoOptimizations::DeactivateStencil()
+{
+	if (!stencilActive)
+		return;
+	logger::trace("[VRStereoOptimizations] Frame: stencilSwapCount={}", stencilSwapCount);
+	stencilActive = false;
+}
+
+//=============================================================================
+// CAS (CONTRAST ADAPTIVE SHARPENING) - POST-TAA
+//=============================================================================
+
+void VRStereoOptimizations::ApplyCAS(RE::RENDER_TARGET a_target)
+{
+	logger::trace("[VRStereoOptimizations] CAS: entered (strength={}, casCS={}, casTex={}, casParamsBuf={})",
+		settings.casStrength, (void*)casCS.get(), (void*)casTex.get(), (void*)casParamsBuf.get());
+
+	if (settings.casStrength <= 0.0f || !casCS || !casTex || !casParamsBuf)
+		return;
+
+	if (!REL::Module::IsVR())
+		return;
+
+	auto renderer = globals::game::renderer;
+	auto context = globals::d3d::context;
+
+	// Get the render target that post-processing just wrote to
+	auto& target = renderer->GetRuntimeData().renderTargets[a_target];
+	if (!target.texture || !target.SRV) {
+		logger::trace("[VRStereoOptimizations] CAS: target RT has no texture/SRV, skipping");
+		return;
+	}
+
+	D3D11_TEXTURE2D_DESC targetDesc;
+	target.texture->GetDesc(&targetDesc);
+	logger::trace("[VRStereoOptimizations] CAS: dispatching on RT {} ({}x{}, strength={})", (int)a_target, targetDesc.Width, targetDesc.Height, settings.casStrength);
+
+	// Check for dimension/format mismatch with intermediate texture
+	D3D11_TEXTURE2D_DESC casTexDesc;
+	static_cast<ID3D11Texture2D*>(casTex->resource.get())->GetDesc(&casTexDesc);
+	if (casTexDesc.Width != targetDesc.Width || casTexDesc.Height != targetDesc.Height || casTexDesc.Format != targetDesc.Format) {
+		logger::info("[VRStereoOptimizations] CAS: recreating casTex to match target ({}x{} fmt={} -> {}x{} fmt={})",
+			casTexDesc.Width, casTexDesc.Height, (int)casTexDesc.Format,
+			targetDesc.Width, targetDesc.Height, (int)targetDesc.Format);
+
+		D3D11_TEXTURE2D_DESC newDesc{};
+		newDesc.Width = targetDesc.Width;
+		newDesc.Height = targetDesc.Height;
+		newDesc.MipLevels = 1;
+		newDesc.ArraySize = 1;
+		newDesc.Format = targetDesc.Format;
+		newDesc.SampleDesc.Count = 1;
+		newDesc.SampleDesc.Quality = 0;
+		newDesc.Usage = D3D11_USAGE_DEFAULT;
+		newDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
+		newDesc.CPUAccessFlags = 0;
+		newDesc.MiscFlags = 0;
+
+		casTex = eastl::make_unique<Texture2D>(newDesc);
+		casTex->CreateSRV(D3D11_SHADER_RESOURCE_VIEW_DESC{
+			.Format = targetDesc.Format,
+			.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D,
+			.Texture2D = { .MostDetailedMip = 0, .MipLevels = 1 } });
+		casTex->CreateUAV(D3D11_UNORDERED_ACCESS_VIEW_DESC{
+			.Format = targetDesc.Format,
+			.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D,
+			.Texture2D = { .MipSlice = 0 } });
+	}
+
+	// Update sharpness parameter via Map/Unmap
+	{
+		D3D11_MAPPED_SUBRESOURCE mapped;
+		if (SUCCEEDED(context->Map(casParamsBuf.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
+			*static_cast<float*>(mapped.pData) = settings.casStrength;
+			context->Unmap(casParamsBuf.get(), 0);
+		}
+	}
+
+	// Unbind the RT so we can read from it
+	context->OMSetRenderTargets(0, nullptr, nullptr);
+
+	// Dispatch CAS: read from target SRV, write to casTex UAV
+	{
+		ID3D11ShaderResourceView* views[2] = { target.SRV, casParamsSRV.get() };
+		context->CSSetShaderResources(0, 2, views);
+
+		ID3D11UnorderedAccessView* uavs[1] = { casTex->uav.get() };
+		context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
+
+		context->CSSetShader(casCS.get(), nullptr, 0);
+
+		context->Dispatch((targetDesc.Width + 7) / 8, (targetDesc.Height + 7) / 8, 1);
+	}
+
+	// Cleanup CS state
+	ID3D11ShaderResourceView* nullSRV[2] = { nullptr, nullptr };
+	context->CSSetShaderResources(0, 2, nullSRV);
+	ID3D11UnorderedAccessView* nullUAV[1] = { nullptr };
+	context->CSSetUnorderedAccessViews(0, 1, nullUAV, nullptr);
+	context->CSSetShader(nullptr, nullptr, 0);
+
+	// Copy sharpened result back to the render target
+	context->CopyResource(target.texture, casTex->resource.get());
+
+	globals::game::stateUpdateFlags->set(RE::BSGraphics::ShaderFlags::DIRTY_RENDERTARGET);
+}

--- a/src/Features/VRStereoOptimizations.h
+++ b/src/Features/VRStereoOptimizations.h
@@ -28,16 +28,16 @@ struct VRStereoOptimizations : public Feature
 	/// Operating mode for stereo reprojection
 	enum class StereoMode : uint32_t
 	{
-		Off = 0,      ///< Feature disabled
-		Enable = 1    ///< Stereo reprojection enabled
+		Off = 0,    ///< Feature disabled
+		Enable = 1  ///< Stereo reprojection enabled
 	};
 
 	/// Per-pixel classification written by StencilCS
 	enum PixelMode : uint8_t
 	{
-		MODE_DISOCCLUDED = 0,  ///< Fully shaded, no reprojection, no blend
-		MODE_EDGE = 1,         ///< Fully shaded + bilateral blend with other eye
-		MODE_MAIN = 2,         ///< Eye 0: no reproject (Perf) / bilateral (Quality). Eye 1: overwrite (Perf) / bilateral (Quality)
+		MODE_DISOCCLUDED = 0,     ///< Fully shaded, no reprojection, no blend
+		MODE_EDGE = 1,            ///< Fully shaded + bilateral blend with other eye
+		MODE_MAIN = 2,            ///< Eye 0: no reproject (Perf) / bilateral (Quality). Eye 1: overwrite (Perf) / bilateral (Quality)
 		MODE_EDGE_NEIGHBOUR = 3,  ///< Outer band: background pixels near edge, blended in post-process
 	};
 
@@ -80,10 +80,10 @@ struct VRStereoOptimizations : public Feature
 		StereoMode stereoMode = StereoMode::Enable;
 		float disocclusionDepthThreshold = 0.01f;
 		float edgeDepthThreshold = 0.05f;
-		int edgeWidth = 3;  ///< Half-width of edge band in pixels (total band = 2 * edgeWidth)
-		float minEdgeDistance = 5000.0f;  ///< Minimum linearized depth for edge AA (game units)
-		float fullBlendDistance = 0.0f;  ///< Linearized depth below which both eyes are fully shaded + blended (game units)
-		float pomDepthScale = 22.5f;  ///< Scale factor for POM depth correction in stereo reprojection
+		int edgeWidth = 3;                 ///< Half-width of edge band in pixels (total band = 2 * edgeWidth)
+		float minEdgeDistance = 5000.0f;   ///< Minimum linearized depth for edge AA (game units)
+		float fullBlendDistance = 0.0f;    ///< Linearized depth below which both eyes are fully shaded + blended (game units)
+		float pomDepthScale = 22.5f;       ///< Scale factor for POM depth correction in stereo reprojection
 		bool debugFullBlendDepth = false;  ///< Show full blend depth zone as cyan overlay
 		float qualityJitterOffset = 0.125f;
 		float foveatedRegionRadius = 0.3f;
@@ -105,11 +105,11 @@ struct VRStereoOptimizations : public Feature
 		// 0 = Off, 1 = All textures (global), 2 = Distant trees only (depth-gated TREE_ANIM)
 		int mipBiasMode = 0;
 		float mipLodBias = -2.0f;
-		float mipBiasNearDist = 2000.0f;   ///< Game units: no bias closer than this
-		float mipBiasFarDist = 6000.0f;    ///< Game units: full bias beyond this
+		float mipBiasNearDist = 2000.0f;  ///< Game units: no bias closer than this
+		float mipBiasFarDist = 6000.0f;   ///< Game units: full bias beyond this
 
 		// CAS (Contrast Adaptive Sharpening) - post-TAA
-		float casStrength = 0.0f;  ///< 0.0 = disabled, 0.0-1.0 = subtle to strong (hidden for now)
+		float casStrength = 0.0f;           ///< 0.0 = disabled, 0.0-1.0 = subtle to strong (hidden for now)
 		float alphaTestThreshold = 0.001f;  ///< Alpha floor for TREE_ANIM zombie texel removal
 	} settings;
 
@@ -119,21 +119,21 @@ struct VRStereoOptimizations : public Feature
 
 	struct alignas(16) VRStereoOptParams
 	{
-		float FrameDim[2];              // Full stereo buffer dimensions
-		float RcpFrameDim[2];           // 1.0 / FrameDim
+		float FrameDim[2];     // Full stereo buffer dimensions
+		float RcpFrameDim[2];  // 1.0 / FrameDim
 
-		uint32_t StereoModeValue;       // Cast of StereoMode enum (0-3)
+		uint32_t StereoModeValue;  // Cast of StereoMode enum (0-3)
 		float DisocclusionThreshold;
 		float EdgeDepthThreshold;
 		uint32_t EdgeWidth;
 
-		float QualityJitter[2];         // Sub-pixel jitter offset (Quality mode)
+		float QualityJitter[2];  // Sub-pixel jitter offset (Quality mode)
 		float FoveatedRadius;
 		float pad2;
 
-		float FoveatedCenter[2];        // Foveal region center UV
+		float FoveatedCenter[2];  // Foveal region center UV
 		float MinEdgeDistance;
-		float FullBlendDistance;   // Linearized depth for full blend zone
+		float FullBlendDistance;  // Linearized depth for full blend zone
 	};
 	static_assert(sizeof(VRStereoOptParams) % 16 == 0, "VRStereoOptParams must be 16-byte aligned for HLSL cbuffer.");
 
@@ -205,8 +205,8 @@ private:
 	//=============================================================================
 
 	eastl::unique_ptr<ConstantBuffer> paramsCB;
-	eastl::unique_ptr<Texture2D> texPerPixelMode;       ///< R8_UINT classification texture (full SBS resolution)
-	eastl::unique_ptr<Texture2D> reprojectionCopyTex;    ///< Copy of main RT for reprojection read
+	eastl::unique_ptr<Texture2D> texPerPixelMode;      ///< R8_UINT classification texture (full SBS resolution)
+	eastl::unique_ptr<Texture2D> reprojectionCopyTex;  ///< Copy of main RT for reprojection read
 
 	winrt::com_ptr<ID3D11DepthStencilState> stencilWriteDSS;
 	winrt::com_ptr<ID3D11RasterizerState> stencilWriteRS;
@@ -220,8 +220,8 @@ private:
 
 	// CAS sharpening resources
 	winrt::com_ptr<ID3D11ComputeShader> casCS;
-	eastl::unique_ptr<Texture2D> casTex;  ///< UAV-capable texture for CAS output
-	winrt::com_ptr<ID3D11Buffer> casParamsBuf;       ///< Structured buffer for CAS sharpness param
+	eastl::unique_ptr<Texture2D> casTex;                    ///< UAV-capable texture for CAS output
+	winrt::com_ptr<ID3D11Buffer> casParamsBuf;              ///< Structured buffer for CAS sharpness param
 	winrt::com_ptr<ID3D11ShaderResourceView> casParamsSRV;  ///< SRV for CAS sharpness param
 
 	/// Cache of original DSS -> modified DSS with stencil NOT_EQUAL enforcement

--- a/src/Features/VRStereoOptimizations.h
+++ b/src/Features/VRStereoOptimizations.h
@@ -1,0 +1,230 @@
+#pragma once
+
+#include "Feature.h"
+
+#include <d3d11.h>
+#include <unordered_map>
+#include <winrt/base.h>
+
+/**
+ * @brief VR Stereo Rendering Optimizations feature.
+ *
+ * Uses hardware stencil culling to skip Eye 1 pixel shading for pixels that can be
+ * reprojected from Eye 0 via lateral stereo reprojection, then runs a compute shader
+ * to fill those pixels. This avoids redundant pixel shading in overlapping stereo regions.
+ *
+ * Pipeline:
+ *   1. DispatchStencil()       - CS classifies per-pixel reprojection viability into a mode texture,
+ *                                then a fullscreen VS/PS pass writes that classification into the stencil buffer.
+ *   2. (Game renders Eye 1)    - Hardware stencil test skips shading for marked pixels.
+ *   3. DispatchReprojection()  - CS reprojects Eye 0 color into the skipped Eye 1 pixels.
+ */
+struct VRStereoOptimizations : public Feature
+{
+	//=============================================================================
+	// ENUMS
+	//=============================================================================
+
+	/// Operating mode for stereo reprojection
+	enum class StereoMode : uint32_t
+	{
+		Off = 0,      ///< Feature disabled
+		Enable = 1    ///< Stereo reprojection enabled
+	};
+
+	/// Per-pixel classification written by StencilCS
+	enum PixelMode : uint8_t
+	{
+		MODE_DISOCCLUDED = 0,  ///< Fully shaded, no reprojection, no blend
+		MODE_EDGE = 1,         ///< Fully shaded + bilateral blend with other eye
+		MODE_MAIN = 2,         ///< Eye 0: no reproject (Perf) / bilateral (Quality). Eye 1: overwrite (Perf) / bilateral (Quality)
+		MODE_EDGE_NEIGHBOUR = 3,  ///< Outer band: background pixels near edge, blended in post-process
+	};
+
+	//=============================================================================
+	// FEATURE BASE CLASS OVERRIDES
+	//=============================================================================
+
+	virtual inline std::string GetName() override { return "VR Stereo Optimizations"; }
+	virtual inline std::string GetShortName() override { return "VRStereoOptimizations"; }
+	virtual inline std::string_view GetShaderDefineName() override { return "VR_STEREO_OPT"; }
+	virtual inline std::string_view GetCategory() const override { return "Display"; }
+	virtual inline bool HasShaderDefine(RE::BSShader::Type t) override { return t == RE::BSShader::Type::Utility; }
+	virtual inline bool SupportsVR() override { return true; }
+
+	virtual void SetupResources() override;
+	virtual void Reset() override;
+	virtual void DrawSettings() override;
+	virtual void SaveSettings(json& o_json) override;
+	virtual void LoadSettings(json& o_json) override;
+	virtual void RestoreDefaultSettings() override;
+	virtual void ClearShaderCache() override;
+
+	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
+	{
+		return {
+			"Stereo rendering optimizations for VR that skip redundant pixel shading via stencil culling and lateral reprojection.",
+			{ "Hardware stencil culling of Eye 1 pixels reprojectable from Eye 0",
+				"Compute shader lateral reprojection to fill culled pixels",
+				"Performance, Quality, and Foveated modes",
+				"Debug visualization overlays" }
+		};
+	}
+
+	//=============================================================================
+	// SETTINGS
+	//=============================================================================
+
+	struct Settings
+	{
+		StereoMode stereoMode = StereoMode::Enable;
+		float disocclusionDepthThreshold = 0.01f;
+		float edgeDepthThreshold = 0.05f;
+		int edgeWidth = 3;  ///< Half-width of edge band in pixels (total band = 2 * edgeWidth)
+		float minEdgeDistance = 5000.0f;  ///< Minimum linearized depth for edge AA (game units)
+		float fullBlendDistance = 0.0f;  ///< Linearized depth below which both eyes are fully shaded + blended (game units)
+		bool debugFullBlendDepth = false;  ///< Show full blend depth zone as cyan overlay
+		float qualityJitterOffset = 0.125f;
+		float foveatedRegionRadius = 0.3f;
+		float foveatedRegionCenterX = 0.5f;
+		float foveatedRegionCenterY = 0.5f;
+		bool useEyeTracking = false;
+
+		int reprojectionMode = 5;  // 0=Blend, 4=Overwrite, 5=Overwrite Eye1 Only
+
+		// Debug controls
+		bool debugVisualization = false;
+		bool debugSkipMerge = false;
+		bool debugForceAllStencil = false;
+		bool debugForceAllReprojectCS = false;
+		bool debugDepthMap = false;
+
+		// MIP LOD Bias (negative = sharper textures)
+		// 0 = Off, 1 = All textures (global), 2 = Distant trees only (depth-gated TREE_ANIM)
+		int mipBiasMode = 0;
+		float mipLodBias = -2.0f;
+		float mipBiasNearDist = 2000.0f;   ///< Game units: no bias closer than this
+		float mipBiasFarDist = 6000.0f;    ///< Game units: full bias beyond this
+
+		// CAS (Contrast Adaptive Sharpening) - post-TAA
+		float casStrength = 0.7f;  ///< 0.0 = disabled, 0.0-1.0 = subtle to strong
+		float alphaTestThreshold = 0.001f;  ///< Alpha floor for TREE_ANIM zombie texel removal
+	} settings;
+
+	//=============================================================================
+	// GPU CONSTANT BUFFER (must match HLSL cbuffer layout exactly)
+	//=============================================================================
+
+	struct alignas(16) VRStereoOptParams
+	{
+		float FrameDim[2];              // Full stereo buffer dimensions
+		float RcpFrameDim[2];           // 1.0 / FrameDim
+
+		uint32_t StereoModeValue;       // Cast of StereoMode enum (0-3)
+		float DisocclusionThreshold;
+		float EdgeDepthThreshold;
+		uint32_t EdgeWidth;
+
+		float QualityJitter[2];         // Sub-pixel jitter offset (Quality mode)
+		float FoveatedRadius;
+		float pad2;
+
+		float FoveatedCenter[2];        // Foveal region center UV
+		float MinEdgeDistance;
+		float FullBlendDistance;   // Linearized depth for full blend zone
+	};
+	static_assert(sizeof(VRStereoOptParams) % 16 == 0, "VRStereoOptParams must be 16-byte aligned for HLSL cbuffer.");
+
+	//=============================================================================
+	// PUBLIC API
+	//=============================================================================
+
+	/**
+	 * @brief Classify Eye 1 pixels and write stencil marks.
+	 *
+	 * Dispatches the stencil classification CS, then performs a fullscreen triangle pass
+	 * to write the classification into the hardware stencil buffer.
+	 * Called from Deferred::StartDeferred() after OverrideBlendStates().
+	 */
+	void DispatchStencil();
+
+	/**
+	 * @brief Reproject Eye 0 color into stencil-culled Eye 1 pixels.
+	 *
+	 * Copies the main render target, then dispatches a CS to fill skipped pixels
+	 * using lateral reprojection from Eye 0.
+	 * Called from Deferred::DeferredPasses() after DeferredCompositeCS.
+	 */
+	void DispatchReprojection();
+
+	/**
+	 * @brief Creates or retrieves a modified DSS with stencil NOT_EQUAL test.
+	 *
+	 * Clones the given DSS with read-only stencil (WriteMask=0x00, Func=NOT_EQUAL, ref=1)
+	 * so that pixels marked by our stencil write pass are skipped during normal rendering.
+	 * Cached per unique input DSS pointer.
+	 *
+	 * @param originalDSS The original depth-stencil state to modify.
+	 * @return Modified DSS with stencil test, or original if creation fails.
+	 */
+	ID3D11DepthStencilState* GetOrCreateModifiedDSS(ID3D11DepthStencilState* originalDSS);
+
+	/// Whether the stencil pass is currently active this frame
+	bool IsStencilActive() const { return stencilActive; }
+
+	/// Deactivate stencil culling (called from Deferred after geometry rendering completes)
+	void DeactivateStencil();
+
+	/// Apply CAS sharpening to the main render target (called after TAA)
+	void ApplyCAS(RE::RENDER_TARGET a_target);
+
+	/// Get mode texture SRV for external consumers (e.g., DeferredCompositeCS Eye 1 skip)
+	ID3D11ShaderResourceView* GetModeTextureSRV() const { return texPerPixelMode ? texPerPixelMode->srv.get() : nullptr; }
+
+private:
+	//=============================================================================
+	// INTERNAL METHODS
+	//=============================================================================
+
+	/// Fullscreen triangle pass: reads mode texture, writes stencil ref=1 for MODE_MAIN pixels
+	void ExecuteStencilWritePass();
+
+	/// Late stencil write callback (placeholder for future multi-pass strategies)
+	void PerformLateStencilWrite();
+
+	/// Compiles all shaders used by this feature
+	void CompileShaders();
+
+	/// Updates the constant buffer with current settings and frame dimensions
+	void UpdateConstantBuffer();
+
+	//=============================================================================
+	// GPU RESOURCES
+	//=============================================================================
+
+	eastl::unique_ptr<ConstantBuffer> paramsCB;
+	eastl::unique_ptr<Texture2D> texPerPixelMode;       ///< R8_UINT classification texture (full SBS resolution)
+	eastl::unique_ptr<Texture2D> reprojectionCopyTex;    ///< Copy of main RT for reprojection read
+
+	winrt::com_ptr<ID3D11DepthStencilState> stencilWriteDSS;
+	winrt::com_ptr<ID3D11RasterizerState> stencilWriteRS;
+	winrt::com_ptr<ID3D11DepthStencilView> stencilWriteReadOnlyDSV;  ///< Read-only-depth DSV for stencil write pass (allows simultaneous depth SRV)
+
+	winrt::com_ptr<ID3D11ComputeShader> stencilCS;
+	winrt::com_ptr<ID3D11ComputeShader> stencilDebugDepthMapCS;
+	winrt::com_ptr<ID3D11VertexShader> stencilWriteVS;
+	winrt::com_ptr<ID3D11PixelShader> stencilWritePS;
+	winrt::com_ptr<ID3D11ComputeShader> reprojectionCS;
+
+	// CAS sharpening resources
+	winrt::com_ptr<ID3D11ComputeShader> casCS;
+	eastl::unique_ptr<Texture2D> casTex;  ///< UAV-capable texture for CAS output
+	winrt::com_ptr<ID3D11Buffer> casParamsBuf;       ///< Structured buffer for CAS sharpness param
+	winrt::com_ptr<ID3D11ShaderResourceView> casParamsSRV;  ///< SRV for CAS sharpness param
+
+	/// Cache of original DSS -> modified DSS with stencil NOT_EQUAL enforcement
+	std::unordered_map<ID3D11DepthStencilState*, winrt::com_ptr<ID3D11DepthStencilState>> dssCache;
+
+	bool stencilActive = false;
+	uint32_t stencilSwapCount = 0;
+};

--- a/src/Features/VRStereoOptimizations.h
+++ b/src/Features/VRStereoOptimizations.h
@@ -83,6 +83,7 @@ struct VRStereoOptimizations : public Feature
 		int edgeWidth = 3;  ///< Half-width of edge band in pixels (total band = 2 * edgeWidth)
 		float minEdgeDistance = 5000.0f;  ///< Minimum linearized depth for edge AA (game units)
 		float fullBlendDistance = 0.0f;  ///< Linearized depth below which both eyes are fully shaded + blended (game units)
+		float pomDepthScale = 22.5f;  ///< Scale factor for POM depth correction in stereo reprojection
 		bool debugFullBlendDepth = false;  ///< Show full blend depth zone as cyan overlay
 		float qualityJitterOffset = 0.125f;
 		float foveatedRegionRadius = 0.3f;
@@ -98,6 +99,7 @@ struct VRStereoOptimizations : public Feature
 		bool debugForceAllStencil = false;
 		bool debugForceAllReprojectCS = false;
 		bool debugDepthMap = false;
+		bool debugPOMDepth = false;  ///< Show POM depth data (Reflectance.w) as heatmap overlay
 
 		// MIP LOD Bias (negative = sharper textures)
 		// 0 = Off, 1 = All textures (global), 2 = Distant trees only (depth-gated TREE_ANIM)
@@ -107,7 +109,7 @@ struct VRStereoOptimizations : public Feature
 		float mipBiasFarDist = 6000.0f;    ///< Game units: full bias beyond this
 
 		// CAS (Contrast Adaptive Sharpening) - post-TAA
-		float casStrength = 0.7f;  ///< 0.0 = disabled, 0.0-1.0 = subtle to strong
+		float casStrength = 0.0f;  ///< 0.0 = disabled, 0.0-1.0 = subtle to strong (hidden for now)
 		float alphaTestThreshold = 0.001f;  ///< Alpha floor for TREE_ANIM zombie texel removal
 	} settings;
 

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -324,8 +324,10 @@ namespace globals
 						pDepthStencilView->GetResource(&clearRes);
 						mainDepth.views[0]->GetResource(&mainRes);
 						bool isMainDSV = (clearRes == mainRes);
-						if (clearRes) clearRes->Release();
-						if (mainRes) mainRes->Release();
+						if (clearRes)
+							clearRes->Release();
+						if (mainRes)
+							mainRes->Release();
 						if (isMainDSV) {
 							ClearFlags &= ~D3D11_CLEAR_STENCIL;
 							if (ClearFlags == 0)

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -314,10 +314,24 @@ namespace globals
 			if (globals::game::isVR) {
 				auto& stereoOpt = globals::features::vrStereoOptimizations;
 				if (stereoOpt.loaded && stereoOpt.IsStencilActive()) {
-					// Strip stencil clear to preserve our marks; allow depth clear to proceed
-					ClearFlags &= ~D3D11_CLEAR_STENCIL;
-					if (ClearFlags == 0)
-						return;  // Nothing left to clear
+					// Only protect the main scene DSV — allow other DSVs to clear normally
+					auto renderer = globals::game::renderer;
+					auto& mainDepth = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
+					if (mainDepth.views[0]) {
+						// Compare the DSV being cleared against the main scene DSV
+						ID3D11Resource* clearRes = nullptr;
+						ID3D11Resource* mainRes = nullptr;
+						pDepthStencilView->GetResource(&clearRes);
+						mainDepth.views[0]->GetResource(&mainRes);
+						bool isMainDSV = (clearRes == mainRes);
+						if (clearRes) clearRes->Release();
+						if (mainRes) mainRes->Release();
+						if (isMainDSV) {
+							ClearFlags &= ~D3D11_CLEAR_STENCIL;
+							if (ClearFlags == 0)
+								return;
+						}
+					}
 				}
 			}
 			func(This, pDepthStencilView, ClearFlags, Depth, Stencil);

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -33,6 +33,7 @@
 #include "Features/VolumetricShadows.h"
 #include "Features/WaterEffects.h"
 #include "Features/WeatherEditor.h"
+#include "Features/VRStereoOptimizations.h"
 #include "Features/WetnessEffects.h"
 #include "Menu.h"
 #include "ShaderCache.h"
@@ -84,6 +85,7 @@ namespace globals
 		RenderDoc renderDoc{};
 		WeatherEditor weatherEditor{};
 		ExponentialHeightFog exponentialHeightFog{};
+		VRStereoOptimizations vrStereoOptimizations{};
 
 		namespace llf
 		{
@@ -266,9 +268,60 @@ namespace globals
 	{
 		static void thunk(ID3D11DeviceContext* This, ID3D11Resource* pResource, UINT Subresource)
 		{
-			if (*globals::game::perFrame.get() == pResource && globals::game::mappedFrameBuffer)
+			if (*globals::game::perFrame.get() == pResource && globals::game::mappedFrameBuffer) {
 				CacheFramebuffer();
+			}
 			func(This, pResource, Subresource);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	/**
+	 * @brief Hooked OMSetDepthStencilState — replaces DSS with stencil-enforcing version when VR stereo opt is active.
+	 *
+	 * vtable index 36 for ID3D11DeviceContext::OMSetDepthStencilState.
+	 * When VRStereoOptimizations has written stencil marks, this hook transparently swaps
+	 * the game's DSS for a modified version that adds a stencil NOT_EQUAL test, causing
+	 * marked Eye 1 pixels to be skipped during normal rendering.
+	 */
+	struct ID3D11DeviceContext_OMSetDepthStencilState
+	{
+		static void thunk(ID3D11DeviceContext* This, ID3D11DepthStencilState* pDepthStencilState, UINT StencilRef)
+		{
+			if (globals::game::isVR && pDepthStencilState) {
+				auto& stereoOpt = globals::features::vrStereoOptimizations;
+				if (stereoOpt.loaded && stereoOpt.IsStencilActive()) {
+					pDepthStencilState = stereoOpt.GetOrCreateModifiedDSS(pDepthStencilState);
+					StencilRef = 1;  // Must match the ref written by our stencil pass
+
+				}
+			}
+			func(This, pDepthStencilState, StencilRef);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	/**
+	 * @brief Hooked ClearDepthStencilView — blocks stencil clears when VR stereo opt stencil is active.
+	 *
+	 * vtable index 53 for ID3D11DeviceContext::ClearDepthStencilView.
+	 * Prevents the game from clearing our stencil marks between the stencil write and
+	 * the reprojection pass by stripping the D3D11_CLEAR_STENCIL flag.
+	 */
+	struct ID3D11DeviceContext_ClearDepthStencilView
+	{
+		static void thunk(ID3D11DeviceContext* This, ID3D11DepthStencilView* pDepthStencilView, UINT ClearFlags, FLOAT Depth, UINT8 Stencil)
+		{
+			if (globals::game::isVR) {
+				auto& stereoOpt = globals::features::vrStereoOptimizations;
+				if (stereoOpt.loaded && stereoOpt.IsStencilActive()) {
+					// Strip stencil clear to preserve our marks; allow depth clear to proceed
+					ClearFlags &= ~D3D11_CLEAR_STENCIL;
+					if (ClearFlags == 0)
+						return;  // Nothing left to clear
+				}
+			}
+			func(This, pDepthStencilView, ClearFlags, Depth, Stencil);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -282,5 +335,11 @@ namespace globals
 	{
 		stl::detour_vfunc<14, ID3D11DeviceContext_Map>(a_context);
 		stl::detour_vfunc<15, ID3D11DeviceContext_Unmap>(a_context);
+
+		// VR stereo optimization hooks: intercept DSS and stencil clear
+		if (globals::game::isVR) {
+			stl::detour_vfunc<36, ID3D11DeviceContext_OMSetDepthStencilState>(a_context);
+			stl::detour_vfunc<53, ID3D11DeviceContext_ClearDepthStencilView>(a_context);
+		}
 	}
 }

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -29,11 +29,11 @@
 #include "Features/UnifiedWater.h"
 #include "Features/Upscaling.h"
 #include "Features/VR.h"
+#include "Features/VRStereoOptimizations.h"
 #include "Features/VolumetricLighting.h"
 #include "Features/VolumetricShadows.h"
 #include "Features/WaterEffects.h"
 #include "Features/WeatherEditor.h"
-#include "Features/VRStereoOptimizations.h"
 #include "Features/WetnessEffects.h"
 #include "Menu.h"
 #include "ShaderCache.h"
@@ -293,7 +293,6 @@ namespace globals
 				if (stereoOpt.loaded && stereoOpt.IsStencilActive()) {
 					pDepthStencilState = stereoOpt.GetOrCreateModifiedDSS(pDepthStencilState);
 					StencilRef = 1;  // Must match the ref written by our stencil pass
-
 				}
 			}
 			func(This, pDepthStencilState, StencilRef);

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -34,6 +34,7 @@ struct ExtendedTranslucency;
 struct Upscaling;
 struct WeatherEditor;
 struct ExponentialHeightFog;
+struct VRStereoOptimizations;
 
 class State;
 class Deferred;
@@ -91,6 +92,7 @@ namespace globals
 		extern RenderDoc renderDoc;
 		extern WeatherEditor weatherEditor;
 		extern ExponentialHeightFog exponentialHeightFog;
+		extern VRStereoOptimizations vrStereoOptimizations;
 
 		namespace llf
 		{

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -881,7 +881,7 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 		SphericalHarmonics::SH2Color dalcSH = SphericalHarmonics::DALCToSH(dalcColors);
 		data.AmbientSHR = { dalcSH.r.c0, dalcSH.r.c1[0], dalcSH.r.c1[1], dalcSH.r.c1[2] };
 		data.AmbientSHG = { dalcSH.g.c0, dalcSH.g.c1[0], dalcSH.g.c1[1], dalcSH.g.c1[2] };
-		data.AmbientSHB = { dalcSH.b.c0, dalcSH.b.c1[0], dalcSH.b.c1[1], dalcSH.b.c1[2] }
+		data.AmbientSHB = { dalcSH.b.c0, dalcSH.b.c1[0], dalcSH.b.c1[1], dalcSH.b.c1[2] };
 
 		sharedDataCB->Update(data);
 	}

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -11,6 +11,7 @@
 #include "Features/TerrainBlending.h"
 #include "Features/TerrainHelper.h"
 #include "Features/Upscaling.h"
+#include "Features/VRStereoOptimizations.h"
 #include "Features/VolumetricShadows.h"
 #include "Features/WeatherEditor.h"
 #include "Menu.h"
@@ -850,6 +851,22 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 			data.MipBias = 0;
 		}
 
+		// VR MIP bias modes: 1 = All (global), 2 = Distant Trees (per-pixel in TREE_ANIM)
+		data.VRMipBias = 0;
+		data.VRMipBiasNearDist = 2000.0f;
+		data.VRMipBiasFarDist = 6000.0f;
+		data.VRMipBiasMode = 0;
+		if (globals::game::isVR) {
+			auto& s = globals::features::vrStereoOptimizations.settings;
+			if (s.mipBiasMode == 1 || s.mipBiasMode == 2) {
+				data.VRMipBias = s.mipLodBias;
+				data.VRMipBiasNearDist = s.mipBiasNearDist;
+				data.VRMipBiasFarDist = s.mipBiasFarDist;
+				data.VRMipBiasMode = static_cast<uint>(s.mipBiasMode);
+			}
+			data.VRAlphaTestThreshold = s.alphaTestThreshold;
+		}
+
 		// DALC to SH
 		const auto& m = dalcTransform.rotate;
 		const auto& t = dalcTransform.translate;
@@ -864,7 +881,7 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 		SphericalHarmonics::SH2Color dalcSH = SphericalHarmonics::DALCToSH(dalcColors);
 		data.AmbientSHR = { dalcSH.r.c0, dalcSH.r.c1[0], dalcSH.r.c1[1], dalcSH.r.c1[2] };
 		data.AmbientSHG = { dalcSH.g.c0, dalcSH.g.c1[0], dalcSH.g.c1[1], dalcSH.g.c1[2] };
-		data.AmbientSHB = { dalcSH.b.c0, dalcSH.b.c1[0], dalcSH.b.c1[1], dalcSH.b.c1[2] };
+		data.AmbientSHB = { dalcSH.b.c0, dalcSH.b.c1[0], dalcSH.b.c1[1], dalcSH.b.c1[2] }
 
 		sharedDataCB->Update(data);
 	}

--- a/src/State.h
+++ b/src/State.h
@@ -215,7 +215,7 @@ public:
 		float VRMipBiasFarDist;
 		uint VRMipBiasMode;   // 0=Off, 1=All Textures, 2=Distant Trees only
 		float VRAlphaTestThreshold;  // Alpha test threshold for VR TREE_ANIM (0 = use vanilla)
-		float pad0;
+		float4 pad0;  // HLSL: float2 + implicit 8-byte gap before float4 AmbientSHR
 		float4 AmbientSHR;
 		float4 AmbientSHG;
 		float4 AmbientSHB;

--- a/src/State.h
+++ b/src/State.h
@@ -213,9 +213,9 @@ public:
 		float VRMipBias;
 		float VRMipBiasNearDist;
 		float VRMipBiasFarDist;
-		uint VRMipBiasMode;   // 0=Off, 1=All Textures, 2=Distant Trees only
+		uint VRMipBiasMode;          // 0=Off, 1=All Textures, 2=Distant Trees only
 		float VRAlphaTestThreshold;  // Alpha test threshold for VR TREE_ANIM (0 = use vanilla)
-		float4 pad0;  // HLSL: float2 + implicit 8-byte gap before float4 AmbientSHR
+		float4 pad0;                 // HLSL: float2 + implicit 8-byte gap before float4 AmbientSHR
 		float4 AmbientSHR;
 		float4 AmbientSHG;
 		float4 AmbientSHB;

--- a/src/State.h
+++ b/src/State.h
@@ -210,6 +210,11 @@ public:
 		uint InMapMenu;
 		uint HideSky;
 		float MipBias;
+		float VRMipBias;
+		float VRMipBiasNearDist;
+		float VRMipBiasFarDist;
+		uint VRMipBiasMode;   // 0=Off, 1=All Textures, 2=Distant Trees only
+		float VRAlphaTestThreshold;  // Alpha test threshold for VR TREE_ANIM (0 = use vanilla)
 		float pad0;
 		float4 AmbientSHR;
 		float4 AmbientSHG;


### PR DESCRIPTION
## Summary

- **VR Stereo Optimizations feature**: Stencil-based culling for Eye 1, CAS sharpening, and DLSS compatibility fix for VR
- **Bilinear color sampling** for stereo reprojection — reduces blocky artifacts in reprojected Eye 1 pixels
- **POM depth-aware reprojection** via Reflectance.w — stores parallax depth offset so StereoBlend can account for POM displacement, reducing ghosting on parallax surfaces
- **SharedData struct alignment fixes** for upstream SH ambient field merge compatibility

## Details

### Stencil Culling & CAS (83769b04)
Core VR stereo optimizations feature adding hardware stencil-based culling to skip Eye 1 pixels during deferred composite (saving ~30% GPU on that pass), CAS contrast-adaptive sharpening for reprojected pixels, and a DLSS viewport fix that was causing crashes in VR.

### Bilinear Color Sampling (bd1c480a)
Upgrades StereoBlendCS from point sampling to bilinear interpolation when fetching reprojected color. This smooths subpixel-accuracy reprojection instead of snapping to nearest texel.

### POM Depth-Aware Reprojection (b130bf5b)
Encodes parallax occlusion mapping depth offset into an unused channel (Reflectance.w) during Lighting.hlsl, then reads it back in StereoBlendCS to adjust the reprojection disparity. This prevents ghosting/smearing on surfaces with strong parallax displacement.

### Struct Alignment Fixes (19edb700, 39d26c67, f58e0c6b)
Merge conflict resolution for SharedData cbuffer after upstream added SH ambient fields — corrects CPMSettings alignment, SharedDataCB padding (`float4 pad0` to match HLSL layout), and a missing semicolon.

## Test plan
- [ ] VR: Verify stereo reprojection renders correctly (Eye 1 matches Eye 0 perspective)
- [ ] VR: Check POM surfaces (stone walls, cobblestone) for reduced ghosting
- [ ] VR: Confirm CAS sharpening toggle works in settings UI
- [ ] VR: Verify stencil culling doesn't cause visual artifacts
- [ ] Flatrim: Confirm no regressions (VR code paths gated behind `REL::Module::IsVR()`)
- [ ] Build: Verify ALL preset compiles cleanly (SE/AE/VR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full VR Stereo Optimizations: per-pixel classification, stencil culling, reprojection, and an overwrite stereo blend path.
  * New VR CAS sharpening and a dedicated post-process for 2x supersampling.

* **Improvements**
  * VR-focused MIP-bias controls and depth-gated adjustments for foliage and grass.
  * Enhanced stereo blending with bilateral depth-weighted blending, edge detection, and expanded debug/visualization modes.
* **UI**
  * Added new debug options for stereo blend ("Overwrite" variants).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->