### PR TITLE
refactor: centralize feature category names

### DIFF
--- a/src/Feature.h
+++ b/src/Feature.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "FeatureCategories.h"
 #include "FeatureConstraints.h"
 #include "FeatureVersions.h"
 #ifdef TRACY_ENABLE
@@ -63,7 +64,7 @@ public:
 	 * Get the category for UI grouping (e.g., "Terrain", "Lighting", "Characters", etc.)
 	 * Core features will be distributed to their respective categories
 	 */
-	virtual std::string_view GetCategory() const { return "Other"; }
+	virtual std::string_view GetCategory() const { return FeatureCategories::kOther; }
 
 	/**
 	 * Whether the feature will show up in the GUI menu

--- a/src/FeatureCategories.h
+++ b/src/FeatureCategories.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <string_view>
+
+namespace FeatureCategories
+{
+	inline constexpr std::string_view kCharacters = "Characters";
+	inline constexpr std::string_view kDisplay = "Display";
+	inline constexpr std::string_view kGrass = "Grass";
+	inline constexpr std::string_view kLandscapeAndTextures = "Landscape & Textures";
+	inline constexpr std::string_view kLighting = "Lighting";
+	inline constexpr std::string_view kMaterials = "Materials";
+	inline constexpr std::string_view kOther = "Other";
+	inline constexpr std::string_view kSky = "Sky";
+	inline constexpr std::string_view kUtility = "Utility";
+	inline constexpr std::string_view kWater = "Water";
+}

--- a/src/Features/CloudShadows.h
+++ b/src/Features/CloudShadows.h
@@ -17,7 +17,7 @@ public:
 	virtual inline std::string GetName() override { return "Cloud Shadows"; }
 	virtual inline std::string GetShortName() override { return "CloudShadows"; }
 	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
-	virtual std::string_view GetCategory() const override { return "Sky"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kSky; }
 	virtual inline std::string_view GetShaderDefineName() override { return "CLOUD_SHADOWS"; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/DynamicCubemaps.h
+++ b/src/Features/DynamicCubemaps.h
@@ -101,7 +101,7 @@ public:
 	virtual inline std::string GetName() override { return "Dynamic Cubemaps"; }
 	virtual inline std::string GetShortName() override { return "DynamicCubemaps"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "DYNAMIC_CUBEMAPS"; }
-	virtual std::string_view GetCategory() const override { return "Materials"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kMaterials; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{
 		return {

--- a/src/Features/ExponentialHeightFog.h
+++ b/src/Features/ExponentialHeightFog.h
@@ -6,7 +6,7 @@ struct ExponentialHeightFog : Feature
 	virtual inline std::string GetName() override { return "Exponential Height Fog"; }
 	virtual inline std::string GetShortName() override { return "ExponentialHeightFog"; }
 	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL("999999"); }
-	virtual std::string_view GetCategory() const override { return "Lighting"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kLighting; }
 
 	virtual inline std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/ExtendedMaterials.h
+++ b/src/Features/ExtendedMaterials.h
@@ -7,7 +7,7 @@ struct ExtendedMaterials : Feature
 	virtual inline std::string GetName() override { return "Extended Materials"; }
 	virtual inline std::string GetShortName() override { return "ExtendedMaterials"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "EXTENDED_MATERIALS"; }
-	virtual std::string_view GetCategory() const override { return "Materials"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kMaterials; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/ExtendedTranslucency.h
+++ b/src/Features/ExtendedTranslucency.h
@@ -11,7 +11,7 @@ struct ExtendedTranslucency final : Feature
 	virtual inline std::string GetShortName() override { return "ExtendedTranslucency"; }
 	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "EXTENDED_TRANSLUCENCY"sv; }
-	virtual inline std::string_view GetCategory() const override { return "Materials"sv; }
+	virtual inline std::string_view GetCategory() const override { return FeatureCategories::kMaterials; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override;
 	virtual bool HasShaderDefine(RE::BSShader::Type shaderType) override { return RE::BSShader::Type::Lighting == shaderType; };
 	virtual void PostPostLoad() override;

--- a/src/Features/GrassCollision.h
+++ b/src/Features/GrassCollision.h
@@ -12,7 +12,7 @@ public:
 	virtual inline std::string GetShortName() override { return "GrassCollision"; }
 	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "GRASS_COLLISION"; }
-	virtual std::string_view GetCategory() const override { return "Grass"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kGrass; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/GrassLighting.h
+++ b/src/Features/GrassLighting.h
@@ -13,7 +13,7 @@ public:
 	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "GRASS_LIGHTING"; }
 	virtual bool HasShaderDefine(RE::BSShader::Type shaderType) override { return shaderType == RE::BSShader::Type::Grass; };
-	virtual std::string_view GetCategory() const override { return "Grass"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kGrass; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/HairSpecular.h
+++ b/src/Features/HairSpecular.h
@@ -9,7 +9,7 @@ public:
 	virtual inline std::string GetName() override { return "Hair Specular"; }
 	virtual inline std::string GetShortName() override { return "HairSpecular"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "CS_HAIR"; }
-	virtual std::string_view GetCategory() const override { return "Characters"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kCharacters; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{
 		return {

--- a/src/Features/IBL.h
+++ b/src/Features/IBL.h
@@ -9,7 +9,7 @@ public:
 	virtual inline std::string GetName() override { return "Image Based Lighting"; }
 	virtual inline std::string GetShortName() override { return "ImageBasedLighting"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "IBL"; }
-	virtual std::string_view GetCategory() const override { return "Lighting"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kLighting; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/InteriorSun.h
+++ b/src/Features/InteriorSun.h
@@ -9,7 +9,7 @@ private:
 public:
 	virtual inline std::string GetName() override { return "Interior Sun"; }
 	virtual inline std::string GetShortName() override { return "InteriorSun"; }
-	virtual std::string_view GetCategory() const override { return "Lighting"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kLighting; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{
 		return {

--- a/src/Features/InverseSquareLighting.h
+++ b/src/Features/InverseSquareLighting.h
@@ -14,7 +14,7 @@ public:
 
 	virtual inline std::string_view GetShaderDefineName() override { return "ISL"; }
 
-	virtual std::string_view GetCategory() const override { return "Lighting"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kLighting; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/LODBlending.h
+++ b/src/Features/LODBlending.h
@@ -5,7 +5,7 @@ struct LODBlending : Feature
 	virtual inline std::string GetName() override { return "LOD Blending"; }
 	virtual inline std::string GetShortName() override { return "LODBlending"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "LOD_BLENDING"; }
-	virtual std::string_view GetCategory() const override { return "Landscape & Textures"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kLandscapeAndTextures; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{
 		return {

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -13,7 +13,7 @@ public:
 	virtual inline std::string GetShortName() override { return "LightLimitFix"; }
 	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "LIGHT_LIMIT_FIX"; }
-	virtual std::string_view GetCategory() const override { return "Lighting"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kLighting; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/LinearLighting.h
+++ b/src/Features/LinearLighting.h
@@ -10,7 +10,7 @@ struct LinearLighting : Feature
 
 	virtual inline std::string GetName() override { return "Linear Lighting"; }
 	virtual inline std::string GetShortName() override { return "LinearLighting"; }
-	virtual std::string_view GetCategory() const override { return "Lighting"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kLighting; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{
 		return {

--- a/src/Features/OverlayFeature.h
+++ b/src/Features/OverlayFeature.h
@@ -32,5 +32,5 @@ struct OverlayFeature : Feature
      *
      * Subclasses may override this to provide a different category.
      */
