### PR TITLE
build: bump versions and reduce false positives

### DIFF
--- a/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
+++ b/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 2-2-3
+Version = 2-3-0

--- a/features/Grass Collision/Shaders/Features/GrassCollision.ini
+++ b/features/Grass Collision/Shaders/Features/GrassCollision.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 3-0-2
+Version = 3-0-3

--- a/features/Grass Lighting/Shaders/Features/GrassLighting.ini
+++ b/features/Grass Lighting/Shaders/Features/GrassLighting.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 2-0-0
+Version = 2-0-1

--- a/features/Hair Specular/Shaders/Features/HairSpecular.ini
+++ b/features/Hair Specular/Shaders/Features/HairSpecular.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 1-0-3
+Version = 1-1-0

--- a/features/IBL/Shaders/Features/ImageBasedLighting.ini
+++ b/features/IBL/Shaders/Features/ImageBasedLighting.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 1-0-1
+Version = 1-1-0

--- a/features/Linear Lighting/Shaders/Features/LinearLighting.ini
+++ b/features/Linear Lighting/Shaders/Features/LinearLighting.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 1-0-0
+Version = 1-1-0

--- a/features/Screen Space GI/Shaders/Features/ScreenSpaceGI.ini
+++ b/features/Screen Space GI/Shaders/Features/ScreenSpaceGI.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 4-0-1
+Version = 4-1-0

--- a/features/Screen-Space Shadows/Shaders/Features/ScreenSpaceShadows.ini
+++ b/features/Screen-Space Shadows/Shaders/Features/ScreenSpaceShadows.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 2-0-0
+Version = 2-1-0

--- a/features/Sky Sync/Shaders/Features/SkySync.ini
+++ b/features/Sky Sync/Shaders/Features/SkySync.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 1-0-0
+Version = 1-0-1

--- a/features/Skylighting/Shaders/Features/Skylighting.ini
+++ b/features/Skylighting/Shaders/Features/Skylighting.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 1-2-3
+Version = 1-2-4

--- a/features/Terrain Blending/Shaders/Features/TerrainBlending.ini
+++ b/features/Terrain Blending/Shaders/Features/TerrainBlending.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 1-0-1
+Version = 1-0-2

--- a/features/Terrain Shadows/Shaders/Features/TerrainShadows.ini
+++ b/features/Terrain Shadows/Shaders/Features/TerrainShadows.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 1-0-2
+Version = 1-1-0

--- a/features/Unified Water/Shaders/Features/UnifiedWater.ini
+++ b/features/Unified Water/Shaders/Features/UnifiedWater.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 1-0-0
+Version = 1-0-1

--- a/features/Upscaling/Shaders/Features/Upscaling.ini
+++ b/features/Upscaling/Shaders/Features/Upscaling.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 1-2-0
+Version = 1-3-0

--- a/features/VR/Shaders/Features/VR.ini
+++ b/features/VR/Shaders/Features/VR.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 1-0-1
+Version = 1-1-0

--- a/features/Volumetric Lighting/Shaders/Features/VolumetricLighting.ini
+++ b/features/Volumetric Lighting/Shaders/Features/VolumetricLighting.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 1-0-0
+Version = 1-1-0

--- a/features/Weather Editor/Shaders/Features/WeatherEditor.ini
+++ b/features/Weather Editor/Shaders/Features/WeatherEditor.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 1-0-0
+Version = 1-1-0

--- a/features/Wetness Effects/Shaders/Features/WetnessEffects.ini
+++ b/features/Wetness Effects/Shaders/Features/WetnessEffects.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 3-0-0
+Version = 3-1-0

--- a/tools/feature_version_audit.py
+++ b/tools/feature_version_audit.py
@@ -40,7 +40,7 @@ RE_COMMIT_FIX = re.compile(r"^fix(\(|:|\s)", re.IGNORECASE)
 RE_COMMIT_REFACTOR = re.compile(r"^refactor(\(|:|\s)", re.IGNORECASE)
 RE_COMMIT_PERF = re.compile(r"^perf(\(|:|\s)", re.IGNORECASE)
 RE_COMMIT_BREAKING = re.compile(r"!\s*:|BREAKING CHANGE:", re.IGNORECASE)
