### PR TITLE
ci: remove v2022 from shader jobs

### DIFF
--- a/.github/actions/prepare-shaders/action.yml
+++ b/.github/actions/prepare-shaders/action.yml
@@ -1,14 +1,20 @@
 name: "Prepare Shaders"
 description: "Prepare shaders for validation or analysis (requires setup-build-environment to be called first)"
 
+inputs:
+    cmake-preset:
+        description: "The CMake configure/build preset to use (e.g. ALL, ALL-VS2022)."
+        required: false
+        default: "ALL"
+
 runs:
     using: "composite"
     steps:
         - name: Prepare shaders
           uses: lukka/run-cmake@v10
           with:
-              configurePreset: ALL
-              buildPreset: ALL
+              configurePreset: ${{ inputs.cmake-preset }}
+              buildPreset: ${{ inputs.cmake-preset }}
               buildPresetAdditionalArgs: "['--target prepare_shaders']"
 
         - name: Setup Python

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -214,27 +214,18 @@ jobs:
              (github.event_name == 'workflow_dispatch' &&
               github.event.inputs.validate-shaders == 'true') ||
              (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')))
-        name: Validate shader compilation (${{ matrix.compiler.name }}, ${{ matrix.config.name }})
+        name: Validate shader compilation (${{ matrix.config.name }})
         runs-on: windows-2025
         permissions:
             contents: read
         strategy:
             matrix:
-                compiler:
-                    - name: vs2026
-                      vs-version: "2026"
-                      cmake-preset: ALL
-                      build-dir: build/ALL
-                    - name: vs2022
-                      vs-version: "2022"
-                      cmake-preset: ALL-VS2022
-                      build-dir: build/ALL-VS2022
                 config:
                     - name: "Flatrim"
                       file: ".github/configs/shader-validation.yaml"
                     - name: "VR"
                       file: ".github/configs/shader-validation-vr.yaml"
-            fail-fast: false # Let all configs run to completion for full output
+            fail-fast: false # Let both configs run to completion for full output
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -253,10 +244,7 @@ jobs:
               if: steps.check-hlsl.outputs.skip != 'true'
               uses: ./.github/actions/setup-build-environment
               with:
-                  cache-key-suffix: "validation-${{ matrix.compiler.name }}-${{ matrix.config.name }}"
-                  vs-version: ${{ matrix.compiler.vs-version }}
-                  cmake-preset: ${{ matrix.compiler.cmake-preset }}
-                  build-dir: ${{ matrix.compiler.build-dir }}
+                  cache-key-suffix: "validation-${{ matrix.config.name }}"
             - name: Prepare shaders
               if: steps.check-hlsl.outputs.skip != 'true'
               uses: ./.github/actions/prepare-shaders
@@ -298,14 +286,14 @@ jobs:
                     echo "fxc.exe not found - shader validation requires fxc.exe. Set --fxc to a valid path or ensure fxc.exe is in PATH." >&2
                     exit 1
                   fi
-                  hlslkit-compile --fxc "${{ steps.find_fxc.outputs.fxc_path }}" --shader-dir ${{ matrix.compiler.build-dir }}/aio/Shaders --output-dir build/ShaderCache --config ${{ matrix.config.file }} --max-warnings 0 --suppress-warnings X1519
+                  hlslkit-compile --fxc "${{ steps.find_fxc.outputs.fxc_path }}" --shader-dir build/ALL/aio/Shaders --output-dir build/ShaderCache --config ${{ matrix.config.file }} --max-warnings 0 --suppress-warnings X1519
               shell: bash
 
             - name: Upload shader validation logs
               if: failure() && steps.check-hlsl.outputs.skip != 'true'
               uses: actions/upload-artifact@v4
               with:
-                  name: shader-validation-logs-${{ matrix.compiler.name }}-${{ matrix.config.name }}
+                  name: shader-validation-logs-${{ matrix.config.name }}
                   path: |
                       build/ShaderCache/new_issues.log
                       build/ShaderCache/*.log
@@ -313,7 +301,7 @@ jobs:
                   if-no-files-found: ignore
 
     shader-unit-tests:
-        name: Run Shader Unit Tests (${{ matrix.compiler.name }})
+        name: Run Shader Unit Tests
         needs: [check-changes]
         if: >
             always() && !cancelled() &&
@@ -325,18 +313,6 @@ jobs:
         runs-on: windows-2025
         permissions:
             contents: read
-        strategy:
-            matrix:
-                compiler:
-                    - name: vs2026
-                      vs-version: "2026"
-                      cmake-preset: ALL
-                      build-dir: build/ALL
-                    - name: vs2022
-                      vs-version: "2022"
-                      cmake-preset: ALL-VS2022
-                      build-dir: build/ALL-VS2022
-            fail-fast: false
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -355,32 +331,29 @@ jobs:
               if: steps.check-hlsl.outputs.skip != 'true'
               uses: ./.github/actions/setup-build-environment
               with:
-                  cache-key-suffix: "tests-${{ matrix.compiler.name }}"
-                  vs-version: ${{ matrix.compiler.vs-version }}
-                  cmake-preset: ${{ matrix.compiler.cmake-preset }}
-                  build-dir: ${{ matrix.compiler.build-dir }}
+                  cache-key-suffix: "tests"
 
             - name: Build shader tests
               if: steps.check-hlsl.outputs.skip != 'true'
               uses: lukka/run-cmake@v10
               with:
-                  configurePreset: ${{ matrix.compiler.cmake-preset }}
+                  configurePreset: ALL
                   configurePresetAdditionalArgs: "['-DBUILD_SHADER_TESTS=ON']"
-                  buildPreset: ${{ matrix.compiler.cmake-preset }}
+                  buildPreset: ALL
                   buildPresetAdditionalArgs: "['--target shader_tests']"
 
             - name: Run shader unit tests
               if: steps.check-hlsl.outputs.skip != 'true'
               run: |
-                  ctest --test-dir ${{ matrix.compiler.build-dir }} -C Release --output-on-failure -R ShaderTests --timeout 300
+                  ctest --test-dir build/ALL -C Release --output-on-failure -R ShaderTests --timeout 300
 
             - name: Upload test results on failure
               if: failure() && steps.check-hlsl.outputs.skip != 'true'
               uses: actions/upload-artifact@v4
               with:
-                  name: shader-test-results-${{ matrix.compiler.name }}
+                  name: shader-test-results
                   path: |
-                      ${{ matrix.compiler.build-dir }}/Testing/**
+                      build/ALL/Testing/**
                   retention-days: 7
                   if-no-files-found: ignore
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved shader compilation workflow with enhanced configuration flexibility for build preset selection
  * Streamlined CI/CD pipeline by optimizing build validation job configurations to reduce redundancy and improve build efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->