### PR TITLE
fix(UI): DPI-aware window layouts

### DIFF
--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -299,7 +299,6 @@ void PerformanceOverlay::DrawOverlay()
 		windowFlags |= ImGuiWindowFlags_NoBackground;
 	} else {
 		windowFlags &= ~ImGuiWindowFlags_NoDecoration;
-		windowFlags &= ~ImGuiWindowFlags_AlwaysAutoResize;
 		windowFlags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse;
 	}
 

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -156,7 +156,7 @@ void HomePageRenderer::RenderQuickLinksSection()
 	ImGui::Text("Quick Links");
 
 	// Center the button layout
-	float buttonWidth = QUICK_LINKS_BUTTON_WIDTH;
+	float buttonWidth = QUICK_LINKS_BUTTON_WIDTH * Util::GetUIScale();
 	float totalWidth = buttonWidth * 3 + ImGui::GetStyle().ItemSpacing.x * 2;  // 3 buttons with spacing
 	ImGui::SetCursorPosX((windowSize.x - totalWidth) * 0.5f);
 

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -172,10 +172,10 @@ void EditorWindow::ShowObjectsWindow()
 	}
 
 	// Create a table with two columns
-	if (ImGui::BeginTable("ObjectTable", 2, ImGuiTableFlags_Resizable | ImGuiTableFlags_BordersInner | ImGuiTableFlags_NoHostExtendX)) {
-		// Set up column widths
-		ImGui::TableSetupColumn("Categories", ImGuiTableColumnFlags_WidthStretch, 0.3f);  // 30% width
-		ImGui::TableSetupColumn("Objects", ImGuiTableColumnFlags_WidthStretch, 0.7f);     // 70% width
+	if (ImGui::BeginTable("ObjectTable", 2, ImGuiTableFlags_Resizable | ImGuiTableFlags_BordersInner)) {
+		// Fixed categories column, objects column fills remaining width
+		ImGui::TableSetupColumn("Categories", ImGuiTableColumnFlags_WidthFixed, 180.0f * Util::GetUIScale());
+		ImGui::TableSetupColumn("Objects", ImGuiTableColumnFlags_WidthStretch);
 
 		ImGui::TableNextRow();
 
@@ -538,14 +538,18 @@ void EditorWindow::ShowObjectsWindow()
 							// Show message that cell lighting is only for interior cells
 							ImGui::TableNextRow();
 							ImGui::TableSetColumnIndex(1);
+							ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
 							ImGui::TextColored(Menu::GetSingleton()->GetTheme().StatusPalette.Warning, "Cell Lighting is only available for interior cells.");
 							ImGui::TextColored(Menu::GetSingleton()->GetTheme().StatusPalette.Disable, "You are currently in an exterior cell.");
+							ImGui::PopTextWrapPos();
 						}
 					} else {
 						// No player or cell
 						ImGui::TableNextRow();
 						ImGui::TableSetColumnIndex(1);
+						ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
 						ImGui::TextColored(Menu::GetSingleton()->GetTheme().StatusPalette.Error, "Player cell not available.");
+						ImGui::PopTextWrapPos();
 					}
 				}
 
@@ -1009,6 +1013,10 @@ void EditorWindow::RenderUI()
 			if (ImGui::Checkbox("Palette", &PaletteWindow::GetSingleton()->open)) {
 			}
 
+			if (ImGui::MenuItem("Reset Window Layout")) {
+				resetLayout = true;
+			}
+
 			ImGui::Separator();
 			ImGui::Text("Open Widgets:");
 			ImGui::Separator();
@@ -1222,14 +1230,32 @@ void EditorWindow::RenderUI()
 
 	auto width = ImGui::GetIO().DisplaySize.x;
 	auto height = ImGui::GetIO().DisplaySize.y;
