### PR TITLE
fix(ISHDR): guard contrastedColorModified against zero avgValue

### DIFF
--- a/package/Shaders/ISHDR.hlsl
+++ b/package/Shaders/ISHDR.hlsl
@@ -1,6 +1,7 @@
 #include "Common/Color.hlsli"
 #include "Common/DummyVSTexCoord.hlsl"
 #include "Common/FrameBuffer.hlsli"
+#include "Common/Math.hlsli"
 #include "Common/SharedData.hlsli"
 
 typedef VS_OUTPUT PS_INPUT;
@@ -175,7 +176,7 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 contrastedColor = lerp(avgValue.x, tintedColor, Cinematic.z);
 
 	// Contrast modified to fix crushed shadows
-	float safeAvgValue = max(avgValue.x, 1e-6);
+	float safeAvgValue = max(avgValue.x, EPSILON_DIVISION);
 	float3 contrastedColorModified = pow(max(0.0, abs(tintedColor) / safeAvgValue), Cinematic.z) * safeAvgValue * sign(tintedColor);
 	contrastedColor = lerp(contrastedColorModified, contrastedColor, saturate(contrastedColorModified / 0.1f));  // blend in modified contrast for shadows
 

--- a/package/Shaders/ISHDR.hlsl
+++ b/package/Shaders/ISHDR.hlsl
@@ -175,7 +175,8 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 contrastedColor = lerp(avgValue.x, tintedColor, Cinematic.z);
 
 	// Contrast modified to fix crushed shadows
-	float3 contrastedColorModified = pow(max(0.0, abs(tintedColor) / avgValue.x), Cinematic.z) * avgValue.x * sign(tintedColor);
+	float safeAvgValue = max(avgValue.x, 1e-6);
+	float3 contrastedColorModified = pow(max(0.0, abs(tintedColor) / safeAvgValue), Cinematic.z) * safeAvgValue * sign(tintedColor);
 	contrastedColor = lerp(contrastedColorModified, contrastedColor, saturate(contrastedColorModified / 0.1f));  // blend in modified contrast for shadows
 
 	outputColor = contrastedColor;


### PR DESCRIPTION
## Summary

Guard the contrast modification path in ISHDR.hlsl against division by zero when `avgValue.x` is 0.

## Why this matters

Line 178 divides `tintedColor` by `avgValue.x` without checking for zero. When `avgValue.x` is 0, the division produces `INF`, which propagates through `pow()` and contaminates `outputColor`. The earlier exposure path (lines ~168-169) already guards this same value with `if (avgValue.x != 0)`, but the contrast modification skips the check. Flagged by @alandtse during review of PR #2103.

## Changes

`package/Shaders/ISHDR.hlsl` line 178: Replace raw `avgValue.x` with `max(avgValue.x, 1e-6)` (epsilon clamp). Both the divisor and the multiplier use the clamped value so the result stays mathematically consistent.

## Testing

HLSL static analysis. The change is a single float substitution with no control flow changes.

Fixes #2104

This contribution was developed with AI assistance (Claude Code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented rare division-by-zero that could produce extreme or unstable shadow contrast in certain lighting, improving rendering stability.
  * Ensured more consistent shadow-contrast behavior in low-intensity/near-zero average lighting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->