### PR TITLE
fix: add anti-firefly pass

### DIFF
--- a/package/Shaders/Common/Color.hlsli
+++ b/package/Shaders/Common/Color.hlsli
@@ -115,6 +115,20 @@ namespace Color
 		return pow(abs(color), 1.0 / 2.2);
 	}
 
+	// Luminance-weighted average of four HDR colors.
+	// Each input is weighted by rcp(1 + luminance) so isolated bright outliers
+	// (fireflies) contribute far less than their neighbors.
+	// Technique: Brian Karis, "Real Shading in Unreal Engine 4", SIGGRAPH 2013, p.10
+	// https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf
+	float3 KarisWeightedAverage(float3 a, float3 b, float3 c, float3 d)
+	{
+		float wa = rcp(1.0 + RGBToLuminance(a));
+		float wb = rcp(1.0 + RGBToLuminance(b));
+		float wc = rcp(1.0 + RGBToLuminance(c));
+		float wd = rcp(1.0 + RGBToLuminance(d));
+		return (a * wa + b * wb + c * wc + d * wd) / (wa + wb + wc + wd);
+	}
+
 #if defined(PSHADER) || defined(CSHADER) || defined(COMPUTESHADER)
 	// Attempt to match vanilla materials that are darker than PBR
 	const static float PBRLightingScale = ENABLE_LL ? 1.0 : 0.65;

--- a/package/Shaders/ISBlur.hlsl
+++ b/package/Shaders/ISBlur.hlsl
@@ -33,19 +33,6 @@ float4 GetImageColor(float2 texCoord, float blurScale)
 #	if defined(BRIGHTPASS)
 static const float kBrightPassSoftKneeRatio = 0.5;
 
-// Karis average: weight each pixel inversely by its luminance so isolated bright outliers
-// (fireflies) are automatically suppressed relative to their local 2x2 neighborhood.
-// Technique: Brian Karis, "Real Shading in Unreal Engine 4", SIGGRAPH 2013, p.10
-// https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf
-float3 KarisWeightedAverage(float3 a, float3 b, float3 c, float3 d)
-{
-	float wa = rcp(1.0 + Color::RGBToLuminance(a));
-	float wb = rcp(1.0 + Color::RGBToLuminance(b));
-	float wc = rcp(1.0 + Color::RGBToLuminance(c));
-	float wd = rcp(1.0 + Color::RGBToLuminance(d));
-	return (a * wa + b * wb + c * wc + d * wd) / (wa + wb + wc + wd);
-}
-
 // Sample a 2x2 neighborhood and Karis-average to suppress isolated HDR outliers.
 float3 SampleKarisFireflySuppress(float2 uv, float2 texelSize)
 {
@@ -53,7 +40,7 @@ float3 SampleKarisFireflySuppress(float2 uv, float2 texelSize)
 	float3 s1 = ImageTex.SampleLevel(ImageSampler, uv + float2(0.5, -0.5) * texelSize, 0).rgb;
 	float3 s2 = ImageTex.SampleLevel(ImageSampler, uv + float2(-0.5, 0.5) * texelSize, 0).rgb;
 	float3 s3 = ImageTex.SampleLevel(ImageSampler, uv + float2(0.5, 0.5) * texelSize, 0).rgb;
-	return KarisWeightedAverage(s0, s1, s2, s3);
+	return Color::KarisWeightedAverage(s0, s1, s2, s3);
 }
 
 float3 ApplyBrightPass(float3 hdrColor)

--- a/package/Shaders/ISBlur.hlsl
+++ b/package/Shaders/ISBlur.hlsl
@@ -1,6 +1,7 @@
 #include "Common/Color.hlsli"
 #include "Common/DummyVSTexCoord.hlsl"
 #include "Common/FrameBuffer.hlsli"
+#include "Common/Math.hlsli"
 
 typedef VS_OUTPUT PS_INPUT;
 
@@ -29,6 +30,33 @@ float4 GetImageColor(float2 texCoord, float blurScale)
 	return ImageTex.Sample(ImageSampler, texCoord) * float4(blurScale.xxx, 1);
 }
 