-	auto viewportWidth = width * 0.5f;                // Make the viewport take up 50% of the width
-	auto sideWidth = (width - viewportWidth) / 2.0f;  // Divide the remaining width equally between the side windows
-	ImGui::SetNextWindowSize(ImVec2(sideWidth, ImGui::GetIO().DisplaySize.y * 0.75f), ImGuiCond_FirstUseEver);
+	const float scale = Util::GetUIScale();
+	const float pad = ThemeManager::Constants::OVERLAY_WINDOW_POSITION * scale;
+	const float menuBarHeight = ImGui::GetFrameHeight();
+	const float availableWidth = width - pad * 3.0f;   // left pad + gap + right pad
+	const float availableHeight = (height - menuBarHeight - pad * 2.0f) * 0.85f;
+	const auto layoutCond = resetLayout ? ImGuiCond_Always : ImGuiCond_FirstUseEver;
+	// Browser gets up to half the available width, capped so ultrawide gives extra to viewport
+	const float maxBrowserWidth = 960.0f * scale;
+	const float browserWidth = std::min(availableWidth * 0.5f, maxBrowserWidth);
+	const float viewportWidth = availableWidth - browserWidth;
+	ImGui::SetNextWindowSize(ImVec2(browserWidth, availableHeight), layoutCond);
+	ImGui::SetNextWindowPos(ImVec2(pad, menuBarHeight + pad), layoutCond);
 	ShowObjectsWindow();
 
 	if (settings.showViewport) {
-		ImGui::SetNextWindowSize(ImVec2(viewportWidth, ImGui::GetIO().DisplaySize.y * 0.5f), ImGuiCond_FirstUseEver);
+		// Size viewport height to match game aspect ratio so the preview fits snugly
+		const float aspectRatio = width / height;
+		const float imageHeight = viewportWidth / aspectRatio;
+		const float chromeHeight = ImGui::GetFrameHeight() + ImGui::GetStyle().WindowPadding.y * 2.0f;
+		const float viewportHeight = imageHeight + chromeHeight;
+		ImGui::SetNextWindowSize(ImVec2(viewportWidth, viewportHeight), layoutCond);
+		ImGui::SetNextWindowPos(ImVec2(pad + browserWidth + pad, menuBarHeight + pad), layoutCond);
+		viewportBottomY = menuBarHeight + pad + viewportHeight;
 		ShowViewportWindow();
+	} else {
+		viewportBottomY = menuBarHeight + pad;
 	}
 
 	auto settingsWindowHeight = height * 0.25f;
@@ -1244,6 +1270,8 @@ void EditorWindow::RenderUI()
 
 	// Show palette window
 	PaletteWindow::GetSingleton()->Draw();
+
+	resetLayout = false;
 
 	// Render notifications on top of everything
 	RenderNotifications();

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -1260,9 +1260,9 @@ void EditorWindow::RenderUI()
 
 	auto settingsWindowHeight = height * 0.25f;
 	auto settingsWindowWidth = width * 0.25f;
