### PR TITLE
perf(SSGI): eliminate radiance copy via direct UAV write

### DIFF
--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -403,7 +403,7 @@ void ScreenSpaceGI::SetupResources()
 		{
 			texRadiance = eastl::make_unique<Texture2D>(texDesc);
 			texRadiance->CreateSRV(srvDesc);
-			texRadiance->CreateUAV(uavDesc);  // Create default UAV for mip 0
+			// No default UAV needed: prefilterRadiance binds per-mip UAVs via uavRadiance[].
 
 			// Create individual UAVs for each mip level for prefiltering
 			for (uint i = 0; i < 5; ++i) {
@@ -415,10 +415,12 @@ void ScreenSpaceGI::SetupResources()
 				DX::ThrowIfFailed(device->CreateUnorderedAccessView(texRadiance->resource.get(), &mipUavDesc, uavRadiance[i].put()));
 			}
 
-			// Create temporary texture for prefiltering (single mip level, used as SRV input)
+			// Staging texture for mip 0 radiance. radianceDisocc writes it directly,
+			// prefilterRadiance reads it as SRV and writes the mip chain back to texRadiance.
+			// Avoids a full-texture CopySubresourceRegion each frame.
 			D3D11_TEXTURE2D_DESC tempTexDesc = texDesc;
 			tempTexDesc.MipLevels = 1;
-			tempTexDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
+			tempTexDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
 
 			D3D11_SHADER_RESOURCE_VIEW_DESC tempSrvDesc = {
 				.Format = DXGI_FORMAT_R11G11B10_FLOAT,
@@ -428,8 +430,15 @@ void ScreenSpaceGI::SetupResources()
 					.MipLevels = 1 }
 			};
 
+			D3D11_UNORDERED_ACCESS_VIEW_DESC tempUavDesc = {
+				.Format = DXGI_FORMAT_R11G11B10_FLOAT,
+				.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D,
+				.Texture2D = { .MipSlice = 0 }
+			};
+
 			texRadianceTemp = eastl::make_unique<Texture2D>(tempTexDesc);
 			texRadianceTemp->CreateSRV(tempSrvDesc);
+			texRadianceTemp->CreateUAV(tempUavDesc);
 		}
 
 		texDesc.BindFlags &= ~D3D11_BIND_RENDER_TARGET;
@@ -774,7 +783,7 @@ void ScreenSpaceGI::DrawSSGI()
 		srvs.at(9) = texGiSpecular[inputAoTexIdx]->srv.get();
 		srvs.at(10) = nullptr;
 
-		uavs.at(0) = texRadiance->uav.get();
+		uavs.at(0) = texRadianceTemp->uav.get();
 		uavs.at(1) = texAccumFrames[!lastFrameAccumTexIdx]->uav.get();
 		uavs.at(2) = texAo[!inputAoTexIdx]->uav.get();
 		uavs.at(3) = texIlY[!inputGITexIdx]->uav.get();
@@ -786,22 +795,19 @@ void ScreenSpaceGI::DrawSSGI()
 		context->CSSetShader(radianceDisoccCompute.get(), nullptr, 0);
 		context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
 
-		// Prefilter radiance texture instead of using GenerateMips for proper dynamic resolution handling
+		// Prefilter radiance texture instead of using GenerateMips for proper dynamic resolution handling.
+		// radianceDisocc wrote mip 0 directly to texRadianceTemp above, so we can bind it
+		// as SRV input here without an intermediate CopySubresourceRegion.
 		{
 			TracyD3D11Zone(globals::state->tracyCtx, "SSGI - Prefilter Radiance");
 
-			// First copy mip 0 from radiance to temporary texture to avoid read/write conflict
-			context->CopySubresourceRegion(
-				texRadianceTemp->resource.get(), 0, 0, 0, 0,
-				texRadiance->resource.get(), 0, nullptr);
-
 			resetViews();
-			srvs.at(0) = texRadianceTemp->srv.get();  // Use temporary texture as input
-			uavs.at(0) = uavRadiance[0].get();        // Mip 0
-			uavs.at(1) = uavRadiance[1].get();        // Mip 1
-			uavs.at(2) = uavRadiance[2].get();        // Mip 2
-			uavs.at(3) = uavRadiance[3].get();        // Mip 3
-			uavs.at(4) = uavRadiance[4].get();        // Mip 4
+			srvs.at(0) = texRadianceTemp->srv.get();
+			uavs.at(0) = uavRadiance[0].get();  // Mip 0
+			uavs.at(1) = uavRadiance[1].get();  // Mip 1
+			uavs.at(2) = uavRadiance[2].get();  // Mip 2
+			uavs.at(3) = uavRadiance[3].get();  // Mip 3
+			uavs.at(4) = uavRadiance[4].get();  // Mip 4
 
 			context->CSSetShaderResources(0, 1, srvs.data());
 			context->CSSetUnorderedAccessViews(0, 5, uavs.data(), nullptr);


### PR DESCRIPTION
## Summary

`radianceDisocc` previously wrote mip 0 to `texRadiance`, then a `CopySubresourceRegion` copied it to `texRadianceTemp` before `prefilterRadiance` could safely read it (avoiding the read/write hazard on the same texture). This PR eliminates that intermediate copy by having `radianceDisocc` write directly to `texRadianceTemp` as a UAV.

- `texRadianceTemp` gains a UAV view (`D3D11_BIND_UNORDERED_ACCESS` replaces `D3D11_BIND_RENDER_TARGET`)
- `radianceDisocc` binds `texRadianceTemp->uav` at slot 0 instead of `texRadiance->uav`
- `prefilterRadiance` continues to read `texRadianceTemp` as SRV and write the mip chain back to `texRadiance` — unchanged
- The `CopySubresourceRegion` call is removed entirely

No behaviour change, no quality impact. Removes one full-texture GPU copy per frame.

## Test plan

- [x] Verified in RenderDoc (VR capture) that `prefilterRadiance` receives correct mip 0 input after the change
- [x] No visual regression in outdoor/interior scenes
- [x] Builds cleanly under ALL preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized the Screen Space Global Illumination pipeline to eliminate an internal copy step and enable direct radiance writes into the staging buffer. This reduces GPU memory traffic, lowers workload, and improves rendering performance and frame-time stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->