### PR TITLE
perf: cache frequent ui checks

### DIFF
--- a/src/Features/LinearLighting.cpp
+++ b/src/Features/LinearLighting.cpp
@@ -105,7 +105,7 @@ void LinearLighting::SetupResources()
 
 void LinearLighting::Prepass()
 {
-	bool isMainLoadingMenu = globals::game::ui && (globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || globals::game::ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME));
+	bool isMainLoadingMenu = globals::state->isMainMenuOpen || globals::state->isLoadingMenuOpen;
 	dirLightMult = 1.0f;
 	if (!settings.enableLinearLighting || isMainLoadingMenu)
 		return;
@@ -148,7 +148,7 @@ LinearLighting::PerFrameData LinearLighting::GetCommonBufferData()
 		data.enableLinearLighting = false;
 		return data;
 	}
-	bool isMainLoadingMenu = globals::game::ui && (globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || globals::game::ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME));
+	bool isMainLoadingMenu = globals::state->isMainMenuOpen || globals::state->isLoadingMenuOpen;
 	auto data = PerFrameData{};
 	data.enableLinearLighting = settings.enableLinearLighting && !isMainLoadingMenu;
 	data.enableGammaCorrection = settings.enableGammaCorrection;

--- a/src/Features/LinearLighting.cpp
+++ b/src/Features/LinearLighting.cpp
@@ -1,5 +1,7 @@
 #include "LinearLighting.h"
 
+#include "State.h"
+
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	LinearLighting::Settings,
 	enableLinearLighting,

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -170,9 +170,8 @@ Skylighting::SkylightingCB Skylighting::GetCommonBufferData(bool a_inWorld)
 	if (!a_inWorld)
 		return Skylighting::SkylightingCB{};
 
-	if (auto ui = globals::game::ui)
-		if (ui->IsMenuOpen(RE::MapMenu::MENU_NAME))
-			return Skylighting::SkylightingCB{};
+	if (globals::state->isMapMenuOpen)
+		return Skylighting::SkylightingCB{};
 
 	static float3 prevCellID = { 0, 0, 0 };
 
@@ -206,9 +205,8 @@ Skylighting::SkylightingCB Skylighting::GetCommonBufferData(bool a_inWorld)
 
 void Skylighting::Prepass()
 {
-	if (auto ui = globals::game::ui)
-		if (ui->IsMenuOpen(RE::MapMenu::MENU_NAME))
-			return;
+	if (globals::state->isMapMenuOpen)
+		return;
 
 	bool interior = true;
 

--- a/src/Features/VR/Input.cpp
+++ b/src/Features/VR/Input.cpp
@@ -28,8 +28,8 @@ void VR::UpdateOverlayMenuStateFromInput()
 		return;
 	}
 
-	bool uiMenusOpen = globals::game::ui &&
-	                   (globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || globals::game::ui->IsMenuOpen(RE::TweenMenu::MENU_NAME));
+	bool uiMenusOpen = globals::state->isMainMenuOpen ||
+	                   (globals::game::ui && globals::game::ui->IsMenuOpen(RE::TweenMenu::MENU_NAME));
 
 	bool inValidMenuState = uiMenusOpen || (globals::game::ui && (isEnabled || overlayEnabled));
 

--- a/src/Features/VR/Input.cpp
+++ b/src/Features/VR/Input.cpp
@@ -1,5 +1,6 @@
 #include "Features/VR.h"
 #include "Menu.h"
+#include "State.h"
 #include "Utils/PerfUtils.h"
 #include "Utils/VRUtils.h"
 

--- a/src/Features/VR/SettingsUI.cpp
+++ b/src/Features/VR/SettingsUI.cpp
@@ -73,7 +73,7 @@ void VR::DrawOverlay()
 	static LARGE_INTEGER overlayShowStart = { 0 };
 	static LARGE_INTEGER freq = { 0 };
 