+#	if defined(BRIGHTPASS)
+static const float kMinFireflyLuminanceLimit = 4.0;
+static const float kFireflyAvgLuminanceMultiplier = 12.0;
+static const float kBrightPassSoftKneeRatio = 0.5;
+
+float3 ApplyBrightPassPrefilter(float3 hdrColor, float avgLum)
+{
+	float threshold = max(BlurBrightPass.x, 0.0);
+	float scale = max(BlurBrightPass.y, 0.0);
+
+	// Clamp isolated HDR outliers before thresholding to suppress firefly-induced bloom flashes.
+	float luminance = max(Color::RGBToLuminance(hdrColor), EPSILON_DIVISION);
+	float luminanceLimit = max(kMinFireflyLuminanceLimit, avgLum * kFireflyAvgLuminanceMultiplier);
+	hdrColor *= min(1.0, luminanceLimit / luminance);
+
+	// Soft-knee threshold avoids binary bloom popping when highlights hover near threshold.
+	float knee = max(threshold * kBrightPassSoftKneeRatio, EPSILON_DIVISION);
+	float brightness = max(Color::RGBToLuminance(hdrColor), EPSILON_DIVISION);
+	float soft = saturate((brightness - threshold + knee) / max(2.0 * knee, EPSILON_DIVISION));
+	soft = soft * soft * (3.0 - 2.0 * soft);
+	float contribution = max(brightness - threshold, 0.0) + soft * knee;
+	float weight = contribution / brightness;
+
+	return hdrColor * weight * scale;
+}
+#	endif
+
 PS_OUTPUT main(PS_INPUT input)
 {
 	PS_OUTPUT psout;
@@ -45,6 +73,10 @@ PS_OUTPUT main(PS_INPUT input)
 	blurScale = 1;
 #	endif
 
+#	if defined(BRIGHTPASS)
+	float avgLum = Color::RGBToLuminance(AvgLumTex.Sample(AvgLumSampler, input.TexCoord.xy).xyz);
+#	endif
+
 	for (int blurIndex = 0; blurIndex < blurRadius; ++blurIndex) {
 		float2 screenPosition = BlurOffsets[blurIndex].xy + input.TexCoord.xy;
 		float4 imageColor = 0;
@@ -57,13 +89,12 @@ PS_OUTPUT main(PS_INPUT input)
 			imageColor = GetImageColor(screenPosition, blurScale.y);
 		}
 #	if defined(BRIGHTPASS)
-		imageColor = BlurBrightPass.y * max(0, -BlurBrightPass.x + imageColor);
+		imageColor.rgb = ApplyBrightPassPrefilter(imageColor.rgb, avgLum);
 #	endif
 		color += imageColor * BlurOffsets[blurIndex].z;
 	}
 
 #	if defined(BRIGHTPASS)
-	float avgLum = Color::RGBToLuminance(AvgLumTex.Sample(AvgLumSampler, input.TexCoord.xy).xyz);
 	color.w = avgLum;
 #	endif
 

--- a/package/Shaders/ISBlur.hlsl
+++ b/package/Shaders/ISBlur.hlsl
@@ -31,19 +31,35 @@ float4 GetImageColor(float2 texCoord, float blurScale)
 }
 
 #	if defined(BRIGHTPASS)
-static const float kMinFireflyLuminanceLimit = 4.0;
-static const float kFireflyAvgLuminanceMultiplier = 12.0;
 static const float kBrightPassSoftKneeRatio = 0.5;
 
