### PR TITLE
fix(dynamic-cubemaps): use com_ptr for exception-safe texture cleanup

### DIFF
--- a/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
+++ b/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 2-3-0
+Version = 2-3-1

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -87,12 +87,12 @@ void DynamicCubemaps::DrawSettings()
 					subresourceData[i].SysMemSlicePitch = sizeof(PixelData);
 				}
 
-				ID3D11Texture2D* tempTexture;
+				winrt::com_ptr<ID3D11Texture2D> tempTexture;
 				DirectX::ScratchImage image;
 
 				try {
-					DX::ThrowIfFailed(device->CreateTexture2D(&texDesc, subresourceData, &tempTexture));
-					DX::ThrowIfFailed(CaptureTexture(device, context, tempTexture, image));
+					DX::ThrowIfFailed(device->CreateTexture2D(&texDesc, subresourceData, tempTexture.put()));
+					DX::ThrowIfFailed(CaptureTexture(device, context, tempTexture.get(), image));
 
 					if (std::filesystem::create_directories(defaultDynamicCubeMapSavePath)) {
 						logger::info("Missing DynamicCubeMap Creator directory created: {}", defaultDynamicCubeMapSavePath);
@@ -114,7 +114,6 @@ void DynamicCubemaps::DrawSettings()
 				}
 
 				image.Release();
-				tempTexture->Release();
 			}
 		}
 		ImGui::TreePop();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal memory management in graphics rendering, enhancing stability and reliability.

* **Chore**
  * Updated feature metadata to version 2-3-1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->