### PR TITLE
build: added MSVC target link for RelWithDebInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,17 @@ target_link_libraries(
         ${DETOURS_LIBRARY}
 )
 
+# Some third-party libs (e.g. FFX backend) are built with /GL.
+# In RelWithDebInfo, align linker options to avoid LNK4075/LNK1218 when warnings are treated as errors.
+if(MSVC)
+    target_link_options(
+        ${PROJECT_NAME}
+        PRIVATE
+            "$<$<CONFIG:RelWithDebInfo>:/LTCG>"
+            "$<$<CONFIG:RelWithDebInfo>:/INCREMENTAL:NO>"
+    )
+endif()
+
 # https://gitlab.kitware.com/cmake/cmake/-/issues/24922#note_1371990
 if(MSVC_VERSION GREATER_EQUAL 1936 AND MSVC_IDE) # 17.6+
     # When using /std:c++latest, "Build ISO C++23 Standard Library Modules" defaults to "Yes".


### PR DESCRIPTION
fix build failure with --config RelWithDebInfo 

error:
ffx_backend_dx11_x64.lib(ffx_dx11.obj) : MSIL .netmodule or module compiled with /GL found; restarting link with /LTCG; add /LTCG to the link command line to improve linker performance
LINK : warning LNK4075: ignoring '/INCREMENTAL' due to '/LTCG' specification [F:\Community-Shaders-Working-Folder\Github-Fork\skyrim-community-shaders\build\ALL\CommunityShaders.vcxproj]
LINK : error LNK1218: warning treated as error; no output file generated [F:\Community-Shaders-Working-Folder\Github-Fork\skyrim-community-shaders\build\ALL\CommunityShaders.vcxproj]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized MSVC build configuration for Release builds with debug information, enabling link-time code generation and removing incremental linking to improve build efficiency and binary optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->