### PR TITLE
build: bump renderdoc to 1.43

### DIFF
--- a/cmake/ports/renderdoc/README.md
+++ b/cmake/ports/renderdoc/README.md
@@ -20,9 +20,13 @@ This port does **not** include the `renderdoc.dll` runtime library because:
 
 ## Getting the Runtime DLL
 
-The `renderdoc.dll` should be obtained from official RenderDoc releases:
+The `renderdoc.dll` should be obtained from official RenderDoc releases. For stable Windows releases the runtime package follows this pattern:
 
--   Download page: https://renderdoc.org/builds
+-   `https://renderdoc.org/stable/${VERSION}/RenderDoc_${VERSION}_64.zip`
+
+For example, for v1.43:
+
+-   `https://renderdoc.org/stable/1.43/RenderDoc_1.43_64.zip`
 
 For Community Shaders, the DLL is stored in `package/SKSE/Plugins/Renderdoc/renderdoc.dll` and is deployed as part of the mod package.
 

--- a/cmake/ports/renderdoc/portfile.cmake
+++ b/cmake/ports/renderdoc/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO baldurk/renderdoc
-    REF v1.40
-    SHA512 6581d1fe7ba069e74d09b64a1de0a413bc0d1e775a45cce87bb8ea125fc2d67e9846439acc802882c0d717028e251f9f44fd896e2022e310456adafa675bf85a
+    REF v1.43
+    SHA512 555d3ff84787db45807f29e67c9e8ea3d475e101ceb01d281b80a74d470b7aa5ef6e39731a8a1a06ca547729b74e316ff2d8394a126ecde9b637a1ca94ef95f3
     HEAD_REF v1.x
 )
 
