### PR TITLE
fix(util): SPID form identity helpers

### DIFF
--- a/features/Weather Editor/Shaders/Features/WeatherEditor.ini
+++ b/features/Weather Editor/Shaders/Features/WeatherEditor.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 1-1-0
+Version = 2-0-0

--- a/src/Utils/Form.cpp
+++ b/src/Utils/Form.cpp
@@ -65,8 +65,8 @@ RE::FormID Util::SpidToFormId(const std::string& spid)
 		return 0;
 	}
 
-	RE::FormID reconstructed = (static_cast<RE::FormID>(file->compileIndex) << 24) +
-	                           (static_cast<RE::FormID>(file->smallFileCompileIndex) << 12) +
+	RE::FormID reconstructed = (static_cast<RE::FormID>(file->compileIndex) << 24) |
+	                           (static_cast<RE::FormID>(file->smallFileCompileIndex) << 12) |
 	                           components.localFormId;
 	auto* directForm = RE::TESForm::LookupByID(reconstructed);
 	if (directForm) {

--- a/src/Utils/Form.cpp
+++ b/src/Utils/Form.cpp
@@ -1,25 +1,126 @@
 #include "Form.h"
 
-auto Util::GetFormFromIdentifier(const std::string& a_identifier) -> RE::TESForm*
+Util::SpidComponents Util::ParseSpid(const std::string& spid)
 {
-	std::istringstream ss{ a_identifier };
-	std::string plugin, id;
+	SpidComponents result;
+	auto tildePos = spid.find('~');
+	std::string hexPart = (tildePos != std::string::npos) ? spid.substr(0, tildePos) : spid;
+	if (tildePos != std::string::npos)
+		result.pluginName = spid.substr(tildePos + 1);
 
-	std::getline(ss, plugin, '|');
-	std::getline(ss, id);
-	RE::FormID relativeID;
-	std::istringstream{ id } >> std::hex >> relativeID;
-	const auto dataHandler = RE::TESDataHandler::GetSingleton();
-	return dataHandler ? dataHandler->LookupForm(relativeID, plugin) : nullptr;
+	// Strip 0x/0X prefix
+	if (hexPart.size() > 2 && hexPart[0] == '0' && (hexPart[1] == 'x' || hexPart[1] == 'X'))
+		hexPart = hexPart.substr(2);
+
+	try {
+		result.localFormId = static_cast<uint32_t>(std::stoul(hexPart, nullptr, 16));
+	} catch (...) {
+		result.localFormId = 0;
+	}
+	return result;
 }
 
-auto Util::GetIdentifierFromForm(const RE::TESForm* a_form) -> std::string
+std::string Util::FormatSpid(uint32_t localFormId, const std::string& pluginName)
 {
-	if (a_form == nullptr) {
-		return "0|Null";
+	if (pluginName.empty())
+		return std::format("0x{:X}", localFormId);
+	return std::format("0x{:X}~{}", localFormId, pluginName);
+}
+
+std::string Util::FormIdToSpid(RE::FormID formId)
+{
+	auto* form = RE::TESForm::LookupByID(formId);
+	if (!form)
+		return std::format("0x{:X}", formId);
+	return GetFormFileKey(form);
+}
+
+RE::FormID Util::SpidToFormId(const std::string& spid)
+{
+	auto components = ParseSpid(spid);
+	if (components.pluginName.empty() || components.localFormId == 0) {
+		logger::warn("[FormIdentity] SpidToFormId: bad parse for '{}' — plugin='{}' localId=0x{:X}", spid, components.pluginName, components.localFormId);
+		return 0;
 	}
-	if (auto file = a_form->GetFile()) {
-		return std::format("{:X}|{}", a_form->GetLocalFormID(), file->GetFilename());
+	auto* handler = RE::TESDataHandler::GetSingleton();
+	if (!handler) {
+		logger::warn("[FormIdentity] SpidToFormId: TESDataHandler is null for '{}'", spid);
+		return 0;
 	}
-	return std::format("{:X}|Generated", a_form->GetLocalFormID());
+
+	// Primary: CommonLibSSE-NG's LookupForm
+	auto* form = handler->LookupForm(components.localFormId, components.pluginName);
+	if (form)
+		return form->GetFormID();
+
+	// Fallback: reconstruct full FormID from compile indices
+	auto* file = handler->LookupModByName(components.pluginName);
+	if (!file) {
+		logger::warn("[FormIdentity] SpidToFormId: plugin '{}' not found in load order", components.pluginName);
+		return 0;
+	}
+
+	if (file->compileIndex == 0xFF) {
+		logger::warn("[FormIdentity] SpidToFormId: plugin '{}' has invalid compile index 0xFF", components.pluginName);
+		return 0;
+	}
+
+	RE::FormID reconstructed = (static_cast<RE::FormID>(file->compileIndex) << 24) +
+	                           (static_cast<RE::FormID>(file->smallFileCompileIndex) << 12) +
+	                           components.localFormId;
+	auto* directForm = RE::TESForm::LookupByID(reconstructed);
+	if (directForm) {
+		logger::info("[FormIdentity] SpidToFormId: '{}' resolved via direct reconstruction to 0x{:08X}", spid, reconstructed);
+		return reconstructed;
+	}
+
+	logger::warn("[FormIdentity] SpidToFormId: plugin '{}' index=0x{:X} smallIndex=0x{:X} localId=0x{:X} reconstructed=0x{:08X} — form not found",
+		components.pluginName, file->compileIndex, file->smallFileCompileIndex, components.localFormId, reconstructed);
+	return 0;
+}
+
+std::string Util::GetFormDisplayName(RE::FormID formId)
+{
+	auto* form = RE::TESForm::LookupByID(formId);
+	if (!form)
+		return std::format("0x{:X}", formId);
+
+	auto editorId = GetFormEditorID(form);
+	if (!editorId.empty())
+		return std::format("{} ({:X})", editorId, form->GetLocalFormID());
+
+	return GetFormFileKey(form);
+}
+
+std::string Util::GetFormEditorID(const RE::TESForm* form)
+{
+	if (!form)
+		return "";
+	const char* editorId = form->GetFormEditorID();
+	if (editorId && editorId[0] != '\0')
+		return std::string(editorId);
+
+	// Search the global EditorID map as fallback
+	auto [map, lock] = RE::TESForm::GetAllFormsByEditorID();
+	if (map) {
+		RE::BSReadLockGuard locker(lock);
+		for (const auto& [name, f] : *map) {
+			if (f == form) {
+				return std::string(name.c_str());
+			}
+		}
+	}
+
+	return "";
+}
+
+std::string Util::GetFormFileKey(const RE::TESForm* form)
+{
+	if (!form)
+		return "Invalid";
+
+	auto* file = form->GetFile(0);
+	if (file)
+		return FormatSpid(form->GetLocalFormID(), std::string(file->GetFilename()));
+	return std::format("0x{:X}", form->GetLocalFormID());
 }

--- a/src/Utils/Form.h
+++ b/src/Utils/Form.h
@@ -2,6 +2,33 @@
 
 namespace Util
 {
-	auto GetFormFromIdentifier(const std::string& a_identifier) -> RE::TESForm*;
-	auto GetIdentifierFromForm(const RE::TESForm* a_form) -> std::string;
+	// --- SPID Helpers (load-order-portable FormID format) ---
+	// SPID format: "0x{localFormId}~{pluginName}" e.g. "0x12F89E~Skyrim.esm"
+
+	struct SpidComponents
+	{
+		uint32_t localFormId = 0;
+		std::string pluginName;
+	};
+
+	/// Parse a SPID string into components.
+	SpidComponents ParseSpid(const std::string& spid);
+
+	/// Format a SPID string from components.
+	std::string FormatSpid(uint32_t localFormId, const std::string& pluginName);
+
+	/// Convert a runtime FormID to a portable SPID string.
+	std::string FormIdToSpid(RE::FormID formId);
+
+	/// Resolve a SPID string to a runtime FormID (0 if not found).
+	RE::FormID SpidToFormId(const std::string& spid);
+
+	/// Get a display name: "EditorID (localFormId)" or SPID fallback.
+	std::string GetFormDisplayName(RE::FormID formId);
+
+	/// Get the EditorID for a form, or empty string if not available.
+	std::string GetFormEditorID(const RE::TESForm* form);
+
+	/// Get a file-safe key for a form: always SPID format for load-order independence.
+	std::string GetFormFileKey(const RE::TESForm* form);
 }

--- a/src/WeatherEditor/Widget.cpp
+++ b/src/WeatherEditor/Widget.cpp
@@ -17,14 +17,14 @@ bool Widget::MatchesSearch(const std::string& text) const
 void Widget::Save()
 {
 	SaveSettings();
-	const std::string filePath = std::format("{}\\{}", Util::PathHelpers::GetCommunityShaderPath().string(), GetFolderName());
-	const std::string file = std::format("{}\\{}.json", filePath, GetEditorID());
+	const auto file = GetSaveFilePath();
+	const auto filePath = std::filesystem::path(file).parent_path();
 
 	if (!std::filesystem::exists(filePath) || !std::filesystem::is_directory(filePath)) {
 		try {
 			std::filesystem::create_directories(filePath);
 		} catch (const std::filesystem::filesystem_error& e) {
-			logger::warn("Error creating directory during Save ({}) : {}\n", filePath, e.what());
+			logger::warn("Error creating directory during Save ({}) : {}\n", filePath.string(), e.what());
 			return;
 		}
 	}
@@ -72,7 +72,7 @@ void Widget::Save()
 
 void Widget::Load()
 {
-	std::string filePath = std::format("{}\\{}\\{}.json", Util::PathHelpers::GetCommunityShaderPath().string(), GetFolderName(), GetEditorID());
+	std::string filePath = GetSaveFilePath();
 
 	if (!std::filesystem::exists(filePath)) {
 		js = json();
@@ -146,7 +146,7 @@ void Widget::Load()
 
 void Widget::Delete()
 {
-	std::string filePath = std::format("{}\\{}\\{}.json", Util::PathHelpers::GetCommunityShaderPath().string(), GetFolderName(), GetEditorID());
+	std::string filePath = GetSaveFilePath();
 
 	if (!std::filesystem::exists(filePath)) {
 		return;
@@ -176,8 +176,7 @@ void Widget::Delete()
 
 bool Widget::HasSavedFile() const
 {
-	std::string filePath = std::format("{}\\{}\\{}.json", Util::PathHelpers::GetCommunityShaderPath().string(), const_cast<Widget*>(this)->GetFolderName(), GetEditorID());
-	return std::filesystem::exists(filePath);
+	return std::filesystem::exists(GetSaveFilePath());
 }
 
 void Widget::DrawMenu()
@@ -242,7 +241,12 @@ void Widget::DrawDeleteConfirmationModal(const char* popupId)
 	}
 }
 
-std::string Widget::GetFolderName()
+std::string Widget::GetSaveFilePath() const
+{
+	return std::format("{}\\{}\\{}.json", Util::PathHelpers::GetCommunityShaderPath().string(), GetFolderName(), GetSaveKey());
+}
+
+std::string Widget::GetFolderName() const
 {
 	switch (form->GetFormType()) {
 	case RE::FormType::Weather:

--- a/src/WeatherEditor/Widget.h
+++ b/src/WeatherEditor/Widget.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "Util.h"
+#include "Utils/Form.h"
 
 class WidgetSharedData
 {
@@ -42,6 +43,15 @@ public:
 		return cachedEditorID;
 	}
 
+	/// SPID-based key for file save/load operations (load-order-portable).
+	std::string GetSaveKey() const
+	{
+		return cachedSaveKey;
+	}
+
+	/// Full path to this widget's save file.
+	std::string GetSaveFilePath() const;
+
 	virtual std::string GetFormID() const
 	{
 		if (!form)
@@ -62,55 +72,34 @@ public:
 	{
 		if (!form) {
 			cachedEditorID = "Invalid";
+			cachedSaveKey = "Invalid";
 			isFallbackEditorID = false;
 			return;
 		}
 
-		// Try GetFormEditorID first
-		const char* editorID = form->GetFormEditorID();
-		if (editorID && editorID[0] != '\0') {
-			cachedEditorID = editorID;
+		// Cache the SPID-based save key (always load-order-portable)
+		cachedSaveKey = Util::GetFormFileKey(form);
+
+		// Try to resolve EditorID via shared utility
+		std::string editorId = Util::GetFormEditorID(form);
+		if (!editorId.empty()) {
+			cachedEditorID = editorId;
 			isFallbackEditorID = false;
 			return;
 		}
 
-		// Search the global EditorID map
-		auto [map, lock] = RE::TESForm::GetAllFormsByEditorID();
-		if (map) {
-			RE::BSReadLockGuard locker(lock);
-			for (const auto& [name, f] : *map) {
-				if (f == form) {
-					cachedEditorID = std::string(name.c_str());
-					isFallbackEditorID = false;
-					return;
-				}
+		// Fallback: type prefix + SPID key
+		const char* prefix = [&]() -> const char* {
+			switch (form->GetFormType()) {
+			case RE::FormType::ImageSpace: return "IS";
+			case RE::FormType::VolumetricLighting: return "VL";
+			case RE::FormType::ShaderParticleGeometryData: return "Particle";
+			case RE::FormType::LensFlare: return "LensFlare";
+			case RE::FormType::ReferenceEffect: return "VisualEffect";
+			default: return "Form";
 			}
-		}
-
-		// Fallback: use SPID-format filename (0xLocalFormID~PluginName) for load-order independence
-		const auto* file = form->GetFile();
-		const auto spidID = file ? std::format("0x{:X}~{}", form->GetLocalFormID(), file->GetFilename()) : std::format("0x{:X}", form->GetLocalFormID());
-		auto formType = form->GetFormType();
-		switch (formType) {
-		case RE::FormType::ImageSpace:
-			cachedEditorID = std::format("IS_{}", spidID);
-			break;
-		case RE::FormType::VolumetricLighting:
-			cachedEditorID = std::format("VL_{}", spidID);
-			break;
-		case RE::FormType::ShaderParticleGeometryData:
-			cachedEditorID = std::format("Particle_{}", spidID);
-			break;
-		case RE::FormType::LensFlare:
-			cachedEditorID = std::format("LensFlare_{}", spidID);
-			break;
-		case RE::FormType::ReferenceEffect:
-			cachedEditorID = std::format("VisualEffect_{}", spidID);
-			break;
-		default:
-			cachedEditorID = std::format("Form_{}", spidID);
-			break;
-		}
+		}();
+		cachedEditorID = std::format("{}_{}", prefix, cachedSaveKey);
 		isFallbackEditorID = true;
 	}
 
@@ -167,9 +156,10 @@ public:
 
 protected:
 	mutable std::string cachedEditorID;
+	mutable std::string cachedSaveKey;
 	mutable bool isFallbackEditorID = false;
 	virtual void DrawMenu();
-	std::string GetFolderName();
+	std::string GetFolderName() const;
 };
 
 // Simple widget for caching form data without full widget functionality

--- a/src/WeatherEditor/Widget.h
+++ b/src/WeatherEditor/Widget.h
@@ -91,12 +91,18 @@ public:
 		// Fallback: type prefix + SPID key
 		const char* prefix = [&]() -> const char* {
 			switch (form->GetFormType()) {
-			case RE::FormType::ImageSpace: return "IS";
-			case RE::FormType::VolumetricLighting: return "VL";
-			case RE::FormType::ShaderParticleGeometryData: return "Particle";
-			case RE::FormType::LensFlare: return "LensFlare";
-			case RE::FormType::ReferenceEffect: return "VisualEffect";
-			default: return "Form";
+			case RE::FormType::ImageSpace:
+				return "IS";
+			case RE::FormType::VolumetricLighting:
+				return "VL";
+			case RE::FormType::ShaderParticleGeometryData:
+				return "Particle";
+			case RE::FormType::LensFlare:
+				return "LensFlare";
+			case RE::FormType::ReferenceEffect:
+				return "VisualEffect";
+			default:
+				return "Form";
 			}
 		}();
 		cachedEditorID = std::format("{}_{}", prefix, cachedSaveKey);

--- a/src/WeatherManager.cpp
+++ b/src/WeatherManager.cpp
@@ -1,6 +1,7 @@
 #include "WeatherManager.h"
 
 #include "State.h"
+#include "Utils/Form.h"
 
 namespace
 {
@@ -294,17 +295,7 @@ bool WeatherManager::LoadSettingsFromWeather(RE::TESWeather* weather, const std:
 
 std::string WeatherManager::GetWeatherKey(RE::TESWeather* weather)
 {
-	if (!weather) {
-		return "None";
-	}
-
-	const char* editorID = weather->GetFormEditorID();
-	if (editorID && editorID[0] != '\0') {
-		return std::string(editorID);
-	}
-
-	// Fallback to FormID if no EditorID
-	return std::format("{:08X}", weather->GetFormID());
+	return Util::GetFormFileKey(weather);
 }
 
 bool WeatherManager::HasWeatherSettings(RE::TESWeather* weather) const


### PR DESCRIPTION
Adds shared SPID utilities for load order portable form identification. Replaces the old pipe delimited format. Weather editor widgets and weather manager now save and load using SPID keys instead of EditorIDs or raw FormIDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Form identification moved to a standardized, load-order‑portable SPID scheme; weather editor save/load now uses SPIDs and improved save path handling.
  * Form name/key resolution updated to prefer editor IDs and provide stable fallbacks.

* **Bug Fixes**
  * Stronger validation and lookup fallbacks for form references to reduce missing/invalid form issues.

* **Chore**
  * Shader feature metadata version bumped (1-1-0 → 2-0-0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->