### PR TITLE
feat(IBL): disable-interior-only toggle button

### DIFF
--- a/src/FeatureBuffer.cpp
+++ b/src/FeatureBuffer.cpp
@@ -49,7 +49,7 @@ std::pair<unsigned char*, size_t> GetFeatureBufferData(bool a_inWorld)
 		globals::features::lodBlending.settings,
 		globals::features::hairSpecular.settings,
 		globals::features::terrainVariation.settings,
-		globals::features::ibl.settings,
+		globals::features::ibl.GetCommonBufferData(),
 		globals::features::extendedTranslucency.GetCommonBufferData(),
 		globals::features::linearLighting.GetCommonBufferData(),
 		globals::features::terrainBlending.settings,

--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -85,8 +85,7 @@ void IBL::DrawSettings()
 void IBL::LoadSettings(json& o_json)
 {
 	settings = o_json;
-	if (o_json.contains("DisableInInteriors"))
-		disableInInteriors = o_json["DisableInInteriors"];
+	disableInInteriors = o_json.value("DisableInInteriors", false);
 }
 
 void IBL::SaveSettings(json& o_json)
@@ -181,14 +180,16 @@ IBL::Settings IBL::GetCommonBufferData() const
 
 void IBL::ReflectionsPrepass()
 {
-	if (loaded && !(disableInInteriors && Util::IsInterior())) {
+	if (loaded) {
 		auto context = globals::d3d::context;
+
+		bool interiorDisabled = disableInInteriors && Util::IsInterior();
 
 		// Set PS shader resource
 		{
 			std::array<ID3D11ShaderResourceView*, 4> srvs = {
-				envIBLTexture->srv.get(),
-				skyIBLTexture->srv.get(),
+				interiorDisabled ? nullptr : envIBLTexture->srv.get(),
+				interiorDisabled ? nullptr : skyIBLTexture->srv.get(),
 				staticDiffuseIBLTexture->srv.get(),
 				staticSpecularIBLTexture->srv.get()
 			};

--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -76,7 +76,7 @@ void IBL::DrawSettings()
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text("When Fog Mix is active, rescales the IBL-tinted fog to keep the original fog brightness.\nPrevents fog from becoming too bright or too dark.");
 	}
-	ImGui::Checkbox("Disable in Interiors", &disableInInteriors);
+	ImGui::Checkbox("Disable in interiors", &disableInInteriors);
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text("Disables IBL in interior cells.");
 	}

--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -76,21 +76,29 @@ void IBL::DrawSettings()
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text("When Fog Mix is active, rescales the IBL-tinted fog to keep the original fog brightness.\nPrevents fog from becoming too bright or too dark.");
 	}
+	ImGui::Checkbox("Disable in Interiors", &disableInInteriors);
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text("Disables IBL in interior cells.");
+	}
 }
 
 void IBL::LoadSettings(json& o_json)
 {
 	settings = o_json;
+	if (o_json.contains("DisableInInteriors"))
+		disableInInteriors = o_json["DisableInInteriors"];
 }
 
 void IBL::SaveSettings(json& o_json)
 {
 	o_json = settings;
+	o_json["DisableInInteriors"] = disableInInteriors;
 }
 
 void IBL::RestoreDefaultSettings()
 {
 	settings = {};
+	disableInInteriors = false;
 }
 
 void IBL::RegisterWeatherVariables()
@@ -163,9 +171,17 @@ void IBL::RegisterWeatherVariables()
 		0.0f, 1.0f));
 }
 
+IBL::Settings IBL::GetCommonBufferData() const
+{
+	Settings data = settings;
+	if (disableInInteriors && Util::IsInterior())
+		data.EnableIBL = 0;
+	return data;
+}
+
 void IBL::ReflectionsPrepass()
 {
-	if (loaded) {
+	if (loaded && !(disableInInteriors && Util::IsInterior())) {
 		auto context = globals::d3d::context;
 
 		// Set PS shader resource
@@ -183,6 +199,9 @@ void IBL::ReflectionsPrepass()
 
 void IBL::Prepass()
 {
+	if (disableInInteriors && Util::IsInterior())
+		return;
+
 	auto context = globals::d3d::context;
 	auto state = globals::state;
 

--- a/src/Features/IBL.h
+++ b/src/Features/IBL.h
@@ -41,6 +41,8 @@ public:
 	virtual void SetupResources() override;
 	virtual void ClearShaderCache() override;
 
+	bool disableInInteriors = false;
+
 	struct Settings
 	{
 		uint EnableIBL = 0;
@@ -60,5 +62,6 @@ public:
 	eastl::unique_ptr<Texture2D> staticDiffuseIBLTexture = nullptr;
 	eastl::unique_ptr<Texture2D> staticSpecularIBLTexture = nullptr;
 
+	Settings GetCommonBufferData() const;
 	ID3D11ComputeShader* GetDiffuseIBLCS();
 };


### PR DESCRIPTION
Adds a button under IBL to toggle it inside interiors easily.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Disable in Interiors" setting for Image-Based Lighting (IBL); when enabled, IBL is automatically turned off inside interior locations.
  * Setting is exposed in the UI, persists to configuration, and defaults to off.
  * When active, IBL rendering and related passes (textures/compute) are skipped in interiors, changing lighting and performance there.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->