### PR TITLE
fix: prevent overflow for home page quick links

### DIFF
--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -134,7 +134,7 @@ void HomePageRenderer::RenderWelcomeSection()
 		}
 	} else {
 		// Fallback button when Discord icon is not available
-		float buttonWidth = QUICK_LINKS_BUTTON_WIDTH * scale;
+		float buttonWidth = DISCORD_BANNER_MIN_WIDTH * scale;
 		ImGui::SetCursorPosX((windowSize.x - buttonWidth) * 0.5f);
 		if (ImGui::Button("Join Discord Server", ImVec2(buttonWidth, 0))) {
 			ShellExecuteA(NULL, "open", DISCORD_URL, NULL, NULL, SW_SHOWNORMAL);

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -155,30 +155,29 @@ void HomePageRenderer::RenderQuickLinksSection()
 	ImGui::SetCursorPosX((windowSize.x - titleSize.x) * 0.5f);
 	ImGui::Text("Quick Links");
 
-	// Center the button layout
-	float buttonWidth = QUICK_LINKS_BUTTON_WIDTH * Util::GetUIScale();
-	float totalWidth = buttonWidth * 3 + ImGui::GetStyle().ItemSpacing.x * 2;  // 3 buttons with spacing
-	ImGui::SetCursorPosX((windowSize.x - totalWidth) * 0.5f);
+	ImGui::Columns(4, nullptr, false);
 
 	// External links in a row
-	if (ImGui::Button("Nexus Mods", ImVec2(buttonWidth, 0))) {
+	if (ImGui::Button("Nexus Mods", ImVec2(-1, 0))) {
 		ShellExecuteA(NULL, "open", "https://www.nexusmods.com/skyrimspecialedition/mods/86492", NULL, NULL, SW_SHOWNORMAL);
 	}
 
-	ImGui::SameLine();
-	if (ImGui::Button("GitHub", ImVec2(buttonWidth, 0))) {
+	ImGui::NextColumn();
+	if (ImGui::Button("GitHub", ImVec2(-1, 0))) {
 		ShellExecuteA(NULL, "open", "https://github.com/doodlum/skyrim-community-shaders", NULL, NULL, SW_SHOWNORMAL);
 	}
 
-	ImGui::SameLine();
-	if (ImGui::Button("Wiki", ImVec2(buttonWidth, 0))) {
+	ImGui::NextColumn();
+	if (ImGui::Button("Wiki", ImVec2(-1, 0))) {
 		ShellExecuteA(NULL, "open", "https://modding.wiki/en/skyrim/developers/community-shaders", NULL, NULL, SW_SHOWNORMAL);
 	}
 
-	ImGui::SameLine();
-	if (ImGui::Button("Developer Wiki", ImVec2(buttonWidth, 0))) {
+	ImGui::NextColumn();
+	if (ImGui::Button("Developer Wiki", ImVec2(-1, 0))) {
 		ShellExecuteA(NULL, "open", "https://github.com/doodlum/skyrim-community-shaders/wiki", NULL, NULL, SW_SHOWNORMAL);
 	}
+
+	ImGui::Columns(1);
 }
 
 void HomePageRenderer::RenderFAQSection()

--- a/src/Menu/HomePageRenderer.h
+++ b/src/Menu/HomePageRenderer.h
@@ -13,7 +13,6 @@ public:
 	static constexpr float HOTKEY_TEXT_SCALE_CAPTURING = 2.0f;
 	static constexpr float HOTKEY_HOVER_DIM_FACTOR = 0.7f;
 	static constexpr float HELP_TEXT_SCALE = 1.35f;
-	static constexpr float QUICK_LINKS_BUTTON_WIDTH = 180.0f;
 	static constexpr float LOGO_WATERMARK_HEIGHT = 156.0f;
 	static constexpr uint8_t MODAL_OVERLAY_ALPHA = 160;
 


### PR DESCRIPTION
Follow up to https://github.com/doodlum/skyrim-community-shaders/pull/2055.

Sort of haphazard on my end, the button widths were hard-coded to only fit 3 in a row, which means the 4th one I added was causing overflow.

This PR refactors so it uses the column system instead of the computed button widths.

This changes the design behaviour though. Previously the buttons were set to a fixed width and then centered. The new behaviour is akin to flex rows in CSS, where it's column-based and the buttons dynamically grow to fit. This means the buttons can stretch really wide (more than the previous 180px) to fit. While it's pretty easy to re-constrain the button widths (apply a container which constrains the columns), the code simplicity might be preferred here. Though if someone feels strongly about constraining the button widths then I can look into that.

<img width="1431" height="422" alt="image" src="https://github.com/user-attachments/assets/47277391-cc82-4101-adbc-7336cd7958c5" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Reorganized the "Quick Links" section from a 3-button centered layout to a 4-column grid layout for improved space utilization.
  * Updated Discord "Join Server" button width calculation for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->