### PR TITLE
fix(terrain-blending): transparency of landscapes

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -3205,9 +3205,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	// Read by StereoBlendCS to adjust Eye 1 (right eye) reprojection depth
 	// at POM-displaced surfaces. Not consumed on flat (SE/AE).
 	psout.Reflectance = float4(indirectLobeWeights.specular,
-		(pixelOffset > 0.0) ? saturate(pixelOffset) : 0.0);
+		(pixelOffset > 0.0) ? saturate(pixelOffset) : psout.Diffuse.w);
 #		else
-	psout.Reflectance = float4(indirectLobeWeights.specular, 0.0);
+	psout.Reflectance = float4(indirectLobeWeights.specular, psout.Diffuse.w);
 #		endif
 	psout.NormalGlossiness = float4(GBuffer::EncodeNormal(screenSpaceNormal), saturate(1.0 - material.Roughness), psout.Diffuse.w);
 


### PR DESCRIPTION
closes #2080
Addresses the issue seen [here](https://github.com/doodlum/skyrim-community-shaders/issues/2080). Confirmed fixed in flatrim, will likely need testing in VR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved VR depth correction handling in stereo rendering scenarios to ensure more accurate visual representation in immersive environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->