### PR TITLE
build: add worktree tools

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -12,6 +12,8 @@
 -   **Fast shader deployment:** `cmake --build build/ALL --target COPY_SHADERS`
 -   **Full build with deployment:** `.\BuildRelease.bat ALL-WITH-AUTO-DEPLOYMENT`
 -   **Run tests:** `cmake --build build/ALL --target run_shader_tests`
+-   **Create a worktree with submodules + local preset:** `pwsh ./tools/new-worktree.ps1 -Name my-branch`
+-   **Install optional git alias:** `pwsh ./tools/install-worktree-alias.ps1`
 
 ### Build Presets
 
@@ -20,6 +22,29 @@
 -   `Dev` - Fast iteration preset (recommended for development)
 
 See `CMakePresets.json` for all available presets.
+
+## Worktrees
+
+Use `tools/new-worktree.ps1` when creating a new worktree for development. The script:
+
+-   Creates the worktree under a sibling `<repo>.worktrees/` directory by default
+-   Reuses an existing local branch or creates a new one from `HEAD`
+-   Runs `git submodule update --init --recursive` in the new worktree
+-   Copies `CMakeUserPresets.json` from the main checkout if it exists there
+-   Does not overwrite an existing `CMakeUserPresets.json` unless `-ForcePresetCopy` is passed
+
+Examples:
+
+-   `pwsh ./tools/new-worktree.ps1 -Name reproj_fixes`
+-   `pwsh ./tools/new-worktree.ps1 -Name vr-debug -StartPoint dev`
+-   `pwsh ./tools/new-worktree.ps1 -Name clean-build -NoSubmodules`
+
+If you want a Git-native command, install the optional repo-local alias:
+
+-   `pwsh ./tools/install-worktree-alias.ps1`
+-   Then use `git new-worktree reproj_fixes`
+
+The alias is installed into local Git config by default, so it does not affect other users unless they opt in.
 
 ## Build Targets
 

--- a/tools/install-worktree-alias.ps1
+++ b/tools/install-worktree-alias.ps1
@@ -1,0 +1,34 @@
+param(
+    [switch]$Global
+)
+
+$repoRoot = (git rev-parse --show-toplevel 2>$null).Trim()
+if (-not $repoRoot) {
+    Write-Error "Run this script from within a git checkout or worktree for this repository."
+    exit 1
+}
+
+$scriptPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "new-worktree.ps1"))
+if (-not (Test-Path $scriptPath)) {
+    Write-Error "Worktree helper not found at $scriptPath"
+    exit 1
+}
+
+$configScope = if ($Global) { "--global" } else { "--local" }
+$scriptPathForAlias = $scriptPath -replace '\\', '/'
+$aliasValue = "!powershell.exe -NoProfile -ExecutionPolicy Bypass -File '$scriptPathForAlias' -Name"
+
+git config $configScope alias.new-worktree $aliasValue
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to install git new-worktree alias."
+    exit $LASTEXITCODE
+}
+
+if ($Global) {
+    Write-Host "Installed global alias: git new-worktree"
+}
+else {
+    Write-Host "Installed repo-local alias: git new-worktree"
+}
+
+Write-Host "Usage: git new-worktree <name> [additional new-worktree.ps1 options]"

--- a/tools/install-worktree-alias.ps1
+++ b/tools/install-worktree-alias.ps1
@@ -2,7 +2,7 @@ param(
     [switch]$Global
 )
 
