### PR TITLE
feat(vr): Screen Space Shadows VR optimization

### DIFF
--- a/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
+++ b/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
@@ -325,6 +325,7 @@ namespace ExtendedMaterials
 	float2 GetParallaxCoords(float distance, float2 coords, float mipLevel, float3 viewDir, float3x3 tbn, float noise, Texture2D<float4> tex, SamplerState texSampler, uint channel, DisplacementParams params, out float pixelOffset)
 #endif
 	{
+		pixelOffset = 0.5;
 		float3 viewDirTS = normalize(mul(tbn, viewDir));
 #if defined(LANDSCAPE)
 		viewDirTS.xy /= viewDirTS.z * 0.7 + 0.3 + params[0].FlattenAmount;  // Fix for objects at extreme viewing angles
@@ -496,7 +497,7 @@ namespace ExtendedMaterials
 #endif
 				nearBlendToFar *= nearBlendToFar;
 			float offset = (1.0 - parallaxAmount) * -maxHeight + minHeight;
-			pixelOffset = lerp(parallaxAmount * scale, 0, nearBlendToFar);
+			pixelOffset = saturate(lerp(parallaxAmount, 0.5, nearBlendToFar));
 			return lerp(viewDirTS.xy * offset + coords.xy, coords, nearBlendToFar);
 		}
 
@@ -509,7 +510,7 @@ namespace ExtendedMaterials
 		weights[5] = input.LandBlendWeights2.y;
 #endif
 
-		pixelOffset = 0;
+		pixelOffset = 0.5;
 		return coords;
 	}
 

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/RaymarchCS.hlsl
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/RaymarchCS.hlsl
@@ -50,7 +50,10 @@ cbuffer PerFrame : register(b1)
 
 	parameters.DynamicRes = DynamicRes;
 
-	parameters.UsePrecisionOffset = true;
+	// VR note: precision offset adds a depth bias that can cause subtle shadow
+	// shifting. Disabled to match the old (stable) SSS implementation.
+	// See: docs/development/Old code/RaymarchCS.hlsl
+	parameters.UsePrecisionOffset = false;
 
 	WriteScreenSpaceShadow(parameters, groupID, groupThreadID);
 }

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/ScreenSpaceShadows.hlsli
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/ScreenSpaceShadows.hlsli
@@ -1,10 +1,82 @@
+// Screen Space Shadows consumption helper.
+// Non-VR: depth-weighted 4-sample Poisson blur for spatial denoising.
+// VR: direct Load — the Poisson blur's per-pixel noise rotation is
+// screen-position-dependent, causing shadows to shift on camera movement.
+// Without TAA to average out the rotation noise, the instability hits
+// the final output directly. Matches the stable v1.2 VR implementation.
+
+#include "Common/Math.hlsli"
 
 namespace ScreenSpaceShadows
 {
 	Texture2D<unorm half> ScreenSpaceShadowsTexture : register(t45);
 
+	float4 GetBlurWeights(float4 depths, float centerDepth)
+	{
+		centerDepth += 1.0;
+		float depthSharpness = saturate((1024.0 * 1024.0) / (centerDepth * centerDepth));
+		float4 depthDifference = (depths - centerDepth) * depthSharpness;
+		return exp2(-depthDifference * depthDifference);
+	}
+
 	float GetScreenSpaceShadow(float3 screenPosition, float2 uv, float noise, uint eyeIndex)
 	{
-		return ScreenSpaceShadowsTexture.Load(int3(int2(screenPosition.xy + 0.5f), 0)).x;
+#if defined(VR)
+		// VR: direct sample, no spatial blur. The Poisson blur's per-pixel noise
+		// rotation is screen-position-dependent — camera movement changes the
+		// rotation angle for the same world surface, causing shadows to visually
+		// shift. Without TAA to average out the rotation noise, the per-frame
+		// instability hits the final output directly. Direct Load avoids this.
+		// Matches the stable v1.2 VR implementation.
+		return ScreenSpaceShadowsTexture.Load(int3(screenPosition.xy, 0));
+#else
+		// Flat: depth-weighted 4-sample Poisson blur for spatial denoising.
+		// Rotated per-pixel by screen-space noise to break structured patterns.
+		// TAA averages out the rotation noise across frames.
+		noise *= Math::TAU;
+
+		float2x2 rotationMatrix = float2x2(cos(noise), sin(noise), -sin(noise), cos(noise));
+
+		float4 shadowSamples = 0;
+		float4 depthSamples = 0;
+
+#	if defined(DEFERRED) && !defined(DO_ALPHA_TEST)
+		depthSamples[0] = screenPosition.z;
+#	else
+		depthSamples[0] = SharedData::DepthTexture.Load(int3(screenPosition.xy, 0)).x;
+#	endif
+
+		shadowSamples[0] = ScreenSpaceShadowsTexture.Load(int3(screenPosition.xy, 0));
+
+		static const float2 BlurOffsets[3] = {
+			float2(-0.6720635096678028f, 0.6601738628451107f),
+			float2(0.6110340335380645f, 0.5269905984201742f),
+			float2(0.20239029763403027f, -0.7841160574831084f),
+		};
+
+		[unroll] for (uint i = 1; i < 4; i++)
+		{
+			float2 offset = mul(BlurOffsets[i - 1], rotationMatrix) * 0.0025;
+
+			float2 sampleUV = uv + offset;
+			sampleUV = saturate(sampleUV);
+
+			int3 sampleCoord = SharedData::ConvertUVToSampleCoord(sampleUV, eyeIndex);
+
+			depthSamples[i] = SharedData::DepthTexture.Load(sampleCoord).x;
+			shadowSamples[i] = ScreenSpaceShadowsTexture.Load(sampleCoord);
+		}
+
+		depthSamples = SharedData::GetScreenDepths(depthSamples);
+
+		float4 blurWeights = GetBlurWeights(depthSamples, depthSamples[0]);
+		float shadow = dot(shadowSamples, blurWeights);
+
+		float blurWeightsTotal = dot(blurWeights, 1.0);
+		[flatten] if (blurWeightsTotal > 0.0)
+			shadow = shadow / blurWeightsTotal;
+
+		return shadow;
+#endif
 	}
 }

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/StereoSyncCS.hlsl
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/StereoSyncCS.hlsl
@@ -15,9 +15,9 @@
 Texture2D<float> SrcDepthTexture : register(t0);
 Texture2D<unorm half> SrcShadowTexture : register(t1);
 
-#if defined(VR_STEREO_OPT)
+#	if defined(VR_STEREO_OPT)
 Texture2D<uint> StereoOptModeTexture : register(t16);
-#endif
+#	endif
 
 RWTexture2D<unorm half> OutShadowTexture : register(u0);
 
@@ -94,7 +94,7 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
 
-#if defined(VR_STEREO_OPT)
+#	if defined(VR_STEREO_OPT)
 	// Eye 1 pixels with mode 1 (edge) or 2 (main) will be overwritten by StereoBlend
 	// reprojection, so skip the expensive stereo sync work and write neutral (unshadowed).
 	if (eyeIndex == 1) {
@@ -104,7 +104,7 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 			return;
 		}
 	}
-#endif
+#	endif
 
 	float depth = SrcDepthTexture[dtid];
 

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/StereoSyncCS.hlsl
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/StereoSyncCS.hlsl
@@ -15,6 +15,10 @@
 Texture2D<float> SrcDepthTexture : register(t0);
 Texture2D<unorm half> SrcShadowTexture : register(t1);
 
+#if defined(VR_STEREO_OPT)
+Texture2D<uint> StereoOptModeTexture : register(t16);
+#endif
+
 RWTexture2D<unorm half> OutShadowTexture : register(u0);
 
 cbuffer StereoSyncCB : register(b1)
@@ -89,6 +93,18 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 	float2 uv = (dtid + 0.5) * RcpFrameDim;
 
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
+
+#if defined(VR_STEREO_OPT)
+	// Eye 1 pixels with mode 1 (edge) or 2 (main) will be overwritten by StereoBlend
+	// reprojection, so skip the expensive stereo sync work and write neutral (unshadowed).
+	if (eyeIndex == 1) {
+		uint mode = StereoOptModeTexture[uint2(dtid.xy)] & 0x0F;
+		if (mode == 1 || mode == 2) {
+			OutShadowTexture[dtid] = 1.0;  // 1.0 = no shadow (neutral)
+			return;
+		}
+	}
+#endif
 
 	float depth = SrcDepthTexture[dtid];
 

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/bend_sss_gpu.hlsli
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/bend_sss_gpu.hlsli
@@ -225,17 +225,15 @@ void WriteScreenSpaceShadow(DispatchParameters inParameters, int3 inGroupID, int
 		// We sample depth twice per pixel per sample, and interpolate with an edge detect filter
 		// Interpolation should only occur on the minor axis of the ray - major axis coordinates should be at pixel centers
 		half2 read_xy = floor(pixel_xy);
-
-		read_xy *= inParameters.DynamicRes;
-
-#if defined(VR)
-		read_xy *= half2(0.5, 1.0);
-#endif
+		// VR fix: do NOT pre-scale read_xy here. DynamicRes and VR 0.5x must be
+		// applied AFTER offset_xy addition so the bilinear neighbor is exactly
+		// 1 texel away. Pre-scaling causes the offset to sample ~3px away,
+		// breaking edge detection and causing shadow instability on camera movement.
+		// See: docs/development/Old code/bend_sss_gpu.hlsli for the correct ordering.
 
 		half minor_axis = x_axis_major ? pixel_xy.y : pixel_xy.x;
 
-		// If a pixel has been detected as an edge, then optionally (inParameters.IgnoreEdgePixels) don't include it in the shadow
-		const half edge_skip = 1e20;  // if edge skipping is enabled, apply an extreme value/blend on edge samples to push the value out of range
+		const half edge_skip = 1e20;
 
 		half2 depths;
 		half bilinear = frac(minor_axis) - 0.5;
@@ -247,34 +245,47 @@ void WriteScreenSpaceShadow(DispatchParameters inParameters, int3 inGroupID, int
 		half bias = bilinear > 0 ? 1 : -1;
 		half2 offset_xy = half2(x_axis_major ? 0 : bias, x_axis_major ? bias : 0);
 
-		// HLSL enforces that a pixel offset is a compile-time constant, which isn't strictly required (and can sometimes be a bit faster)
-		// So this fallback will use a manual uv offset instead
-		half2 coord = read_xy * inParameters.InvDepthTextureSize;
-		half2 coord_with_offset = (read_xy + offset_xy) * inParameters.InvDepthTextureSize;
+		// VR fix: scale by DynamicRes AFTER offset_xy is incorporated, so the
+		// offset represents exactly 1 texel in the final UV space.
+		half2 coord = read_xy * inParameters.InvDepthTextureSize * inParameters.DynamicRes;
+		half2 coord_with_offset = (read_xy + offset_xy) * inParameters.InvDepthTextureSize * inParameters.DynamicRes;
 
 #if defined(VR)
+		// VR side-by-side: halve x to map stereo pixel coords to texture UV
+		coord *= half2(0.5, 1.0);
+		coord_with_offset *= half2(0.5, 1.0);
+
 #	if defined(RIGHT)
-		// Right eye: valid UV range is [0.5, 1.0]
+		// Right eye: valid UV range is [0.5*DynRes.x, DynRes.x]
 		bool coord_out_of_eye = coord.x < 0.5 * inParameters.DynamicRes.x;
 		bool coord_offset_out_of_eye = coord_with_offset.x < 0.5 * inParameters.DynamicRes.x;
 #	else
-		// Left eye: valid UV range is [0.0, 0.5)
+		// Left eye: valid UV range is [0.0, 0.5*DynRes.x)
 		bool coord_out_of_eye = coord.x >= 0.5 * inParameters.DynamicRes.x;
 		bool coord_offset_out_of_eye = coord_with_offset.x >= 0.5 * inParameters.DynamicRes.x;
 #	endif
 
+		// Clamp cross-eye depth reads to FarDepthValue (1.0) so rays near the SBS
+		// center seam don't sample the other eye's depth. At distance, stereo parallax
+		// makes cross-eye depth noticeably different, causing shadow patterns to shift
+		// with camera movement. Clamping to 1.0 means the ray sees “no occluder” at
+		// the boundary — shadow weakens by ~1 pixel but stays temporally stable.
+		// The WRITE guard is intentionally removed (see below GroupMemoryBarrier section)
+		// so both dispatches write to the seam overlap, preventing a visible gap/line.
 		depths.x = coord_out_of_eye ? 1.0 : inParameters.DepthTexture.SampleLevel(inParameters.PointBorderSampler, coord, 0);
 		depths.y = coord_offset_out_of_eye ? 1.0 : inParameters.DepthTexture.SampleLevel(inParameters.PointBorderSampler, coord_with_offset, 0);
 
-		depths.x = lerp(depths.x, 1.0, (float)(depths.x == 0));  // Stencil area
-		depths.y = lerp(depths.y, 1.0, (float)(depths.y == 0));  // Stencil area
+		// VR HMD mask: depth==0 is outside the visible lens area. Remap to
+		// FarDepthValue (1.0) so mask pixels don't cast false shadows.
+		depths.x = lerp(depths.x, 1.0, (float)(depths.x == 0));
+		depths.y = lerp(depths.y, 1.0, (float)(depths.y == 0));
 #else
 		depths.x = inParameters.DepthTexture.SampleLevel(inParameters.PointBorderSampler, coord, 0);
 		depths.y = inParameters.DepthTexture.SampleLevel(inParameters.PointBorderSampler, coord_with_offset, 0);
 #endif
 
 		// Depth thresholds (bilinear/shadow thickness) are based on a fractional ratio of the difference between sampled depth and the far clip depth
-		depth_thickness_scale[i] = abs(inParameters.FarDepthValue - depths.x);
+		depth_thickness_scale[i] = max(abs(inParameters.FarDepthValue - depths.x), 1e-4);
 
 		// If depth variance is more than a specific threshold, then just use point filtering
 		bool use_point_filter = abs(depths.x - depths.y) > depth_thickness_scale[i] * inParameters.BilinearThreshold;
@@ -321,18 +332,6 @@ void WriteScreenSpaceShadow(DispatchParameters inParameters, int3 inGroupID, int
 	// Sync wavefronts now groupshared DepthData is written
 	GroupMemoryBarrierWithGroupSync();
 
-#if defined(VR)
-	// Check if the pixel we're writing to is on the correct eye side
-	half writeX = write_xy.x * inParameters.InvDepthTextureSize.x;
-
-#	if defined(RIGHT)
-	if (writeX < 0.0)
-		return;
-#	else
-	if (writeX > 1.0)
-		return;
-#	endif
-#endif
 
 	half start_depth = sampling_depth[0];
 
@@ -381,5 +380,6 @@ void WriteScreenSpaceShadow(DispatchParameters inParameters, int3 inGroupID, int
 
 	// Asking the GPU to write scattered single-byte pixels isn't great,
 	// But thankfully the latency is hidden by all the work we're doing...
+
 	inParameters.OutputTexture[(int2)write_xy] = result;
 }

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/bend_sss_gpu.hlsli
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/bend_sss_gpu.hlsli
@@ -332,7 +332,6 @@ void WriteScreenSpaceShadow(DispatchParameters inParameters, int3 inGroupID, int
 	// Sync wavefronts now groupshared DepthData is written
 	GroupMemoryBarrierWithGroupSync();
 
-
 	half start_depth = sampling_depth[0];
 
 	if (start_depth == 0.0 || start_depth == 1.0)

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -20,10 +20,10 @@ namespace SharedData
 		float Timer;
 		uint FrameCount;
 		uint FrameCountAlwaysActive;
-		bool InInterior;             // If the area lacks a directional shadow light e.g. the sun or moon
-		bool InMapMenu;              // If the world/local map is open (note that the renderer is still deferred here)
-		bool HideSky;                // HideSky flag in WorldSpace, e.g. Blackreach
-		float MipBias;               // Offset to mip level for TAA sharpness
+		bool InInterior;  // If the area lacks a directional shadow light e.g. the sun or moon
+		bool InMapMenu;   // If the world/local map is open (note that the renderer is still deferred here)
+		bool HideSky;     // HideSky flag in WorldSpace, e.g. Blackreach
+		float MipBias;    // Offset to mip level for TAA sharpness
 		float pad0;
 		float4 AmbientSHR;
 		float4 AmbientSHG;

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -20,10 +20,10 @@ namespace SharedData
 		float Timer;
 		uint FrameCount;
 		uint FrameCountAlwaysActive;
-		bool InInterior;  // If the area lacks a directional shadow light e.g. the sun or moon
-		bool InMapMenu;   // If the world/local map is open (note that the renderer is still deferred here)
-		bool HideSky;     // HideSky flag in WorldSpace, e.g. Blackreach
-		float MipBias;    // Offset to mip level for TAA sharpness#
+		bool InInterior;             // If the area lacks a directional shadow light e.g. the sun or moon
+		bool InMapMenu;              // If the world/local map is open (note that the renderer is still deferred here)
+		bool HideSky;                // HideSky flag in WorldSpace, e.g. Blackreach
+		float MipBias;               // Offset to mip level for TAA sharpness
 		float pad0;
 		float4 AmbientSHR;
 		float4 AmbientSHG;
@@ -52,7 +52,7 @@ namespace SharedData
 		bool EnableShadows;
 		bool ExtendShadows;
 		bool EnableParallaxWarpingFix;
-		float1 pad0;
+		bool pad0;
 	};
 
 	struct CubemapCreatorSettings

--- a/package/Shaders/Common/VR.hlsli
+++ b/package/Shaders/Common/VR.hlsli
@@ -21,6 +21,7 @@ cbuffer VRValues : register(b13)
 	float2 EyeOffsetScale : packoffset(c0.z);
 	float4 EyeClipEdge[2] : packoffset(c1);
 }
+
 #endif
 
 namespace Stereo

--- a/package/Shaders/DeferredCompositeCS.hlsl
+++ b/package/Shaders/DeferredCompositeCS.hlsl
@@ -19,6 +19,10 @@ RWTexture2D<float4> NormalTAAMaskSpecularMaskRW : register(u1);
 RWTexture2D<float2> MotionVectorsRW : register(u2);
 Texture2D<float> DepthTexture : register(t4);
 
+#if defined(VR_STEREO_OPT)
+Texture2D<uint> StereoOptModeTexture : register(t16);
+#endif
+
 #if defined(DYNAMIC_CUBEMAPS)
 Texture2D<float3> ReflectanceTexture : register(t5);
 TextureCube<float3> EnvTexture : register(t6);
@@ -92,6 +96,16 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, inout float ao, out float3 il,
 	uv *= FrameBuffer::DynamicResolutionParams2.xy;  // adjust for dynamic res
 
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
+
+#if defined(VR_STEREO_OPT)
+	if (eyeIndex == 1) {
+		uint mode = StereoOptModeTexture[uint2(dispatchID.xy)] & 0x0F;
+		if (mode == 2 || mode == 1) {  // MODE_MAIN or MODE_EDGE — stencil-culled, reprojected by StereoBlend
+			return;
+		}
+	}
+#endif
+
 	uv = Stereo::ConvertFromStereoUV(uv, eyeIndex);
 
 	float3 normalGlossiness = NormalRoughnessTexture[dispatchID.xy];

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -3166,7 +3166,15 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	}
 #		endif
 
-	psout.Reflectance = float4(indirectLobeWeights.specular, psout.Diffuse.w);
+#		if defined(VR) && (defined(EMAT) || defined(TRUE_PBR)) && (defined(PARALLAX) || defined(LANDSCAPE) || defined(TRUE_PBR))
+	// VR: store POM parallax amount for stereo reprojection depth correction.
+	// Read by StereoBlendCS to adjust Eye 1 (right eye) reprojection depth
+	// at POM-displaced surfaces. Not consumed on flat (SE/AE).
+	psout.Reflectance = float4(indirectLobeWeights.specular,
+		(pixelOffset > 0.0) ? saturate(pixelOffset) : 0.0);
+#		else
+	psout.Reflectance = float4(indirectLobeWeights.specular, 0.0);
+#		endif
 	psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), saturate(1.0 - material.Roughness), psout.Diffuse.w);
 
 #		if defined(SNOW)

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -850,7 +850,6 @@ PS_OUTPUT main(PS_INPUT input)
 
 #		if defined(RENDER_DEPTH)
 	float diffuseAlpha = input.VertexColor.w * baseColor.w;
