### PR TITLE
fix(VR): bad llf offset

### DIFF
--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -230,7 +230,7 @@ public:
 			stl::write_vfunc<0x6, BSWaterShader_SetupGeometry>(RE::VTABLE_BSWaterShader[0]);
 
 			stl::write_thunk_call<ValidLight1>(REL::RelocationID(100994, 107781).address() + 0x92);
-			stl::write_thunk_call<ValidLight2>(REL::RelocationID(100997, 107784).address() + REL::Relocate(0x139, 0x12A));
+			stl::write_thunk_call<ValidLight2>(REL::RelocationID(100997, 107784).address() + REL::Relocate(0x139, 0x12A, 0x133));
 			stl::write_thunk_call<ValidLight3>(REL::RelocationID(101296, 108283).address() + REL::Relocate(0xB7, 0x7E));
 
 			logger::info("[LLF] Installed hooks");

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -149,7 +149,7 @@ bool Load()
 	}
 
 	if (REL::Module::IsVR()) {
-		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.200.0", true);
+		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.207.0", true);
 	}
 
 	auto privateProfileRedirectorVersion = Util::GetDllVersion(L"Data/SKSE/Plugins/PrivateProfileRedirector.dll");


### PR DESCRIPTION
Need to also bump VR Address library to 0.207.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected light limit relocation handling for improved compatibility.

* **Chores**
  * Updated support for VR address library version 0.207.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->