### PR TITLE
feat(UI): dim overlapping windows for readability

### DIFF
--- a/src/Menu/OverlayRenderer.cpp
+++ b/src/Menu/OverlayRenderer.cpp
@@ -24,6 +24,94 @@
 #include "Features/PerformanceOverlay/ABTesting/ABTesting.h"
 #include "Features/VR.h"
 
+namespace
+{
+	std::unordered_map<ImGuiID, float> s_windowOverlapAlpha;
+
+	constexpr ImGuiWindowFlags SKIP_WINDOW_FLAGS = ImGuiWindowFlags_Tooltip | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoMove;
+	constexpr const char* MAIN_WINDOW_PREFIX = "Community Shaders";
+
+	bool IsMainWindow(ImGuiWindow* win) { return win->Name && strncmp(win->Name, MAIN_WINDOW_PREFIX, strlen(MAIN_WINDOW_PREFIX)) == 0; }
+
+	bool IsVisibleRootWindow(ImGuiWindow* win)
+	{
+		if (!win || !win->WasActive || win->Hidden)
+			return false;
+		return !(win->ParentWindow && !win->DockIsActive) && !(win->Flags & SKIP_WINDOW_FLAGS);
+	}
+
+	// Patches DrawList background vertices for windows involved in overlap.
+	void PatchOverlappingWindowBackgrounds()
+	{
+		auto* ctx = ImGui::GetCurrentContext();
+		if (!ctx)
+			return;
+
+		using C = ThemeManager::Constants;
+		const float dt = ImGui::GetIO().DeltaTime;
+
+		struct WinInfo
+		{
+			ImGuiWindow* win;
+			ImRect rect;
+		};
+		std::vector<WinInfo> windows;
+		for (int i = 0; i < ctx->Windows.Size; i++) {
+			auto* win = ctx->Windows[i];
+			if (IsVisibleRootWindow(win))
+				windows.push_back({ win, win->Rect() });
+		}
+
+		std::unordered_set<ImGuiID> overlapping;
+		for (size_t i = 0; i < windows.size(); i++)
+			for (size_t j = i + 1; j < windows.size(); j++)
+				if (windows[i].rect.Overlaps(windows[j].rect)) {
+					auto* a = windows[i].win;
+					auto* b = windows[j].win;
+					// Main CS window never dims; other windows yield to it
+					if (IsMainWindow(a))
+						overlapping.insert(b->ID);
+					else if (IsMainWindow(b))
+						overlapping.insert(a->ID);
+					else
+						overlapping.insert(a->FocusOrder > b->FocusOrder ? a->ID : b->ID);
+				}
+
+		const ImU32 bgRGB = ImGui::GetColorU32(ImGuiCol_WindowBg) & ~IM_COL32_A_MASK;
+
+		for (auto& [win, rect] : windows) {
+			const float target = overlapping.count(win->ID) ? C::OVERLAP_MIN_ALPHA : 0.0f;
+			float& alpha = s_windowOverlapAlpha[win->ID];
+			const float speed = (target > alpha) ? C::OVERLAP_FADEIN_SPEED : C::OVERLAP_FADEOUT_SPEED;
+			alpha += (target - alpha) * (std::min)(1.0f, dt * speed);
+
+			if (alpha < C::OVERLAP_ALPHA_EPSILON) {
+				alpha = 0.0f;
+				continue;
+			}
+
+			auto* dl = win->DrawList;
+			if (!dl || dl->VtxBuffer.Size == 0)
+				continue;
+
+			// Clamp background rect vertex alpha (contiguous bgRGB block at start of DrawList)
+			const ImU32 minA = static_cast<ImU32>(alpha * 255.0f);
+			for (int v = 0; v < dl->VtxBuffer.Size; v++) {
+				auto& vtx = dl->VtxBuffer[v];
+				if ((vtx.col & ~IM_COL32_A_MASK) != bgRGB)
+					break;
+				ImU32 a = (vtx.col >> IM_COL32_A_SHIFT) & 0xFF;
+				if (a > 0 && a < minA)
+					vtx.col = bgRGB | (minA << IM_COL32_A_SHIFT);
+			}
+		}
+
+		// Prune stale entries
+		for (auto it = s_windowOverlapAlpha.begin(); it != s_windowOverlapAlpha.end();)
+			it->second < C::OVERLAP_ALPHA_EPSILON ? it = s_windowOverlapAlpha.erase(it) : ++it;
+	}
+}  // namespace
+
 void OverlayRenderer::RenderOverlay(
 	Menu& menu,
 	const std::function<void()>& processInputEventQueue,
@@ -43,6 +131,7 @@ void OverlayRenderer::RenderOverlay(
 		auto& io = ImGui::GetIO();
 		io.ClearInputKeys();
 		io.ClearEventsQueue();
+		s_windowOverlapAlpha.clear();
 		return;
 	}
 
@@ -78,6 +167,7 @@ void OverlayRenderer::RenderOverlay(
 	RenderFeatureOverlays();
 	RenderFirstTimeSetupOverlay();
 	HandleABTesting();
+	PatchOverlappingWindowBackgrounds();
 	FinalizeImGuiFrame();
 }
 

--- a/src/Menu/ThemeManager.h
+++ b/src/Menu/ThemeManager.h
@@ -206,10 +206,10 @@ public:
 		static constexpr float COMBO_SEARCH_PADDING_LEFT = 24.0f;  // Left padding to make room for icon
 
 		// Window overlap readability constants
-		static constexpr float OVERLAP_MIN_ALPHA = 0.85f;        // Background alpha when windows overlap
-		static constexpr float OVERLAP_FADEIN_SPEED = 8.0f;      // Fade-in speed (units/sec)
-		static constexpr float OVERLAP_FADEOUT_SPEED = 4.0f;     // Fade-out speed (units/sec)
-		static constexpr float OVERLAP_ALPHA_EPSILON = 0.005f;   // Below this alpha is clamped to zero
+		static constexpr float OVERLAP_MIN_ALPHA = 0.85f;       // Background alpha when windows overlap
+		static constexpr float OVERLAP_FADEIN_SPEED = 8.0f;     // Fade-in speed (units/sec)
+		static constexpr float OVERLAP_FADEOUT_SPEED = 4.0f;    // Fade-out speed (units/sec)
+		static constexpr float OVERLAP_ALPHA_EPSILON = 0.005f;  // Below this alpha is clamped to zero
 	};
 
 	static ThemeManager* GetSingleton()