-
 	if ((diffuseAlpha - AlphaTestRefRS) < 0) {
 		discard;
 	}

--- a/package/Shaders/VR/StereoBlendCS.hlsl
+++ b/package/Shaders/VR/StereoBlendCS.hlsl
@@ -11,12 +11,37 @@
 
 #include "Common/Color.hlsli"
 #include "Common/FrameBuffer.hlsli"
+#include "Common/SharedData.hlsli"
 #include "Common/VR.hlsli"
 
 Texture2D<float4> ColorTexture : register(t0);
 Texture2D<float> DepthTexture : register(t1);
 
 RWTexture2D<float4> OutputRW : register(u0);
+
+#ifdef STEREO_OVERWRITE
+RWTexture2D<float2> MotionRW : register(u1);
+Texture2D<uint> ModeTexture : register(t2);
+Texture2D<float4> ReflectanceTexture : register(t3);  // .w = POM pixelOffset from Lighting pass
+SamplerState LinearSampler : register(s0);
+
+#	include "VRStereoOptimizations/modes.hlsli"
+
+// Hardware bilinear color sample from reprojected pixel coordinates.
+// Converts integer pixel coords to proper full-texture UV for SampleLevel,
+// clamped to the active DRS viewport to prevent sampling stale data.
+// Motion vectors stay as integer Load() — filtering them breaks DLSS.
+float4 SampleReprojectedColor(float2 stereoUV, float2 frameDim)
+{
+	uint texW, texH;
+	ColorTexture.GetDimensions(texW, texH);
+	float2 texSize = float2(texW, texH);
+	float2 minUV = 0.5 / texSize;
+	float2 maxUV = (frameDim - 0.5) / texSize;
+	stereoUV = clamp(stereoUV, minUV, maxUV);
+	return ColorTexture.SampleLevel(LinearSampler, stereoUV, 0);
+}
+#endif
 
 cbuffer StereoBlendCB : register(b1)
 {
@@ -25,11 +50,16 @@ cbuffer StereoBlendCB : register(b1)
 	float DepthSigma;
 	float MaxBlendFactor;
 	float ColorDiffThreshold;
-	float pad;
+	float DebugEdgeTint;
+	uint DebugMode;  // 0 = normal, 1 = depth map diagnostic, 2 = full blend depth visualizer, 3 = POM depth heatmap
+	float FullBlendDistance;
+	float POMDepthScale;
+	float _pad;
 };
 
-static const float kEdgeDepthThreshold = 0.05;  // NDC depth difference above which a pixel is considered a depth discontinuity and excluded from stereo blend
-static const int kEdgeMargin = 2;               // Neighbor offset (pixels) for destination edge + mask boundary check
+static const float kEdgeDepthThreshold = 0.05;        // NDC depth difference above which a pixel is considered a depth discontinuity and excluded from stereo blend
+static const int kEdgeMargin = 2;                     // Neighbor offset (pixels) for destination edge + mask boundary check
+static const float kDepthAgreementThreshold = 0.015;  // Relative depth difference threshold for overwrite mode disocclusion rejection
 
 // Samples four depth neighbors in a cross pattern (±offset pixels) around center,
 // clamped to eyeIndex's half of the packed stereo buffer to avoid seam contamination.
@@ -45,6 +75,192 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 [numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
 	if (any(dtid >= uint2(FrameDim)))
 		return;
+
+#ifdef STEREO_OVERWRITE
+	// =========================================================================
+	// Mode-driven stereo merge: reads per-pixel classification from StencilCS
+	// and applies appropriate action per mode and eye.
+	// Mode texture is full SBS resolution — ModeTexture[dtid] maps directly.
+	// =========================================================================
+
+	float2 uv = (dtid + 0.5) * RcpFrameDim;
+	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
+
+	float centerDepth = DepthTexture[dtid];
+
+	// HMD mask pixels (depth >= 1.0 in reversed-Z) — always skip
+	if (centerDepth >= 1.0)
+		return;
+
+	uint pixelMode = ModeTexture[dtid];
+
+	// Debug mode 1: depth map diagnostic — show mode texture as solid colors (all pixels)
+	if (DebugMode == 1) {
+		float4 c = ColorTexture[dtid];
+		if (pixelMode == MODE_EDGE)
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(0, 1, 0), 0.5), c.a);
+		else if (pixelMode == MODE_EDGE_NEIGHBOUR)
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(1, 0, 1), 0.5), c.a);
+		else if (pixelMode == MODE_DISOCCLUDED)
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(0, 0.5, 1), 0.3), c.a);
+		else if (pixelMode == MODE_FULL_BLEND)
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(1, 0.5, 0), 0.5), c.a);
+		return;
+	}
+
+	// Debug mode 2: full blend depth visualizer — cyan tint based on proximity to FullBlendDistance
+	if (DebugMode == 2) {
+		if (centerDepth < 1e-5 || centerDepth >= 1.0)
+			return;
+		float linDepth = SharedData::GetScreenDepth(centerDepth);
+		if (linDepth < FullBlendDistance) {
+			float4 c = ColorTexture[dtid];
+			float proximity = saturate(1.0 - linDepth / max(FullBlendDistance, 1.0));
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(0, 1, 1), proximity * 0.4), c.a);
+		}
+		return;
+	}
+
+	// Debug mode 3: POM depth data visualizer — show Reflectance.w as color
+	if (DebugMode == 3) {
+		float pomVal = ReflectanceTexture[dtid].w;
+		float4 c = ColorTexture[dtid];
+		if (pomVal > 1e-2) {
+			// POM pixel: red-to-green gradient based on parallaxAmount
+			// Red = peak (high pomVal, closer to camera), Green = valley (low pomVal, farther), Yellow = geometry plane
+			float3 pomColor = float3(pomVal, 1.0 - pomVal, 0);
+			OutputRW[dtid] = float4(lerp(c.rgb, pomColor, 0.7), c.a);
+		}
+		// Non-POM pixels (pomVal ~ 0) left untouched
+		return;
+	}
+
+	// MODE_DISOCCLUDED: fully shaded, leave untouched
+	if (pixelMode == MODE_DISOCCLUDED)
+		return;
+
+	// MODE_FULL_BLEND: bilateral blend for 2x supersampling
+	if (pixelMode == MODE_FULL_BLEND) {
+		float4 center = ColorTexture[dtid];
+
+		// Check for POM depth offset at this pixel
+		// pixelOffset = parallaxAmount (0-1) from ExtendedMaterials, 0.5 = geometry plane.
+		// Values > 0.5 are peaks (closer to camera), < 0.5 are valleys (farther from camera).
+		// Correction: high pomVal should push depth closer (smaller linear depth),
+		// so we use (0.5 - pomOffset) to get a negative correction for peaks.
+		// Non-POM pixels store 0.0, so threshold > 1e-2 distinguishes them.
+		float reprojDepthFB = centerDepth;
+		float pomOffsetFB = ReflectanceTexture[dtid].w;
+		if (pomOffsetFB > 1e-2 && POMDepthScale > 0) {
+			float linDepthFB = SharedData::GetScreenDepth(centerDepth);
+			float depthCorrectionFB = (0.5 - pomOffsetFB) * POMDepthScale;
+			float newLinDepthFB = max(linDepthFB + depthCorrectionFB, 1e-4);
+			reprojDepthFB = (SharedData::CameraData.x - SharedData::CameraData.w / newLinDepthFB) / SharedData::CameraData.z;
+		}
+
+		// Reproject to the other eye
+		Stereo::StereoBilateralResult r = Stereo::ReprojectToOtherEye(uv, reprojDepthFB, eyeIndex, FrameDim);
+		if (!r.valid) {
+			// Debug tint for failed reprojection
+			if (DebugEdgeTint > 0)
+				OutputRW[dtid] = float4(lerp(center.rgb, float3(1, 0.5, 0), DebugEdgeTint), center.a);
+			return;
+		}
+
+		// Only blend with pixels that have valid composited data in both eyes
+		uint otherMode = ModeTexture[r.otherPx];
+		if (otherMode != MODE_FULL_BLEND && otherMode != MODE_DISOCCLUDED)
+			return;
+
+		float4 otherColor = SampleReprojectedColor(r.otherStereoUV, FrameDim);
+		float otherDepth = DepthTexture[r.otherPx];
+
+		// Depth-weighted bilateral blend
+		float maxDepth = max(max(centerDepth, otherDepth), 1e-5);
+		float depthAgreement = 1.0 - saturate(abs(centerDepth - otherDepth) / maxDepth / 0.02);
+		float blendWeight = 0.5 * depthAgreement;
+
+		float4 result = lerp(center, otherColor, blendWeight);
+
+		if (DebugEdgeTint > 0)
+			result.rgb = lerp(result.rgb, float3(0, 1, 1), DebugEdgeTint);
+
+		OutputRW[dtid] = result;
+		return;
+	}
+
+	if (eyeIndex == 0) {
+		// Eye 0 (left eye): fully shaded for all modes — only apply debug tint to edge pixels
+		if (DebugEdgeTint > 0 && pixelMode == MODE_EDGE) {
+			float4 c = ColorTexture[dtid];
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(0, 1, 0), DebugEdgeTint), c.a);
+		}
+		return;
+	}
+
+	// Eye 1 (right eye): reproject all non-disoccluded, non-full-blend pixels
+	// (MAIN, EDGE) from Eye 0 (left eye). In VR stereo rendering, Eye 0 is
+	// fully shaded; Eye 1 pixels marked as reprojectable by StencilCS are
+	// filled with reprojected color from Eye 0 to save GPU work.
+	// StencilCS already performed the authoritative disocclusion check with the correct
+	// depth buffer state — no redundant depth agreement check here.
+	float reprojDepth = centerDepth;
+
+	// First-pass reprojection to find Eye 0 source pixel
+	Stereo::StereoBilateralResult r = Stereo::ReprojectToOtherEye(uv, reprojDepth, eyeIndex, FrameDim);
+	if (!r.valid)
+		return;
+
+	// Save first-pass result as fallback before POM adjustment
+	Stereo::StereoBilateralResult firstPassR = r;
+
+	// Read POM offset from Eye 0 source's reflectance.w
+	// pixelOffset = parallaxAmount (0-1) from ExtendedMaterials, 0.5 = geometry plane.
+	// Values > 0.5 are peaks (closer to camera), < 0.5 are valleys (farther from camera).
+	// Correction: high pomVal should push depth closer (smaller linear depth),
+	// so we use (0.5 - pomOffset) to get a negative correction for peaks.
+	// Non-POM pixels store 0.0, so threshold > 1e-2 distinguishes them.
+	float pomOffset = ReflectanceTexture[r.otherPx].w;
+	if (pomOffset > 1e-2) {
+		// Re-reproject with POM-adjusted depth centered at geometry plane
+		float linearDepth = SharedData::GetScreenDepth(centerDepth);
+		float depthCorrection = (0.5 - pomOffset) * POMDepthScale;
+		float newLinearDepth = max(linearDepth + depthCorrection, 1e-4);
+		reprojDepth = (SharedData::CameraData.x - SharedData::CameraData.w / newLinearDepth) / SharedData::CameraData.z;
+		r = Stereo::ReprojectToOtherEye(uv, reprojDepth, eyeIndex, FrameDim);
+		if (!r.valid)
+			r = firstPassR;  // Fall back to non-POM reprojection
+	}
+
+	// Skip if the Eye 0 source pixel is sky/unrendered (depth at clear value).
+	// At DeferredPasses time, sky hasn't rendered yet — source would have clear color.
+	// Let the sky/water pass fill these pixels later instead.
+	float sourceDepth = DepthTexture[r.otherPx];
+	if (sourceDepth >= 1.0 || sourceDepth < 1e-5) {
+		// POM adjustment landed on sky — try the original first-pass source
+		if (r.otherPx.x != firstPassR.otherPx.x || r.otherPx.y != firstPassR.otherPx.y) {
+			float fallbackDepth = DepthTexture[firstPassR.otherPx];
+			if (fallbackDepth < 1.0 && fallbackDepth >= 1e-5) {
+				r = firstPassR;
+			} else {
+				return;
+			}
+		} else {
+			return;
+		}
+	}
+
+	OutputRW[dtid] = SampleReprojectedColor(r.otherStereoUV, FrameDim);
+	MotionRW[dtid] = MotionRW[r.otherPx];
+
+#else  // Normal bilateral blend path
+
+#	ifdef EYE0_ONLY
+	// Only process Eye 0 (left half) - Eye 1 left untouched
+	float2 uvCheck = (dtid + 0.5) * RcpFrameDim;
+	if (Stereo::GetEyeIndexFromTexCoord(uvCheck) == 1)
+		return;
+#	endif
 
 	float2 uv = (dtid + 0.5) * RcpFrameDim;
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
@@ -78,10 +294,6 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 			if (r.valid) {
 				float otherDepth = DepthTexture[r.otherPx];
 
-				// Destination edge detection: skip if the reprojected pixel is near the HMD
-				// mask boundary or at a depth discontinuity in the other eye. Due to VR
-				// parallax the arm silhouette appears at a different screen position per eye,
-				// so the reprojection can cross a boundary invisible from this eye.
 				float4 dstEdgeDepths = SampleCrossDepths(r.otherPx, kEdgeMargin, 1 - eyeIndex);
 				if (any(dstEdgeDepths < 1e-5) || Stereo::MaxDepthDiff(otherDepth, dstEdgeDepths) > kEdgeDepthThreshold) {
 					debugState = 2;
@@ -89,9 +301,6 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 					float4 otherColor = ColorTexture[r.otherPx];
 					Stereo::FinalizeStereoBlend(r, uv, centerDepth, otherDepth, eyeIndex, FrameDim, DepthSigma, MaxBlendFactor);
 
-					// Only blend where the two eyes actually disagree (screen-space effect
-					// inconsistency). Luminance difference below the threshold means both
-					// eyes computed the same result and blending would only destroy parallax.
 					float colorDiff = abs(dot(centerColor.rgb, float3(0.2126, 0.7152, 0.0722)) -
 										  dot(otherColor.rgb, float3(0.2126, 0.7152, 0.0722)));
 					float colorGate = smoothstep(ColorDiffThreshold * 0.5, ColorDiffThreshold * 2.0, colorDiff);
@@ -106,7 +315,7 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 		}
 	}
 
-#ifdef DEBUG_BACKCHECK
+#	ifdef DEBUG_BACKCHECK
 	// Debug visualization (6 states):
 	//   Blue   = mask/sky: skipped
 	//   Yellow = source edge: depth discontinuity at this pixel
@@ -123,7 +332,7 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 		float3(0.5, 0.0, 0.0)   // 5: back-check failed - red
 	};
 	OutputRW[dtid] = float4(lerp(centerColor.rgb, debugColors[debugState], 0.7), centerColor.a);
-#elif defined(DEBUG_BLEND_WEIGHT)
+#	elif defined(DEBUG_BLEND_WEIGHT)
 	// Blend weight heatmap: only pixels with actual blend activity are colorized.
 	// Untouched pixels pass through unmodified.
 	float w = saturate(r.blendWeight / max(MaxBlendFactor, 1e-5));
