### PR TITLE
fix: preserve vanilla water TAA when no upscaler is active

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1029,15 +1029,22 @@ void Upscaling::ConfigureTAA()
 {
 	auto upscaleMethod = GetUpscaleMethod();
 
+	// When no upscaling method is active, leave vanilla TAA state untouched.
+	// The original UpdateJitter (called after this) manages water TAA and jitter
+	// correctly for the non-upscaling case.  Overriding here disables ISWaterBlend,
+	// removing the 95% temporal history blend that stabilizes water reflections.
+	if (upscaleMethod == UpscaleMethod::kNONE)
+		return;
+
 	auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
 	GET_INSTANCE_MEMBER(BSImagespaceShaderISTemporalAA, imageSpaceManager);
 
-	// Disable water TAA when upscaling is enabled
+	// CS TAA replaces vanilla TAA entirely, so disable water TAA (CS handles it).
+	// For FSR/DLSS, keep water TAA enabled since the upscaler needs the blend data.
 	bool* enableWaterTAA = reinterpret_cast<bool*>(reinterpret_cast<uintptr_t>(BSImagespaceShaderISTemporalAA) + 0x38LL);
-	*enableWaterTAA = !(upscaleMethod == UpscaleMethod::kNONE || upscaleMethod == UpscaleMethod::kTAA);
+	*enableWaterTAA = (upscaleMethod != UpscaleMethod::kTAA);
 
-	// Force enable TAA if needed
-	BSImagespaceShaderISTemporalAA->taaEnabled = upscaleMethod != UpscaleMethod::kNONE;
+	BSImagespaceShaderISTemporalAA->taaEnabled = true;
 }
 
 void Upscaling::ConfigureUpscaling(RE::BSGraphics::State* a_viewport)


### PR DESCRIPTION
Fixes #1979

## Problem

Two hooks in the Upscaling module unconditionally override the engine's TAA state, disabling water temporal stabilization when no upscaler is active (`kNONE`):

**1. `ConfigureTAA()`** — runs every frame via `Main_UpdateJitter` before the vanilla jitter function:
```cpp
*enableWaterTAA = !(upscaleMethod == kNONE || upscaleMethod == kTAA);  // false for kNONE
BSImagespaceShaderISTemporalAA->taaEnabled = upscaleMethod != kNONE;   // false for kNONE
```

**2. `Main_PostProcessing::thunk()`** — runs later, right before the actual post-processing dispatch:
```cpp
BSImagespaceShaderISTemporalAA->taaEnabled = upscaleMethod == kTAA;    // false for kNONE
func(a_this, a3, a_target, a_4, a_5);                                  // ISWaterBlend skipped
BSImagespaceShaderISTemporalAA->taaEnabled = false;
```

Both disable ISWaterBlend's 95% temporal history blend that stabilizes water reflections. Without it, every per-frame variation in auto-exposure adaptation is directly visible as water flickering between transparent, white/opaque, and normal reflections (~6 second convergence when stationary).

## Fix

**`ConfigureTAA()`**: Early return when `kNONE` — let the vanilla `UpdateJitter` function (called immediately after) manage TAA state correctly.

**`Main_PostProcessing::thunk()`**: Skip all TAA state overrides when `kNONE` — call `func()` with vanilla state preserved.

For `kTAA`, `kFSR`, and `kDLSS`, behavior is unchanged from the original code.

## Testing

Isolated Upscaling as the sole trigger via binary search across 20 features added since 1.4.7 RC. Verified fix eliminates flickering for Upscaler Disabled and TAA modes. FSR/DLSS water flicker is a separate pre-existing issue (ISWaterBlend was already disabled for those modes in the original code).

Tested on: Skyrim SE v1.6.1170, RX 9060 XT, 5120×1440, Upscaler Disabled and TAA modes.