-	ImGui::SetNextWindowSizeConstraints(ImVec2(settingsWindowWidth, settingsWindowHeight), ImVec2(FLT_MAX, FLT_MAX));
-	ImGui::SetNextWindowPos({ (width / 2.0f) - (settingsWindowWidth / 2.0f), (height / 2.0f) - (settingsWindowHeight / 2.0f) }, ImGuiCond_Appearing);
 	if (showSettingsWindow) {
+		ImGui::SetNextWindowSize(ImVec2(settingsWindowWidth, settingsWindowHeight), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowPos({ (width / 2.0f) - (settingsWindowWidth / 2.0f), (height / 2.0f) - (settingsWindowHeight / 2.0f) }, ImGuiCond_Appearing);
 		ShowSettingsWindow();
 	}
 

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -1233,7 +1233,7 @@ void EditorWindow::RenderUI()
 	const float scale = Util::GetUIScale();
 	const float pad = ThemeManager::Constants::OVERLAY_WINDOW_POSITION * scale;
 	const float menuBarHeight = ImGui::GetFrameHeight();
-	const float availableWidth = width - pad * 3.0f;   // left pad + gap + right pad
+	const float availableWidth = width - pad * 3.0f;  // left pad + gap + right pad
 	const float availableHeight = (height - menuBarHeight - pad * 2.0f) * 0.85f;
 	const auto layoutCond = resetLayout ? ImGuiCond_Always : ImGuiCond_FirstUseEver;
 	// Browser gets up to half the available width, capped so ultrawide gives extra to viewport

--- a/src/WeatherEditor/EditorWindow.h
+++ b/src/WeatherEditor/EditorWindow.h
@@ -48,6 +48,12 @@ public:
 	RE::TESWeather* lockedWeather = nullptr;
 	bool weatherLockActive = false;
 
+	/// When true, resets all window positions/sizes on next frame (auto-cleared).
+	bool resetLayout = false;
+
+	/// Bottom Y of the viewport window, set during layout for palette positioning.
+	float viewportBottomY = 0.0f;
+
 	// Time control constants
 	static constexpr float kVanillaTimeScale = 20.0f;
 	static constexpr float kGameHourMax = 23.99f;

--- a/src/WeatherEditor/PaletteWindow.cpp
+++ b/src/WeatherEditor/PaletteWindow.cpp
@@ -1,5 +1,6 @@
 #include "PaletteWindow.h"
 #include "EditorWindow.h"
+#include "Menu/ThemeManager.h"
 #include "Utils/UI.h"
 
 // Forward declaration from EditorWindow.cpp
@@ -10,9 +11,20 @@ void PaletteWindow::Draw()
 	if (!open)
 		return;
 
+	const auto* editor = EditorWindow::GetSingleton();
 	const float scale = Util::GetUIScale();
-	ImGui::SetNextWindowSize(ImVec2(600 * scale, 400 * scale), ImGuiCond_FirstUseEver);
-	ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x - 620 * scale, ImGui::GetIO().DisplaySize.y - 420 * scale), ImGuiCond_FirstUseEver);
+	const float pad = ThemeManager::Constants::OVERLAY_WINDOW_POSITION * scale;
+	const auto& displaySize = ImGui::GetIO().DisplaySize;
+	const float paletteWidth = std::min(600.0f * scale, displaySize.x - pad * 2.0f);
+	const float bottomY = displaySize.y - pad;
+	const float spaceBelow = bottomY - editor->viewportBottomY - pad;  // room between viewport bottom and screen bottom
+	const float paletteHeight = std::min(400.0f * scale, spaceBelow);
+	const auto layoutCond = editor->resetLayout ? ImGuiCond_Always : ImGuiCond_FirstUseEver;
+	ImGui::SetNextWindowSizeConstraints(ImVec2(200.0f * scale, 150.0f * scale), ImVec2(FLT_MAX, FLT_MAX));
+	ImGui::SetNextWindowSize(ImVec2(paletteWidth, paletteHeight), layoutCond);
+	ImGui::SetNextWindowPos(
+		ImVec2(displaySize.x - paletteWidth - pad, bottomY - paletteHeight),
+		layoutCond);
 	if (ImGui::Begin("Palette", &open, ImGuiWindowFlags_NoFocusOnAppearing)) {
 		if (ImGui::BeginTabBar("PaletteTabs")) {
 			if (ImGui::BeginTabItem("Colours")) {

--- a/src/WeatherEditor/PaletteWindow.cpp
+++ b/src/WeatherEditor/PaletteWindow.cpp
@@ -20,7 +20,6 @@ void PaletteWindow::Draw()
 	const float spaceBelow = bottomY - editor->viewportBottomY - pad;  // room between viewport bottom and screen bottom
 	const float paletteHeight = std::min(400.0f * scale, spaceBelow);
 	const auto layoutCond = editor->resetLayout ? ImGuiCond_Always : ImGuiCond_FirstUseEver;
-	ImGui::SetNextWindowSizeConstraints(ImVec2(200.0f * scale, 150.0f * scale), ImVec2(FLT_MAX, FLT_MAX));
 	ImGui::SetNextWindowSize(ImVec2(paletteWidth, paletteHeight), layoutCond);
 	ImGui::SetNextWindowPos(
 		ImVec2(displaySize.x - paletteWidth - pad, bottomY - paletteHeight),

--- a/src/WeatherEditor/Weather/CellLightingWidget.cpp
+++ b/src/WeatherEditor/Weather/CellLightingWidget.cpp
@@ -5,7 +5,7 @@
 void CellLightingWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
-	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
+	SetupWidgetWindowDefaults();
 	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		DrawWidgetHeader("##CellLightingSearch", true, true);
 	}

--- a/src/WeatherEditor/Weather/ImageSpaceWidget.cpp
+++ b/src/WeatherEditor/Weather/ImageSpaceWidget.cpp
@@ -33,7 +33,7 @@ void ImageSpaceWidget::DrawWidget()
 	WeatherUtils::SetCurrentWidget(this);
 	auto editorWindow = EditorWindow::GetSingleton();
 
-	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
+	SetupWidgetWindowDefaults();
 	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		// Draw header with search and Save/Load/Delete buttons
 		DrawWidgetHeader("##ImageSpaceSearch", false, true);

--- a/src/WeatherEditor/Weather/LensFlareWidget.cpp
+++ b/src/WeatherEditor/Weather/LensFlareWidget.cpp
@@ -4,7 +4,7 @@
 
 void LensFlareWidget::DrawWidget()
 {
-	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
+	SetupWidgetWindowDefaults();
 	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		DrawWidgetHeader("##LensFlareSearch", true, true);
 	}

--- a/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
+++ b/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
@@ -29,7 +29,7 @@ LightingTemplateWidget::~LightingTemplateWidget()
 void LightingTemplateWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
-	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
+	SetupWidgetWindowDefaults();
 	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		// Draw header with search and Save/Load/Delete buttons
 		DrawWidgetHeader("##LightingTemplateSearch", false, true);

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -5,7 +5,7 @@
 void PrecipitationWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
-	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
+	SetupWidgetWindowDefaults();
 	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		DrawWidgetHeader("##PrecipitationSearch", true, true);
 

--- a/src/WeatherEditor/Weather/ReferenceEffectWidget.cpp
+++ b/src/WeatherEditor/Weather/ReferenceEffectWidget.cpp
@@ -4,7 +4,7 @@
 
 void ReferenceEffectWidget::DrawWidget()
 {
-	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
+	SetupWidgetWindowDefaults();
 	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		DrawWidgetHeader("##ReferenceEffectSearch", true, true);
 		BeginScrollableContent("##REScroll");

--- a/src/WeatherEditor/Weather/VolumetricLightingWidget.cpp
+++ b/src/WeatherEditor/Weather/VolumetricLightingWidget.cpp
@@ -5,7 +5,7 @@
 void VolumetricLightingWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
-	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
+	SetupWidgetWindowDefaults();
 	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		DrawWidgetHeader("##VolumetricLightingSearch", true, true);
 	}

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -56,7 +56,7 @@ void WeatherWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
 	const float scale = Util::GetUIScale();
-	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
+	SetupWidgetWindowDefaults();
 	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		// Draw header with search and all buttons
 		DrawWidgetHeader("##WeatherSearch", false, true, true, weather);
@@ -1069,8 +1069,7 @@ void WeatherWidget::DrawCloudSettings()
 			ImGui::Spacing();
 			ImGui::Spacing();
 
-			// Make sliders 1/3 width
-			ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x * 0.4f);
+			ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x * 0.3f);
 			if (WeatherUtils::DrawSliderInt8(std::format("Cloud Layer Speed Y##{}", layer), settings.clouds[i].cloudLayerSpeedY))
 				changed = true;
 			ImGui::Spacing();
@@ -1102,7 +1101,7 @@ void WeatherWidget::DrawCloudSettings()
 
 			ImGui::Spacing();
 			ImGui::Spacing();
-			if (TOD::BeginTODTable((layer + "_TOD_Table").c_str(), 120.0f * scale)) {
+			if (TOD::BeginTODTable((layer + "_TOD_Table").c_str(), 120.0f)) {
 				TOD::RenderTODHeader();
 				TOD::DrawTODSeparator();
 
@@ -1165,17 +1164,19 @@ void WeatherWidget::DrawFogSettings()
 	bool changed = false;
 
 	const float scale = Util::GetUIScale();
-	if (ImGui::BeginTable("FogTable", 3, ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_SizingFixedFit)) {
-		ImGui::TableSetupColumn("Parameter", ImGuiTableColumnFlags_WidthFixed, 200.0f * scale);
-		ImGui::TableSetupColumn("Day", ImGuiTableColumnFlags_WidthFixed, 250.0f * scale);
-		ImGui::TableSetupColumn("Night", ImGuiTableColumnFlags_WidthFixed, 250.0f * scale);
+	if (ImGui::BeginTable("FogTable", 3, ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_SizingStretchSame)) {
+		ImGui::TableSetupColumn("Parameter", ImGuiTableColumnFlags_WidthFixed, 80.0f * scale);
+		ImGui::TableSetupColumn("Day", ImGuiTableColumnFlags_WidthStretch, 1.0f);
+		ImGui::TableSetupColumn("Night", ImGuiTableColumnFlags_WidthStretch, 1.0f);
 
 		// Header row
 		ImGui::TableNextRow();
 		ImGui::TableSetColumnIndex(0);
 		ImGui::TableSetColumnIndex(1);
+		ImGui::AlignTextToFramePadding();
 		ImGui::Text("Day");
 		ImGui::TableSetColumnIndex(2);
+		ImGui::AlignTextToFramePadding();
 		ImGui::Text("Night");
 
 		ImGui::TableNextRow();
@@ -1203,6 +1204,7 @@ void WeatherWidget::DrawFogSettings()
 			ImGui::PopStyleColor(2);
 			ImGui::SameLine();
 		}
+		ImGui::AlignTextToFramePadding();
 		ImGui::Text("Near");
 		ImGui::TableSetColumnIndex(1);
 		ImGui::SetNextItemWidth(-1);
@@ -1230,6 +1232,7 @@ void WeatherWidget::DrawFogSettings()
 			ImGui::PopStyleColor(2);
 			ImGui::SameLine();
 		}
+		ImGui::AlignTextToFramePadding();
 		ImGui::Text("Far");
 		ImGui::TableSetColumnIndex(1);
 		ImGui::SetNextItemWidth(-1);
@@ -1257,6 +1260,7 @@ void WeatherWidget::DrawFogSettings()
 			ImGui::PopStyleColor(2);
 			ImGui::SameLine();
 		}
+		ImGui::AlignTextToFramePadding();
 		ImGui::Text("Power");
 		ImGui::TableSetColumnIndex(1);
 		ImGui::SetNextItemWidth(-1);
@@ -1284,6 +1288,7 @@ void WeatherWidget::DrawFogSettings()
 			ImGui::PopStyleColor(2);
 			ImGui::SameLine();
 		}
+		ImGui::AlignTextToFramePadding();
 		ImGui::Text("Max");
 		ImGui::TableSetColumnIndex(1);
 		ImGui::SetNextItemWidth(-1);
@@ -1327,6 +1332,8 @@ void WeatherWidget::DrawProperties(std::string category, std::map<std::string, i
 	bool changed = false;
 	auto* editorWindow = EditorWindow::GetSingleton();
 	bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
+
+	ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x * WidgetDefaults::kSliderWidthRatio);
 
 	for (auto& p : properties) {
 		// Filter individual properties based on search
@@ -1382,6 +1389,8 @@ void WeatherWidget::DrawProperties(std::string category, std::map<std::string, i
 			ImGui::PopStyleColor(2);
 		}
 	}
+
+	ImGui::PopItemWidth();
 
 	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
 		ApplyChanges();

--- a/src/WeatherEditor/WeatherUtils.cpp
+++ b/src/WeatherEditor/WeatherUtils.cpp
@@ -10,9 +10,6 @@ void SetupWidgetWindowDefaults()
 {
 	const float scale = Util::GetUIScale();
 	const auto cond = EditorWindow::GetSingleton()->resetLayout ? ImGuiCond_Always : ImGuiCond_FirstUseEver;
-	ImGui::SetNextWindowSizeConstraints(
-		ImVec2(WidgetDefaults::kMinWidth * scale, WidgetDefaults::kMinHeight * scale),
-		ImVec2(FLT_MAX, FLT_MAX));
 	ImGui::SetNextWindowSize(
 		ImVec2(WidgetDefaults::kInitialWidth * scale, WidgetDefaults::kInitialHeight * scale),
 		cond);

--- a/src/WeatherEditor/WeatherUtils.cpp
+++ b/src/WeatherEditor/WeatherUtils.cpp
@@ -6,6 +6,18 @@
 // Global widget context for undo tracking
 static Widget* g_currentWidget = nullptr;
 
+void SetupWidgetWindowDefaults()
+{
+	const float scale = Util::GetUIScale();
+	const auto cond = EditorWindow::GetSingleton()->resetLayout ? ImGuiCond_Always : ImGuiCond_FirstUseEver;
+	ImGui::SetNextWindowSizeConstraints(
+		ImVec2(WidgetDefaults::kMinWidth * scale, WidgetDefaults::kMinHeight * scale),
+		ImVec2(FLT_MAX, FLT_MAX));
+	ImGui::SetNextWindowSize(
+		ImVec2(WidgetDefaults::kInitialWidth * scale, WidgetDefaults::kInitialHeight * scale),
+		cond);
+}
+
 bool ContainsStringIgnoreCase(const std::string_view a_string, const std::string_view a_substring)
 {
 	if (a_substring.empty())
@@ -400,6 +412,7 @@ namespace TOD
 
 	static void DrawCenteredLabel(const char* label)
 	{
+		ImGui::AlignTextToFramePadding();
 		float colWidth = ImGui::GetColumnWidth();
 		float textWidth = ImGui::CalcTextSize(label).x;
 		float offset = (colWidth - textWidth) * 0.5f;
@@ -999,9 +1012,9 @@ namespace TOD
 	bool BeginTODTable(const char* tableId, float paramColumnWidth)
 	{
 		if (paramColumnWidth <= 0.0f)
-			paramColumnWidth = 200.0f;
+			paramColumnWidth = WidgetDefaults::kTODLabelWidth;
 		if (ImGui::BeginTable(tableId, 2, ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_SizingStretchProp)) {
-			ImGui::TableSetupColumn("Parameter", ImGuiTableColumnFlags_WidthFixed, paramColumnWidth);
+			ImGui::TableSetupColumn("Parameter", ImGuiTableColumnFlags_WidthFixed, paramColumnWidth * Util::GetUIScale());
 			ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
 			return true;
 		}
@@ -1090,6 +1103,16 @@ namespace PropertyDrawer
 		ImGui::Separator();
 	}
 
+	void DrawLabel(const char* label)
+	{
+		ImGui::TableNextRow();
+		ImGui::TableSetColumnIndex(0);
+		ImGui::AlignTextToFramePadding();
+		ImGui::Text("%s", label);
+		ImGui::TableSetColumnIndex(1);
+		ImGui::SetNextItemWidth(-1);
+	}
+
 	bool MatchesSearch(const char* label, const char* searchBuffer)
 	{
 		if (!searchBuffer || searchBuffer[0] == '\0')
@@ -1103,11 +1126,7 @@ namespace PropertyDrawer
 		if (!MatchesSearch(label, searchBuffer))
 			return false;
 
-		ImGui::TableNextRow();
-		ImGui::TableSetColumnIndex(0);
-		ImGui::Text("%s", label);
-		ImGui::TableSetColumnIndex(1);
-		ImGui::SetNextItemWidth(-1);
+		DrawLabel(label);
 
 		std::string id = std::string("##") + label;
 		return ImGui::SliderFloat(id.c_str(), &value, minVal, maxVal, format);
@@ -1118,11 +1137,7 @@ namespace PropertyDrawer
 		if (!MatchesSearch(label, searchBuffer))
 			return false;
 
-		ImGui::TableNextRow();
-		ImGui::TableSetColumnIndex(0);
-		ImGui::Text("%s", label);
-		ImGui::TableSetColumnIndex(1);
-		ImGui::SetNextItemWidth(-1);
+		DrawLabel(label);
 
 		std::string id = std::string("##") + label;
 		return ImGui::SliderInt(id.c_str(), &value, minVal, maxVal);
@@ -1133,11 +1148,7 @@ namespace PropertyDrawer
 		if (!MatchesSearch(label, searchBuffer))
 			return false;
 
-		ImGui::TableNextRow();
-		ImGui::TableSetColumnIndex(0);
-		ImGui::Text("%s", label);
-		ImGui::TableSetColumnIndex(1);
-		ImGui::SetNextItemWidth(-1);
+		DrawLabel(label);
 
 		return WeatherUtils::DrawColorEdit(label, value);
 	}
@@ -1147,10 +1158,7 @@ namespace PropertyDrawer
 		if (!MatchesSearch(label, searchBuffer))
 			return false;
 
-		ImGui::TableNextRow();
-		ImGui::TableSetColumnIndex(0);
-		ImGui::Text("%s", label);
-		ImGui::TableSetColumnIndex(1);
+		DrawLabel(label);
 
 		std::string id = std::string("##") + label;
 		return ImGui::Checkbox(id.c_str(), &value);

--- a/src/WeatherEditor/WeatherUtils.h
+++ b/src/WeatherEditor/WeatherUtils.h
@@ -108,6 +108,24 @@ inline bool BeginScrollableContent(const char* id = "##ScrollContent") { return 
 inline void EndScrollableContent() { ImGui::EndChild(); }
 
 // ============================================================================
+// Widget Window Defaults - DPI-aware sizing for all editor widget windows
+// ============================================================================
+
+namespace WidgetDefaults
+{
+	constexpr float kMinWidth = 200.0f;
+	constexpr float kMinHeight = 150.0f;
+	constexpr float kInitialWidth = 580.0f;
+	constexpr float kInitialHeight = 580.0f;
+	constexpr float kSliderWidthRatio = 0.6f;       ///< Fraction of available width for slider/input controls
+	constexpr float kTODLabelWidth = 150.0f;          ///< Default label column width for time-of-day tables
+}
+
+/// Apply standard DPI-scaled size constraints and initial size for widget windows. Call before ImGui::Begin().
+/// Respects EditorWindow::resetLayout to re-apply defaults on demand.
+void SetupWidgetWindowDefaults();
+
+// ============================================================================
 // PropertyDrawer - Unified table-based property drawing with search support
 // ============================================================================
 namespace PropertyDrawer
@@ -118,6 +136,9 @@ namespace PropertyDrawer
 
 	// Draw a table separator row
 	void DrawSeparator();
+
+	// Draw a vertically-centered label in the first table column. Call between TableNextRow and drawing the value.
+	void DrawLabel(const char* label);
 
 	// Draw properties with optional search filtering.
 	// searchBuffer can be nullptr to skip search filtering.

--- a/src/WeatherEditor/WeatherUtils.h
+++ b/src/WeatherEditor/WeatherUtils.h
@@ -117,8 +117,8 @@ namespace WidgetDefaults
 	constexpr float kMinHeight = 150.0f;
 	constexpr float kInitialWidth = 580.0f;
 	constexpr float kInitialHeight = 580.0f;
-	constexpr float kSliderWidthRatio = 0.6f;       ///< Fraction of available width for slider/input controls
-	constexpr float kTODLabelWidth = 150.0f;          ///< Default label column width for time-of-day tables
+	constexpr float kSliderWidthRatio = 0.6f;  ///< Fraction of available width for slider/input controls
+	constexpr float kTODLabelWidth = 150.0f;   ///< Default label column width for time-of-day tables
 }
 
 /// Apply standard DPI-scaled size constraints and initial size for widget windows. Call before ImGui::Begin().

--- a/src/WeatherEditor/Widget.cpp
+++ b/src/WeatherEditor/Widget.cpp
@@ -279,21 +279,18 @@ void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSav
 			ImGui::SetKeyboardFocusHere(-1);
 	};
 
-	auto drawForceWeatherButton = [&](float height) {
+	auto drawForceWeatherButton = [&]() {
 		if (!showForceWeather || !weather)
 			return;
 		ImGui::SameLine();
 		bool isLocked = editorWindow->IsWeatherLocked() && editorWindow->GetLockedWeather() == weather;
 		const char* lockLabel = isLocked ? "Unlock" : "Force Weather";
-		ImVec2 lockSize = ImGui::CalcTextSize(lockLabel);
-		lockSize.x += ImGui::GetStyle().FramePadding.x * 2.0f;
-		lockSize.y = height;
 
 		if (isLocked) {
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.2f, 0.8f, 0.2f, 1.0f));
 			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.3f, 0.9f, 0.3f, 1.0f));
 		}
-		if (ImGui::Button(lockLabel, lockSize)) {
+		if (ImGui::Button(lockLabel)) {
 			if (isLocked)
 				editorWindow->UnlockWeather();
 			else
@@ -321,7 +318,7 @@ void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSav
 		ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4.0f * scale, ImGui::GetStyle().ItemSpacing.y));
 
 		drawSearchBar();
-		drawForceWeatherButton(iconSize);
+		drawForceWeatherButton();
 
 		// Transparent icon button style
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 0.0f);
@@ -367,14 +364,14 @@ void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSav
 		const float buttonHeight = ImGui::GetFrameHeight();
 		if (!menu) {
 			drawSearchBar();
-			drawForceWeatherButton(buttonHeight);
+			drawForceWeatherButton();
 			ImGui::Separator();
 			return;
 		}
 		const auto& palette = menu->GetTheme().StatusPalette;
 
 		drawSearchBar();
-		drawForceWeatherButton(buttonHeight);
+		drawForceWeatherButton();
 
 		auto styledTextButton = [&](const char* label, const ImVec4& color, const char* tooltip, auto callback) {
 			ImGui::SameLine();


### PR DESCRIPTION
Changes default window positions and sizes to scale correctly with DPI. Tested from 16:10 to ultrawide resolutions. Added a reset window layout button to the weather editor. 

Default window positions for weather editor:
<img width="3840" height="2160" alt="Skyrim Special Edition 3_22_2026 10_46_12 AM" src="https://github.com/user-attachments/assets/943e3e49-1ea0-4ea5-99fe-240f8abdba6a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Reset Window Layout" added to restore default editor window positions and sizes.
  * UI elements (menus, palette, quick links) now respond to UI scaling for consistent layout.

* **Bug Fixes**
  * Viewport now preserves image aspect ratio when enabled.
  * Improved text wrapping and vertical alignment for informational messages.
  * Performance overlay border no longer breaks automatic resizing.

* **Refactor**
  * Standardized widget window sizing and simplified header button sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->