@@ -133,7 +342,7 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 	} else {
 		OutputRW[dtid] = centerColor;
 	}
-#elif defined(DEBUG_EDGE_DETECTION)
+#	elif defined(DEBUG_EDGE_DETECTION)
 	// Edge detection visualizer: highlights pixels excluded by depth discontinuity checks.
 	// Non-edge pixels show the normal blended output for scene context.
 	//   Bright yellow = source edge: discontinuity at this pixel
@@ -145,7 +354,9 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 	} else {
 		OutputRW[dtid] = blendedColor;
 	}
-#else
+#	else
 	OutputRW[dtid] = blendedColor;
-#endif
+#	endif
+
+#endif  // STEREO_OVERWRITE
 }

--- a/package/Shaders/VR/VRPostProcessCS.hlsl
+++ b/package/Shaders/VR/VRPostProcessCS.hlsl
@@ -1,0 +1,109 @@
+// VR Post-Process - Bilateral blend for near-camera 2x supersampling
+//
+// Runs after all compositing and stereo blending is complete.
+// Reads per-pixel classification from StencilCS and applies:
+//   - MODE_FULL_BLEND: bilateral depth-weighted blend for 2x supersampling
+//
+// Only MODE_FULL_BLEND pixels are processed. All others pass through untouched.
+
+#include "Common/FrameBuffer.hlsli"
+#include "Common/SharedData.hlsli"
+#include "Common/VR.hlsli"
+
+Texture2D<float4> ColorTexture : register(t0);  // Copy of final composited image
+Texture2D<uint> ModeTexture : register(t1);
+Texture2D<float> DepthTexture : register(t2);
+
+RWTexture2D<float4> OutputRW : register(u0);
+
+cbuffer VRPostProcessCB : register(b1)
+{
+	float2 FrameDim;
+	float2 RcpFrameDim;
+	float DebugEdgeTint;      // 0 = off, >0 = debug visualization strength
+	uint DebugMode;           // 0 = normal, 1 = depth map diagnostic, 2 = full blend depth visualizer
+	float FullBlendDistance;  // Linearized depth threshold for full blend zone visualization
+	float _pad;               // Pad to 16-byte alignment
+};
+
+#include "VRStereoOptimizations/modes.hlsli"
+
+[numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
+	if (any(dtid >= uint2(FrameDim)))
+		return;
+
+	uint pixelMode = ModeTexture[dtid];
+
+	// Depth map diagnostic: show mode texture contents as solid colors
+	if (DebugMode == 1) {
+		float4 c = ColorTexture[dtid];
+		if (pixelMode == MODE_EDGE)
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(0, 1, 0), 0.5), c.a);
+		else if (pixelMode == MODE_EDGE_NEIGHBOUR)
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(1, 0, 1), 0.5), c.a);
+		else if (pixelMode == MODE_DISOCCLUDED)
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(0, 0.5, 1), 0.3), c.a);
+		else if (pixelMode == MODE_FULL_BLEND)
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(1, 0.5, 0), 0.5), c.a);  // Orange = full blend zone
+		return;
+	}
+
+	// Full blend depth visualizer: shows the depth boundary as a cyan tint
+	if (DebugMode == 2) {
+		float2 uvDb = (dtid + 0.5) * RcpFrameDim;
+		float depthDb = DepthTexture[dtid];
+		if (depthDb < 1e-5 || depthDb >= 1.0)
+			return;
+		float linDepth = SharedData::GetScreenDepth(depthDb);
+		if (linDepth < FullBlendDistance) {
+			float4 c = ColorTexture[dtid];
+			float proximity = saturate(1.0 - linDepth / max(FullBlendDistance, 1.0));
+			OutputRW[dtid] = float4(lerp(c.rgb, float3(0, 1, 1), proximity * 0.4), c.a);
+		}
+		return;
+	}
+
+	// Only process full blend pixels
+	if (pixelMode != MODE_FULL_BLEND)
+		return;
+
+	float2 uv = (dtid + 0.5) * RcpFrameDim;
+	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
+
+	float4 result = ColorTexture[dtid];
+
+	// === MODE_FULL_BLEND: bilateral blend for 2x supersampling ===
+	{
+		float4 center = result;
+		float centerDepth = DepthTexture[dtid];
+
+		// Reproject to the other eye
+		Stereo::StereoBilateralResult r = Stereo::ReprojectToOtherEye(uv, centerDepth, eyeIndex, FrameDim);
+		if (!r.valid) {
+			// Debug tint for failed reprojection
+			if (DebugEdgeTint > 0)
+				OutputRW[dtid] = float4(lerp(center.rgb, float3(1, 0.5, 0), DebugEdgeTint), center.a);
+			return;
+		}
+
+		// Only blend with pixels that have valid composited data in both eyes.
+		uint otherMode = ModeTexture[r.otherPx];
+		if (otherMode != MODE_FULL_BLEND && otherMode != MODE_DISOCCLUDED)
+			return;
+
+		float4 otherColor = ColorTexture[r.otherPx];
+		float otherDepth = DepthTexture[r.otherPx];
+
+		// Depth-weighted bilateral blend
+		float maxDepth = max(max(centerDepth, otherDepth), 1e-5);
+		float depthAgreement = 1.0 - saturate(abs(centerDepth - otherDepth) / maxDepth / 0.02);
+		float blendWeight = 0.5 * depthAgreement;
+
+		result = lerp(center, otherColor, blendWeight);
+
+		if (DebugEdgeTint > 0)
+			result.rgb = lerp(result.rgb, float3(0, 1, 1), DebugEdgeTint);
+	}
+
+	OutputRW[dtid] = result;
+}

--- a/package/Shaders/VRStereoOptimizations/ReprojectionCS.hlsl
+++ b/package/Shaders/VRStereoOptimizations/ReprojectionCS.hlsl
@@ -1,0 +1,55 @@
+// VR Stereo Optimizations - Reprojection Compute Shader
+//
+// Fills Eye 1 pixels that were stencil-culled during rendering by reprojecting
+// color data from Eye 0. Only operates on pixels classified as MODE_MAIN.
+//
+// Reads Eye 0 color directly from the OutputRW UAV (left half) and writes to
+// Eye 1 (right half). No read-write conflict because reads and writes target
+// strictly different halves of the texture.
+//
+// Input:
+//   t0 = Depth buffer
+//   t1 = Per-pixel mode classification texture
+// Output:
+//   u0 = Main render target UAV (reads Eye 0, writes Eye 1)
+
+#include "Common/VR.hlsli"
+#include "VRStereoOptimizations/cbuffers.hlsli"
+
+Texture2D<float> DepthTexture : register(t0);
+Texture2D<uint> ModeTexture : register(t1);
+
+RWTexture2D<float4> OutputRW : register(u0);
+
+[numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
+	uint eyeWidth = (uint)FrameDim.x / 2;
+	uint eyeHeight = (uint)FrameDim.y;
+
+	if (any(dtid >= uint2(eyeWidth, eyeHeight)))
+		return;
+
+	// dtid is in Eye 1 local coords; convert to stereo buffer coords
+	uint2 stereoCoord = uint2(dtid.x + eyeWidth, dtid.y);
+
+	// Only fill pixels that were marked for reprojection
+	// Mode texture is full SBS resolution, so use stereoCoord for Eye 1
+	uint mode = ModeTexture[stereoCoord];
+	if (mode != MODE_MAIN)
+		return;
+
+	float depth = DepthTexture[stereoCoord];
+
+	// Compute mono UV for this Eye 1 pixel
+	float2 stereoUV = (float2(stereoCoord) + 0.5) * RcpFrameDim;
+	float2 monoUV = Stereo::ConvertFromStereoUV(stereoUV, 1);
+
+	// Reproject to Eye 0 and sample color
+	float3 otherEyeUV = Stereo::ConvertMonoUVToOtherEye(float3(monoUV, depth), 1);
+	float2 eye0StereoUV = Stereo::ConvertToStereoUV(otherEyeUV.xy, 0);
+	int2 eye0Px = clamp(int2(eye0StereoUV * FrameDim), int2(0, 0), int2(FrameDim) - 1);
+
+	float4 reprojectedColor = OutputRW[eye0Px];
+
+	// Write to Eye 1 in the main render target
+	OutputRW[stereoCoord] = reprojectedColor;
+}

--- a/package/Shaders/VRStereoOptimizations/StencilCS.hlsl
+++ b/package/Shaders/VRStereoOptimizations/StencilCS.hlsl
@@ -1,0 +1,153 @@
+// VR Stereo Optimizations - Stencil Classification Compute Shader
+//
+// Classifies BOTH eyes over the full SBS buffer. Each pixel is tagged as:
+//   MODE_DISOCCLUDED    - Must be fully shaded (sky, HMD mask, parallax-occluded)
+//   MODE_EDGE           - Depth edge boundary (dist 1) or inner/foreground band; fully shaded + bilateral blend
+//   MODE_MAIN           - Standard pixel eligible for reprojection / bilateral blend
+//   MODE_FULL_BLEND     - Near-camera geometry: both eyes fully shaded for 2x supersampling
+//
+// Dispatched over full SBS resolution (FrameDim.x x FrameDim.y).
+
+#include "Common/SharedData.hlsli"
+#include "Common/VR.hlsli"
+#include "VRStereoOptimizations/cbuffers.hlsli"
+
+Texture2D<float> DepthTexture : register(t0);
+
+RWTexture2D<uint> ModeTextureRW : register(u0);
+
+[numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
+	if (any(dtid >= uint2(FrameDim)))
+		return;
+
+	// Determine which eye this pixel belongs to
+	float2 uv = (float2(dtid) + 0.5) / FrameDim;
+	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
+
+	// Read depth directly in SBS coords
+	float centerDepth = DepthTexture[dtid];
+
+#ifdef DEBUG_DEPTH_MAP
+	// DIAGNOSTIC: Visualize what depth values StencilCS sees.
+	// Green (MODE_EDGE) = depth >= 1.0 (HMD mask threshold)
+	// Magenta (MODE_EDGE_NEIGHBOUR) = depth < 1e-5 (sky threshold)
+	// No tint (MODE_MAIN) = normal geometry with valid depth
+	if (centerDepth >= 1.0) {
+		ModeTextureRW[dtid] = MODE_EDGE;
+		return;
+	}
+	if (centerDepth < 1e-5) {
+		ModeTextureRW[dtid] = MODE_EDGE_NEIGHBOUR;
+		return;
+	}
+	ModeTextureRW[dtid] = MODE_MAIN;
+	return;
+#endif
+
+	// Sky/unrendered pixels (depth >= 1.0 at z-prepass time = depth buffer clear value)
+	// and HMD mask pixels both have depth >= 1.0 here. Treat them the same as sky:
+	// let edge detection run so geometry-vs-sky boundaries get classified.
+	// HMD mask pixels are in lens corners with no nearby geometry, so they'll
+	// fall through to MODE_DISOCCLUDED at the end.
+	bool isSky = (centerDepth < 1e-5) || (centerDepth >= 1.0);
+	float linCenter = isSky ? 999999.0 : SharedData::GetScreenDepth(centerDepth);
+
+	// Near-camera supersampling: geometry closer than FullBlendDistance gets full
+	// shading in both eyes for bilateral blend (2x supersampling in VRPostProcess).
+	if (!isSky && linCenter < FullBlendDistance) {
+		ModeTextureRW[dtid] = MODE_FULL_BLEND;
+		return;
+	}
+
+	// --- Disocclusion detection via reprojection (runs for all non-sky pixels) ---
+	// Early return: disoccluded pixels are always MODE_DISOCCLUDED regardless of edge proximity.
+	// This ensures MinEdgeDistance never affects disocclusion classification.
+	if (!isSky) {
+		Stereo::StereoBilateralResult reproj = Stereo::ReprojectToOtherEye(
+			uv,
+			centerDepth,
+			eyeIndex,
+			FrameDim);
+
+		bool isDisoccluded = false;
+		if (!reproj.valid) {
+			isDisoccluded = true;
+		} else {
+			float otherDepth = DepthTexture[reproj.otherPx];
+			// Raw reversed-Z depth comparison for disocclusion detection.
+			// Using raw depth avoids concentric semicircle artifacts that occur
+			// with linearized depth due to precision band boundaries in the
+			// hyperbolic depth-to-linear conversion.
+			float maxRaw = max(max(centerDepth, otherDepth), 1e-7);
+			float rawRelDiff = abs(centerDepth - otherDepth) / maxRaw;
+			isDisoccluded = (rawRelDiff > DisocclusionThreshold);
+		}
+
+		if (isDisoccluded) {
+			ModeTextureRW[dtid] = MODE_DISOCCLUDED;
+			return;
+		}
+	}
+
+	// Depth gate: skip edge detection for nearby geometry (saves perf, distant AA matters more)
+	// Sky pixels always run edge detection — they need to expand the edge band outward.
+	// Disocclusion detection (above) is independent of this gate and always runs.
+	bool skipEdgeDetection = !isSky && (linCenter < MinEdgeDistance);
+
+	// --- Edge detection with two-tier classification ---
+	// MODE_EDGE:           immediate neighbor (distance 1) has depth discontinuity, OR
+	//                      inner/foreground band (distance <= kInnerWidth).
+	static const uint kInnerWidth = 2;
+	int2 offsets[4] = { int2(-1, 0), int2(1, 0), int2(0, -1), int2(0, 1) };
+
+	uint nearestEdgeDist = 0xFFFFFFFF;  // nearest distance at which a discontinuity was found
+	bool nearestWeAreOuter = false;     // whether we are on the background side at that nearest hit
+
+	// Use the larger of inner/outer widths for the search
+	uint maxWidth = kInnerWidth;
+
+	if (!skipEdgeDetection) {
+		[loop] for (uint d = 1; d <= maxWidth; d++)
+		{
+			[unroll] for (int i = 0; i < 4; i++)
+			{
+				int2 rawNeighbor = int2(dtid) + offsets[i] * (int)d;
+				uint2 neighborCoord = Stereo::ClampToEyeBounds(rawNeighbor, eyeIndex, FrameDim);
+
+				float neighborDepth = DepthTexture[neighborCoord];
+				bool neighborIsSky = (neighborDepth < 1e-5) || (neighborDepth >= 1.0);
+				float linNeighbor = neighborIsSky ? 999999.0 : SharedData::GetScreenDepth(neighborDepth);
+				float maxLin = max(max(linCenter, linNeighbor), 1e-5);
+				float relDepthDiff = abs(linCenter - linNeighbor) / maxLin;
+
+				if (relDepthDiff > EdgeDepthThreshold && d < nearestEdgeDist) {
+					nearestEdgeDist = d;
+					nearestWeAreOuter = (linNeighbor < linCenter);  // neighbor closer to camera = we are background
+				}
+			}
+		}
+
+	}  // !skipEdgeDetection
+
+	if (nearestEdgeDist != 0xFFFFFFFF) {
+		// Classify based on distance and side
+		if (nearestEdgeDist == 1) {
+			// Immediate neighbor discontinuity: always MODE_EDGE regardless of side
+			ModeTextureRW[dtid] = MODE_EDGE;
+			return;
+		} else if (!nearestWeAreOuter && nearestEdgeDist <= kInnerWidth) {
+			// Inner/foreground band beyond distance 1
+			ModeTextureRW[dtid] = MODE_EDGE;
+			return;
+		}
+	}
+
+	// Sky pixels that aren't near edges -> disoccluded (reprojection is meaningless for sky)
+	if (isSky) {
+		ModeTextureRW[dtid] = MODE_DISOCCLUDED;
+		return;
+	}
+
+	// Standard pixel
+	ModeTextureRW[dtid] = MODE_MAIN;
+}

--- a/package/Shaders/VRStereoOptimizations/StencilWritePS.hlsl
+++ b/package/Shaders/VRStereoOptimizations/StencilWritePS.hlsl
@@ -1,0 +1,54 @@
+// VR Stereo Optimizations - Stencil Write Pixel Shader
+//
+// Reads from the per-pixel mode classification texture and depth texture.
+// Discards pixels that should NOT be stencil-culled:
+//   - MODE_DISOCCLUDED (0) = fully shaded in Eye 1, no reprojection needed
+//   - MODE_FULL_BLEND (4) = near-camera pixels fully shaded in both eyes for supersampling
+//   - Sky/HMD-mask pixels (depth >= 1.0 or depth < 1e-5) = need normal rendering
+//     in the sky pass; they keep their MODE_EDGE tag in
+//     the mode texture for VRPostProcess but must not be stencil-culled.
+//
+// Only geometry MODE_MAIN/MODE_EDGE pixels survive and get stencil ref=1 written.
+//
+// Mode texture is full SBS resolution (same as render target).
+// The DSS is configured with StencilFunc=ALWAYS, StencilPassOp=REPLACE, ref=1.
+// Pixels that survive (not discarded) get stencil=1 written.
+
+#include "VRStereoOptimizations/cbuffers.hlsli"
+
+Texture2D<uint> ModeTexture : register(t0);
+Texture2D<float> DepthTexture : register(t1);
+
+struct PS_INPUT
+{
+	float4 Position: SV_Position;
+	float2 TexCoord: TEXCOORD0;
+};
+
+void main(PS_INPUT input)
+{
+	// Mode texture is full SBS resolution — SV_Position maps directly
+	// (viewport is Eye 1 half, so SV_Position.x starts at eyeWidth)
+	int2 modeCoord = int2(input.Position.xy);
+
+	uint mode = ModeTexture[modeCoord];
+
+	// MODE_MAIN and MODE_EDGE in Eye 1 write stencil ref=1 (reprojectable).
+	// These are reprojected from Eye 0; MODE_DISOCCLUDED and MODE_FULL_BLEND are fully shaded in Eye 1.
+	if (mode == MODE_DISOCCLUDED)
+		discard;
+
+	// Sky/HMD-mask pixels must not be stencil-culled regardless of edge classification.
+	// They keep their MODE_EDGE tag in the mode texture for VRPostProcess,
+	// but must render normally in the sky pass (which runs after stencil culling).
+	float depth = DepthTexture[modeCoord];
+	if (depth >= 1.0 || depth < 1e-5)
+		discard;
+
+	// MODE_FULL_BLEND: near-camera pixels fully shaded in both eyes for supersampling
+	if (mode == MODE_FULL_BLEND)
+		discard;
+
+	// Pixel survives: DSS writes stencil ref=1
+	// No color output (no RTV bound)
+}

