### PR TITLE
docs: update in game links

### DIFF
--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -166,12 +166,17 @@ void HomePageRenderer::RenderQuickLinksSection()
 	}
 
 	ImGui::SameLine();
-	if (ImGui::Button("GitHub Repository", ImVec2(buttonWidth, 0))) {
+	if (ImGui::Button("GitHub", ImVec2(buttonWidth, 0))) {
 		ShellExecuteA(NULL, "open", "https://github.com/doodlum/skyrim-community-shaders", NULL, NULL, SW_SHOWNORMAL);
 	}
 
 	ImGui::SameLine();
-	if (ImGui::Button("GitHub Wiki", ImVec2(buttonWidth, 0))) {
+	if (ImGui::Button("Wiki", ImVec2(buttonWidth, 0))) {
+		ShellExecuteA(NULL, "open", "https://modding.wiki/en/skyrim/developers/community-shaders", NULL, NULL, SW_SHOWNORMAL);
+	}
+
+	ImGui::SameLine();
+	if (ImGui::Button("Developer Wiki", ImVec2(buttonWidth, 0))) {
 		ShellExecuteA(NULL, "open", "https://github.com/doodlum/skyrim-community-shaders/wiki", NULL, NULL, SW_SHOWNORMAL);
 	}
 }
@@ -210,18 +215,8 @@ void HomePageRenderer::RenderFAQSection()
 	if (ImGui::CollapsingHeader("I have \"Failed Shaders\" when compiling?")) {
 		ImGui::TextWrapped(
 			"Failed shaders are usually caused by mixed file versions. Ensure all features are up to date "
-			"and avoid mixing files from test builds or outdated versions.");
-		ImGui::Spacing();
-		ImGui::Text("Remove these outdated pre-1.0 CS features:");
-		ImGui::BulletText("Vanilla HDR");
-		ImGui::BulletText("Tree LOD Lighting");
-		ImGui::BulletText("Complex Parallax Materials");
-		ImGui::BulletText("Water Blending");
-		ImGui::BulletText("Water Caustics");
-		ImGui::BulletText("Water Parallax");
-		ImGui::BulletText("Dynamic Cubemaps");
-		ImGui::Spacing();
-		ImGui::TextWrapped("Note: All of these features are now included in the base Community Shaders install.");
+			"and avoid mixing files from test builds or outdated versions. Please review the 'Feature Issues' tab "
+			"and/or Wiki for more information. Update your features and remove any obsolete features.");
 	}
 
 	if (ImGui::CollapsingHeader("How do I improve performance?")) {


### PR DESCRIPTION
Very minor UI text changes on the home page.

A user on Nexus recently read some outdated information on the GitHub wiki, which is no longer maintained for user support. This PR adds a link to the newer Modding.wiki Wiki. Though fundamentally the issue is probably the fact that the wiki links on the official Nexus page still point to GitHub.

Also changed the FAQ for `Failed Shaders` which is sort of outdated now since the list is larger now. To avoid having to continuously maintain it, I've just made it a generic message which points to where they need to look for information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized Quick Links with simplified GitHub button and separated Wiki navigation into community Wiki and Developer Wiki options.
  * Streamlined FAQ guidance for shader compilation issues, directing users to Feature Issues and Wiki resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->