--- a/src/Menu/ThemeManager.h
+++ b/src/Menu/ThemeManager.h
@@ -204,6 +204,12 @@ public:
 		static constexpr float COMBO_SEARCH_ICON_ALPHA = 0.5f;     // Icon alpha for subtle appearance
 		static constexpr float COMBO_SEARCH_ICON_OFFSET_X = 5.0f;  // Icon horizontal offset from input edge
 		static constexpr float COMBO_SEARCH_PADDING_LEFT = 24.0f;  // Left padding to make room for icon
+
+		// Window overlap readability constants
+		static constexpr float OVERLAP_MIN_ALPHA = 0.85f;        // Background alpha when windows overlap
+		static constexpr float OVERLAP_FADEIN_SPEED = 8.0f;      // Fade-in speed (units/sec)
+		static constexpr float OVERLAP_FADEOUT_SPEED = 4.0f;     // Fade-out speed (units/sec)
+		static constexpr float OVERLAP_ALPHA_EPSILON = 0.005f;   // Below this alpha is clamped to zero
 	};
 
 	static ThemeManager* GetSingleton()


### PR DESCRIPTION
Low opacity background themes will dim overlapping windows automatically for better readability. 
<img width="3840" height="2160" alt="Skyrim Special Edition 3_31_2026 3_45_09 PM" src="https://github.com/user-attachments/assets/94d66bb1-b058-42e6-af0a-35bcd39f224c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved window overlap visibility and readability. The interface now automatically applies intelligent dimming to overlapping windows with smooth fade-in and fade-out visual transitions. This enhancement significantly reduces visual clutter, improves readability when managing multiple overlapping windows simultaneously, and provides better visual hierarchy to help users navigate complex menu layouts more effectively and intuitively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->