--- a/package/Shaders/VRStereoOptimizations/StencilWriteVS.hlsl
+++ b/package/Shaders/VRStereoOptimizations/StencilWriteVS.hlsl
@@ -1,0 +1,24 @@
+// VR Stereo Optimizations - Stencil Write Vertex Shader
+//
+// Procedural fullscreen triangle covering Eye 1 (right half of SBS buffer).
+// No vertex buffer needed — vertex positions are generated from SV_VertexID.
+// The viewport is set to Eye 1 by the C++ code, so we just emit a standard
+// fullscreen triangle in clip space.
+
+struct VS_OUTPUT
+{
+	float4 Position: SV_Position;
+	float2 TexCoord: TEXCOORD0;
+};
+
+VS_OUTPUT main(uint vertexID : SV_VertexID)
+{
+	VS_OUTPUT output;
+
+	// Fullscreen triangle: 3 vertices covering [-1,1] clip space
+	float2 uv = float2((vertexID << 1) & 2, vertexID & 2);
+	output.Position = float4(uv * float2(2, -2) + float2(-1, 1), 0, 1);
+	output.TexCoord = uv;
+
+	return output;
+}

--- a/package/Shaders/VRStereoOptimizations/cbuffers.hlsli
+++ b/package/Shaders/VRStereoOptimizations/cbuffers.hlsli
@@ -1,0 +1,31 @@
+// VR Stereo Optimizations - Shared constant buffer layout
+// Must match VRStereoOptParams in VRStereoOptimizations.h exactly
+
+#ifndef __VR_STEREO_OPT_CBUFFERS_HLSLI__
+#define __VR_STEREO_OPT_CBUFFERS_HLSLI__
+
+cbuffer VRStereoOptParams : register(b1)
+{
+	float2 FrameDim;     // Full stereo buffer dimensions (both eyes)
+	float2 RcpFrameDim;  // 1.0 / FrameDim
+
+	uint StereoModeValue;         // 0=Off, 1=Enable
+	float DisocclusionThreshold;  // Depth difference threshold for disocclusion detection
+	float EdgeDepthThreshold;     // Relative depth difference threshold for edge detection
+	uint EdgeWidth;               // Half-width of edge detection band in pixels
+
+	float2 QualityJitter;  // Sub-pixel jitter offset (Quality mode)
+	float FoveatedRadius;  // Radius of foveal region in UV space
+	float pad2;
+
+	float2 FoveatedCenter;  // Center of foveal region in UV space
+	float MinEdgeDistance;
+	float FullBlendDistance;  // Linearized depth below which pixels get MODE_FULL_BLEND (game units)
+};
+
+#define STEREO_MODE_OFF 0
+#define STEREO_MODE_ENABLE 1
+
+#include "VRStereoOptimizations/modes.hlsli"
+
+#endif

--- a/package/Shaders/VRStereoOptimizations/modes.hlsli
+++ b/package/Shaders/VRStereoOptimizations/modes.hlsli
@@ -1,0 +1,10 @@
+#ifndef __VR_STEREO_OPT_MODES_HLSLI__
+#define __VR_STEREO_OPT_MODES_HLSLI__
+
+#define MODE_DISOCCLUDED    0
+#define MODE_EDGE           1
+#define MODE_MAIN           2
+#define MODE_EDGE_NEIGHBOUR 3
+#define MODE_FULL_BLEND     4
+
+#endif

--- a/package/Shaders/VRStereoOptimizations/modes.hlsli
+++ b/package/Shaders/VRStereoOptimizations/modes.hlsli
@@ -1,10 +1,10 @@
 #ifndef __VR_STEREO_OPT_MODES_HLSLI__
 #define __VR_STEREO_OPT_MODES_HLSLI__
 
-#define MODE_DISOCCLUDED    0
-#define MODE_EDGE           1
-#define MODE_MAIN           2
+#define MODE_DISOCCLUDED 0
+#define MODE_EDGE 1
+#define MODE_MAIN 2
 #define MODE_EDGE_NEIGHBOUR 3
-#define MODE_FULL_BLEND     4
+#define MODE_FULL_BLEND 4
 
 #endif

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -279,6 +279,11 @@ void Deferred::StartDeferred()
 	PrepassPasses();
 
 	OverrideBlendStates();
+
+	// VR: Classify Eye 1 pixels and write hardware stencil marks before geometry rendering
+	if (globals::game::isVR) {
+		globals::features::vr.stereoOpt.DispatchStencil();
+	}
 }
 
 void Deferred::DeferredPasses()
@@ -367,6 +372,13 @@ void Deferred::DeferredPasses()
 
 		context->CSSetShaderResources(0, ARRAYSIZE(srvs), srvs);
 
+		// Bind VRStereoOptimizations mode texture for Eye 1 skip
+		auto& vrStereoOpt = globals::features::vr.stereoOpt;
+		if (vrStereoOpt.loaded) {
+			ID3D11ShaderResourceView* modeSRV = vrStereoOpt.GetModeTextureSRV();
+			context->CSSetShaderResources(16, 1, &modeSRV);
+		}
+
 		ID3D11UnorderedAccessView* uavs[3]{ main.UAV, normals.UAV, motionVectors.UAV };
 		context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
 
@@ -374,13 +386,28 @@ void Deferred::DeferredPasses()
 		context->CSSetShader(shader, nullptr, 0);
 
 		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
+
+		// Unbind mode texture SRV
+		if (vrStereoOpt.loaded) {
+			ID3D11ShaderResourceView* nullSRV = nullptr;
+			context->CSSetShaderResources(16, 1, &nullSRV);
+		}
 	}
 
-	// VR stereo consistency blend - depth-aware bilateral blend at the eye seam
-	// Runs after composite as a general safety net for all screen-space effects.
-	// Must run before clearing b12/b13 -- needs FrameBuffer matrices for reprojection.
-	if (globals::game::isVR)
+	// VR: Deactivate stencil culling now that geometry rendering is complete.
+	// Must happen before StereoBlend so the blend pass itself isn't stencil-blocked.
+	if (globals::game::isVR) {
+		auto& stereoOpt = globals::features::vr.stereoOpt;
+		if (stereoOpt.IsStencilActive()) {
+			stereoOpt.DeactivateStencil();
+		}
+	}
+
+	// VR: Stereo reprojection fills Eye 1 holes here (after DeferredComposite, before SSR/water/sky)
+	// so that ISReflectionsRayTracing sees valid pixels in both eyes.
+	if (globals::game::isVR) {
 		globals::features::vr.DrawStereoBlend();
+	}
 
 	// Clear
 	{
@@ -479,6 +506,10 @@ void Deferred::OverrideBlendStates()
 								blendDesc.RenderTarget[i].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
 							}
 
+							// RT[5] = REFLECTANCE: enable alpha writes for POM depth data
+							// stored in Reflectance.w, used by StereoBlendCS for depth-aware reprojection
+							blendDesc.RenderTarget[5].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+
 							DX::ThrowIfFailed(device->CreateBlendState(&blendDesc, &deferredBlendStates[a][b][c][d]));
 						} else {
 							deferredBlendStates[a][b][c][d] = nullptr;
@@ -555,6 +586,9 @@ ID3D11ComputeShader* Deferred::GetComputeMainComposite()
 		if (REL::Module::IsVR())
 			defines.push_back({ "FRAMEBUFFER", nullptr });
 
+		if (REL::Module::IsVR() && globals::features::vr.stereoOpt.loaded)
+			defines.push_back({ "VR_STEREO_OPT", nullptr });
+
 		mainCompositeCS = static_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\DeferredCompositeCS.hlsl", defines, "cs_5_0"));
 	}
 	return mainCompositeCS;
@@ -580,6 +614,9 @@ ID3D11ComputeShader* Deferred::GetComputeMainCompositeInterior()
 		if (REL::Module::IsVR())
 			defines.push_back({ "FRAMEBUFFER", nullptr });
 
+		if (REL::Module::IsVR() && globals::features::vr.stereoOpt.loaded)
+			defines.push_back({ "VR_STEREO_OPT", nullptr });
+
 		mainCompositeInteriorCS = static_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\DeferredCompositeCS.hlsl", defines, "cs_5_0"));
 	}
 	return mainCompositeInteriorCS;
@@ -597,6 +634,7 @@ void Deferred::Hooks::Main_RenderWorld::thunk(bool a1)
 	state->permutationData.ExtraShaderDescriptor |= static_cast<uint32_t>(State::ExtraShaderDescriptors::InWorld);
 	state->inWorld = true;
 	func(a1);
+
 	state->inWorld = false;
 	state->permutationData.ExtraShaderDescriptor &= ~static_cast<uint32_t>(State::ExtraShaderDescriptors::InWorld);
 };

--- a/src/Features/ExtendedMaterials.h
+++ b/src/Features/ExtendedMaterials.h
@@ -36,7 +36,7 @@ struct ExtendedMaterials : Feature
 		uint ExtendShadows = 1;
 		uint EnableParallaxWarpingFix = 1;
 
-		float pad[1];
+		uint pad0 = 0;
 	};
 	STATIC_ASSERT_ALIGNAS_16(Settings);
 

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -260,8 +260,8 @@ void ScreenSpaceShadows::DrawShadows()
 		auto lightProjectionRightF = CalculateLightProjection(1);
 
 		bool useStereoOpt = REL::Module::IsVR() &&
-			globals::features::vr.stereoOpt.loaded &&
-			globals::features::vr.stereoOpt.settings.stereoMode != VRStereoOptimizations::StereoMode::Off;
+		                    globals::features::vr.stereoOpt.loaded &&
+		                    globals::features::vr.stereoOpt.settings.stereoMode != VRStereoOptimizations::StereoMode::Off;
 
 		if (useStereoOpt) {
 			// Reduced sample count for right eye — StereoBlend overwrites most of it
@@ -448,5 +448,4 @@ void ScreenSpaceShadows::SetupResources()
 			stereoSyncCopyTex->CreateSRV(srvDesc);
 		}
 	}
-
 }

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -1,6 +1,7 @@
 #include "ScreenSpaceShadows.h"
 
 #include "State.h"
+#include "VR.h"
 
 #pragma warning(push)
 #pragma warning(disable: 4838 4244)
@@ -40,13 +41,13 @@ void ScreenSpaceShadows::DrawSettings()
 		if (auto _tt = Util::HoverTooltipWrapper())
 			ImGui::Text("Contrast boost for the shadow transition. Higher values produce harder shadow edges.");
 
-		if (globals::game::isVR && globals::state->IsDeveloperMode()) {
+		if (globals::game::isVR) {
 			ImGui::Checkbox("VR Stereo Sync", &enableStereoSync);
 			if (auto _tt = Util::HoverTooltipWrapper())
 				ImGui::Text(
 					"Synchronizes shadow data between left and right eyes via bilateral reprojection "
 					"and applies a depth-weighted blur to reduce per-eye noise. "
-					"Uses min-blend so if either eye detects an occluder, the shadow is preserved. ");
+					"Uses min-blend so if either eye detects an occluder, the shadow is preserved.");
 		}
 
 		ImGui::Spacing();
@@ -65,6 +66,10 @@ void ScreenSpaceShadows::InvalidateRaymarchShaders()
 		raymarchRightCS->Release();
 		raymarchRightCS = nullptr;
 	}
+	if (raymarchRightReducedCS) {
+		raymarchRightReducedCS->Release();
+		raymarchRightReducedCS = nullptr;
+	}
 }
 
 void ScreenSpaceShadows::ClearShaderCache()
@@ -78,23 +83,13 @@ void ScreenSpaceShadows::ClearShaderCache()
 
 uint ScreenSpaceShadows::GetScaledSampleCount()
 {
-	float2 renderSize = Util::ConvertToDynamic(globals::state->screenSize);
-
-	// In VR, renderSize covers both eyes side-by-side; raymarch dispatches per-eye
-	if (globals::game::isVR)
-		renderSize.x /= 2.0f;
-
-	// Scale sample count based on both dimensions relative to 1920x1080 reference
-	float2 referenceRes = { 1920.0f, 1080.0f };
-	float referenceArea = referenceRes.x * referenceRes.y;
-	float currentArea = renderSize.x * renderSize.y;
-	float areaScale = std::sqrt(currentArea / referenceArea);
-	uint scaledSampleCount = static_cast<uint>(std::round(bendSettings.SampleCount * 60 * areaScale));
-
-	// Quantize to steps of 8 to prevent frequent recompilation from small DRS oscillations
-	scaledSampleCount = ((scaledSampleCount + 7u) / 8u) * 8u;
-	scaledSampleCount = std::max(scaledSampleCount, 8u);
-
+	// Shadow reach in pixels is resolution-independent: a tree branch casts
+	// the same pixel-length shadow at 1080p and 3000p. Sample count controls
+	// reach, not quality-per-pixel. The old formula (multiplier * 64) was
+	// correct; the area-based scaling produced 2-8x more samples at VR
+	// resolution with no quality benefit, only GPU cost.
+	// Always produces WAVE_SIZE-aligned counts for correct Bend READ_COUNT.
+	uint scaledSampleCount = bendSettings.SampleCount * 64;
 	return scaledSampleCount;
 }
 
@@ -117,9 +112,42 @@ ID3D11ComputeShader* ScreenSpaceShadows::GetComputeRaymarchRight()
 {
 	if (!raymarchRightCS) {
 		uint scaledSampleCount = GetScaledSampleCount();
-		raymarchRightCS = (ID3D11ComputeShader*)Util::CompileShader(L"Data\\Shaders\\ScreenSpaceShadows\\RaymarchCS.hlsl", { { "SAMPLE_COUNT", std::format("{}", scaledSampleCount).c_str() }, { "RIGHT", "" } }, "cs_5_0");
+		auto sampleCountStr = std::format("{}", scaledSampleCount);
+		std::vector<std::pair<const char*, const char*>> defines = {
+			{ "SAMPLE_COUNT", sampleCountStr.c_str() },
+			{ "RIGHT", "" }
+		};
+		raymarchRightCS = (ID3D11ComputeShader*)Util::CompileShader(L"Data\\Shaders\\ScreenSpaceShadows\\RaymarchCS.hlsl", defines, "cs_5_0");
 	}
 	return raymarchRightCS;
+}
+
+ID3D11ComputeShader* ScreenSpaceShadows::GetComputeRaymarchRightReduced()
+{
+	uint fullCount = GetScaledSampleCount();
+	uint divisor = (stereoOptRightEyeReduction == 1) ? 4 : 2;
+	uint reducedCount = std::max(fullCount / divisor, 64u);
+	// Quantize to WAVE_SIZE (64) for clean READ_COUNT in Bend's algorithm
+	reducedCount = ((reducedCount + 63u) / 64u) * 64u;
+
+	if (reducedCount != lastCompiledReducedSampleCount) {
+		lastCompiledReducedSampleCount = reducedCount;
+		if (raymarchRightReducedCS) {
+			raymarchRightReducedCS->Release();
+			raymarchRightReducedCS = nullptr;
+		}
+	}
+
+	if (!raymarchRightReducedCS) {
+		auto sampleCountStr = std::format("{}", reducedCount);
+		std::vector<std::pair<const char*, const char*>> defines = {
+			{ "SAMPLE_COUNT", sampleCountStr.c_str() },
+			{ "RIGHT", "" }
+		};
+		raymarchRightReducedCS = (ID3D11ComputeShader*)Util::CompileShader(
+			L"Data\\Shaders\\ScreenSpaceShadows\\RaymarchCS.hlsl", defines, "cs_5_0");
+	}
+	return raymarchRightReducedCS;
 }
 
 void ScreenSpaceShadows::DrawShadows()
@@ -148,6 +176,7 @@ void ScreenSpaceShadows::DrawShadows()
 	auto lightProjectionF = CalculateLightProjection(0);
 
 	float2 renderSize = Util::ConvertToDynamic(state->screenSize);
+
 	int viewportSize[2] = { (int)renderSize.x, (int)renderSize.y };
 
 	if (globals::game::isVR)
@@ -156,12 +185,11 @@ void ScreenSpaceShadows::DrawShadows()
 	int minRenderBounds[2] = { 0, 0 };
 	int maxRenderBounds[2] = { viewportSize[0], viewportSize[1] };
 
-	// Setup common render state
 	auto* depthSRV = Util::GetCurrentSceneDepthSRV();
-	context->CSSetShaderResources(0, 1, &depthSRV);
+	auto* shadowUAV = screenSpaceShadowsTexture->uav.get();
 
-	auto uav = screenSpaceShadowsTexture->uav.get();
-	context->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
+	context->CSSetShaderResources(0, 1, &depthSRV);
+	context->CSSetUnorderedAccessViews(0, 1, &shadowUAV, nullptr);
 
 	context->CSSetSamplers(0, 1, &pointBorderSampler);
 
@@ -170,7 +198,8 @@ void ScreenSpaceShadows::DrawShadows()
 
 	auto viewport = globals::game::graphicsState;
 