-float3 ApplyBrightPassPrefilter(float3 hdrColor, float avgLum)
+// Karis average: weight each pixel inversely by its luminance so isolated bright outliers
+// (fireflies) are automatically suppressed relative to their local 2x2 neighborhood.
+// Technique: Brian Karis, "Real Shading in Unreal Engine 4", SIGGRAPH 2013, p.10
+// https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf
+float3 KarisWeightedAverage(float3 a, float3 b, float3 c, float3 d)
+{
+	float wa = rcp(1.0 + Color::RGBToLuminance(a));
+	float wb = rcp(1.0 + Color::RGBToLuminance(b));
+	float wc = rcp(1.0 + Color::RGBToLuminance(c));
+	float wd = rcp(1.0 + Color::RGBToLuminance(d));
+	return (a * wa + b * wb + c * wc + d * wd) / (wa + wb + wc + wd);
+}
+
+// Sample a 2x2 neighborhood and Karis-average to suppress isolated HDR outliers.
+float3 SampleKarisFireflySuppress(float2 uv, float2 texelSize)
+{
+	float3 s0 = ImageTex.SampleLevel(ImageSampler, uv + float2(-0.5, -0.5) * texelSize, 0).rgb;
+	float3 s1 = ImageTex.SampleLevel(ImageSampler, uv + float2(0.5, -0.5) * texelSize, 0).rgb;
+	float3 s2 = ImageTex.SampleLevel(ImageSampler, uv + float2(-0.5, 0.5) * texelSize, 0).rgb;
+	float3 s3 = ImageTex.SampleLevel(ImageSampler, uv + float2(0.5, 0.5) * texelSize, 0).rgb;
+	return KarisWeightedAverage(s0, s1, s2, s3);
+}
+
+float3 ApplyBrightPass(float3 hdrColor)
 {
 	float threshold = max(BlurBrightPass.x, 0.0);
 	float scale = max(BlurBrightPass.y, 0.0);
-
-	// Clamp isolated HDR outliers before thresholding to suppress firefly-induced bloom flashes.
-	float luminance = max(Color::RGBToLuminance(hdrColor), EPSILON_DIVISION);
-	float luminanceLimit = max(kMinFireflyLuminanceLimit, avgLum * kFireflyAvgLuminanceMultiplier);
-	hdrColor *= min(1.0, luminanceLimit / luminance);
 
 	// Soft-knee threshold avoids binary bloom popping when highlights hover near threshold.
 	float knee = max(threshold * kBrightPassSoftKneeRatio, EPSILON_DIVISION);
@@ -75,11 +91,20 @@ PS_OUTPUT main(PS_INPUT input)
 
 #	if defined(BRIGHTPASS)
 	float avgLum = Color::RGBToLuminance(AvgLumTex.Sample(AvgLumSampler, input.TexCoord.xy).xyz);
+	uint imgWidth, imgHeight;
+	ImageTex.GetDimensions(imgWidth, imgHeight);
+	float2 texelSize = rcp(float2(imgWidth, imgHeight));
 #	endif
 
 	for (int blurIndex = 0; blurIndex < blurRadius; ++blurIndex) {
 		float2 screenPosition = BlurOffsets[blurIndex].xy + input.TexCoord.xy;
 		float4 imageColor = 0;
+#	if defined(BRIGHTPASS)
+		{
+			float2 sampleUV = (BlurScale.x < 0.5) ? FrameBuffer::GetDynamicResolutionAdjustedScreenPosition(screenPosition) : screenPosition;
+			imageColor.rgb = ApplyBrightPass(SampleKarisFireflySuppress(sampleUV, texelSize));
+		}
+#	else
 		[branch] if (BlurScale.x < 0.5)
 		{
 			imageColor = GetImageColor(FrameBuffer::GetDynamicResolutionAdjustedScreenPosition(screenPosition), blurScale.y);
@@ -88,8 +113,6 @@ PS_OUTPUT main(PS_INPUT input)
 		{
 			imageColor = GetImageColor(screenPosition, blurScale.y);
 		}
-#	if defined(BRIGHTPASS)
-		imageColor.rgb = ApplyBrightPassPrefilter(imageColor.rgb, avgLum);
 #	endif
 		color += imageColor * BlurOffsets[blurIndex].z;
 	}

--- a/package/Shaders/Tests/TestColor.hlsl
+++ b/package/Shaders/Tests/TestColor.hlsl
@@ -88,9 +88,44 @@
 	ASSERT(IsTrue, overSat.b >= 0.0f);
 }
 
-	/// @tags color, gamma, colorspace
-	[numthreads(1, 1, 1)] void TestGammaConversionRoundtrip()
+	/// @tags color, bloom, firefly
+	[numthreads(1, 1, 1)] void TestKarisWeightedAverage()
 {
+	// Test 1: Identical inputs should return that same value (weights cancel)
+	float3 gray = float3(0.3, 0.3, 0.3);
+	float3 result = Color::KarisWeightedAverage(gray, gray, gray, gray);
+	ASSERT(IsTrue, abs(result.r - gray.r) < 0.001f);
+	ASSERT(IsTrue, abs(result.g - gray.g) < 0.001f);
+	ASSERT(IsTrue, abs(result.b - gray.b) < 0.001f);
+
+	// Test 2: One extreme firefly among three dark neighbors.
+	// The average should stay close to the dark neighbors, not blow up.
+	float3 dark = float3(0.1, 0.1, 0.1);
+	float3 firefly = float3(100.0, 100.0, 100.0);
+	float3 mixed = Color::KarisWeightedAverage(dark, dark, dark, firefly);
+	// Result should be much closer to dark than to firefly
+	ASSERT(IsTrue, Color::RGBToLuminance(mixed) < 1.0f);
+
+	// Test 3: Two bright, two dark - result should sit between them
+	float3 bright = float3(5.0, 5.0, 5.0);
+	float3 between = Color::KarisWeightedAverage(dark, dark, bright, bright);
+	float betweenLum = Color::RGBToLuminance(between);
+	ASSERT(IsTrue, betweenLum > Color::RGBToLuminance(dark));
+	ASSERT(IsTrue, betweenLum < Color::RGBToLuminance(bright));
+
+	// Test 4: Output should never exceed the maximum input luminance
+	float3 a = float3(0.2, 0.5, 0.1);
+	float3 b = float3(0.8, 0.3, 0.4);
+	float3 c = float3(0.1, 0.9, 0.2);
+	float3 d = float3(0.6, 0.1, 0.7);
+	float maxInputLum = max(max(Color::RGBToLuminance(a), Color::RGBToLuminance(b)),
+		max(Color::RGBToLuminance(c), Color::RGBToLuminance(d)));
+	float3 avg = Color::KarisWeightedAverage(a, b, c, d);
+	ASSERT(IsTrue, Color::RGBToLuminance(avg) <= maxInputLum + 0.001f);
+}
+
+/// @tags color, gamma, colorspace
+[numthreads(1, 1, 1)] void TestGammaConversionRoundtrip() {
 	float3 testColors[3] = {
 		float3(0.5, 0.5, 0.5),
 		float3(0.2, 0.7, 0.3),
@@ -118,8 +153,9 @@
 	}
 }
 
-/// @tags color, luminance
-[numthreads(1, 1, 1)] void TestRGBToLuminanceVariants() {
+	/// @tags color, luminance
+	[numthreads(1, 1, 1)] void TestRGBToLuminanceVariants()
+{
 	float3 testColor = float3(0.6, 0.4, 0.3);
 
 	float lum1 = Color::RGBToLuminance(testColor);
@@ -134,9 +170,8 @@
 	ASSERT(IsTrue, abs(lum1 - lum3) < 0.2f);
 }
 
-	/// @tags color, lighting
-	[numthreads(1, 1, 1)] void TestDiffuseAndLight()
-{
+/// @tags color, lighting
+[numthreads(1, 1, 1)] void TestDiffuseAndLight() {
 	float3 color = float3(0.5, 0.3, 0.7);
 
 	float3 diffuse = Color::Diffuse(color);


### PR DESCRIPTION
Meant to address this issue:

<img width="513" height="405" alt="image" src="https://github.com/user-attachments/assets/60e29330-42b2-4f86-a1e2-1caf6834286a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Further reduced extreme bright-pixel "fireflies" in bloom for cleaner highlights.
  * Softer, more natural bright-pass using luminance-aware soft-knee shaping.
  * Improved blur sampling for higher-quality bloom in high-contrast scenes and at small blur scales/dynamic resolution.
  * Minor performance stabilization by avoiding redundant luminance work during blur.

* **Tests**
  * Replaced/updated color tests to validate the new weighted-average suppression behavior and related luminance bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->