### PR TITLE
chore(VR): disable stereoopt by default

### DIFF
--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -586,7 +586,7 @@ ID3D11ComputeShader* Deferred::GetComputeMainComposite()
 		if (REL::Module::IsVR())
 			defines.push_back({ "FRAMEBUFFER", nullptr });
 
-		if (globals::features::vr.IsStereoOptimizationCullingReady())
+		if (REL::Module::IsVR())
 			defines.push_back({ "VR_STEREO_OPT", nullptr });
 
 		mainCompositeCS = static_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\DeferredCompositeCS.hlsl", defines, "cs_5_0"));
@@ -614,7 +614,7 @@ ID3D11ComputeShader* Deferred::GetComputeMainCompositeInterior()
 		if (REL::Module::IsVR())
 			defines.push_back({ "FRAMEBUFFER", nullptr });
 
-		if (globals::features::vr.IsStereoOptimizationCullingReady())
+		if (REL::Module::IsVR())
 			defines.push_back({ "VR_STEREO_OPT", nullptr });
 
 		mainCompositeInteriorCS = static_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\DeferredCompositeCS.hlsl", defines, "cs_5_0"));

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -586,7 +586,7 @@ ID3D11ComputeShader* Deferred::GetComputeMainComposite()
 		if (REL::Module::IsVR())
 			defines.push_back({ "FRAMEBUFFER", nullptr });
 
-		if (REL::Module::IsVR() && globals::features::vr.stereoOpt.loaded)
+		if (globals::features::vr.IsStereoOptimizationCullingReady())
 			defines.push_back({ "VR_STEREO_OPT", nullptr });
 
 		mainCompositeCS = static_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\DeferredCompositeCS.hlsl", defines, "cs_5_0"));
@@ -614,7 +614,7 @@ ID3D11ComputeShader* Deferred::GetComputeMainCompositeInterior()
 		if (REL::Module::IsVR())
 			defines.push_back({ "FRAMEBUFFER", nullptr });
 
-		if (REL::Module::IsVR() && globals::features::vr.stereoOpt.loaded)
+		if (globals::features::vr.IsStereoOptimizationCullingReady())
 			defines.push_back({ "VR_STEREO_OPT", nullptr });
 
 		mainCompositeInteriorCS = static_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\DeferredCompositeCS.hlsl", defines, "cs_5_0"));

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -120,9 +120,11 @@ void VR::SetupResources()
 	stereoBlendCopyTex->CreateSRV(srvDesc);
 	stereoBlendCB = eastl::make_unique<ConstantBuffer>(ConstantBufferDesc<StereoBlendCB>());
 
-	if (REL::Module::IsVR()) {
+	if (globals::game::isVR && stereoOpt.settings.stereoMode != VRStereoOptimizations::StereoMode::Off) {
 		stereoOpt.SetupResources();
 		stereoOpt.loaded = stereoOpt.GetModeTextureSRV() != nullptr;
+	} else {
+		stereoOpt.loaded = false;
 	}
 
 	DetectOpenVRInfo();

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -111,7 +111,7 @@ public:
 	}
 
 	virtual inline std::string_view GetShaderDefineName() override { return "VR_STEREO_OPT"; }
-	virtual inline bool HasShaderDefine(RE::BSShader::Type t) override { return stereoOpt.loaded && t == RE::BSShader::Type::Utility; }
+	virtual inline bool HasShaderDefine(RE::BSShader::Type t) override { return stereoOpt.CanDispatchStencil() && t == RE::BSShader::Type::Utility; }
 	virtual void Reset() override;
 	virtual void SetupResources() override;
 	virtual void ClearShaderCache() override;
@@ -171,7 +171,7 @@ public:
 		float MinOccludeeBoxExtent = 10.0f;  ///< Minimum bounding box size for occlusion culling
 
 		// Stereo consistency blend pass (post-composite safety net)
-		bool EnableStereoBlend = true;            ///< Enable depth-aware bilateral blend between eyes
+		bool EnableStereoBlend = false;           ///< Enable depth-aware bilateral blend between eyes
 		float StereoBlendDepthSigma = 0.01f;      ///< Depth sensitivity for bilateral weight (lower = stricter)
 		float StereoBlendMaxFactor = 0.1f;        ///< Maximum blend factor; keep low to preserve stereo parallax
 		float StereoBlendColorThreshold = 0.02f;  ///< Minimum color difference to trigger blending (luminance)

--- a/src/Features/VRStereoOptimizations.h
+++ b/src/Features/VRStereoOptimizations.h
@@ -63,7 +63,7 @@ struct VRStereoOptimizations
 
 	struct Settings
 	{
-		StereoMode stereoMode = StereoMode::Enable;
+		StereoMode stereoMode = StereoMode::Off;
 		float disocclusionDepthThreshold = 0.01f;
 		float edgeDepthThreshold = 0.05f;
 		float minEdgeDistance = 5000.0f;     ///< Minimum linearized depth for edge AA (game units)

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -358,7 +358,7 @@ namespace globals
 		stl::detour_vfunc<15, ID3D11DeviceContext_Unmap>(a_context);
 
 		// VR stereo optimization hooks: intercept DSS and stencil clear
-		if (globals::game::isVR && globals::features::vr.IsStereoOptimizationCullingReady()) {
+		if (globals::game::isVR && globals::features::vr.stereoOpt.settings.stereoMode != VRStereoOptimizations::StereoMode::Off) {
 			stl::detour_vfunc<36, ID3D11DeviceContext_OMSetDepthStencilState>(a_context);
 			stl::detour_vfunc<53, ID3D11DeviceContext_ClearDepthStencilView>(a_context);
 		}

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -358,7 +358,7 @@ namespace globals
 		stl::detour_vfunc<15, ID3D11DeviceContext_Unmap>(a_context);
 
 		// VR stereo optimization hooks: intercept DSS and stencil clear
-		if (globals::game::isVR) {
+		if (globals::game::isVR && globals::features::vr.IsStereoOptimizationCullingReady()) {
 			stl::detour_vfunc<36, ID3D11DeviceContext_OMSetDepthStencilState>(a_context);
 			stl::detour_vfunc<53, ID3D11DeviceContext_ClearDepthStencilView>(a_context);
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened VR stereo-optimization activation to respect runtime VR state and stereo mode, reducing incorrect resource use.
  * Fixed shader-define behavior so VR stereo optimizations are applied only when stencil/reprojection can dispatch.

* **Defaults**
  * Changed defaults to disable stereo optimization and stereo consistency blend by default for safer VR behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->