### PR TITLE
feat: detect obsolete shader mods with no feature INIs

### DIFF
--- a/src/FeatureIssues.cpp
+++ b/src/FeatureIssues.cpp
@@ -91,7 +91,20 @@ namespace FeatureIssues
 									 .userMessage = "This functionality is now built into Community Shaders. Remove the old feature as it's no longer needed.",
 									 .removedInVersion = { 0, 8, 0 },
 									 .modifiedShaderDirectory = true,
-									 .issueType = FeatureIssueInfo::IssueType::OBSOLETE } }
+									 .issueType = FeatureIssueInfo::IssueType::OBSOLETE } },
+		{ "VanillaHDR", { .shortName = "VanillaHDR",
+							.displayName = "Vanilla HDR",
+							.rejectionReason = "Replaced by Community Shaders",
+							.replacementFeature = "",
+							.userMessage = "Vanilla HDR conflicts with Community Shaders. Uninstall it with your mod manager.",
+							.removedInVersion = { 1, 0, 0 },
+							.modifiedShaderDirectory = false,
+							.issueType = FeatureIssueInfo::IssueType::OBSOLETE } }
+	};
+
+	// Obsolete mods with shader files that do not have a corresponding feature INI, value is the path to trigger the issue
+	static const std::map<std::string, const char*> s_obsoleteShaderModTriggerPaths = {
+		{ "VanillaHDR", "ISHDR/VanillaHDRSettings.fxh" },
 	};
 
 	const std::vector<FeatureIssueInfo>& GetFeatureIssues()
@@ -644,7 +657,9 @@ namespace FeatureIssues
 		// Show delete button for:
 		// 1. Features that don't modify shader directories (safe to delete)
 		// 2. Obsolete features with replacements (user can install replacement after deletion)
-		bool canSafelyDelete = (!issue.ModifiedShaderDirectory() || (issue.IsObsolete() && !issue.replacementFeature.empty())) && !IsVersionMismatchForCoreFeature(issue);
+		bool canSafelyDelete = (!issue.ModifiedShaderDirectory() || (issue.IsObsolete() && !issue.replacementFeature.empty())) &&
+		                       !IsVersionMismatchForCoreFeature(issue) &&
+		                       (issue.fileInfo.hasINI || issue.fileInfo.hasDeployedFolder);
 		if (canSafelyDelete) {
 			ImGui::SameLine();
 			std::string deleteButtonId = "Delete##" + issue.shortName;
@@ -826,6 +841,40 @@ namespace FeatureIssues
 			logger::warn("Error scanning Features directory: {}", e.what());
 		}
 	}
+
+	void ScanForObsoleteShaderMods()
+	{
+		const std::filesystem::path shadersRoot = Util::PathHelpers::GetShadersPath();
+		if (!std::filesystem::exists(shadersRoot)) {
+			return;
+		}
+
+		try {
+			for (const auto& [shortName, triggerPath] : s_obsoleteShaderModTriggerPaths) {
+				const std::filesystem::path pathToCheck = shadersRoot / triggerPath;
+				if (!std::filesystem::exists(pathToCheck)) {
+					continue;
+				}
+				logger::warn("Found incompatible shader mod: {}", shortName);
+
+				// Fallback if a developer did not add the feature to the obsolete features map
+				if (!IsObsoleteFeature(shortName)) {
+					FeatureFileInfo fileInfo = GetFeatureFileInfo(shortName);
+					AddFeatureIssue(shortName, "Unknown",
+						std::format("{} is incompatible with this CS version", shortName),
+						FeatureIssueInfo::IssueType::UNKNOWN, fileInfo);
+					continue;
+				}
+
+				const auto& obsoleteMeta = s_obsoleteFeatureData.find(shortName)->second;
+				AddFeatureIssue(shortName, "Unknown", obsoleteMeta.rejectionReason,
+					FeatureIssueInfo::IssueType::OBSOLETE, {});
+			}
+		} catch (const std::filesystem::filesystem_error& e) {
+			logger::warn("Error scanning Shaders directory: {}", e.what());
+		}
+	}
+
 	// Developer mode test INI functionality
 	namespace Test
 	{
@@ -1446,6 +1495,7 @@ namespace FeatureIssues
 			// Use checkLoadedFeatures=true to detect all issues including from loaded features
 			ClearFeatureIssues();
 			ScanForOrphanedFeatureINIs(true);
+			ScanForObsoleteShaderMods();
 
 			if (success) {
 				logger::info("Successfully restored original state. Feature issues updated.");

--- a/src/FeatureIssues.h
+++ b/src/FeatureIssues.h
@@ -179,6 +179,11 @@ namespace FeatureIssues
 	void ScanForOrphanedFeatureINIs(bool checkLoadedFeatures = false);
 
 	/**
+	 * Detect obsolete mods with shader files that do not have a corresponding feature INI.
+	 */
+	void ScanForObsoleteShaderMods();
+
+	/**
 	 * Developer mode functionality for testing feature issues.
 	 * These functions are only available when IsDeveloperMode() returns true.
 	 */

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -403,6 +403,7 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 		}
 
 		FeatureIssues::ScanForOrphanedFeatureINIs();
+		FeatureIssues::ScanForObsoleteShaderMods();
 
 		logger::info("Loading Settings Complete");
 	} catch (const json::exception& e) {


### PR DESCRIPTION
Open to feedback on the infrastructure or UX.

The purpose of this change is to detect Vanilla HDR, which is a mod that includes shader files but does not include a feature INI file. This causes shader compilation failures.

The idea behind this implementation is that a developer can easily add a new entry in `s_obsoleteShaderModTriggerPaths` with a trigger path. This hypothetically can expand outside of the `Shaders` directory and detect all sorts of mods.

<img width="1111" height="316" alt="image" src="https://github.com/user-attachments/assets/d2dd9fde-793b-4235-96a7-ce8211f07fd7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection system for obsolete and incompatible shader mods.

* **Bug Fixes**
  * Improved safety validation when removing features or mods.
  * Enhanced post-configuration validation during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->