### PR TITLE
fix(VR): allow for Engine Fixes VR 7.x (NG)

### DIFF
--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -194,18 +194,20 @@ bool Load()
 		}
 	}
 
+	auto pushMissingDllError = [&](std::string_view dllName) {
+		auto errorMessage = std::format("Required DLL {} was missing", dllName);
+		logger::error("{}", errorMessage);
+		errors.push_back(errorMessage);
+	};
+
 	// Engine Fixes: VR accepts either EngineFixesVR.dll or the EngineFixes.dll NG
 	if (REL::Module::IsVR()) {
 		if (!LoadLibrary(L"Data/SKSE/Plugins/EngineFixesVR.dll") && !LoadLibrary(L"Data/SKSE/Plugins/EngineFixes.dll")) {
-			auto errorMessage = std::string("Required DLL EngineFixesVR.dll or EngineFixes.dll was missing");
-			logger::error("{}", errorMessage);
-			errors.push_back(errorMessage);
+			pushMissingDllError("EngineFixesVR.dll or EngineFixes.dll");
 		}
 	} else {
 		if (!LoadLibrary(L"Data/SKSE/Plugins/EngineFixes.dll")) {
-			auto errorMessage = std::format("Required DLL {} was missing", stl::utf16_to_utf8(L"Data/SKSE/Plugins/EngineFixes.dll").value_or("<unicode conversion error>"s));
-			logger::error("{}", errorMessage);
-			errors.push_back(errorMessage);
+			pushMissingDllError(stl::utf16_to_utf8(L"Data/SKSE/Plugins/EngineFixes.dll").value_or("<unicode conversion error>"s));
 		}
 	}
 
@@ -215,9 +217,7 @@ bool Load()
 
 	for (const auto dll : requiredDLLs) {
 		if (!LoadLibrary(dll)) {
-			auto errorMessage = std::format("Required DLL {} was missing", stl::utf16_to_utf8(dll).value_or("<unicode conversion error>"s));
-			logger::error("{}", errorMessage);
-			errors.push_back(errorMessage);
+			pushMissingDllError(stl::utf16_to_utf8(dll).value_or("<unicode conversion error>"s));
 		}
 	}
 

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -194,8 +194,22 @@ bool Load()
 		}
 	}
 
+	// Engine Fixes: VR accepts either EngineFixesVR.dll or the EngineFixes.dll NG
+	if (REL::Module::IsVR()) {
+		if (!LoadLibrary(L"Data/SKSE/Plugins/EngineFixesVR.dll") && !LoadLibrary(L"Data/SKSE/Plugins/EngineFixes.dll")) {
+			auto errorMessage = std::string("Required DLL EngineFixesVR.dll or EngineFixes.dll was missing");
+			logger::error("{}", errorMessage);
+			errors.push_back(errorMessage);
+		}
+	} else {
+		if (!LoadLibrary(L"Data/SKSE/Plugins/EngineFixes.dll")) {
+			auto errorMessage = std::format("Required DLL {} was missing", stl::utf16_to_utf8(L"Data/SKSE/Plugins/EngineFixes.dll").value_or("<unicode conversion error>"s));
+			logger::error("{}", errorMessage);
+			errors.push_back(errorMessage);
+		}
+	}
+
 	const std::array requiredDLLs = {
-		REL::Module::IsVR() ? L"Data/SKSE/Plugins/EngineFixesVR.dll" : L"Data/SKSE/Plugins/EngineFixes.dll",
 		L"Data/SKSE/Plugins/CrashLogger.dll"
 	};
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of plugin dependency loading so VR-specific and standard variants are attempted with a fallback.
  * Enhanced and centralized error messages when a required plugin fails to load, making missing-dependency reports clearer.
  * Reduced strict-required list so only the crash-reporting plugin remains mandatory; other variants now report failures via the new messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->