-	float2 dynamicRes = { viewport->GetRuntimeData().dynamicResolutionWidthRatio, viewport->GetRuntimeData().dynamicResolutionHeightRatio };
+	float2 dynamicRes = { viewport->GetRuntimeData().dynamicResolutionWidthRatio,
+		viewport->GetRuntimeData().dynamicResolutionHeightRatio };
 
 	// Shared dispatch logic for both VR and non-VR
 	auto DispatchEye = [&](const char* eyeName, ID3D11ComputeShader* shader, const float* lightProj,
@@ -228,9 +257,21 @@ void ScreenSpaceShadows::DrawShadows()
 	} else {
 		DispatchEye("Left Eye", GetComputeRaymarch(), lightProjectionF.data(), InvTexSizeX, InvTexSizeY);
 
-		// Calculate light projection for right eye
 		auto lightProjectionRightF = CalculateLightProjection(1);
-		DispatchEye("Right Eye", GetComputeRaymarchRight(), lightProjectionRightF.data(), InvTexSizeX, InvTexSizeY);
+
+		bool useStereoOpt = REL::Module::IsVR() &&
+			globals::features::vr.stereoOpt.loaded &&
+			globals::features::vr.stereoOpt.settings.stereoMode != VRStereoOptimizations::StereoMode::Off;
+
+		if (useStereoOpt) {
+			// Reduced sample count for right eye — StereoBlend overwrites most of it
+			DispatchEye("Right Eye (Reduced)", GetComputeRaymarchRightReduced(),
+				lightProjectionRightF.data(), InvTexSizeX, InvTexSizeY);
+		} else {
+			// Full sample count
+			DispatchEye("Right Eye", GetComputeRaymarchRight(),
+				lightProjectionRightF.data(), InvTexSizeX, InvTexSizeY);
+		}
 	}
 
 	ID3D11ShaderResourceView* views[1]{ nullptr };
@@ -326,16 +367,26 @@ void ScreenSpaceShadows::Prepass()
 void ScreenSpaceShadows::LoadSettings(json& o_json)
 {
 	bendSettings = o_json;
+	if (o_json.contains("StereoOptRightEyeReduction"))
+		stereoOptRightEyeReduction = o_json["StereoOptRightEyeReduction"];
+	if (o_json.contains("EnableStereoSync"))
+		enableStereoSync = o_json["EnableStereoSync"].get<bool>();
 }
 
 void ScreenSpaceShadows::SaveSettings(json& o_json)
 {
 	o_json = bendSettings;
+	o_json["StereoOptRightEyeReduction"] = stereoOptRightEyeReduction;
+	o_json["EnableStereoSync"] = enableStereoSync;
 }
 
 void ScreenSpaceShadows::RestoreDefaultSettings()
 {
 	bendSettings = {};
+	stereoOptRightEyeReduction = 0;
+	enableStereoSync = false;
+	if (globals::game::isVR)
+		bendSettings.SampleCount = 2;
 }
 
 bool ScreenSpaceShadows::HasShaderDefine(RE::BSShader::Type)
@@ -346,7 +397,6 @@ bool ScreenSpaceShadows::HasShaderDefine(RE::BSShader::Type)
 void ScreenSpaceShadows::SetupResources()
 {
 	raymarchCB = new ConstantBuffer(ConstantBufferDesc<RaymarchCB>());
-
 	if (globals::game::isVR) {
 		stereoSyncCB = new ConstantBuffer(ConstantBufferDesc<StereoSyncCB>());
 	}
@@ -398,4 +448,5 @@ void ScreenSpaceShadows::SetupResources()
 			stereoSyncCopyTex->CreateSRV(srvDesc);
 		}
 	}
+
 }

--- a/src/Features/ScreenSpaceShadows.h
+++ b/src/Features/ScreenSpaceShadows.h
@@ -35,7 +35,7 @@ public:
 		float BilinearThreshold = 0.02f;
 		float ShadowContrast = !globals::game::isVR ? 1.0f : 4.0f;
 		uint Enable = 1;
-		uint SampleCount = 1;
+		uint SampleCount = !globals::game::isVR ? 1u : 2u;
 		uint pad0[3];
 	};
 
@@ -62,7 +62,7 @@ public:
 	};
 	STATIC_ASSERT_ALIGNAS_16(RaymarchCB);
 
-	bool enableStereoSync = true;
+	bool enableStereoSync = false;
 
 	struct alignas(16) StereoSyncCB
 	{
@@ -71,11 +71,15 @@ public:
 	};
 	STATIC_ASSERT_ALIGNAS_16(StereoSyncCB);
 
+	int stereoOptRightEyeReduction = 0;  // 0 = Half, 1 = Quarter sample count
+
 	ID3D11SamplerState* pointBorderSampler = nullptr;
 
 	ConstantBuffer* raymarchCB = nullptr;
 	ID3D11ComputeShader* raymarchCS = nullptr;
 	ID3D11ComputeShader* raymarchRightCS = nullptr;
+	ID3D11ComputeShader* raymarchRightReducedCS = nullptr;
+	uint lastCompiledReducedSampleCount = 0;
 
 	Texture2D* screenSpaceShadowsTexture = nullptr;
 
@@ -94,6 +98,7 @@ public:
 	uint lastCompiledSampleCount = 0;
 	ID3D11ComputeShader* GetComputeRaymarch();
 	ID3D11ComputeShader* GetComputeRaymarchRight();
+	ID3D11ComputeShader* GetComputeRaymarchRightReduced();
 
 	virtual void Prepass() override;
 

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -44,7 +44,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	EnableStereoBlend,
 	StereoBlendDepthSigma,
 	StereoBlendMaxFactor,
-	StereoBlendColorThreshold)
+	StereoBlendColorThreshold,
+	StereoBlendDebugMode)
 
 //=============================================================================
 // FEATURE BASE CLASS OVERRIDES
@@ -54,16 +55,26 @@ void VR::LoadSettings(json& o_json)
 {
 	settings = o_json.get<Settings>();
 	settings.ClampToValidRanges();
+	if (o_json.contains("StereoOptimizations")) {
+		json stereoOptJson = o_json["StereoOptimizations"];
+		stereoOpt.LoadSettings(stereoOptJson);
+	}
 }
 
 void VR::SaveSettings(json& o_json)
 {
 	o_json = settings;
+	{
+		json stereoOptJson;
+		stereoOpt.SaveSettings(stereoOptJson);
+		o_json["StereoOptimizations"] = stereoOptJson;
+	}
 }
 
 void VR::RestoreDefaultSettings()
 {
 	settings = {};
+	stereoOpt.RestoreDefaultSettings();
 }
 
 void VR::SetupResources()
@@ -88,6 +99,12 @@ void VR::SetupResources()
 	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", edgeDetectionDefines, "cs_5_0")))
 		stereoBlendDebugEdgeDetectionCS.attach(rawPtr);
 
+	// Overwrite mode: direct replacement instead of blend (for stencil culling)
+	auto overwriteDefines = defines;
+	overwriteDefines.push_back({ "STEREO_OVERWRITE", "" });
+	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", overwriteDefines, "cs_5_0")))
+		stereoBlendOverwriteCS.attach(rawPtr);
+
 	auto renderer = globals::game::renderer;
 	auto mainTex = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];
 	D3D11_TEXTURE2D_DESC mainDesc;
@@ -102,6 +119,11 @@ void VR::SetupResources()
 	};
 	stereoBlendCopyTex->CreateSRV(srvDesc);
 	stereoBlendCB = eastl::make_unique<ConstantBuffer>(ConstantBufferDesc<StereoBlendCB>());
+
+	if (REL::Module::IsVR()) {
+		stereoOpt.SetupResources();
+		stereoOpt.loaded = stereoOpt.GetModeTextureSRV() != nullptr;
+	}
 
 	DetectOpenVRInfo();
 
@@ -273,4 +295,9 @@ void VR::DetectOpenVRInfo()
 bool VR::IsOpenVRCompatible() const
 {
 	return globals::game::isVR && openVRInfo.isCompatible;
+}
+
+void VR::Reset()
+{
+	stereoOpt.Reset();
 }

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -1,9 +1,9 @@
 #pragma once
 #include "Menu.h"
 #include "OverlayFeature.h"
-#include "VRStereoOptimizations.h"
 #include "Utils/Input.h"
 #include "VR/OpenVRDetection.h"  // In Features/VR/
+#include "VRStereoOptimizations.h"
 #include <algorithm>
 #include <d3d11.h>
 #include <imgui_impl_dx11.h>

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Menu.h"
 #include "OverlayFeature.h"
+#include "VRStereoOptimizations.h"
 #include "Utils/Input.h"
 #include "VR/OpenVRDetection.h"  // In Features/VR/
 #include <algorithm>
@@ -109,6 +110,9 @@ public:
 		};
 	}
 
+	virtual inline std::string_view GetShaderDefineName() override { return "VR_STEREO_OPT"; }
+	virtual inline bool HasShaderDefine(RE::BSShader::Type t) override { return stereoOpt.loaded && t == RE::BSShader::Type::Utility; }
+	virtual void Reset() override;
 	virtual void SetupResources() override;
 	virtual void ClearShaderCache() override;
 	virtual bool SupportsVR() override { return true; }
@@ -260,7 +264,7 @@ public:
 			StereoBlendDepthSigma = std::clamp(StereoBlendDepthSigma, 0.001f, 0.1f);
 			StereoBlendMaxFactor = std::clamp(StereoBlendMaxFactor, 0.0f, 0.5f);
 			StereoBlendColorThreshold = std::clamp(StereoBlendColorThreshold, 0.0f, 0.2f);
-			StereoBlendDebugMode = std::clamp(StereoBlendDebugMode, 0, 3);
+			StereoBlendDebugMode = std::clamp(StereoBlendDebugMode, 0, 5);
 		}
 	};
 
@@ -358,8 +362,12 @@ public:
 	winrt::com_ptr<ID3D11ComputeShader> stereoBlendDebugBackCheckCS;
 	winrt::com_ptr<ID3D11ComputeShader> stereoBlendDebugBlendWeightCS;
 	winrt::com_ptr<ID3D11ComputeShader> stereoBlendDebugEdgeDetectionCS;
+	winrt::com_ptr<ID3D11ComputeShader> stereoBlendOverwriteCS;
 	eastl::unique_ptr<Texture2D> stereoBlendCopyTex;
 	eastl::unique_ptr<ConstantBuffer> stereoBlendCB;
+	winrt::com_ptr<ID3D11SamplerState> stereoBlendLinearSampler;
+
+	VRStereoOptimizations stereoOpt;
 
 	struct alignas(16) StereoBlendCB
 	{
@@ -368,7 +376,11 @@ public:
 		float DepthSigma;
 		float MaxBlendFactor;
 		float ColorDiffThreshold;
-		float pad;
+		float DebugEdgeTint;
+		uint32_t DebugMode;
+		float FullBlendDistance;
+		float POMDepthScale;
+		float _pad;
 	};
 
 	// Engine hook integration points

--- a/src/Features/VR/SettingsUI.cpp
+++ b/src/Features/VR/SettingsUI.cpp
@@ -73,7 +73,7 @@ void VR::DrawOverlay()
 	static LARGE_INTEGER overlayShowStart = { 0 };
 	static LARGE_INTEGER freq = { 0 };
 
-	bool shouldShow = settings.kAutoHideSeconds > 0 && globals::state->isMainMenuOpen && globals::menu && !globals::menu->IsEnabled;
+	bool shouldShow = settings.kAutoHideSeconds > 0 && globals::game::ui && globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) && globals::menu && !globals::menu->IsEnabled;
 
 	if (!shouldShow) {
 		overlayShowStart.QuadPart = 0;
@@ -108,7 +108,7 @@ void VR::DrawOverlay()
 
 	ImGui::Begin("HowToUseOverlay", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav);
 
-	ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 500.0f * scale);
+	ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 500.0f);
 	ImGui::TextWrapped("How to Use VR Community Shaders Menu:");
 	ImGui::Separator();
 	ImGui::TextWrapped("You must open the Main Menu or Tween Menu before VR controls work.");
@@ -124,7 +124,7 @@ void VR::DrawOverlay()
 	Util::DrawButtonCombo(settings.VRMenuCloseKeys, true);
 
 	ImGui::Spacing();
-	ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 500.0f * scale);
+	ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 500.0f);
 	ImGui::TextWrapped("Grip + Thumbstick: Adjust overlay depth (closer/farther)");
 	ImGui::Spacing();
 	ImGui::TextWrapped("Tip: Disable this VR overlay by setting Attach Mode to 'None' in VR settings.");
@@ -324,25 +324,16 @@ namespace
 
 		ImGui::Separator();
 
-		const char* debugModes[] = { "Off", "Back-Check", "Blend Weight", "Edge Detection" };
+		const char* debugModes[] = { "Off", "Back-Check", "Blend Weight", "Edge Detection", "Overwrite", "Overwrite Eye1" };
 		ImGui::Combo("Debug View", &settings.StereoBlendDebugMode, debugModes, IM_ARRAYSIZE(debugModes));
 		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text(
-				"Off: Normal rendering.\n\n"
-				"Back-Check: Visualize reprojection outcomes.\n"
-				"  Blue   = sky or HMD mask (skipped).\n"
-				"  Yellow = source edge rejected (depth discontinuity at this pixel).\n"
-				"  Orange = destination edge rejected (discontinuity at reprojected pixel).\n"
-				"  Grey   = other eye can't see this point (out of bounds).\n"
-				"  Green  = back-check passed (surfaces match in both eyes).\n"
-				"  Red    = back-check failed (occlusion edge, blend penalized).\n\n"
-				"Blend Weight: Heatmap of stereo blend strength.\n"
-				"  Cool/black = no blending. Hot/white = maximum blending.\n"
-				"  Shows where the two eyes disagree and correction is applied.\n\n"
-				"Edge Detection: Highlights pixels excluded by depth discontinuity checks.\n"
-				"  Yellow = source edge (discontinuity at this pixel).\n"
-				"  Orange = destination edge (discontinuity at reprojected pixel).\n"
-				"  Scene  = all other pixels shown with normal blending.");
+			ImGui::Text("Stereo blend debug visualization modes:");
+			ImGui::Text("  Off: Normal rendering");
+			ImGui::Text("  Back-Check: Shows round-trip reprojection validation");
+			ImGui::Text("  Blend Weight: Heatmap of bilateral blend intensity");
+			ImGui::Text("  Edge Detection: Highlights depth discontinuities");
+			ImGui::Text("  Overwrite: Shows stereo reprojection mode classification");
+			ImGui::Text("    (Eye 0 = left eye, fully shaded; Eye 1 = right eye, reprojected)");
 		}
 
 		ImGui::EndDisabled();
