### PR TITLE
refactor(epsilon constants): :recycle: standardize epsilon constants in HLSL shaders (#1227)

### DIFF
--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/radianceDisocc.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/radianceDisocc.cs.hlsl
@@ -1,7 +1,7 @@
-#include "Common/Math.hlsli"
 #include "Common/Color.hlsli"
 #include "Common/FrameBuffer.hlsli"
 #include "Common/GBuffer.hlsli"
+#include "Common/Math.hlsli"
 #include "Common/VR.hlsli"
 #include "ScreenSpaceGI/common.hlsli"
 

--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/radianceDisocc.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/radianceDisocc.cs.hlsl
@@ -1,3 +1,4 @@
+#include "Common/Math.hlsli"
 #include "Common/Color.hlsli"
 #include "Common/FrameBuffer.hlsli"
 #include "Common/GBuffer.hlsli"
@@ -126,7 +127,7 @@ void readHistory(
 			prev_ao, prev_y, prev_co_cg, prev_ambient, accum_frames, prev_gi_specular, wsum);
 
 		if (wsum > 1e-2) {
-			float rcpWsum = rcp(wsum + 1e-10);
+			float rcpWsum = rcp(wsum + EPSILON_WEIGHT_SUM);
 #	ifdef TEMPORAL_DENOISER
 			prev_ao *= rcpWsum;
 			prev_y *= rcpWsum;

--- a/features/Skylighting/Shaders/Skylighting/Skylighting.hlsli
+++ b/features/Skylighting/Shaders/Skylighting/Skylighting.hlsli
@@ -111,7 +111,7 @@ namespace Skylighting
 					wsum += w;
 				}
 
-		return SphericalHarmonics::Scale(sum, rcp(wsum + 1e-10));
+		return SphericalHarmonics::Scale(sum, rcp(wsum + EPSILON_WEIGHT_SUM));
 	}
 
 	sh2 sampleNoBias(SharedData::SkylightingSettings params, Texture3D<sh2> probeArray, float3 positionMS)
@@ -157,7 +157,7 @@ namespace Skylighting
 			wsum += w;
 		}
 
-		return SphericalHarmonics::Scale(sum, rcp(wsum + 1e-10));
+		return SphericalHarmonics::Scale(sum, rcp(wsum + EPSILON_WEIGHT_SUM));
 	}
 }
 

--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -7,6 +7,7 @@
 
 #include "Common/Random.hlsli"
 #include "Common/SharedData.hlsli"
+#include "Common/Math.hlsli"
 
 // --------------------- CONSTANTS AND STRUCTURES --------------------- //
 // Height blend operator settings - DO NOT CHANGE THESE VALUES.
@@ -62,7 +63,7 @@ inline float3 NormalizeWeights(float3 weights)
 	// Skip expensive division if already normalized
 	if (abs(weightSum - 1.0) < 0.01)
 		return weights;
-	float rcpWeightSum = rcp(max(weightSum, 1e-6));
+	float rcpWeightSum = rcp(max(weightSum, EPSILON_DIVISION));
 	return weights * rcpWeightSum;
 }
 

--- a/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
+++ b/features/Terrain Variation/Shaders/TerrainVariation/TerrainVariation.hlsli
@@ -5,9 +5,9 @@
 #ifndef TERRAIN_VARIATION_HLSLI
 #define TERRAIN_VARIATION_HLSLI
 
+#include "Common/Math.hlsli"
 #include "Common/Random.hlsli"
 #include "Common/SharedData.hlsli"
-#include "Common/Math.hlsli"
 
 // --------------------- CONSTANTS AND STRUCTURES --------------------- //
 // Height blend operator settings - DO NOT CHANGE THESE VALUES.

--- a/package/Shaders/Common/Glints/Glints2023.hlsli
+++ b/package/Shaders/Common/Glints/Glints2023.hlsli
@@ -439,7 +439,7 @@ namespace Glints
 		// ACCURATE PIXEL FOOTPRINT ELLIPSE
 		float2 ellipseMajor, ellipseMinor;
 		GetGradientEllipse(duvdx, duvdy, ellipseMajor, ellipseMinor);
-		float ellipseRatio = length(ellipseMajor) / (length(ellipseMinor) + 1e-8);
+		float ellipseRatio = length(ellipseMajor) / (length(ellipseMinor) + EPSILON_GLINTS);
 
 		// SHARED GLINT NDF VALUES
 		float halfScreenSpaceScaler = screenSpaceScale * 0.5;

