### PR TITLE
ci: support semver postfix in tag version check

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -189,7 +189,7 @@ jobs:
               shell: pwsh
               run: |
                   $tag = '${{ github.ref_name }}'
-                  $expected = $tag.TrimStart('v')
+                  $expected = ($tag -replace '^v([0-9]+\.[0-9]+\.[0-9]+).*', '$1')
                   $version = '${{ steps.get_version.outputs.version }}'
                   if (-not $version -or $version -eq "") {
                     Write-Error "Version extraction failed: no version found in previous step" -ErrorAction Stop


### PR DESCRIPTION
TrimStart('v') kept the full postfix (e.g. '-VR-hotfix'), causing a mismatch against the numeric CMake version. Extract only the major.minor.patch portion from the tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD build verification logic for version tag matching to ensure accurate version validation during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->