-RE_COMMIT_NONFUNCTIONAL = re.compile(r"^(chore|docs|style|ci|test|build)(\(|:|\s)", re.IGNORECASE)
+RE_COMMIT_NONFUNCTIONAL = re.compile(r"^(chore|docs|style|ci|test|build|refactor|perf)(\(|:|\s)", re.IGNORECASE)
 
 # =====================
 # End Configuration
@@ -128,7 +128,7 @@ def get_bump_commit(file_path, base_ref):
             if len(parts) < 2:
                 continue
             commit_hash, msg = parts
-            if RE_COMMIT_FEAT.match(msg) or RE_COMMIT_FIX.match(msg) or RE_COMMIT_REFACTOR.match(msg) or RE_COMMIT_PERF.match(msg) or RE_COMMIT_BREAKING.search(msg):
+            if RE_COMMIT_FEAT.match(msg) or RE_COMMIT_FIX.match(msg) or RE_COMMIT_BREAKING.search(msg):
                 return commit_hash
     except Exception:
         pass
@@ -272,7 +272,7 @@ def propose_new_version(prior_version, commits):
         return None
 
     is_minor = any(RE_COMMIT_FEAT.match(c) or RE_COMMIT_BREAKING.search(c) for c in commits)
-    is_patch = any(RE_COMMIT_FIX.match(c) or RE_COMMIT_REFACTOR.match(c) or RE_COMMIT_PERF.match(c) for c in commits)
+    is_patch = any(RE_COMMIT_FIX.match(c) for c in commits)
     is_nonfunctional_only = all(RE_COMMIT_NONFUNCTIONAL.match(c) for c in commits)
 
     if is_minor:

--- a/tools/feature_version_audit.py
+++ b/tools/feature_version_audit.py
@@ -123,13 +123,17 @@ def get_bump_commit(file_path, base_ref):
             ["git", "log", f"{base_ref}..HEAD", "--pretty=%H %s", "--", file_path],
             stderr=subprocess.DEVNULL,
         ).decode("utf-8")
+        fallback_commit = None
         for line in output.splitlines():
             parts = line.split(" ", 1)
             if len(parts) < 2:
                 continue
             commit_hash, msg = parts
+            if fallback_commit is None:
+                fallback_commit = commit_hash
             if RE_COMMIT_FEAT.match(msg) or RE_COMMIT_FIX.match(msg) or RE_COMMIT_BREAKING.search(msg):
                 return commit_hash
+        return fallback_commit
     except Exception:
         pass
     return None

--- a/tools/feature_version_audit.py
+++ b/tools/feature_version_audit.py
@@ -110,34 +110,36 @@ def get_changed_files(feature_path, base_ref, file_types=None):
 def get_commits_for_file(file_path, base_ref):
     try:
         output = subprocess.check_output(
-            ["git", "log", f"{base_ref}..HEAD", "--pretty=%s", "--", file_path],
+            ["git", "log", f"{base_ref}..HEAD", "--pretty=%B%x1e", "--", file_path],
             stderr=subprocess.DEVNULL,
         ).decode("utf-8")
-        return [line.strip() for line in output.splitlines() if line.strip()]
+        return [msg.strip() for msg in output.split("\x1e") if msg.strip()]
     except Exception:
         return []
 
 def get_bump_commit(file_path, base_ref):
     try:
         output = subprocess.check_output(
-            ["git", "log", f"{base_ref}..HEAD", "--pretty=%H %s", "--", file_path],
+            ["git", "log", f"{base_ref}..HEAD", "--pretty=%H%x1f%B%x1e", "--", file_path],
             stderr=subprocess.DEVNULL,
         ).decode("utf-8")
-        for line in output.splitlines():
-            parts = line.split(" ", 1)
+        for entry in output.split("\x1e"):
+            if not entry.strip():
+                continue
+            parts = entry.strip().split("\x1f", 1)
             if len(parts) < 2:
                 continue
             commit_hash, msg = parts
             if RE_COMMIT_FEAT.match(msg) or RE_COMMIT_FIX.match(msg) or RE_COMMIT_BREAKING.search(msg):
-                return commit_hash
+                return commit_hash.strip()
     except Exception:
         pass
     return None
 