@@ -970,6 +961,9 @@ void VR::DrawSettings()
 		if (BeginTabItemWithFont("Stereo", Menu::FontRole::Subheading)) {
 			if (ImGui::BeginChild("##VRStereoFrame", { 0, 0 }, true)) {
 				DrawStereoBlendSettings();
+				if (ImGui::CollapsingHeader("Stereo Optimizations", ImGuiTreeNodeFlags_DefaultOpen)) {
+					stereoOpt.DrawSettings();
+				}
 			}
 			ImGui::EndChild();
 			ImGui::EndTabItem();

--- a/src/Features/VR/StereoBlend.cpp
+++ b/src/Features/VR/StereoBlend.cpp
@@ -1,9 +1,11 @@
 #include "Features/VR.h"
 
+#include "Deferred.h"
 #include "Features/DynamicCubemaps.h"
 #include "Features/ScreenSpaceGI.h"
 #include "Features/ScreenSpaceShadows.h"
 #include "State.h"
+#include "Utils/D3D.h"
 
 void VR::ClearShaderCache()
 {
@@ -11,6 +13,8 @@ void VR::ClearShaderCache()
 	stereoBlendDebugBackCheckCS = nullptr;
 	stereoBlendDebugBlendWeightCS = nullptr;
 	stereoBlendDebugEdgeDetectionCS = nullptr;
+	stereoBlendOverwriteCS = nullptr;
+	stereoOpt.ClearShaderCache();
 }
 
 bool VR::AnyScreenSpaceEffectLoaded()
@@ -22,10 +26,20 @@ bool VR::AnyScreenSpaceEffectLoaded()
 
 void VR::DrawStereoBlend()
 {
-	if (!REL::Module::IsVR() || !settings.EnableStereoBlend || !stereoBlendCS || !stereoBlendCopyTex || !stereoBlendCB)
+	bool vrStereoOptActive = globals::features::vr.stereoOpt.loaded &&
+	                         globals::features::vr.stereoOpt.settings.stereoMode != VRStereoOptimizations::StereoMode::Off &&
+	                         stereoBlendOverwriteCS;
+
+	if (!REL::Module::IsVR() || !stereoBlendCopyTex || !stereoBlendCB)
 		return;
 
-	if (!AnyScreenSpaceEffectLoaded() && !globals::state->IsDeveloperMode())
+	if (vrStereoOptActive && globals::features::vr.stereoOpt.settings.debugSkipMerge)
+		return;
+
+	if (!vrStereoOptActive && (!settings.EnableStereoBlend || !stereoBlendCS))
+		return;
+
+	if (!vrStereoOptActive && !AnyScreenSpaceEffectLoaded() && !globals::state->IsDeveloperMode())
 		return;
 
 	ZoneScoped;
@@ -55,36 +69,116 @@ void VR::DrawStereoBlend()
 	cbData.MaxBlendFactor = settings.StereoBlendMaxFactor;
 	cbData.ColorDiffThreshold = settings.StereoBlendColorThreshold;
 
+	// Pass debug edge tint from VRStereoOptimizations settings
+	if (vrStereoOptActive && globals::features::vr.stereoOpt.settings.debugVisualization)
+		cbData.DebugEdgeTint = 0.3f;
+	else
+		cbData.DebugEdgeTint = 0.0f;
+
+	// Debug mode: 0=normal, 1=depth map diagnostic, 2=full blend depth visualizer
+	if (vrStereoOptActive && globals::features::vr.stereoOpt.settings.debugDepthMap)
+		cbData.DebugMode = 1u;
+	else if (vrStereoOptActive && globals::features::vr.stereoOpt.settings.debugFullBlendDepth)
+		cbData.DebugMode = 2u;
+	else if (vrStereoOptActive && globals::features::vr.stereoOpt.settings.debugPOMDepth)
+		cbData.DebugMode = 3u;
+	else
+		cbData.DebugMode = 0u;
+
+	cbData.FullBlendDistance = vrStereoOptActive ? globals::features::vr.stereoOpt.settings.fullBlendDistance : 0.0f;
+	cbData.POMDepthScale = vrStereoOptActive ? globals::features::vr.stereoOpt.settings.pomDepthScale : 1.0f;
+
 	stereoBlendCB->Update(cbData);
 	auto cbPtr = stereoBlendCB->CB();
 
-	ID3D11ShaderResourceView* srvs[2]{ stereoBlendCopyTex->srv.get(), depthSRV };
-	ID3D11UnorderedAccessView* uavs[1]{ main.UAV };
+	auto& motionVectors = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMOTION_VECTOR];
+
+	bool isOverwriteMode = vrStereoOptActive;
 
 	ID3D11ComputeShader* activeCS = stereoBlendCS.get();
-	if (settings.StereoBlendDebugMode == 1 && stereoBlendDebugBackCheckCS)
-		activeCS = stereoBlendDebugBackCheckCS.get();
-	else if (settings.StereoBlendDebugMode == 2 && stereoBlendDebugBlendWeightCS)
-		activeCS = stereoBlendDebugBlendWeightCS.get();
-	else if (settings.StereoBlendDebugMode == 3 && stereoBlendDebugEdgeDetectionCS)
-		activeCS = stereoBlendDebugEdgeDetectionCS.get();
+	if (vrStereoOptActive) {
+		activeCS = stereoBlendOverwriteCS.get();
+	} else {
+		int effectiveMode = settings.StereoBlendDebugMode;
+		if (effectiveMode == 1 && stereoBlendDebugBackCheckCS)
+			activeCS = stereoBlendDebugBackCheckCS.get();
+		else if (effectiveMode == 2 && stereoBlendDebugBlendWeightCS)
+			activeCS = stereoBlendDebugBlendWeightCS.get();
+		else if (effectiveMode == 3 && stereoBlendDebugEdgeDetectionCS)
+			activeCS = stereoBlendDebugEdgeDetectionCS.get();
+	}
 
+	// Save and unbind DSV to avoid SRV/DSV conflict on depth buffer in overwrite mode
+	ID3D11RenderTargetView* savedRTVs[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT] = {};
+	ID3D11DepthStencilView* savedDSV = nullptr;
+	if (isOverwriteMode) {
+		context->OMGetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, savedRTVs, &savedDSV);
+		context->OMSetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, savedRTVs, nullptr);
+		for (auto& rtv : savedRTVs) {
+			if (rtv)
+				rtv->Release();
+		}
+	}
+
+	ID3D11ShaderResourceView* srvs[2]{ stereoBlendCopyTex->srv.get(), depthSRV };
 	context->CSSetConstantBuffers(1, 1, &cbPtr);
 	context->CSSetShaderResources(0, 2, srvs);
-	context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
-	context->CSSetShader(activeCS, nullptr, 0);
 
+	if (isOverwriteMode) {
+		ID3D11ShaderResourceView* modeSRV = globals::features::vr.stereoOpt.GetModeTextureSRV();
+		context->CSSetShaderResources(2, 1, &modeSRV);
+
+		// Bind REFLECTANCE SRV for POM depth offset (stored in .w by Lighting pass)
+		auto& reflectanceRT = renderer->GetRuntimeData().renderTargets[REFLECTANCE];
+		context->CSSetShaderResources(3, 1, &reflectanceRT.SRV);
+
+		ID3D11UnorderedAccessView* uavs[2]{ main.UAV, motionVectors.UAV };
+		context->CSSetUnorderedAccessViews(0, 2, uavs, nullptr);
+	} else {
+		ID3D11UnorderedAccessView* uavs[1]{ main.UAV };
+		context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
+	}
+
+	// Bind linear sampler for hardware bilinear color sampling in overwrite mode
+	if (isOverwriteMode) {
+		if (!stereoBlendLinearSampler) {
+			D3D11_SAMPLER_DESC sampDesc = {};
+			sampDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+			sampDesc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+			sampDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+			sampDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+			globals::d3d::device->CreateSamplerState(&sampDesc, stereoBlendLinearSampler.put());
+		}
+		ID3D11SamplerState* samplers[] = { stereoBlendLinearSampler.get() };
+		context->CSSetSamplers(0, 1, samplers);
+	}
+
+	context->CSSetShader(activeCS, nullptr, 0);
 	context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
 
 	// Cleanup
-	srvs[0] = nullptr;
-	srvs[1] = nullptr;
-	uavs[0] = nullptr;
-	cbPtr = nullptr;
-	context->CSSetShaderResources(0, 2, srvs);
-	context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
-	context->CSSetConstantBuffers(1, 1, &cbPtr);
+	ID3D11ShaderResourceView* nullSRVs[4] = {};
+	context->CSSetShaderResources(0, isOverwriteMode ? 4 : 2, nullSRVs);
+	ID3D11UnorderedAccessView* nullUAVs[2] = {};
+	context->CSSetUnorderedAccessViews(0, isOverwriteMode ? 2 : 1, nullUAVs, nullptr);
+	ID3D11Buffer* nullCB = nullptr;
+	context->CSSetConstantBuffers(1, 1, &nullCB);
+	if (isOverwriteMode) {
+		ID3D11SamplerState* nullSampler[] = { nullptr };
+		context->CSSetSamplers(0, 1, nullSampler);
+	}
 	context->CSSetShader(nullptr, nullptr, 0);
+
+	// Restore DSV after CS dispatch in overwrite mode
+	if (isOverwriteMode && savedDSV) {
+		context->OMGetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, savedRTVs, nullptr);
+		context->OMSetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, savedRTVs, savedDSV);
+		for (auto& rtv : savedRTVs) {
+			if (rtv)
+				rtv->Release();
+		}
+		savedDSV->Release();
+	}
 
 	if (globals::state->frameAnnotations)
 		globals::state->EndPerfEvent();

--- a/src/Features/VRStereoOptimizations.cpp
+++ b/src/Features/VRStereoOptimizations.cpp
@@ -206,7 +206,6 @@ void VRStereoOptimizations::CompileShaders()
 		reprojectionCS.attach(reinterpret_cast<ID3D11ComputeShader*>(ptr));
 	else
 		logger::error("[VRStereoOptimizations] Failed to compile ReprojectionCS");
-
 }
 
 void VRStereoOptimizations::ClearShaderCache()
@@ -648,4 +647,3 @@ void VRStereoOptimizations::DeactivateStencil()
 	logger::trace("[VRStereoOptimizations] Frame: stencilSwapCount={}", stencilSwapCount);
 	stencilActive = false;
 }
-

