### PR TITLE
fix(IBL): glowing metals in shadow

### DIFF
--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -73,6 +73,7 @@ namespace DynamicCubemaps
 				skySpecular = Color::IrradianceToLinear(max(0, fullSample - envSample)) * SharedData::iblSettings.SkyIBLScale;
 #			if defined(SKYLIGHTING)
 				skySpecular *= skylightingSpecular;
+				envSpecular *= skylightingSpecular;
 #			endif
 			} else {
 				// Mode 0/1: IBL ratio-based
@@ -81,6 +82,7 @@ namespace DynamicCubemaps
 				skySpecular = Color::IrradianceToLinear(max(0, fullSample - envSample)) * SharedData::iblSettings.SkyIBLScale;
 #			if defined(SKYLIGHTING)
 				skySpecular *= skylightingSpecular;
+				envSpecular *= skylightingSpecular;
 #			endif
 			}
 
@@ -179,6 +181,7 @@ namespace DynamicCubemaps
 				skySpecular = Color::IrradianceToLinear(max(0, fullSample - envSample)) * SharedData::iblSettings.SkyIBLScale;
 #			if defined(SKYLIGHTING)
 				skySpecular *= skylightingSpecular;
+				envSpecular *= skylightingSpecular;
 #			endif
 			} else {
 				// Mode 0/1: IBL ratio-based
@@ -187,6 +190,7 @@ namespace DynamicCubemaps
 				skySpecular = Color::IrradianceToLinear(max(0, fullSample - envSample)) * SharedData::iblSettings.SkyIBLScale;
 #			if defined(SKYLIGHTING)
 				skySpecular *= skylightingSpecular;
+				envSpecular *= skylightingSpecular;
 #			endif
 			}
 

--- a/package/Shaders/DeferredCompositeCS.hlsl
+++ b/package/Shaders/DeferredCompositeCS.hlsl
@@ -217,6 +217,7 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, inout float ao, out float3 il,
 				skySpecular = Color::IrradianceToLinear(max(0, fullSample - envSample)) * SharedData::iblSettings.SkyIBLScale;
 #		if defined(SKYLIGHTING)
 				skySpecular *= skylightingSpecular;
+				envSpecular *= skylightingSpecular;
 #		elif defined(INTERIOR)
 				skySpecular = 0;
 #		endif
@@ -227,6 +228,7 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, inout float ao, out float3 il,
 				skySpecular = Color::IrradianceToLinear(max(0, fullSample - envSample)) * SharedData::iblSettings.SkyIBLScale;
 #		if defined(SKYLIGHTING)
 				skySpecular *= skylightingSpecular;
+				envSpecular *= skylightingSpecular;
 #		elif defined(INTERIOR)
 				skySpecular = 0;
 #		endif


### PR DESCRIPTION
adds a envspecular mult to the skylighting calculations with ibl. previously this was missing causing glowing metals.
<img width="2560" height="1440" alt="SkyrimSE 2026-04-11 09-34-56_694" src="https://github.com/user-attachments/assets/a25af591-b357-4fdb-b68d-996be5fa3765" />
<img width="2560" height="1440" alt="SkyrimSE 2026-04-11 09-34-15_211" src="https://github.com/user-attachments/assets/c2bd477d-d88a-4b87-b7cb-33a2299fc29b" />
<img width="2560" height="1440" alt="SkyrimSE 2026-04-11 09-34-18_301" src="https://github.com/user-attachments/assets/2709620c-6673-42af-9760-d35e5d27f832" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed inconsistent skylighting application to environment reflections in dynamic cubemap rendering across different IBL modes, ensuring uniform visual quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->