-$repoRoot = (git rev-parse --show-toplevel 2>$null).Trim()
+$repoRoot = ([string](git rev-parse --show-toplevel 2>$null)).Trim()
 if (-not $repoRoot) {
     Write-Error "Run this script from within a git checkout or worktree for this repository."
     exit 1

--- a/tools/new-worktree.ps1
+++ b/tools/new-worktree.ps1
@@ -9,13 +9,13 @@ param(
     [switch]$ForcePresetCopy
 )
 
-$repoRoot = (git rev-parse --show-toplevel 2>$null).Trim()
+$repoRoot = ([string](git rev-parse --show-toplevel 2>$null)).Trim()
 if (-not $repoRoot) {
     Write-Error "Run this script from within a git checkout or worktree for this repository."
     exit 1
 }
 
-$commonDir = (git rev-parse --path-format=absolute --git-common-dir 2>$null).Trim()
+$commonDir = ([string](git rev-parse --path-format=absolute --git-common-dir 2>$null)).Trim()
 if (-not $commonDir) {
     Write-Error "Failed to resolve the repository common git directory."
     exit 1
@@ -70,8 +70,14 @@ $targetPreset = Join-Path $Path "CMakeUserPresets.json"
 
 if (Test-Path $sourcePreset) {
     if ((-not (Test-Path $targetPreset)) -or $ForcePresetCopy) {
-        Copy-Item $sourcePreset $targetPreset -Force
-        Write-Host "Copied CMakeUserPresets.json into the new worktree"
+        try {
+            Copy-Item $sourcePreset $targetPreset -Force -ErrorAction Stop
+            Write-Host "Copied CMakeUserPresets.json into the new worktree"
+        }
+        catch {
+            Write-Error "Failed to copy CMakeUserPresets.json: $($_.Exception.Message)"
+            exit 1
+        }
     }
     else {
         Write-Host "Skipped preset copy because the worktree already has CMakeUserPresets.json"

--- a/tools/new-worktree.ps1
+++ b/tools/new-worktree.ps1
@@ -1,0 +1,84 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+
+    [string]$Branch = $Name,
+    [string]$Path,
+    [string]$StartPoint = "HEAD",
+    [switch]$NoSubmodules,
+    [switch]$ForcePresetCopy
+)
+
+$repoRoot = (git rev-parse --show-toplevel 2>$null).Trim()
+if (-not $repoRoot) {
+    Write-Error "Run this script from within a git checkout or worktree for this repository."
+    exit 1
+}
+
+$commonDir = (git rev-parse --path-format=absolute --git-common-dir 2>$null).Trim()
+if (-not $commonDir) {
+    Write-Error "Failed to resolve the repository common git directory."
+    exit 1
+}
+
+$mainRepoRoot = Split-Path $commonDir -Parent
+$repoName = Split-Path $mainRepoRoot -Leaf
+$defaultWorktreeRoot = Join-Path (Split-Path $mainRepoRoot -Parent) ($repoName + ".worktrees")
+
+if (-not $Path) {
+    $Path = Join-Path $defaultWorktreeRoot $Name
+}
+
+$Path = [System.IO.Path]::GetFullPath($Path)
+$targetParent = Split-Path $Path -Parent
+if (-not (Test-Path $targetParent)) {
+    New-Item -ItemType Directory -Path $targetParent -Force | Out-Null
+}
+
+if (Test-Path $Path) {
+    Write-Error "Target path already exists: $Path"
+    exit 1
+}
+
+& git -C $mainRepoRoot show-ref --verify --quiet "refs/heads/$Branch"
+$branchExists = $LASTEXITCODE -eq 0
+
+if ($branchExists) {
+    Write-Host "Creating worktree for existing branch '$Branch' at $Path"
+    & git -C $mainRepoRoot worktree add $Path $Branch
+}
+else {
+    Write-Host "Creating worktree at $Path with new branch '$Branch' from '$StartPoint'"
+    & git -C $mainRepoRoot worktree add -b $Branch $Path $StartPoint
+}
+
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+if (-not $NoSubmodules) {
+    Write-Host "Initializing submodules in new worktree"
+    & git -C $Path submodule update --init --recursive
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Submodule initialization failed. The worktree was created but may be incomplete."
+        exit $LASTEXITCODE
+    }
+}
+
+$sourcePreset = Join-Path $mainRepoRoot "CMakeUserPresets.json"
+$targetPreset = Join-Path $Path "CMakeUserPresets.json"
+
+if (Test-Path $sourcePreset) {
+    if ((-not (Test-Path $targetPreset)) -or $ForcePresetCopy) {
+        Copy-Item $sourcePreset $targetPreset -Force
+        Write-Host "Copied CMakeUserPresets.json into the new worktree"
+    }
+    else {
+        Write-Host "Skipped preset copy because the worktree already has CMakeUserPresets.json"
+    }
+}
+else {
+    Write-Host "No CMakeUserPresets.json found in the main repo checkout; skipping preset copy"
+}
+
+Write-Host "Worktree ready: $Path"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tools to create and manage Git worktrees from the repo (branch creation/reuse, optional submodule init, conditional config/preset copy, start-point support).
  * Added an installable Git alias for invoking the worktree tool (repo-local or global scope).

* **Documentation**
  * Expanded development guide with a “Worktrees” section, usage examples, and alias installation instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->