--- a/src/Features/VRStereoOptimizations.cpp
+++ b/src/Features/VRStereoOptimizations.cpp
@@ -1,0 +1,651 @@
+#include "VRStereoOptimizations.h"
+
+#include "ExtendedMaterials.h"
+#include "Globals.h"
+#include "State.h"
+#include "Utils/D3D.h"
+#include "Utils/Game.h"
+
+#include <imgui.h>
+
+// JSON enum serialization for StereoMode
+NLOHMANN_JSON_SERIALIZE_ENUM(VRStereoOptimizations::StereoMode, {
+																	{ VRStereoOptimizations::StereoMode::Off, "Off" },
+																	{ VRStereoOptimizations::StereoMode::Enable, "Enable" },
+																})
+
+//=============================================================================
+// SETTINGS MANAGEMENT
+//=============================================================================
+
+void VRStereoOptimizations::SaveSettings(json& o_json)
+{
+	o_json["StereoMode"] = settings.stereoMode;
+	o_json["DisocclusionDepthThreshold"] = settings.disocclusionDepthThreshold;
+	o_json["FullBlendDistance"] = settings.fullBlendDistance;
+	o_json["QualityJitterOffset"] = settings.qualityJitterOffset;
+	o_json["FoveatedRegionRadius"] = settings.foveatedRegionRadius;
+	o_json["FoveatedRegionCenterX"] = settings.foveatedRegionCenterX;
+	o_json["FoveatedRegionCenterY"] = settings.foveatedRegionCenterY;
+	o_json["UseEyeTracking"] = settings.useEyeTracking;
+	o_json["DebugVisualization"] = settings.debugVisualization;
+	o_json["DebugSkipMerge"] = settings.debugSkipMerge;
+	o_json["DebugForceAllStencil"] = settings.debugForceAllStencil;
+	o_json["DebugForceAllReprojectCS"] = settings.debugForceAllReprojectCS;
+	o_json["DebugDepthMap"] = settings.debugDepthMap;
+	o_json["POMDepthScale"] = settings.pomDepthScale;
+}
+
+void VRStereoOptimizations::LoadSettings(json& o_json)
+{
+	if (o_json.contains("StereoMode"))
+		settings.stereoMode = o_json["StereoMode"].get<StereoMode>();
+	if (auto it = o_json.find("DisocclusionDepthThreshold"); it != o_json.end() && it->is_number())
+		settings.disocclusionDepthThreshold = std::clamp(it->get<float>(), 0.001f, 0.1f);
+	if (auto it = o_json.find("QualityJitterOffset"); it != o_json.end() && it->is_number())
+		settings.qualityJitterOffset = std::clamp(it->get<float>(), 0.0f, 1.0f);
+	if (auto it = o_json.find("FoveatedRegionRadius"); it != o_json.end() && it->is_number())
+		settings.foveatedRegionRadius = std::clamp(it->get<float>(), 0.0f, 1.0f);
+	if (auto it = o_json.find("FoveatedRegionCenterX"); it != o_json.end() && it->is_number())
+		settings.foveatedRegionCenterX = std::clamp(it->get<float>(), 0.0f, 1.0f);
+	if (auto it = o_json.find("FoveatedRegionCenterY"); it != o_json.end() && it->is_number())
+		settings.foveatedRegionCenterY = std::clamp(it->get<float>(), 0.0f, 1.0f);
+	if (auto it = o_json.find("UseEyeTracking"); it != o_json.end() && it->is_boolean())
+		settings.useEyeTracking = it->get<bool>();
+	if (auto it = o_json.find("DebugVisualization"); it != o_json.end() && it->is_boolean())
+		settings.debugVisualization = it->get<bool>();
+	if (auto it = o_json.find("DebugSkipMerge"); it != o_json.end() && it->is_boolean())
+		settings.debugSkipMerge = it->get<bool>();
+	if (auto it = o_json.find("DebugForceAllStencil"); it != o_json.end() && it->is_boolean())
+		settings.debugForceAllStencil = it->get<bool>();
+	if (auto it = o_json.find("DebugForceAllReprojectCS"); it != o_json.end() && it->is_boolean())
+		settings.debugForceAllReprojectCS = it->get<bool>();
+	if (auto it = o_json.find("DebugDepthMap"); it != o_json.end() && it->is_boolean())
+		settings.debugDepthMap = it->get<bool>();
+	if (auto it = o_json.find("FullBlendDistance"); it != o_json.end() && it->is_number())
+		settings.fullBlendDistance = std::clamp(it->get<float>(), 0.0f, 50000.0f);
+	if (auto it = o_json.find("POMDepthScale"); it != o_json.end() && it->is_number())
+		settings.pomDepthScale = std::clamp(it->get<float>(), 0.0f, 500.0f);
+}
+
+void VRStereoOptimizations::RestoreDefaultSettings()
+{
+	settings = {};
+}
+
+//=============================================================================
+// RESOURCE SETUP
+//=============================================================================
+
+void VRStereoOptimizations::SetupResources()
+{
+	if (!REL::Module::IsVR())
+		return;
+
+	auto device = globals::d3d::device;
+	auto renderer = globals::game::renderer;
+
+	// Constant buffers
+	paramsCB = eastl::make_unique<ConstantBuffer>(ConstantBufferDesc<VRStereoOptParams>());
+
+	// Get main RT dimensions for per-eye calculations
+	auto& main = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];
+	D3D11_TEXTURE2D_DESC mainDesc;
+	main.texture->GetDesc(&mainDesc);
+
+	// Per-pixel mode texture (R8_UINT, full SBS resolution = both eyes)
+	{
+		D3D11_TEXTURE2D_DESC modeDesc{};
+		modeDesc.Width = mainDesc.Width;
+		modeDesc.Height = mainDesc.Height;
+		modeDesc.MipLevels = 1;
+		modeDesc.ArraySize = 1;
+		modeDesc.Format = DXGI_FORMAT_R8_UINT;
+		modeDesc.SampleDesc.Count = 1;
+		modeDesc.SampleDesc.Quality = 0;
+		modeDesc.Usage = D3D11_USAGE_DEFAULT;
+		modeDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
+		modeDesc.CPUAccessFlags = 0;
+		modeDesc.MiscFlags = 0;
+
+		texPerPixelMode = eastl::make_unique<Texture2D>(modeDesc);
+		texPerPixelMode->CreateSRV(D3D11_SHADER_RESOURCE_VIEW_DESC{
+			.Format = DXGI_FORMAT_R8_UINT,
+			.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D,
+			.Texture2D = { .MostDetailedMip = 0, .MipLevels = 1 } });
+		texPerPixelMode->CreateUAV(D3D11_UNORDERED_ACCESS_VIEW_DESC{
+			.Format = DXGI_FORMAT_R8_UINT,
+			.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D,
+			.Texture2D = { .MipSlice = 0 } });
+	}
+
+	// Depth-stencil state for stencil write pass:
+	// Depth test OFF (not rendering geometry), stencil ALWAYS + REPLACE with ref=1
+	{
+		D3D11_DEPTH_STENCIL_DESC dssDesc{};
+		dssDesc.DepthEnable = FALSE;
+		dssDesc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ZERO;
+		dssDesc.StencilEnable = TRUE;
+		dssDesc.StencilReadMask = 0xFF;
+		dssDesc.StencilWriteMask = 0xFF;
+		dssDesc.FrontFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
+		dssDesc.FrontFace.StencilDepthFailOp = D3D11_STENCIL_OP_KEEP;
+		dssDesc.FrontFace.StencilPassOp = D3D11_STENCIL_OP_REPLACE;
+		dssDesc.FrontFace.StencilFunc = D3D11_COMPARISON_ALWAYS;
+		dssDesc.BackFace = dssDesc.FrontFace;
+
+		DX::ThrowIfFailed(device->CreateDepthStencilState(&dssDesc, stencilWriteDSS.put()));
+	}
+
+	// Rasterizer state for stencil write: no culling, no depth clip
+	{
+		D3D11_RASTERIZER_DESC rsDesc{};
+		rsDesc.FillMode = D3D11_FILL_SOLID;
+		rsDesc.CullMode = D3D11_CULL_NONE;
+		rsDesc.DepthClipEnable = FALSE;
+
+		DX::ThrowIfFailed(device->CreateRasterizerState(&rsDesc, stencilWriteRS.put()));
+	}
+
+	// Read-only depth DSV for stencil write pass: allows simultaneous depth SRV binding.
+	// We write stencil but never write depth, so D3D11_DSV_READ_ONLY_DEPTH is safe.
+	{
+		auto& depthData = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
+		if (depthData.views[0] && depthData.texture) {
+			D3D11_DEPTH_STENCIL_VIEW_DESC dsvDesc{};
+			depthData.views[0]->GetDesc(&dsvDesc);
+			dsvDesc.Flags = D3D11_DSV_READ_ONLY_DEPTH;
+
+			DX::ThrowIfFailed(device->CreateDepthStencilView(depthData.texture, &dsvDesc, stencilWriteReadOnlyDSV.put()));
+		} else {
+			logger::warn("[VRStereoOptimizations] Could not create read-only DSV: depth stencil data not available");
+		}
+	}
+
+	CompileShaders();
+
+	logger::info("[VRStereoOptimizations] Resources created: mode tex {}x{} (full SBS)", mainDesc.Width, mainDesc.Height);
+}
+
+void VRStereoOptimizations::CompileShaders()
+{
+	std::vector<std::pair<const char*, const char*>> csDefines = {
+		{ "VR", nullptr },
+		{ "FRAMEBUFFER", nullptr }
+	};
+
+	std::vector<std::pair<const char*, const char*>> vspsDefines = {
+		{ "VR", nullptr }
+	};
+
+	if (auto* ptr = Util::CompileShader(L"Data\\Shaders\\VRStereoOptimizations\\StencilCS.hlsl", csDefines, "cs_5_0"))
+		stencilCS.attach(reinterpret_cast<ID3D11ComputeShader*>(ptr));
+	else
+		logger::error("[VRStereoOptimizations] Failed to compile StencilCS");
+
+	{
+		auto debugDefines = csDefines;
+		debugDefines.push_back({ "DEBUG_DEPTH_MAP", nullptr });
+		if (auto* ptr = Util::CompileShader(L"Data\\Shaders\\VRStereoOptimizations\\StencilCS.hlsl", debugDefines, "cs_5_0"))
+			stencilDebugDepthMapCS.attach(reinterpret_cast<ID3D11ComputeShader*>(ptr));
+		else
+			logger::error("[VRStereoOptimizations] Failed to compile StencilCS (DEBUG_DEPTH_MAP)");
+	}
+
+	if (auto* ptr = Util::CompileShader(L"Data\\Shaders\\VRStereoOptimizations\\StencilWriteVS.hlsl", vspsDefines, "vs_5_0"))
+		stencilWriteVS.attach(reinterpret_cast<ID3D11VertexShader*>(ptr));
+	else
+		logger::error("[VRStereoOptimizations] Failed to compile StencilWriteVS");
+
+	if (auto* ptr = Util::CompileShader(L"Data\\Shaders\\VRStereoOptimizations\\StencilWritePS.hlsl", vspsDefines, "ps_5_0"))
+		stencilWritePS.attach(reinterpret_cast<ID3D11PixelShader*>(ptr));
+	else
+		logger::error("[VRStereoOptimizations] Failed to compile StencilWritePS");
+
+	if (auto* ptr = Util::CompileShader(L"Data\\Shaders\\VRStereoOptimizations\\ReprojectionCS.hlsl", csDefines, "cs_5_0"))
+		reprojectionCS.attach(reinterpret_cast<ID3D11ComputeShader*>(ptr));
+	else
+		logger::error("[VRStereoOptimizations] Failed to compile ReprojectionCS");
+
+}
+
+void VRStereoOptimizations::ClearShaderCache()
+{
+	stencilCS = nullptr;
+	stencilDebugDepthMapCS = nullptr;
+	stencilWriteVS = nullptr;
+	stencilWritePS = nullptr;
+	reprojectionCS = nullptr;
+	dssCache.clear();
+}
+
+void VRStereoOptimizations::Reset()
+{
+	stencilActive = false;
+	stencilSwapCount = 0;
+}
+
+//=============================================================================
+// IMGUI SETTINGS
+//=============================================================================
+
+void VRStereoOptimizations::DrawSettings()
+{
+	const char* modeNames[] = { "Off", "Enable" };
+	int currentMode = static_cast<int>(settings.stereoMode);
+	if (ImGui::Combo("Feature Enable", &currentMode, modeNames, IM_ARRAYSIZE(modeNames)))
+		settings.stereoMode = static_cast<StereoMode>(currentMode);
+
+	if (settings.stereoMode == StereoMode::Off)
+		return;
+
+	ImGui::SliderFloat("Disocclusion Depth Threshold", &settings.disocclusionDepthThreshold, 0.001f, 0.1f, "%.4f");
+
+	if (globals::state->IsDeveloperMode()) {
+		if (ImGui::TreeNode("Debug")) {
+			ImGui::SliderFloat("Full Blend Distance", &settings.fullBlendDistance, 0.0f, 10000.0f, "%.0f");
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip("Geometry closer than this distance (game units) is fully shaded in both eyes and bilaterally blended for 2x supersampling. 0 = disabled.");
+
+			ImGui::SliderFloat("POM Depth Scale", &settings.pomDepthScale, 0.0f, 500.0f, "%.1f");
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip("Scale factor for POM depth correction in stereo reprojection.\n1.0 = physical scale. Increase for more visible POM stereo depth.");
+			ImGui::Checkbox("Skip Pixel Reprojection", &settings.debugSkipMerge);
+			ImGui::Checkbox("Full Blend Depth View", &settings.debugFullBlendDepth);
+			ImGui::Checkbox("Debug POM Depth", &settings.debugPOMDepth);
+			if (settings.debugFullBlendDepth)
+				ImGui::TextColored(ImVec4(0, 1, 1, 1), "  Cyan = full blend zone (closer = stronger tint)");
+			ImGui::Text("Stencil swaps this frame: %u", stencilSwapCount);
+			ImGui::TreePop();
+		}
+	}
+}
+
+//=============================================================================
+// CONSTANT BUFFER UPDATE
+//=============================================================================
+
+void VRStereoOptimizations::UpdateConstantBuffer()
+{
+	float2 resolution = Util::ConvertToDynamic(globals::state->screenSize);
+
+	VRStereoOptParams params{};
+	params.FrameDim[0] = resolution.x;
+	params.FrameDim[1] = resolution.y;
+	params.RcpFrameDim[0] = 1.0f / resolution.x;
+	params.RcpFrameDim[1] = 1.0f / resolution.y;
+	params.StereoModeValue = static_cast<uint32_t>(settings.stereoMode);
+	params.DisocclusionThreshold = settings.disocclusionDepthThreshold;
+	params.EdgeDepthThreshold = settings.edgeDepthThreshold;
+	params.EdgeWidth = 2;
+	params.QualityJitter[0] = settings.qualityJitterOffset;
+	params.QualityJitter[1] = settings.qualityJitterOffset;
+	params.FoveatedRadius = settings.foveatedRegionRadius;
+	params.FoveatedCenter[0] = settings.foveatedRegionCenterX;
+	params.FoveatedCenter[1] = settings.foveatedRegionCenterY;
+	params.MinEdgeDistance = settings.minEdgeDistance;
+	params.FullBlendDistance = settings.fullBlendDistance;
+
+	paramsCB->Update(params);
+}
+
+//=============================================================================
+// PHASE 1: STENCIL CLASSIFICATION + WRITE
+//=============================================================================
+
+void VRStereoOptimizations::DispatchStencil()
+{
+	if (!REL::Module::IsVR())
+		return;
+	if (settings.stereoMode == StereoMode::Off)
+		return;
+	if (!stencilCS || !stencilWriteVS || !stencilWritePS || !texPerPixelMode || !paramsCB ||
+		!stencilWriteReadOnlyDSV || !stencilWriteDSS || !stencilWriteRS)
+		return;
+
+	ZoneScoped;
+	TracyD3D11Zone(globals::state->tracyCtx, "VR Stereo Opt - Stencil");
+
+	if (globals::state->frameAnnotations)
+		globals::state->BeginPerfEvent("VR Stereo Opt - Stencil");
+
+	auto context = globals::d3d::context;
+
+	UpdateConstantBuffer();
+	auto cbPtr = paramsCB->CB();
+	// Use live depth buffer (kMAIN) instead of kPOST_ZPREPASS_COPY — at StartDeferred time,
+	// kPOST_ZPREPASS_COPY is stale (previous frame). kMAIN has fresh z-prepass depth so
+	// StencilCS can correctly detect sky-vs-geometry edges in the current frame.
+	auto renderer = globals::game::renderer;
+	auto* depthSRV = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN].depthSRV;
+	if (!depthSRV) {
+		logger::warn("[VRStereoOptimizations] DispatchStencil: depthSRV is null, skipping");
+		if (globals::state->frameAnnotations)
+			globals::state->EndPerfEvent();
+		return;
+	}
+
+	// Dispatch classification CS over Eye 1 region
+	// Input: t0 = depth, b1 = params CB
+	// Output: u0 = per-pixel mode texture
+	{
+		ID3D11ShaderResourceView* srvs[1]{ depthSRV };
+		ID3D11UnorderedAccessView* uavs[1]{ texPerPixelMode->uav.get() };
+
+		context->CSSetConstantBuffers(1, 1, &cbPtr);
+		context->CSSetShaderResources(0, 1, srvs);
+		context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
+		auto* activeStencilCS = (settings.debugDepthMap && stencilDebugDepthMapCS) ? stencilDebugDepthMapCS.get() : stencilCS.get();
+		context->CSSetShader(activeStencilCS, nullptr, 0);
+
+		uint32_t fullWidth = texPerPixelMode->desc.Width;
+		uint32_t fullHeight = texPerPixelMode->desc.Height;
+		context->Dispatch((fullWidth + 7) / 8, (fullHeight + 7) / 8, 1);
+
+		// Cleanup CS bindings
+		ID3D11ShaderResourceView* nullSRV = nullptr;
+		ID3D11UnorderedAccessView* nullUAV = nullptr;
+		ID3D11Buffer* nullCB = nullptr;
+		context->CSSetShaderResources(0, 1, &nullSRV);
+		context->CSSetUnorderedAccessViews(0, 1, &nullUAV, nullptr);
+		context->CSSetConstantBuffers(1, 1, &nullCB);
+		context->CSSetShader(nullptr, nullptr, 0);
+	}
+
+	// Transfer classification to hardware stencil buffer
+	ExecuteStencilWritePass();
+
+	stencilActive = true;
+	stencilSwapCount = 0;
+
+	if (globals::state->frameAnnotations)
+		globals::state->EndPerfEvent();
+}
+
+void VRStereoOptimizations::ExecuteStencilWritePass()
+{
+	auto context = globals::d3d::context;
+	auto renderer = globals::game::renderer;
+
+	// ===== SAVE FULL D3D11 PIPELINE STATE =====
+
+	ID3D11RenderTargetView* savedRTVs[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT] = {};
+	ID3D11DepthStencilView* savedDSV = nullptr;
+	context->OMGetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, savedRTVs, &savedDSV);
+
+	ID3D11DepthStencilState* savedDSS = nullptr;
+	UINT savedStencilRef = 0;
+	context->OMGetDepthStencilState(&savedDSS, &savedStencilRef);
+
+	ID3D11BlendState* savedBlendState = nullptr;
+	FLOAT savedBlendFactor[4] = {};
+	UINT savedSampleMask = 0;
+	context->OMGetBlendState(&savedBlendState, savedBlendFactor, &savedSampleMask);
+
+	ID3D11RasterizerState* savedRS = nullptr;
+	context->RSGetState(&savedRS);
+
+	D3D11_VIEWPORT savedViewports[D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE] = {};
+	UINT numViewports = D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE;
+	context->RSGetViewports(&numViewports, savedViewports);
+
+	ID3D11VertexShader* savedVS = nullptr;
+	context->VSGetShader(&savedVS, nullptr, nullptr);
+
+	ID3D11PixelShader* savedPS = nullptr;
+	context->PSGetShader(&savedPS, nullptr, nullptr);
+
+	ID3D11GeometryShader* savedGS = nullptr;
+	context->GSGetShader(&savedGS, nullptr, nullptr);
+
+	ID3D11InputLayout* savedInputLayout = nullptr;
+	context->IAGetInputLayout(&savedInputLayout);
+
+	D3D11_PRIMITIVE_TOPOLOGY savedTopology = D3D11_PRIMITIVE_TOPOLOGY_UNDEFINED;
+	context->IAGetPrimitiveTopology(&savedTopology);
+
+	ID3D11ShaderResourceView* savedPSSRVs[2] = {};
+	context->PSGetShaderResources(0, 2, savedPSSRVs);
+
+	ID3D11Buffer* savedPSCB = nullptr;
+	context->PSGetConstantBuffers(1, 1, &savedPSCB);
+
+	// ===== SET UP STENCIL WRITE PASS =====
+
+	// Use our custom read-only-depth DSV to allow simultaneous depth SRV binding (t1).
+	// D3D11_DSV_READ_ONLY_DEPTH permits depth SRV + stencil write simultaneously.
+	// Using views[0] would cause D3D11 to silently NULL the depth SRV.
+	// depthData.readOnlyViews[0] has BOTH read-only flags and doesn't allow stencil writes.
+	// Clear stencil buffer to 0 before writing classification.
+	// The engine's z-prepass may have written stencil values (e.g., stencil=1) for rendered geometry.
+	// Without this clear, StencilWritePS discards for MODE_DISOCCLUDED pixels leave the engine's
+	// stencil value intact, which can match our NOT_EQUAL ref=1 culling test and incorrectly
+	// skip those pixels during the Lighting pass.
+	{
+		auto& depthData = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
+		context->ClearDepthStencilView(depthData.views[0], D3D11_CLEAR_STENCIL, 1.0f, 0);
+	}
+
+	context->OMSetRenderTargets(0, nullptr, stencilWriteReadOnlyDSV.get());
+	context->OMSetDepthStencilState(stencilWriteDSS.get(), 1);
+	context->RSSetState(stencilWriteRS.get());
+
+	// Eye 1 viewport (right half of SBS buffer)
+	{
+		D3D11_TEXTURE2D_DESC mainDesc;
+		renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN].texture->GetDesc(&mainDesc);
+
+		D3D11_VIEWPORT vp{};
+		vp.TopLeftX = static_cast<float>(mainDesc.Width / 2);
+		vp.TopLeftY = 0.0f;
+		vp.Width = static_cast<float>(mainDesc.Width / 2);
+		vp.Height = static_cast<float>(mainDesc.Height);
+		vp.MinDepth = 0.0f;
+		vp.MaxDepth = 1.0f;
+		context->RSSetViewports(1, &vp);
+	}
+
+	// Bind shaders and mode texture
+	context->VSSetShader(stencilWriteVS.get(), nullptr, 0);
+	context->PSSetShader(stencilWritePS.get(), nullptr, 0);
+	context->GSSetShader(nullptr, nullptr, 0);
+
+	ID3D11ShaderResourceView* modeSRV = texPerPixelMode->srv.get();
+	context->PSSetShaderResources(0, 1, &modeSRV);
+
+	auto* depthSRV = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN].depthSRV;
+	context->PSSetShaderResources(1, 1, &depthSRV);
+
+	// Bind params CB to pixel shader (CS and PS have separate CB bindings)
+	auto cbPtr = paramsCB->CB();
+	context->PSSetConstantBuffers(1, 1, &cbPtr);
+
+	// Fullscreen triangle: no VB/IB, procedurally generated in VS
+	context->IASetInputLayout(nullptr);
+	context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+	context->Draw(3, 0);
+
+	// ===== RESTORE FULL D3D11 PIPELINE STATE =====
+
+	ID3D11ShaderResourceView* nullSRVs[2] = {};
+	context->PSSetShaderResources(0, 2, nullSRVs);
+
+	context->PSSetConstantBuffers(1, 1, &savedPSCB);
+
+	context->OMSetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, savedRTVs, savedDSV);
+	context->OMSetDepthStencilState(savedDSS, savedStencilRef);
+	context->OMSetBlendState(savedBlendState, savedBlendFactor, savedSampleMask);
+	context->RSSetState(savedRS);
+	context->RSSetViewports(numViewports, savedViewports);
+	context->VSSetShader(savedVS, nullptr, 0);
+	context->PSSetShader(savedPS, nullptr, 0);
+	context->GSSetShader(savedGS, nullptr, 0);
+	context->IASetInputLayout(savedInputLayout);
+	context->IASetPrimitiveTopology(savedTopology);
+	context->PSSetShaderResources(0, 2, savedPSSRVs);
+
+	// Release COM references acquired by Get* calls
+	for (auto& rtv : savedRTVs) {
+		if (rtv)
+			rtv->Release();
+	}
+	if (savedDSV)
+		savedDSV->Release();
+	if (savedDSS)
+		savedDSS->Release();
+	if (savedBlendState)
+		savedBlendState->Release();
+	if (savedRS)
+		savedRS->Release();
+	if (savedVS)
+		savedVS->Release();
+	if (savedPS)
+		savedPS->Release();
+	if (savedGS)
+		savedGS->Release();
+	if (savedInputLayout)
+		savedInputLayout->Release();
+	if (savedPSSRVs[0])
+		savedPSSRVs[0]->Release();
+	if (savedPSSRVs[1])
+		savedPSSRVs[1]->Release();
+	if (savedPSCB)
+		savedPSCB->Release();
+}
+
+void VRStereoOptimizations::PerformLateStencilWrite()
+{
+	// Placeholder for future multi-pass stencil strategies
+}
+
+//=============================================================================
+// DSS CACHE: CLONE + STENCIL NOT_EQUAL ENFORCEMENT
+//=============================================================================
+
+ID3D11DepthStencilState* VRStereoOptimizations::GetOrCreateModifiedDSS(ID3D11DepthStencilState* originalDSS)
+{
+	if (!stencilActive)
+		return originalDSS;
+
+	// Check cache (nullptr is a valid key — represents D3D11 default state)
+	if (auto it = dssCache.find(originalDSS); it != dssCache.end())
+		return it->second.get();
+
+	D3D11_DEPTH_STENCIL_DESC desc;
+	if (originalDSS) {
+		originalDSS->GetDesc(&desc);
+	} else {
+		// D3D11 default state: depth enabled, stencil disabled
+		desc = {};
+		desc.DepthEnable = TRUE;
+		desc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ALL;
+		desc.DepthFunc = D3D11_COMPARISON_LESS;
+		desc.StencilEnable = FALSE;
+		desc.StencilReadMask = D3D11_DEFAULT_STENCIL_READ_MASK;
+		desc.StencilWriteMask = D3D11_DEFAULT_STENCIL_WRITE_MASK;
+		desc.FrontFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
+		desc.FrontFace.StencilDepthFailOp = D3D11_STENCIL_OP_KEEP;
+		desc.FrontFace.StencilPassOp = D3D11_STENCIL_OP_KEEP;
+		desc.FrontFace.StencilFunc = D3D11_COMPARISON_ALWAYS;
+		desc.BackFace = desc.FrontFace;
+	}
+
+	desc.StencilEnable = TRUE;
+	desc.StencilReadMask = 0xFF;
+	desc.StencilWriteMask = 0x00;
+
+	desc.FrontFace.StencilFunc = D3D11_COMPARISON_NOT_EQUAL;
+	desc.FrontFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
+	desc.FrontFace.StencilDepthFailOp = D3D11_STENCIL_OP_KEEP;
+	desc.FrontFace.StencilPassOp = D3D11_STENCIL_OP_KEEP;
+	desc.BackFace = desc.FrontFace;
+
+	winrt::com_ptr<ID3D11DepthStencilState> modifiedDSS;
+	HRESULT hr = globals::d3d::device->CreateDepthStencilState(&desc, modifiedDSS.put());
+	if (FAILED(hr)) {
+		logger::warn("[VRStereoOptimizations] Failed to create modified DSS (HRESULT: {:#x})", static_cast<uint32_t>(hr));
+		return originalDSS;
+	}
+
+	auto* result = modifiedDSS.get();
+	dssCache[originalDSS] = std::move(modifiedDSS);
+
+	return result;
+}
+
+//=============================================================================
+// PHASE 3: REPROJECTION COMPUTE SHADER
+//=============================================================================
+
+void VRStereoOptimizations::DispatchReprojection()
+{
+	if (!REL::Module::IsVR())
+		return;
+	if (settings.stereoMode == StereoMode::Off)
+		return;
+	if (!reprojectionCS || !texPerPixelMode || !paramsCB) {
+		DeactivateStencil();
+		return;
+	}
+	if (settings.debugSkipMerge) {
+		DeactivateStencil();
+		return;
+	}
+
+	ZoneScoped;
+	TracyD3D11Zone(globals::state->tracyCtx, "VR Stereo Opt - Reprojection");
+
+	if (globals::state->frameAnnotations)
+		globals::state->BeginPerfEvent("VR Stereo Opt - Reprojection");
+
+	auto context = globals::d3d::context;
+	auto renderer = globals::game::renderer;
+	auto& main = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];
+
+	UpdateConstantBuffer();
+	auto cbPtr = paramsCB->CB();
+	auto* depthSRV = Util::GetCurrentSceneDepthSRV();
+
+	// Bind: t0 = depth, t1 = mode texture, u0 = main UAV, b1 = params
+	ID3D11ShaderResourceView* srvs[2]{
+		depthSRV,
+		texPerPixelMode->srv.get()
+	};
+	ID3D11UnorderedAccessView* uavs[1]{ main.UAV };
+
+	context->CSSetConstantBuffers(1, 1, &cbPtr);
+	context->CSSetShaderResources(0, 2, srvs);
+	context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
+	context->CSSetShader(reprojectionCS.get(), nullptr, 0);
+
+	// Dispatch over Eye 1 only (shader treats dtid as Eye 1 local coords)
+	uint32_t eyeWidth = texPerPixelMode->desc.Width / 2;
+	uint32_t eyeHeight = texPerPixelMode->desc.Height;
+	context->Dispatch((eyeWidth + 7) / 8, (eyeHeight + 7) / 8, 1);
+
+	// Cleanup
+	ID3D11ShaderResourceView* nullSRVs[2] = {};
+	ID3D11UnorderedAccessView* nullUAV = nullptr;
+	ID3D11Buffer* nullCB = nullptr;
+	context->CSSetShaderResources(0, 2, nullSRVs);
+	context->CSSetUnorderedAccessViews(0, 1, &nullUAV, nullptr);
+	context->CSSetConstantBuffers(1, 1, &nullCB);
+	context->CSSetShader(nullptr, nullptr, 0);
+
+	// Stencil culling is done for this frame
+	logger::trace("[VRStereoOptimizations] Frame: stencilSwapCount={}", stencilSwapCount);
+	stencilActive = false;
+
+	if (globals::state->frameAnnotations)
+		globals::state->EndPerfEvent();
+}
+
+void VRStereoOptimizations::DeactivateStencil()
+{
+	if (!stencilActive)
+		return;
+	logger::trace("[VRStereoOptimizations] Frame: stencilSwapCount={}", stencilSwapCount);
+	stencilActive = false;
+}
+

