### PR TITLE
fix(emat): detect bad format textures

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1085,8 +1085,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		if defined(ENVMAP) || defined(MULTI_LAYER_PARALLAX) || defined(EYE)
 	float4 envMaskSample = TexEnvMaskSampler.Sample(SampEnvMaskSampler, uv);
 	float envMaskBase = envMaskSample.x;
-	if (SharedData::extendedMaterialSettings.EnableComplexMaterial)
-	{
+	if (SharedData::extendedMaterialSettings.EnableComplexMaterial) {
 		const float kMaskEpsilon = (4.0 / 255.0);
 
 		complexMaterial = envMaskSample.w < (1.0 - kMaskEpsilon);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1085,7 +1085,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 #		if defined(EMAT_ENVMAP)
 
-		if (SharedData::extendedMaterialSettings.EnableComplexMaterial)
+	if (SharedData::extendedMaterialSettings.EnableComplexMaterial)
 	{
 		const float kMaskEpsilon = (4.0 / 255.0);
 
@@ -1114,7 +1114,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 			envMaskBase = envMaskSample.x;
 		}
 	}
-
+#		elif defined(ENVMAP)
+	envMaskBase = TexEnvMaskSampler.Sample(SampEnvMaskSampler, uv).x;
 #		endif  // ENVMAP
 
 #		if defined(TRUE_PBR) && !defined(LANDSCAPE) && !defined(LODLANDSCAPE)

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1086,7 +1086,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float envMask
 #		if defined(EMAT_ENVMAP)
 
-	if (SharedData::extendedMaterialSettings.EnableComplexMaterial) {
+		if (SharedData::extendedMaterialSettings.EnableComplexMaterial)
+	{
 		const float kMaskEpsilon = (4.0 / 255.0);
 
 		float4 envMaskSample = TexEnvMaskSampler.Sample(SampEnvMaskSampler, uv);
@@ -1099,7 +1100,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 			complexMaterial = false;
 
 		if (complexMaterial) {
-    		if (envMaskSample.w > kMaskEpsilon) {
+			if (envMaskSample.w > kMaskEpsilon) {
 				complexMaterialParallax = true;
 				mipLevel = ExtendedMaterials::GetMipLevel(uv, TexEnvMaskSampler, screenNoise);
 				uv = ExtendedMaterials::GetParallaxCoords(viewPosition.z, uv, mipLevel, viewDirection, tbnTr, screenNoise, TexEnvMaskSampler, SampTerrainParallaxSampler, 3, displacementParams, pixelOffset);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1086,7 +1086,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	if (SharedData::extendedMaterialSettings.EnableComplexMaterial) {
 		float4 envMaskTest = TexEnvMaskSampler.SampleLevel(SampEnvMaskSampler, uv, 15);
 		complexMaterial = envMaskTest.w < (1.0 - (4.0 / 255.0));
-		
+
 		// Detect textures which have been saved in the wrong format
 		if (abs(envMaskTest.x - envMaskTest.y) < (4.0 / 255.0) && abs(envMaskTest.x - envMaskTest.z) < (4.0 / 255.0) && abs(envMaskTest.y - envMaskTest.z) < (4.0 / 255.0))
 			complexMaterial = false;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1084,8 +1084,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 #		if defined(ENVMAP) || defined(MULTI_LAYER_PARALLAX) || defined(EYE)
 	float envMaskBase = 1.0;
-	if (SharedData::extendedMaterialSettings.EnableComplexMaterial)
-	{
+	if (SharedData::extendedMaterialSettings.EnableComplexMaterial) {
 		const float kMaskEpsilon = (4.0 / 255.0);
 
 		float4 envMaskSample = TexEnvMaskSampler.Sample(SampEnvMaskSampler, uv);
@@ -1110,7 +1109,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 			}
 			envMaskBase = complexMaterialColor.x;
 		} else {
-			envMaskBase = envMaskSample.x; 
+			envMaskBase = envMaskSample.x;
 		}
 	}
 #		endif  // ENVMAP

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1083,7 +1083,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	float envMaskBase = 1.0;
 
-	float envMask
 #		if defined(EMAT_ENVMAP)
 
 	if (SharedData::extendedMaterialSettings.EnableComplexMaterial) {

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1084,15 +1084,19 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		if defined(EMAT_ENVMAP)
 
 	if (SharedData::extendedMaterialSettings.EnableComplexMaterial) {
-		float4 envMaskTest = TexEnvMaskSampler.SampleLevel(SampEnvMaskSampler, uv, 15);
-		complexMaterial = envMaskTest.w < (1.0 - (4.0 / 255.0));
-		
-		// Detect textures which have been saved in the wrong format
-		if (abs(envMaskTest.x - envMaskTest.y) < (4.0 / 255.0) && abs(envMaskTest.x - envMaskTest.z) < (4.0 / 255.0) && abs(envMaskTest.y - envMaskTest.z) < (4.0 / 255.0))
+		const float kMaskEpsilon = (4.0 / 255.0);
+
+		float4 envMask = TexEnvMaskSampler.SampleBias(SampEnvMaskSampler, uv, SharedData:MipBias);
+		complexMaterial = envMask.w < (1.0 - kMaskEpsilon);
+
+		// Detect texture saved in the wrong format
+		if ((abs(envMask.x - envMask.y) < kMaskEpsilon) &&
+			(abs(envMask.x - envMask.z) < kMaskEpsilon) &&
+			(abs(envMask.y - envMask.z) < kMaskEpsilon))
 			complexMaterial = false;
 
 		if (complexMaterial) {
-			if (envMaskTest.w > (4.0 / 255.0)) {
+    		if (envMask.w > kMaskEpsilon) {
 				complexMaterialParallax = true;
 				mipLevel = ExtendedMaterials::GetMipLevel(uv, TexEnvMaskSampler, screenNoise);
 				uv = ExtendedMaterials::GetParallaxCoords(viewPosition.z, uv, mipLevel, viewDirection, tbnTr, screenNoise, TexEnvMaskSampler, SampTerrainParallaxSampler, 3, displacementParams, pixelOffset);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1083,12 +1083,12 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float4 complexMaterialColor = 1.0;
 
 #		if defined(ENVMAP) || defined(MULTI_LAYER_PARALLAX) || defined(EYE)
-	float envMaskBase = 1.0;
+	float4 envMaskSample = TexEnvMaskSampler.Sample(SampEnvMaskSampler, uv);
+	float envMaskBase = envMaskSample.x;
 	if (SharedData::extendedMaterialSettings.EnableComplexMaterial)
 	{
 		const float kMaskEpsilon = (4.0 / 255.0);
 
-		float4 envMaskSample = TexEnvMaskSampler.Sample(SampEnvMaskSampler, uv);
 		complexMaterial = envMaskSample.w < (1.0 - kMaskEpsilon);
 
 		// Detect texture saved in the wrong format
@@ -1109,8 +1109,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 				complexMaterialColor = envMaskSample;
 			}
 			envMaskBase = complexMaterialColor.x;
-		} else {
-			envMaskBase = envMaskSample.x; 
 		}
 	}
 #		endif  // ENVMAP

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1067,6 +1067,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float3 refractedViewDirection = viewDirection;
 	float4 sampledCoatColor = PBRParams2;
 	float3 complexSpecular = 1.0;  // Declare complexSpecular at a higher scope so it's available throughout the shader (NEEDED FOR STOCH. FIX)
+
 #	if defined(EMAT)
 #		if defined(PARALLAX)
 	if (SharedData::extendedMaterialSettings.EnableParallax) {
@@ -1081,8 +1082,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	bool complexMaterialParallax = false;
 	float4 complexMaterialColor = 1.0;
 
+#		if defined(ENVMAP) || defined(MULTI_LAYER_PARALLAX) || defined(EYE)
 	float envMaskBase = 1.0;
-#		if defined(EMAT_ENVMAP)
 	if (SharedData::extendedMaterialSettings.EnableComplexMaterial)
 	{
 		const float kMaskEpsilon = (4.0 / 255.0);
@@ -1112,8 +1113,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 			envMaskBase = envMaskSample.x;
 		}
 	}
-#		elif defined(ENVMAP)
-	envMaskBase = TexEnvMaskSampler.Sample(SampEnvMaskSampler, uv).x;
 #		endif  // ENVMAP
 
 #		if defined(TRUE_PBR) && !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
@@ -1156,6 +1155,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	}
 #		endif  // TRUE_PBR
 
+#	elif defined(ENVMAP) || defined(MULTI_LAYER_PARALLAX) || defined(EYE)
+	float envMaskBase = TexEnvMaskSampler.Sample(SampEnvMaskSampler, uv).x;
 #	endif  // EMAT
 
 #	if defined(SNOW)

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1110,7 +1110,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 			}
 			envMaskBase = complexMaterialColor.x;
 		} else {
-			envMaskBase = envMaskSample.x;
+			envMaskBase = envMaskSample.x; 
 		}
 	}
 #		endif  // ENVMAP

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1082,9 +1082,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float4 complexMaterialColor = 1.0;
 
 	float envMaskBase = 1.0;
-
 #		if defined(EMAT_ENVMAP)
-
 	if (SharedData::extendedMaterialSettings.EnableComplexMaterial)
 	{
 		const float kMaskEpsilon = (4.0 / 255.0);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1081,30 +1081,37 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	bool complexMaterialParallax = false;
 	float4 complexMaterialColor = 1.0;
 
+	float envMaskBase = 1.0;
+
+	float envMask
 #		if defined(EMAT_ENVMAP)
 
 	if (SharedData::extendedMaterialSettings.EnableComplexMaterial) {
 		const float kMaskEpsilon = (4.0 / 255.0);
 
-		float4 envMask = TexEnvMaskSampler.SampleBias(SampEnvMaskSampler, uv, SharedData:MipBias);
-		complexMaterial = envMask.w < (1.0 - kMaskEpsilon);
+		float4 envMaskSample = TexEnvMaskSampler.Sample(SampEnvMaskSampler, uv);
+		complexMaterial = envMaskSample.w < (1.0 - kMaskEpsilon);
 
 		// Detect texture saved in the wrong format
-		if ((abs(envMask.x - envMask.y) < kMaskEpsilon) &&
-			(abs(envMask.x - envMask.z) < kMaskEpsilon) &&
-			(abs(envMask.y - envMask.z) < kMaskEpsilon))
+		if ((abs(envMaskSample.x - envMaskSample.y) < kMaskEpsilon) &&
+			(abs(envMaskSample.x - envMaskSample.z) < kMaskEpsilon) &&
+			(abs(envMaskSample.y - envMaskSample.z) < kMaskEpsilon))
 			complexMaterial = false;
 
 		if (complexMaterial) {
-    		if (envMask.w > kMaskEpsilon) {
+    		if (envMaskSample.w > kMaskEpsilon) {
 				complexMaterialParallax = true;
 				mipLevel = ExtendedMaterials::GetMipLevel(uv, TexEnvMaskSampler, screenNoise);
 				uv = ExtendedMaterials::GetParallaxCoords(viewPosition.z, uv, mipLevel, viewDirection, tbnTr, screenNoise, TexEnvMaskSampler, SampTerrainParallaxSampler, 3, displacementParams, pixelOffset);
 				if (SharedData::extendedMaterialSettings.EnableShadows && (parallaxShadowQuality > 0.0f || SharedData::extendedMaterialSettings.ExtendShadows))
 					sh0 = TexEnvMaskSampler.SampleLevel(SampEnvMaskSampler, uv, mipLevel).w;
+				complexMaterialColor = TexEnvMaskSampler.Sample(SampEnvMaskSampler, uv);
+			} else {
+				complexMaterialColor = envMaskSample;
 			}
-
-			complexMaterialColor = TexEnvMaskSampler.Sample(SampEnvMaskSampler, uv);
+			envMaskBase = complexMaterialColor.x;
+		} else {
+			envMaskBase = envMaskSample.x;
 		}
 	}
 
@@ -2220,7 +2227,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	if (envMask > 0.0) {
 		if (EnvmapData.y) {
-			envMask *= TexEnvMaskSampler.Sample(SampEnvMaskSampler, uv).x;
+			envMask *= envMaskBase;
 		} else {
 			envMask *= glossiness;
 		}

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1084,11 +1084,15 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #		if defined(EMAT_ENVMAP)
 
 	if (SharedData::extendedMaterialSettings.EnableComplexMaterial) {
-		float envMaskTest = TexEnvMaskSampler.SampleLevel(SampEnvMaskSampler, uv, 15).w;
-		complexMaterial = envMaskTest < (1.0 - (4.0 / 255.0));
+		float4 envMaskTest = TexEnvMaskSampler.SampleLevel(SampEnvMaskSampler, uv, 15);
+		complexMaterial = envMaskTest.w < (1.0 - (4.0 / 255.0));
+		
+		// Detect textures which have been saved in the wrong format
+		if (abs(envMaskTest.x - envMaskTest.y) < (4.0 / 255.0) && abs(envMaskTest.x - envMaskTest.z) < (4.0 / 255.0) && abs(envMaskTest.y - envMaskTest.z) < (4.0 / 255.0))
+			complexMaterial = false;
 
 		if (complexMaterial) {
-			if (envMaskTest > (4.0 / 255.0)) {
+			if (envMaskTest.w > (4.0 / 255.0)) {
 				complexMaterialParallax = true;
 				mipLevel = ExtendedMaterials::GetMipLevel(uv, TexEnvMaskSampler, screenNoise);
 				uv = ExtendedMaterials::GetParallaxCoords(viewPosition.z, uv, mipLevel, viewDirection, tbnTr, screenNoise, TexEnvMaskSampler, SampTerrainParallaxSampler, 3, displacementParams, pixelOffset);


### PR DESCRIPTION
Detects _m textures which have been saved with multiple channels. Ignores the w channel in detection because sometimes transparency is baked into it.
The math is a bit messy because due to compression the channels are not truly the same.

bugged
<img width="2560" height="1440" alt="ScreenShot27" src="https://github.com/user-attachments/assets/0ed7a6db-bcc6-4404-a330-67c2914cbbce" />

fixed
<img width="2560" height="1440" alt="ScreenShot28" src="https://github.com/user-attachments/assets/51bc2498-e8af-4e35-918b-c85fbf01d441" />


Fixes https://github.com/doodlum/skyrim-community-shaders/issues/1969

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened envmap handling to apply to additional material modes for more consistent reflections.
  * Replaced mip-based mask test with a direct env mask sample and added a guard against improperly formatted env mask textures.
  * Ensured parallax, shadow/mip, and UV selection use the corrected env mask test.
  * Split complex-material color sampling so parallax-updated UVs are sampled correctly.
  * Unified env-mask base sampling and modulation to avoid redundant lookups and visual inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->