--- a/package/Shaders/Common/Math.hlsli
+++ b/package/Shaders/Common/Math.hlsli
@@ -1,11 +1,11 @@
 #ifndef __MATH_DEPENDENCY_HLSL__
 #define __MATH_DEPENDENCY_HLSL__
 
-#define EPSILON_SSS_ALBEDO 1e-3f  // For albedo clamping in SSS calculations
-#define EPSILON_DOT_CLAMP 1e-5f   // For dot product clamping
-#define EPSILON_DIVISION 1e-6f    // For division to avoid division by zero
-#define EPSILON_GLINTS      1e-8f    // For glints calculations
-#define EPSILON_WEIGHT_SUM  1e-10f   // For weight normalization
+#define EPSILON_SSS_ALBEDO 1e-3f   // For albedo clamping in SSS calculations
+#define EPSILON_DOT_CLAMP 1e-5f    // For dot product clamping
+#define EPSILON_DIVISION 1e-6f     // For division to avoid division by zero
+#define EPSILON_GLINTS 1e-8f       // For glints calculations
+#define EPSILON_WEIGHT_SUM 1e-10f  // For weight normalization
 
 namespace Math
 {

--- a/package/Shaders/Common/Math.hlsli
+++ b/package/Shaders/Common/Math.hlsli
@@ -4,6 +4,8 @@
 #define EPSILON_SSS_ALBEDO 1e-3f  // For albedo clamping in SSS calculations
 #define EPSILON_DOT_CLAMP 1e-5f   // For dot product clamping
 #define EPSILON_DIVISION 1e-6f    // For division to avoid division by zero
+#define EPSILON_GLINTS      1e-8f    // For glints calculations
+#define EPSILON_WEIGHT_SUM  1e-10f   // For weight normalization
 
 namespace Math
 {

--- a/package/Shaders/Common/PBRMath.hlsli
+++ b/package/Shaders/Common/PBRMath.hlsli
@@ -119,7 +119,7 @@ namespace PBR
 	inline float HairGaussian(float B, float Theta)
 	{
 		// Guard against division by zero: clamp B to a minimum value
-		float B_safe = max(B, 1e-6);
+		float B_safe = max(B, EPSILON_DIVISION);
 		return exp(-0.5 * Theta * Theta / (B_safe * B_safe)) / (sqrt(Math::TAU) * B_safe);
 	}
 


### PR DESCRIPTION
Add domain-specific epsilon constants to Math.hlsli and replace hardcoded values throughout the codebase for consistency and maintainability.

New constants added:
- EPSILON_GLINTS (1e-8f): For glints ellipse ratio calculations
- EPSILON_WEIGHT_SUM (1e-10f): For spherical harmonics weight normalization

Replacements:
- Skylighting.hlsli: 1e-10 → EPSILON_WEIGHT_SUM (rcp weight normalization)
- radianceDisocc.cs.hlsl: 1e-10 → EPSILON_WEIGHT_SUM (rcp weight normalization)
- Glints2023.hlsli: 1e-8 → EPSILON_GLINTS (ellipse ratio division)
- TerrainVariation.hlsli: 1e-6 → EPSILON_DIVISION (weight sum normalization)
- PBRMath.hlsli: 1e-6 → EPSILON_DIVISION (HairGaussian division guard)

Notes on deviations from the issue description:
- Common/BRDF.hlsli: 1e-6f occurrences were already replaced by EPSILON_DIVISION in PR #1226. No changes needed.
- Common/PBR.hlsli: Most 1e-5 occurrences replaced by EPSILON_DOT_CLAMP. One remaining occurrence (max(luma, 1e-5) in GetHairDiffuseAttenuationKajiyaKay) was intentionally left unchanged — it guards luminance-based division, not a dot product clamp, and its value doesn't match EPSILON_DIVISION (1e-6f). Left for follow-up.
- DynamicCubemaps/DynamicCubemaps.hlsli: The hardcoded 0.00001 mentioned in the issue was not found in the current codebase. Left untouched.
- Skylighting/Skylighting.hlsli: Two occurrences of 1e-10 (unitSH / 1e-10) were intentionally left unchanged — they construct a large fallback value for the interior case, not weight normalization guards.
- ScreenSpaceGI/ScreenSpaceGI.hlsli and TerrainBlending/TerrainBlending.hlsli: The hardcoded 1e-4 values mentioned in the issue were not found in the current codebase. Left untouched.

Closes #1227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized numerical precision constants across shader modules for improved consistency and maintainability in Screen Space GI, Skylighting, Terrain Variation, Glints, and PBR rendering calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->