-	bool shouldShow = settings.kAutoHideSeconds > 0 && globals::game::ui && globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) && globals::menu && !globals::menu->IsEnabled;
+	bool shouldShow = settings.kAutoHideSeconds > 0 && globals::state->isMainMenuOpen && globals::menu && !globals::menu->IsEnabled;
 
 	if (!shouldShow) {
 		overlayShowStart.QuadPart = 0;

--- a/src/Menu/BackgroundBlur.cpp
+++ b/src/Menu/BackgroundBlur.cpp
@@ -6,6 +6,7 @@
 #include "../Features/Upscaling.h"
 #include "../Globals.h"
 #include "../ShaderCache.h"
+#include "../State.h"
 #include "../Util.h"
 
 #include <algorithm>

--- a/src/Menu/BackgroundBlur.cpp
+++ b/src/Menu/BackgroundBlur.cpp
@@ -505,8 +505,7 @@ namespace BackgroundBlur
 
 		// Back buffer is black on main/loading menu during shader compilation without upscaling
 		if (!useUpscalingBackbuffer && !(upscaling.loaded && upscaling.IsUpscalingActive())) {
-			auto ui = globals::game::ui;
-			bool isMainOrLoading = ui && (ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME));
+			bool isMainOrLoading = globals::state->isMainMenuOpen || globals::state->isLoadingMenuOpen;
 			auto shaderCache = globals::shaderCache;
 			if (isMainOrLoading && shaderCache && shaderCache->IsCompiling()) {
 				return;

--- a/src/SceneSettingsManager.cpp
+++ b/src/SceneSettingsManager.cpp
@@ -2,6 +2,7 @@
 
 #include "Feature.h"
 #include "Globals.h"
+#include "State.h"
 #include "Utils/FileSystem.h"
 #include "Utils/Game.h"
 

--- a/src/SceneSettingsManager.cpp
+++ b/src/SceneSettingsManager.cpp
@@ -303,8 +303,7 @@ void SceneSettingsManager::Update()
 {
 	// Revert interior overrides on main/loading menu (same check as LinearLighting)
 	if (isCurrentlyApplied) {
-		bool isMainOrLoading = globals::game::ui &&
-		                       (globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || globals::game::ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME));
+		bool isMainOrLoading = globals::state->isMainMenuOpen || globals::state->isLoadingMenuOpen;
 		if (isMainOrLoading) {
 			RevertToExteriorSettings();
 			isCurrentlyApplied = false;

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -146,6 +146,19 @@ void State::Reset()
 	Feature::ForEachLoadedFeature("Reset", [](Feature* feature) { feature->Reset(); });
 	if (!globals::game::ui->GameIsPaused())
 		timer += RE::GetSecondsSinceLastFrame();
+
+	// Cache menu open states once per frame to avoid repeated IsMenuOpen calls
+	// (each call constructs a BSFixedString, which is expensive at scale).
+	if (auto ui = globals::game::ui) {
+		isMainMenuOpen = ui->IsMenuOpen(RE::MainMenu::MENU_NAME);
+		isLoadingMenuOpen = ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME);
+		isMapMenuOpen = ui->IsMenuOpen(RE::MapMenu::MENU_NAME);
+	} else {
+		isMainMenuOpen = false;
+		isLoadingMenuOpen = false;
+		isMapMenuOpen = false;
+	}
+
 	lastModifiedPixelDescriptor = 0;
 	lastModifiedVertexDescriptor = 0;
 	lastPixelDescriptor = 0;
@@ -831,10 +844,7 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 		else
 			data.HideSky = false;
 
-		if (globals::game::ui)
-			data.InMapMenu = globals::game::ui->IsMenuOpen(RE::MapMenu::MENU_NAME);
-		else
-			data.InMapMenu = false;
+		data.InMapMenu = isMapMenuOpen;
 
 		auto& upscaling = globals::features::upscaling;
 

--- a/src/State.h
+++ b/src/State.h
@@ -172,6 +172,12 @@ public:
 	bool inWorld = false;
 	bool activeReflections = false;
 
+	// Cached menu open states, updated once per frame in Reset().
+	// Avoids repeated IsMenuOpen calls (each constructs a BSFixedString).
+	bool isMainMenuOpen = false;
+	bool isLoadingMenuOpen = false;
+	bool isMapMenuOpen = false;
+
 	void UpdateSharedData(bool a_inWorld, bool a_prepass);
 
 	struct PermutationCB


### PR DESCRIPTION
https://github.com/doodlum/skyrim-community-shaders/issues/1972

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Menu open state is now tracked centrally per frame, streamlining checks across visuals, VR overlays, lighting, and background blur.
* **Bug Fixes**
  * More consistent behavior for overlays, lighting, and background blur when main, loading, or map menus are open—reduces spurious rendering, incorrect overlay visibility, and edge-case glitches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->