-def get_latest_commit(file_path, base_ref):
+def get_latest_commit(file_paths, base_ref):
     try:
         output = subprocess.check_output(
-            ["git", "log", f"{base_ref}..HEAD", "-1", "--pretty=%H", "--", file_path],
+            ["git", "log", f"{base_ref}..HEAD", "-1", "--pretty=%H", "--", *sorted(file_paths)],
             stderr=subprocess.DEVNULL,
         ).decode("utf-8").strip()
         return output or None
@@ -386,19 +388,17 @@ def analyze_features(FEATURES_DIR, feature_meta_map, base_ref, only_changed=Fals
         all_commits = []
         bump_commit = None
         bump_author = None
-        any_commit = None
         for status, f in changes:
-            commits = get_commits_for_file(f, base_ref)
-            all_commits.extend(commits)
+            all_commits.extend(get_commits_for_file(f, base_ref))
             if not bump_commit:
                 bump_commit = get_bump_commit(f, base_ref)
                 if bump_commit:
                     bump_author = get_commit_author(bump_commit)
-            if not any_commit:
-                any_commit = get_latest_commit(f, base_ref)
-        if not bump_commit and any_commit:
-            bump_commit = any_commit
-            bump_author = get_commit_author(any_commit)
+        if not bump_commit and changes:
+            any_commit = get_latest_commit([f for _, f in changes], base_ref)
+            if any_commit:
+                bump_commit = any_commit
+                bump_author = get_commit_author(any_commit)
 
         proposed_ver = propose_new_version(prior_ver, all_commits) if ini_path else None
         needs_bump = (proposed_ver is not None and new_ver is not None and proposed_ver > new_ver)

--- a/tools/feature_version_audit.py
+++ b/tools/feature_version_audit.py
@@ -123,17 +123,24 @@ def get_bump_commit(file_path, base_ref):
             ["git", "log", f"{base_ref}..HEAD", "--pretty=%H %s", "--", file_path],
             stderr=subprocess.DEVNULL,
         ).decode("utf-8")
-        fallback_commit = None
         for line in output.splitlines():
             parts = line.split(" ", 1)
             if len(parts) < 2:
                 continue
             commit_hash, msg = parts
-            if fallback_commit is None:
-                fallback_commit = commit_hash
             if RE_COMMIT_FEAT.match(msg) or RE_COMMIT_FIX.match(msg) or RE_COMMIT_BREAKING.search(msg):
                 return commit_hash
-        return fallback_commit
+    except Exception:
+        pass
+    return None
+
+def get_latest_commit(file_path, base_ref):
+    try:
+        output = subprocess.check_output(
+            ["git", "log", f"{base_ref}..HEAD", "-1", "--pretty=%H", "--", file_path],
+            stderr=subprocess.DEVNULL,
+        ).decode("utf-8").strip()
+        return output or None
     except Exception:
         pass
     return None
@@ -379,6 +386,7 @@ def analyze_features(FEATURES_DIR, feature_meta_map, base_ref, only_changed=Fals
         all_commits = []
         bump_commit = None
         bump_author = None
+        any_commit = None
         for status, f in changes:
             commits = get_commits_for_file(f, base_ref)
             all_commits.extend(commits)
@@ -386,6 +394,11 @@ def analyze_features(FEATURES_DIR, feature_meta_map, base_ref, only_changed=Fals
                 bump_commit = get_bump_commit(f, base_ref)
                 if bump_commit:
                     bump_author = get_commit_author(bump_commit)
+            if not any_commit:
+                any_commit = get_latest_commit(f, base_ref)
+        if not bump_commit and any_commit:
+            bump_commit = any_commit
+            bump_author = get_commit_author(any_commit)
 
         proposed_ver = propose_new_version(prior_ver, all_commits) if ini_path else None
         needs_bump = (proposed_ver is not None and new_ver is not None and proposed_ver > new_ver)


### PR DESCRIPTION
Removing perf and refactor from audit bumping. This means we have to be careful those don't change any actual apis/features requiring new hlsl files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped version metadata across multiple shader feature configs and normalized line endings.
  * Enhanced version-audit tooling: refined which commit types are considered nonfunctional vs. bump-worthy, tightened rules for triggering version bumps, improved commit parsing, and added fallback logic to derive a version bump from the latest change when an explicit bump commit isn’t found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->