### PR TITLE
fix(UI): input spam after alt-tab

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1089,28 +1089,20 @@ void Menu::ProcessInputEventQueue()
 				}
 			}
 
-			io.AddKeyEvent(Util::Input::VirtualKeyToImGuiKey(key), event.IsPressed());
+			// DirectInput loses key-up events after alt-tab; validate against OS state.
+			bool pressed = event.IsPressed() && (GetAsyncKeyState(key) & Constants::KEY_PRESSED_MASK);
+			io.AddKeyEvent(Util::Input::VirtualKeyToImGuiKey(key), pressed);
 
 			if (key == VK_LCONTROL || key == VK_RCONTROL)
-				io.AddKeyEvent(ImGuiMod_Ctrl, event.IsPressed());
+				io.AddKeyEvent(ImGuiMod_Ctrl, pressed);
 			else if (key == VK_LSHIFT || key == VK_RSHIFT)
-				io.AddKeyEvent(ImGuiMod_Shift, event.IsPressed());
+				io.AddKeyEvent(ImGuiMod_Shift, pressed);
 			else if (key == VK_LMENU || key == VK_RMENU)
-				io.AddKeyEvent(ImGuiMod_Alt, event.IsPressed());
+				io.AddKeyEvent(ImGuiMod_Alt, pressed);
 		}
 	}
 
 	_keyEventQueue.clear();
-
-	// Fallback: release stuck Shift and Tab if OS reports them not pressed
-	if ((io.KeysDown[ImGuiKey_LeftShift] && !(GetAsyncKeyState(VK_LSHIFT) & Constants::KEY_PRESSED_MASK)) ||
-		(io.KeysDown[ImGuiKey_RightShift] && !(GetAsyncKeyState(VK_RSHIFT) & Constants::KEY_PRESSED_MASK))) {
-		io.AddKeyEvent(ImGuiKey_LeftShift, false);
-		io.AddKeyEvent(ImGuiKey_RightShift, false);
-	}
-	if (io.KeysDown[ImGuiKey_Tab] && !(GetAsyncKeyState(VK_TAB) & Constants::KEY_PRESSED_MASK)) {
-		io.AddKeyEvent(ImGuiKey_Tab, false);
-	}
 }
 
 void Menu::addToEventQueue(KeyEvent e)


### PR DESCRIPTION
Fixes spammed inputs after alt-tabbing out of skyrim window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard input stability when switching applications. Fixed an issue where key inputs could become unresponsive or stuck after using alt-tab to switch windows. The system now accurately tracks and synchronizes key states with the operating system, ensuring consistent keyboard responsiveness whether you're switching between applications or working within a single window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->