### PR TITLE
refactor(ibl): move DisableInInteriors to settings

### DIFF
--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -197,7 +197,8 @@ namespace SharedData
 		float SkyIBLSaturation;
 		float FogAmount;
 		uint DALCMode;  // 0: Luminance Ratio, 1: Color Ratio, 2: DALC + Sky
-		float2 pad0;
+		uint DisableInInteriors;
+		float pad0;
 	};
 
 	struct ExtendedTranslucencySettings

--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -20,7 +20,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	EnvIBLSaturation,
 	SkyIBLSaturation,
 	FogAmount,
-	DALCMode)
+	DALCMode,
+	DisableInInteriors)
 
 void IBL::DrawSettings()
 {
@@ -76,7 +77,7 @@ void IBL::DrawSettings()
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text("When Fog Mix is active, rescales the IBL-tinted fog to keep the original fog brightness.\nPrevents fog from becoming too bright or too dark.");
 	}
-	ImGui::Checkbox("Disable in interiors", &disableInInteriors);
+	ImGui::Checkbox("Disable in interiors", (bool*)&settings.DisableInInteriors);
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text("Disables IBL in interior cells.");
 	}
@@ -85,19 +86,16 @@ void IBL::DrawSettings()
 void IBL::LoadSettings(json& o_json)
 {
 	settings = o_json;
-	disableInInteriors = o_json.value("DisableInInteriors", false);
 }
 
 void IBL::SaveSettings(json& o_json)
 {
 	o_json = settings;
-	o_json["DisableInInteriors"] = disableInInteriors;
 }
 
 void IBL::RestoreDefaultSettings()
 {
 	settings = {};
-	disableInInteriors = false;
 }
 
 void IBL::RegisterWeatherVariables()
@@ -173,7 +171,7 @@ void IBL::RegisterWeatherVariables()
 IBL::Settings IBL::GetCommonBufferData() const
 {
 	Settings data = settings;
-	if (disableInInteriors && Util::IsInterior())
+	if (settings.DisableInInteriors && Util::IsInterior())
 		data.EnableIBL = 0;
 	return data;
 }
@@ -183,7 +181,7 @@ void IBL::ReflectionsPrepass()
 	if (loaded) {
 		auto context = globals::d3d::context;
 
-		bool interiorDisabled = disableInInteriors && Util::IsInterior();
+		bool interiorDisabled = settings.DisableInInteriors && Util::IsInterior();
 
 		// Set PS shader resource
 		{
@@ -200,7 +198,7 @@ void IBL::ReflectionsPrepass()
 
 void IBL::Prepass()
 {
-	if (disableInInteriors && Util::IsInterior())
+	if (settings.DisableInInteriors && Util::IsInterior())
 		return;
 
 	auto context = globals::d3d::context;

--- a/src/Features/IBL.h
+++ b/src/Features/IBL.h
@@ -41,8 +41,6 @@ public:
 	virtual void SetupResources() override;
 	virtual void ClearShaderCache() override;
 
-	bool disableInInteriors = false;
-
 	struct Settings
 	{
 		uint EnableIBL = 0;
@@ -55,7 +53,7 @@ public:
 		float SkyIBLSaturation = 1.0f;
 		float FogAmount = 0.0f;
 		uint DALCMode = 2;  // 0: Luminance Ratio, 1: Color Ratio, 2: DALC + Sky
-		float pad0 = 0.0f;
+		uint DisableInInteriors = 1;
 		float pad1 = 0.0f;
 	} settings;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Disable in Interiors" option for Image-Based Lighting to control rendering in indoor environments

* **Improvements**
  * Enhanced settings integration for Image-Based Lighting controls with improved persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->