### PR TITLE
fix(truepbr): apply vertex color to base color for  pbr metals

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2755,9 +2755,12 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	{
 		float3 glowColor = Color::Glowmap(TexGlowSampler.Sample(SampGlowSampler, uv).xyz);
 		emitColor *= glowColor;
-		// Tint emission color by vertex color
-		// Without this, metals colored by vertex color would emit white/gray
+#		if defined(TRUE_PBR)
+		// TRUE_PBR sets vertexColor=1 and adds emitColor directly to color (see below),
+		// so vertex tint must be applied here. Non-PBR folds emitColor into diffuseColor
+		// and the global color.xyz *= vertexColor (line 2918) already covers it.
 		emitColor *= input.Color.xyz;
+#		endif
 	}
 #	endif
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2117,6 +2117,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	material.Metallic = saturate(rawRMAOS.y);
 	material.AO = rawRMAOS.z;
 
+	// Apply vertex color to base color so PBR metals use it
+	baseColor.xyz *= input.Color.xyz;
+
 	if (!SharedData::linearLightingSettings.enableLinearLighting) {
 		material.F0 = lerp(rawRMAOS.w, Color::SrgbToLinear(baseColor.xyz), material.Metallic);
 	} else {
@@ -2752,6 +2755,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	{
 		float3 glowColor = Color::Glowmap(TexGlowSampler.Sample(SampGlowSampler, uv).xyz);
 		emitColor *= glowColor;
+		emitColor *= input.Color.xyz;
 	}
 #	endif
 
@@ -2853,8 +2857,15 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float vertexAO = max(max(vertexColor.r, vertexColor.g), vertexColor.b);
 	// Modify skylightingDiffuse such that skylightingDiffuse * vertexAO = min(skylightingDiffuse, vertexAO)
 	skylightingDiffuse = saturate(skylightingDiffuse / max(vertexAO, 1e-5));
+#		if defined(TRUE_PBR)
+	vertexColor = 1;
+#		endif
 #	else
+#		if defined(TRUE_PBR)
+	float3 vertexColor = 1;
+#		else
 	float3 vertexColor = input.Color.xyz;
+#		endif
 #	endif  // defined (HAIR)
 
 	float4 color = 0;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2755,6 +2755,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	{
 		float3 glowColor = Color::Glowmap(TexGlowSampler.Sample(SampGlowSampler, uv).xyz);
 		emitColor *= glowColor;
+		// Tint emission color by vertex color
+		// Without this, metals colored by vertex color would emit white/gray
 		emitColor *= input.Color.xyz;
 	}
 #	endif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Per-vertex colors now correctly tint PBR base color and influence metallic/F0-driven appearance.
  * Emissive/glow output now respects per-vertex color tinting when applicable for more accurate glow coloration.
  * Skylighting and ambient calculations adjusted so vertex color usage is consistent across rendering modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->