-	virtual std::string_view GetCategory() const override { return "Utility"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kUtility; }
 };

--- a/src/Features/RenderDoc.h
+++ b/src/Features/RenderDoc.h
@@ -49,7 +49,7 @@ public:
 	// Feature overrides
 	std::string GetName() override { return "RenderDoc"; }
 	std::string GetShortName() override { return "RenderDoc"; }
-	std::string_view GetCategory() const override { return "Utility"; }
+	std::string_view GetCategory() const override { return FeatureCategories::kUtility; }
 	bool IsCore() const override { return true; }
 	bool IsInMenu() const override { return true; }
 	std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/ScreenSpaceGI.h
+++ b/src/Features/ScreenSpaceGI.h
@@ -13,7 +13,7 @@ public:
 	virtual inline std::string GetName() override { return "Screen Space GI"; }
 	virtual inline std::string GetShortName() override { return "ScreenSpaceGI"; }
 	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
-	virtual std::string_view GetCategory() const override { return "Lighting"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kLighting; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/ScreenSpaceShadows.h
+++ b/src/Features/ScreenSpaceShadows.h
@@ -12,7 +12,7 @@ public:
 	virtual inline std::string GetShortName() override { return "ScreenSpaceShadows"; }
 	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "SCREEN_SPACE_SHADOWS"; }