--- a/src/Features/VRStereoOptimizations.h
+++ b/src/Features/VRStereoOptimizations.h
@@ -42,7 +42,7 @@ struct VRStereoOptimizations
 		MODE_EDGE = 1,            ///< Fully shaded + bilateral blend with other eye
 		MODE_MAIN = 2,            ///< Eye 0: no reproject (Perf) / bilateral (Quality). Eye 1: overwrite (Perf) / bilateral (Quality)
 		MODE_EDGE_NEIGHBOUR = 3,  ///< Outer band: background pixels near edge, blended in post-process
-		MODE_FULL_BLEND = 4,  ///< Near-camera pixels: fully shaded in both eyes + bilateral blended
+		MODE_FULL_BLEND = 4,      ///< Near-camera pixels: fully shaded in both eyes + bilateral blended
 	};
 
 	//=============================================================================

--- a/src/Features/VRStereoOptimizations.h
+++ b/src/Features/VRStereoOptimizations.h
@@ -1,0 +1,198 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+#include <d3d11.h>
+#include <unordered_map>
+#include <winrt/base.h>
+
+/**
+ * @brief VR Stereo Rendering Optimizations feature.
+ *
+ * Uses hardware stencil culling to skip Eye 1 pixel shading for pixels that can be
+ * reprojected from Eye 0 via lateral stereo reprojection, then runs a compute shader
+ * to fill those pixels. This avoids redundant pixel shading in overlapping stereo regions.
+ *
+ * Pipeline:
+ *   1. DispatchStencil()       - CS classifies per-pixel reprojection viability into a mode texture,
+ *                                then a fullscreen VS/PS pass writes that classification into the stencil buffer.
+ *   2. (Game renders Eye 1)    - Hardware stencil test skips shading for marked pixels.
+ *   3. DispatchReprojection()  - CS reprojects Eye 0 color into the skipped Eye 1 pixels.
+ */
+struct VRStereoOptimizations
+{
+	bool loaded = false;
+
+	//=============================================================================
+	// ENUMS
+	//=============================================================================
+
+	/// Operating mode for stereo reprojection
+	enum class StereoMode : uint32_t
+	{
+		Off = 0,    ///< Feature disabled
+		Enable = 1  ///< Stereo reprojection enabled
+	};
+
+	/// Per-pixel classification written by StencilCS
+	enum PixelMode : uint8_t
+	{
+		MODE_DISOCCLUDED = 0,     ///< Fully shaded, no reprojection, no blend
+		MODE_EDGE = 1,            ///< Fully shaded + bilateral blend with other eye
+		MODE_MAIN = 2,            ///< Eye 0: no reproject (Perf) / bilateral (Quality). Eye 1: overwrite (Perf) / bilateral (Quality)
+		MODE_EDGE_NEIGHBOUR = 3,  ///< Outer band: background pixels near edge, blended in post-process
+		MODE_FULL_BLEND = 4,  ///< Near-camera pixels: fully shaded in both eyes + bilateral blended
+	};
+
+	//=============================================================================
+	// PUBLIC METHODS
+	//=============================================================================
+
+	void SetupResources();
+	void Reset();
+	void DrawSettings();
+	void SaveSettings(json& o_json);
+	void LoadSettings(json& o_json);
+	void RestoreDefaultSettings();
+	void ClearShaderCache();
+
+	//=============================================================================
+	// SETTINGS
+	//=============================================================================
+
+	struct Settings
+	{
+		StereoMode stereoMode = StereoMode::Enable;
+		float disocclusionDepthThreshold = 0.01f;
+		float edgeDepthThreshold = 0.05f;
+		float minEdgeDistance = 5000.0f;   ///< Minimum linearized depth for edge AA (game units)
+		float fullBlendDistance = 0.0f;    ///< Linearized depth below which both eyes are fully shaded + blended (game units)
+		float pomDepthScale = 22.5f;       ///< Scale factor for POM depth correction in stereo reprojection
+		bool debugFullBlendDepth = false;  ///< Show full blend depth zone as cyan overlay
+		float qualityJitterOffset = 0.125f;
+		float foveatedRegionRadius = 0.3f;
+		float foveatedRegionCenterX = 0.5f;
+		float foveatedRegionCenterY = 0.5f;
+		bool useEyeTracking = false;
+
+		int reprojectionMode = 5;  // 0=Blend, 4=Overwrite, 5=Overwrite Eye1 Only
+
+		// Debug controls
+		bool debugVisualization = false;
+		bool debugSkipMerge = false;
+		bool debugForceAllStencil = false;
+		bool debugForceAllReprojectCS = false;
+		bool debugDepthMap = false;
+		bool debugPOMDepth = false;  ///< Show POM depth data (Reflectance.w) as heatmap overlay
+
+	} settings;
+
+	//=============================================================================
+	// GPU CONSTANT BUFFER (must match HLSL cbuffer layout exactly)
+	//=============================================================================
+
+	struct alignas(16) VRStereoOptParams
+	{
+		float FrameDim[2];     // Full stereo buffer dimensions
+		float RcpFrameDim[2];  // 1.0 / FrameDim
+
+		uint32_t StereoModeValue;  // Cast of StereoMode enum (0-3)
+		float DisocclusionThreshold;
+		float EdgeDepthThreshold;
+		uint32_t EdgeWidth;
+
+		float QualityJitter[2];  // Sub-pixel jitter offset (Quality mode)
+		float FoveatedRadius;
+		float pad2;
+
+		float FoveatedCenter[2];  // Foveal region center UV
+		float MinEdgeDistance;
+		float FullBlendDistance;  // Linearized depth for full blend zone
+	};
+	static_assert(sizeof(VRStereoOptParams) % 16 == 0, "VRStereoOptParams must be 16-byte aligned for HLSL cbuffer.");
+
+	//=============================================================================
+	// PUBLIC API
+	//=============================================================================
+
+	/**
+	 * @brief Classify Eye 1 pixels and write stencil marks.
+	 *
+	 * Dispatches the stencil classification CS, then performs a fullscreen triangle pass
+	 * to write the classification into the hardware stencil buffer.
+	 * Called from Deferred::StartDeferred() after OverrideBlendStates().
+	 */
+	void DispatchStencil();
+
+	/**
+	 * @brief Reproject Eye 0 color into stencil-culled Eye 1 pixels.
+	 *
+	 * Copies the main render target, then dispatches a CS to fill skipped pixels
+	 * using lateral reprojection from Eye 0.
+	 * Called from Deferred::DeferredPasses() after DeferredCompositeCS.
+	 */
+	void DispatchReprojection();
+
+	/**
+	 * @brief Creates or retrieves a modified DSS with stencil NOT_EQUAL test.
+	 *
+	 * Clones the given DSS with read-only stencil (WriteMask=0x00, Func=NOT_EQUAL, ref=1)
+	 * so that pixels marked by our stencil write pass are skipped during normal rendering.
+	 * Cached per unique input DSS pointer.
+	 *
+	 * @param originalDSS The original depth-stencil state to modify.
+	 * @return Modified DSS with stencil test, or original if creation fails.
+	 */
+	ID3D11DepthStencilState* GetOrCreateModifiedDSS(ID3D11DepthStencilState* originalDSS);
+
+	/// Whether the stencil pass is currently active this frame
+	bool IsStencilActive() const { return stencilActive; }
+
+	/// Deactivate stencil culling (called from Deferred after geometry rendering completes)
+	void DeactivateStencil();
+
+	/// Get mode texture SRV for external consumers (e.g., DeferredCompositeCS Eye 1 skip)
+	ID3D11ShaderResourceView* GetModeTextureSRV() const { return texPerPixelMode ? texPerPixelMode->srv.get() : nullptr; }
+
+private:
+	//=============================================================================
+	// INTERNAL METHODS
+	//=============================================================================
+
+	/// Fullscreen triangle pass: reads mode texture, writes stencil ref=1 for MODE_MAIN pixels
+	void ExecuteStencilWritePass();
+
+	/// Late stencil write callback (placeholder for future multi-pass strategies)
+	void PerformLateStencilWrite();
+
+	/// Compiles all shaders used by this feature
+	void CompileShaders();
+
+	/// Updates the constant buffer with current settings and frame dimensions
+	void UpdateConstantBuffer();
+
+	//=============================================================================
+	// GPU RESOURCES
+	//=============================================================================
+
+	eastl::unique_ptr<ConstantBuffer> paramsCB;
+	eastl::unique_ptr<Texture2D> texPerPixelMode;      ///< R8_UINT classification texture (full SBS resolution)
+	eastl::unique_ptr<Texture2D> reprojectionCopyTex;  ///< Copy of main RT for reprojection read
+
+	winrt::com_ptr<ID3D11DepthStencilState> stencilWriteDSS;
+	winrt::com_ptr<ID3D11RasterizerState> stencilWriteRS;
+	winrt::com_ptr<ID3D11DepthStencilView> stencilWriteReadOnlyDSV;  ///< Read-only-depth DSV for stencil write pass (allows simultaneous depth SRV)
+
+	winrt::com_ptr<ID3D11ComputeShader> stencilCS;
+	winrt::com_ptr<ID3D11ComputeShader> stencilDebugDepthMapCS;
+	winrt::com_ptr<ID3D11VertexShader> stencilWriteVS;
+	winrt::com_ptr<ID3D11PixelShader> stencilWritePS;
+	winrt::com_ptr<ID3D11ComputeShader> reprojectionCS;
+
+	/// Cache of original DSS -> modified DSS with stencil NOT_EQUAL enforcement
+	std::unordered_map<ID3D11DepthStencilState*, winrt::com_ptr<ID3D11DepthStencilState>> dssCache;
+
+	bool stencilActive = false;
+	uint32_t stencilSwapCount = 0;
+};

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -266,9 +266,75 @@ namespace globals
 	{
 		static void thunk(ID3D11DeviceContext* This, ID3D11Resource* pResource, UINT Subresource)
 		{
-			if (*globals::game::perFrame.get() == pResource && globals::game::mappedFrameBuffer)
+			if (*globals::game::perFrame.get() == pResource && globals::game::mappedFrameBuffer) {
 				CacheFramebuffer();
+			}
 			func(This, pResource, Subresource);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	/**
+	 * @brief Hooked OMSetDepthStencilState — replaces DSS with stencil-enforcing version when VR stereo opt is active.
+	 *
+	 * vtable index 36 for ID3D11DeviceContext::OMSetDepthStencilState.
+	 * When VRStereoOptimizations has written stencil marks, this hook transparently swaps
+	 * the game's DSS for a modified version that adds a stencil NOT_EQUAL test, causing
+	 * marked Eye 1 pixels to be skipped during normal rendering.
+	 */
+	struct ID3D11DeviceContext_OMSetDepthStencilState
+	{
+		static void thunk(ID3D11DeviceContext* This, ID3D11DepthStencilState* pDepthStencilState, UINT StencilRef)
+		{
+			if (globals::game::isVR) {
+				auto& stereoOpt = globals::features::vr.stereoOpt;
+				if (stereoOpt.loaded && stereoOpt.IsStencilActive()) {
+					pDepthStencilState = stereoOpt.GetOrCreateModifiedDSS(pDepthStencilState);
+					StencilRef = 1;  // Must match the ref written by our stencil pass
+				}
+			}
+			func(This, pDepthStencilState, StencilRef);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	/**
+	 * @brief Hooked ClearDepthStencilView — blocks stencil clears when VR stereo opt stencil is active.
+	 *
+	 * vtable index 53 for ID3D11DeviceContext::ClearDepthStencilView.
+	 * Prevents the game from clearing our stencil marks between the stencil write and
+	 * the reprojection pass by stripping the D3D11_CLEAR_STENCIL flag.
+	 */
+	struct ID3D11DeviceContext_ClearDepthStencilView
+	{
+		static void thunk(ID3D11DeviceContext* This, ID3D11DepthStencilView* pDepthStencilView, UINT ClearFlags, FLOAT Depth, UINT8 Stencil)
+		{
+			if (globals::game::isVR) {
+				auto& stereoOpt = globals::features::vr.stereoOpt;
+				if (stereoOpt.loaded && stereoOpt.IsStencilActive()) {
+					// Only protect the main scene DSV — allow other DSVs to clear normally
+					auto renderer = globals::game::renderer;
+					auto& mainDepth = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
+					if (mainDepth.views[0]) {
+						// Compare the DSV being cleared against the main scene DSV
+						ID3D11Resource* clearRes = nullptr;
+						ID3D11Resource* mainRes = nullptr;
+						pDepthStencilView->GetResource(&clearRes);
+						mainDepth.views[0]->GetResource(&mainRes);
+						bool isMainDSV = (clearRes == mainRes);
+						if (clearRes)
+							clearRes->Release();
+						if (mainRes)
+							mainRes->Release();
+						if (isMainDSV) {
+							ClearFlags &= ~D3D11_CLEAR_STENCIL;
+							if (ClearFlags == 0)
+								return;
+						}
+					}
+				}
+			}
+			func(This, pDepthStencilView, ClearFlags, Depth, Stencil);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -282,5 +348,11 @@ namespace globals
 	{
 		stl::detour_vfunc<14, ID3D11DeviceContext_Map>(a_context);
 		stl::detour_vfunc<15, ID3D11DeviceContext_Unmap>(a_context);
+
+		// VR stereo optimization hooks: intercept DSS and stencil clear
+		if (globals::game::isVR) {
+			stl::detour_vfunc<36, ID3D11DeviceContext_OMSetDepthStencilState>(a_context);
+			stl::detour_vfunc<53, ID3D11DeviceContext_ClearDepthStencilView>(a_context);
+		}
 	}
 }

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -11,6 +11,7 @@
 #include "Features/TerrainBlending.h"
 #include "Features/TerrainHelper.h"
 #include "Features/Upscaling.h"
+#include "Features/VRStereoOptimizations.h"
 #include "Features/VolumetricShadows.h"
 #include "Features/WeatherEditor.h"
 #include "Menu.h"


### PR DESCRIPTION
Reduces right-eye SSS cost when VR stereo optimizations are active.

- Reduced sample count for right eye (StereoBlend overwrites most right-eye pixels)
- Configurable reduction level (half or quarter samples)
- StereoSync toggle exposed in VR settings UI

**Depends on:** #2002 (VR stereo reprojection optimizations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VR stereo optimization system with stencil-based culling and lateral reprojection for improved performance.
  * Introduced new debug visualization modes for stereo rendering analysis.
  * Added depth-weighted bilateral blending for VR post-processing effects.

* **Improvements**
  * Enhanced screen-space shadows with improved depth sampling and blur weighting.
  * Optimized parallax offset calculations in extended materials.
  * Improved VR stereo blend rendering with enhanced reprojection handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->