@@ -14,6 +14,30 @@ file(INSTALL "${SOURCE_PATH}/renderdoc/api/app/renderdoc_app.h"
 
 # Install copyright/license
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
+
+# Runtime DLL automation template:
+# The RenderDoc runtime DLL is distributed separately from the API header.
+# To automate runtime retrieval, use the official stable package URL pattern:
+#
+#   https://renderdoc.org/stable/${VERSION}/RenderDoc_${VERSION}_64.zip
+#
+# Example vcpkg template:
+#
+#   set(RENDERDOC_VERSION 1.40)
+#   set(RENDERDOC_RUNTIME_ARCHIVE "RenderDoc_${RENDERDOC_VERSION}_64.zip")
+#   vcpkg_download_distfile(
+#       OUT_FILE "${SOURCE_PATH}/${RENDERDOC_RUNTIME_ARCHIVE}"
+#       URL "https://renderdoc.org/stable/${RENDERDOC_VERSION}/${RENDERDOC_RUNTIME_ARCHIVE}"
+#       SHA512 <SHA512>
+#   )
+#   vcpkg_extract_source_archive_ex(
+#       OUT_SOURCE_PATH RUNTIME_SOURCE_PATH
+#       ARCHIVE "${SOURCE_PATH}/${RENDERDOC_RUNTIME_ARCHIVE}"
+#   )
+#   file(INSTALL "${RUNTIME_SOURCE_PATH}/renderdoc.dll"
+#        DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+#
+# Replace <SHA512> with the archive checksum for the selected RenderDoc version.
 
 # Create usage file with instructions for getting the runtime DLL
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage"
@@ -27,7 +51,7 @@ To use RenderDoc in your application:
 3. Initialize the API as described in the documentation
 
 To obtain renderdoc.dll:
-- Download the portable zip from: https://renderdoc.org/builds
+- Download the portable zip from: https://renderdoc.org/stable/${VERSION}/RenderDoc_${VERSION}_64.zip
 - Or build from source: https://github.com/baldurk/renderdoc
 - Deploy renderdoc.dll alongside your application
 

--- a/cmake/ports/renderdoc/vcpkg.json
+++ b/cmake/ports/renderdoc/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "renderdoc",
-    "version": "1.40",
+    "version": "1.43",
     "description": "RenderDoc in-application API for frame capture and debugging",
     "homepage": "https://github.com/baldurk/renderdoc",
     "license": "MIT",

--- a/features/RenderDoc/README.md
+++ b/features/RenderDoc/README.md
@@ -1,5 +1,0 @@
-RenderDoc integration feature
-
-Place renderdoc.dll and any helper runtime DLLs into this folder before packaging. This folder is treated as a core feature and will be included into the AIO package.
-
-When installing to the game Data directory, the RenderDoc DLLs should end up in Renderdoc/ for runtime loading by the plugin.

--- a/features/RenderDoc/Renderdoc/LICENSE.md
+++ b/features/RenderDoc/Renderdoc/LICENSE.md
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-Copyright (c) 2015-2025 Baldur Karlsson
+Copyright (c) 2015-2026 Baldur Karlsson
 
 Copyright (c) 2014 Crytek
 

--- a/features/RenderDoc/Renderdoc/README.md
+++ b/features/RenderDoc/Renderdoc/README.md
@@ -4,15 +4,19 @@ This directory contains the RenderDoc runtime library for frame capture function
 
 ## Version
 
-Current version: **1.40**
+Current version: **1.43**
 
 ## Source
 
-The `renderdoc.dll` file must be manually obtained from official RenderDoc releases:
+The `renderdoc.dll` file must be obtained from official RenderDoc releases.
 
--   Website: https://renderdoc.org/builds
--   Direct download (MSI): https://renderdoc.org/stable/
--   GitHub releases: https://github.com/baldurk/renderdoc/releases/tag/
+For stable Windows builds, the runtime package uses this pattern:
+
+-   `https://renderdoc.org/stable/${VERSION}/RenderDoc_${VERSION}_64.zip`
+
+For example, for v1.43:
+
+-   `https://renderdoc.org/stable/1.43/RenderDoc_1.43_64.zip`
 
 ## Installation Steps
 

--- a/features/RenderDoc/Shaders/Features/RenderDoc.ini
+++ b/features/RenderDoc/Shaders/Features/RenderDoc.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 1-0-0
+Version = 1-0-1

--- a/src/Features/RenderDoc.cpp
+++ b/src/Features/RenderDoc.cpp
@@ -91,7 +91,7 @@ void RenderDoc::Load()
 	}
 
 	// Get the API interface
-	int ret = RENDERDOC_GetAPI(eRENDERDOC_API_Version_1_6_0, (void**)&renderDocApi);
+	int ret = RENDERDOC_GetAPI(eRENDERDOC_API_Version_1_7_0, (void**)&renderDocApi);
 	if (ret != 1 || !renderDocApi) {
 		logger::warn("[RenderDoc] Failed to get API interface");
 		FreeLibrary((HMODULE)renderDocModule);

--- a/src/Features/RenderDoc.h
+++ b/src/Features/RenderDoc.h
@@ -14,7 +14,7 @@ using json = nlohmann::json;
 
 // Forward declarations
 struct ID3D11Device;
-struct RENDERDOC_API_1_6_0;
+struct RENDERDOC_API_1_7_0;
 
 // Structure to hold capture file information for UI display
 struct CaptureFileInfo
@@ -104,7 +104,7 @@ public:
 
 	// RenderDoc library and API
 	void* renderDocModule = nullptr;
-	RENDERDOC_API_1_6_0* renderDocApi = nullptr;
+	RENDERDOC_API_1_7_0* renderDocApi = nullptr;
 
 	// Pending comments to attach to the next capture (applied when a new capture is detected)
 	std::string pendingCaptureComments;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated RenderDoc package to version 1.43.
  * Bumped bundled RenderDoc API to the newer release.
  * Updated bundled feature metadata version.
  * Updated license copyright year.

* **Documentation**
  * Streamlined runtime DLL download instructions to a stable, versioned build URL pattern with a v1.43 example.
  * Removed obsolete packaging instructions for the RenderDoc feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->