-	virtual std::string_view GetCategory() const override { return "Lighting"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kLighting; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -9,7 +9,7 @@ private:
 public:
 	virtual inline std::string GetName() override { return "Sky Sync"; }
 	virtual inline std::string GetShortName() override { return "SkySync"; }
-	virtual std::string_view GetCategory() const override { return "Sky"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kSky; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/Skylighting.h
+++ b/src/Features/Skylighting.h
@@ -12,7 +12,7 @@ public:
 	virtual inline std::string GetShortName() override { return "Skylighting"; }
 	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "SKYLIGHTING"; }
-	virtual std::string_view GetCategory() const override { return "Lighting"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kLighting; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{
 		return {

--- a/src/Features/SubsurfaceScattering.h
+++ b/src/Features/SubsurfaceScattering.h
@@ -72,7 +72,7 @@ public:
 	virtual inline std::string GetShortName() override { return "SubsurfaceScattering"; }
 	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "SSS"; }
-	virtual std::string_view GetCategory() const override { return "Characters"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kCharacters; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/TerrainBlending.h
+++ b/src/Features/TerrainBlending.h
@@ -6,7 +6,7 @@ public:
 	virtual inline std::string GetName() override { return "Terrain Blending"; }
 	virtual inline std::string GetShortName() override { return "TerrainBlending"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "TERRAIN_BLENDING"; }
-	virtual std::string_view GetCategory() const override { return "Landscape & Textures"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kLandscapeAndTextures; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{
 		return {

--- a/src/Features/TerrainHelper.h
+++ b/src/Features/TerrainHelper.h
@@ -9,7 +9,7 @@ public:
 	virtual inline std::string GetName() override { return "Terrain Helper"; }
 	virtual inline std::string GetShortName() override { return "TerrainHelper"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "TERRAIN_HELPER"; }
-	virtual std::string_view GetCategory() const override { return "Landscape & Textures"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kLandscapeAndTextures; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/TerrainShadows.h
+++ b/src/Features/TerrainShadows.h
@@ -13,7 +13,7 @@ public:
 	virtual inline std::string GetShortName() override { return "TerrainShadows"; }
 	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "TERRAIN_SHADOWS"; }
-	virtual std::string_view GetCategory() const override { return "Landscape & Textures"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kLandscapeAndTextures; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{
 		return {

--- a/src/Features/TerrainVariation.h
+++ b/src/Features/TerrainVariation.h
@@ -16,7 +16,7 @@ public:
 	}
 	virtual bool IsCore() const override { return false; };
 	virtual bool SupportsVR() override { return true; }
-	virtual std::string_view GetCategory() const override { return "Landscape & Textures"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kLandscapeAndTextures; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/UnifiedWater.h
+++ b/src/Features/UnifiedWater.h
@@ -8,7 +8,7 @@ struct UnifiedWater : OverlayFeature
 	virtual inline std::string GetName() override { return "Unified Water"; }
 	virtual inline std::string GetShortName() override { return "UnifiedWater"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "UNIFIED_WATER"; }
-	virtual std::string_view GetCategory() const override { return "Water"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kWater; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{
 		return {

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -23,7 +23,7 @@ public:
 	virtual inline std::string GetShortName() override { return "Upscaling"; }
 	virtual inline bool SupportsVR() override { return true; }
 	virtual inline bool IsCore() const override { return false; }
-	virtual inline std::string_view GetCategory() const override { return "Display"; }
+	virtual inline std::string_view GetCategory() const override { return FeatureCategories::kDisplay; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -130,7 +130,7 @@ public:
 
 	virtual void DrawSettings() override;
 
-	virtual std::string_view GetCategory() const override { return "Utility"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kUtility; }
 
 	//=============================================================================
 	// OVERLAY FEATURE OVERRIDES

--- a/src/Features/VolumetricLighting.h
+++ b/src/Features/VolumetricLighting.h
@@ -26,7 +26,7 @@ public:
 
 	virtual inline std::string GetName() override { return "Volumetric Lighting"; }
 	virtual inline std::string GetShortName() override { return "VolumetricLighting"; }
-	virtual std::string_view GetCategory() const override { return "Lighting"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kLighting; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/VolumetricShadows.h
+++ b/src/Features/VolumetricShadows.h
@@ -8,7 +8,7 @@ public:
 	virtual inline std::string GetName() override { return "Volumetric Shadows"; }
 	virtual inline std::string GetShortName() override { return "VolumetricShadows"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "VOLUMETRIC_SHADOWS"; }
-	virtual std::string_view GetCategory() const override { return "Lighting"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kLighting; }
 	virtual bool IsCore() const override { return true; }
 	virtual bool IsInMenu() const override { return true; }
 

--- a/src/Features/WaterEffects.h
+++ b/src/Features/WaterEffects.h
@@ -13,7 +13,7 @@ public:
 	virtual inline std::string GetShortName() override { return "WaterEffects"; }
 	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "WATER_EFFECTS"; }
-	virtual std::string_view GetCategory() const override { return "Water"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kWater; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{

--- a/src/Features/WeatherEditor.h
+++ b/src/Features/WeatherEditor.h
@@ -17,7 +17,7 @@ public:
 	virtual inline std::string GetName() override { return "Weather Editor"; }
 	virtual inline std::string GetShortName() override { return "WeatherEditor"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "WEATHER"; }
-	virtual inline std::string_view GetCategory() const override { return "Utility"; }
+	virtual inline std::string_view GetCategory() const override { return FeatureCategories::kUtility; }
 	virtual bool SupportsVR() override { return true; }
 	virtual bool IsCore() const override { return true; }
 	virtual bool IsInMenu() const override { return true; }

--- a/src/Features/WetnessEffects.h
+++ b/src/Features/WetnessEffects.h
@@ -12,7 +12,7 @@ public:
 	virtual inline std::string GetShortName() override { return "WetnessEffects"; }
 	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "WETNESS_EFFECTS"; }
-	virtual std::string_view GetCategory() const override { return "Water"; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kWater; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{


### PR DESCRIPTION
## Summary

Replaces all hard-coded category string literals in `GetCategory()` overrides with `constexpr std::string_view` constants from a new `FeatureCategories` namespace.

## Changes

- **New file:** `src/FeatureCategories.h` - 10 constants (Characters, Display, Grass, Landscape & Textures, Lighting, Materials, Other, Sky, Utility, Water)
- **`src/Feature.h`:** Default `GetCategory()` now returns `FeatureCategories::kOther`
- **33 feature headers:** Each `GetCategory()` override updated to use the corresponding constant

34 files changed, 35 insertions(+), 34 deletions(-).

Closes #1265

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized feature category definitions for improved code maintainability and consistency across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->