### PR TITLE
ci: add semantic release and nexus upload pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,62 @@
+name: Semantic Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            release_type:
+                description: "Release type: rc or stable"
+                required: true
+                default: "rc"
+
+permissions:
+    contents: write
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        outputs:
+            new_release_published: ${{ steps.semantic.outputs.new_release_published }}
+            new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
+            - name: Apply feature version bumps
+              run: |
+                  python tools/feature_version_audit.py \
+                    --apply-bumps \
+                    --ci \
+                    --output /tmp/feature-version-audit.txt
+
+            - name: Semantic Release
+              id: semantic
+              uses: cycjimmy/semantic-release-action@v6
+              with:
+                  extra_plugins: |
+                      @google/semantic-release-replace-plugin
+                      @semantic-release/git
+                  tag_format: "v${version}"
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+
+    notify-upload:
+        name: Notify of pending Nexus uploads
+        runs-on: ubuntu-latest
+        needs: release
+        if: needs.release.outputs.new_release_published == 'true'
+        steps:
+            - name: Create job summary
+              run: |
+                  RELEASE_TAG="v${{ needs.release.outputs.new_release_version }}"
+                  echo "## Release Complete - Nexus Upload Pending" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "✓ Release **$RELEASE_TAG** created successfully" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Next step:** Upload to Nexus Mods" >> $GITHUB_STEP_SUMMARY
+                  echo "- [Trigger Nexus Upload Workflow](https://github.com/${{ github.repository }}/actions/workflows/upload-nexus.yaml)" >> $GITHUB_STEP_SUMMARY
+                  echo "- Use tag: \`$RELEASE_TAG\`" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Note:** Feature changelogs are ready and will be included automatically."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,9 +7,14 @@ on:
                 description: "Release type: rc or stable"
                 required: true
                 default: "rc"
+            dry_run:
+                description: "Dry-run for downstream Nexus upload (true uploads nothing)"
+                required: false
+                default: "true"
 
 permissions:
     contents: write
+    actions: write
 
 jobs:
     release:
@@ -42,21 +47,31 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   RELEASE_TYPE: ${{ github.event.inputs.release_type }}
 
-    notify-upload:
-        name: Notify of pending Nexus uploads
+    dispatch-upload:
+        name: Trigger Nexus upload workflow
         runs-on: ubuntu-latest
         needs: release
         if: needs.release.outputs.new_release_published == 'true'
         steps:
-            - name: Create job summary
+            - name: Dispatch upload-nexus.yaml
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  REPO: ${{ github.repository }}
+                  RELEASE_TAG: v${{ needs.release.outputs.new_release_version }}
+                  DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
               run: |
-                  RELEASE_TAG="v${{ needs.release.outputs.new_release_version }}"
-                  echo "## Release Complete - Nexus Upload Pending" >> $GITHUB_STEP_SUMMARY
+                  gh workflow run upload-nexus.yaml \
+                    --repo "$REPO" \
+                    --ref "${GITHUB_REF_NAME}" \
+                    -f tag="$RELEASE_TAG" \
+                    -f dry_run="$DRY_RUN"
+
+            - name: Create job summary
+              env:
+                  RELEASE_TAG: v${{ needs.release.outputs.new_release_version }}
+                  DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+              run: |
+                  echo "## Release Complete - Nexus Upload Dispatched" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "✓ Release **$RELEASE_TAG** created successfully" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "**Next step:** Upload to Nexus Mods" >> $GITHUB_STEP_SUMMARY
-                  echo "- [Trigger Nexus Upload Workflow](https://github.com/${{ github.repository }}/actions/workflows/upload-nexus.yaml)" >> $GITHUB_STEP_SUMMARY
-                  echo "- Use tag: \`$RELEASE_TAG\`" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "**Note:** Feature changelogs are ready and will be included automatically."
+                  echo "✓ Dispatched [upload-nexus.yaml](https://github.com/${{ github.repository }}/actions/workflows/upload-nexus.yaml) with tag \`$RELEASE_TAG\` (dry_run=\`$DRY_RUN\`)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/upload-nexus.yaml
+++ b/.github/workflows/upload-nexus.yaml
@@ -29,12 +29,6 @@ on:
             changelog:
                 description: "Optional release notes or changelog for Nexus"
                 required: false
-    workflow_run:
-        workflows:
-            - Semantic Release
-            - Build Community Shaders and addons
-        types:
-            - completed
 
 jobs:
     prepare-nexus-matrix:
@@ -46,7 +40,6 @@ jobs:
             version: ${{ steps.resolve.outputs.version }}
             dry_run: ${{ steps.dryrun.outputs.dry_run }}
             has_uploads: ${{ steps.generate.outputs.has_uploads }}
-            skip: ${{ steps.resolve.outputs.skip }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
@@ -61,54 +54,30 @@ jobs:
             - name: Resolve release tag
               id: resolve
               run: |
-                  if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-                    TAG="$INPUT_TAG"
-                  else
-                    # Resolve the tag pointing at the head SHA of the triggering workflow run
-                    TAG=$(gh api "repos/$REPO/git/refs/tags" \
-                      --jq ".[] | select(.object.sha == \"$HEAD_SHA\") | .ref | ltrimstr(\"refs/tags/\")" \
-                      2>/dev/null | head -1)
-                  fi
-
+                  TAG="$INPUT_TAG"
                   if [ -z "$TAG" ]; then
-                    if [ "$EVENT_NAME" = "workflow_run" ]; then
-                      echo 'No release tag for triggering workflow run; skipping Nexus upload.' >&2
-                      echo 'skip=true' >> $GITHUB_OUTPUT
-                      echo 'tag=' >> $GITHUB_OUTPUT
-                      echo 'version=' >> $GITHUB_OUTPUT
-                      exit 0
-                    fi
-                    echo 'No tag found for Nexus upload' >&2
+                    echo 'No tag provided for Nexus upload' >&2
                     exit 1
                   fi
-
                   VERSION="${TAG#v}"
-                  echo "skip=false" >> $GITHUB_OUTPUT
                   echo "tag=$TAG" >> $GITHUB_OUTPUT
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  EVENT_NAME: ${{ github.event_name }}
-                  REPO: ${{ github.repository }}
                   INPUT_TAG: ${{ github.event.inputs.tag || '' }}
-                  HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
 
             - name: Compute dry-run mode
               id: dryrun
-              if: steps.resolve.outputs.skip != 'true'
               run: |
-                  if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$INPUT_DRY_RUN" = "false" ]; then
+                  if [ "$INPUT_DRY_RUN" = "false" ]; then
                     echo "dry_run=false" >> $GITHUB_OUTPUT
                   else
                     echo "dry_run=true" >> $GITHUB_OUTPUT
                   fi
               env:
-                  EVENT_NAME: ${{ github.event_name }}
                   INPUT_DRY_RUN: ${{ github.event.inputs.dry_run || '' }}
 
             - name: Generate Nexus upload matrix
               id: generate
-              if: steps.resolve.outputs.skip != 'true'
               run: |
                   ARGS=( --export-nexus-matrix --matrix-output nexus-matrix-raw.json )
                   PREVIOUS_TAG=$(git tag --merged "$RELEASE_TAG" --list 'v*.*.*' --sort=-v:refname 2>/dev/null \
@@ -157,15 +126,6 @@ jobs:
 
     prepare-artifacts:
         needs: prepare-nexus-matrix
-        if: >
-            needs.prepare-nexus-matrix.outputs.skip != 'true' &&
-            (
-              github.event_name == 'workflow_dispatch' ||
-              (
-                github.event_name == 'workflow_run' &&
-                github.event.workflow_run.conclusion == 'success'
-              )
-            )
         runs-on: ubuntu-latest
         strategy:
             matrix: ${{ fromJson(needs.prepare-nexus-matrix.outputs.matrix) }}
@@ -232,16 +192,8 @@ jobs:
         # filtering is needed in the if condition (matrix is not available in job-level if).
         needs: [prepare-nexus-matrix, prepare-artifacts]
         if: >
-            needs.prepare-nexus-matrix.outputs.skip != 'true' &&
             needs.prepare-nexus-matrix.outputs.dry_run != 'true' &&
-            needs.prepare-nexus-matrix.outputs.has_uploads == 'true' &&
-            (
-              github.event_name == 'workflow_dispatch' ||
-              (
-                github.event_name == 'workflow_run' &&
-                github.event.workflow_run.conclusion == 'success'
-              )
-            )
+            needs.prepare-nexus-matrix.outputs.has_uploads == 'true'
         strategy:
             matrix: ${{ fromJson(needs.prepare-nexus-matrix.outputs.upload_matrix) }}
             fail-fast: false
@@ -263,7 +215,7 @@ jobs:
         name: Upload Summary
         runs-on: ubuntu-latest
         needs: [prepare-nexus-matrix, prepare-artifacts, upload-to-nexus]
-        if: always() && needs.prepare-nexus-matrix.outputs.skip != 'true'
+        if: always() && needs.prepare-nexus-matrix.result == 'success'
         steps:
             - name: Check upload status
               run: |

--- a/.github/workflows/upload-nexus.yaml
+++ b/.github/workflows/upload-nexus.yaml
@@ -1,0 +1,267 @@
+name: Upload Nexus Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: "Release tag to upload to Nexus"
+                required: true
+            nexus_game_id:
+                description: "Nexus game ID"
+                required: false
+                default: "skyrimspecialedition"
+            nexus_mod_id:
+                description: "Nexus mod ID"
+                required: false
+                default: "86492"
+            artifact_pattern:
+                description: "Artifact glob pattern to select the package to upload"
+                required: false
+                default: "CommunityShaders-*.7z"
+            mod_filename:
+                description: "Filename used for the Nexus mod upload"
+                required: false
+                default: "Community Shaders"
+            dry_run:
+                description: "If true, do not upload to Nexus; only report the planned upload"
+                required: false
+                default: "true"
+            changelog:
+                description: "Optional release notes or changelog for Nexus"
+                required: false
+    workflow_run:
+        workflows:
+            - Semantic Release
+            - Build Community Shaders and addons
+        types:
+            - completed
+
+jobs:
+    prepare-nexus-matrix:
+        runs-on: ubuntu-latest
+        outputs:
+            matrix: ${{ steps.generate.outputs.matrix }}
+            upload_matrix: ${{ steps.generate.outputs.upload_matrix }}
+            tag: ${{ steps.resolve.outputs.tag }}
+            version: ${{ steps.resolve.outputs.version }}
+            dry_run: ${{ steps.dryrun.outputs.dry_run }}
+            has_uploads: ${{ steps.generate.outputs.has_uploads }}
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Setup Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.11"
+
+            - name: Resolve release tag
+              id: resolve
+              run: |
+                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+                    TAG='${{ github.event.inputs.tag }}'
+                  else
+                    # Resolve the tag pointing at the head SHA of the triggering workflow run
+                    HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+                    TAG=$(gh api repos/${{ github.repository }}/git/refs/tags \
+                      --jq ".[] | select(.object.sha == \"$HEAD_SHA\") | .ref | ltrimstr(\"refs/tags/\")" \
+                      2>/dev/null | head -1)
+                  fi
+
+                  if [ -z "$TAG" ]; then
+                    echo 'No tag found for Nexus upload' >&2
+                    exit 1
+                  fi
+
+                  VERSION="${TAG#v}"
+                  echo "tag=$TAG" >> $GITHUB_OUTPUT
+                  echo "version=$VERSION" >> $GITHUB_OUTPUT
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Compute dry-run mode
+              id: dryrun
+              run: |
+                  if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.dry_run }}" = "false" ]; then
+                    echo "dry_run=false" >> $GITHUB_OUTPUT
+                  else
+                    echo "dry_run=true" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Generate Nexus upload matrix
+              id: generate
+              run: |
+                  ARGS=( --export-nexus-matrix --matrix-output nexus-matrix-raw.json )
+                  if [ -n "${{ github.event.inputs.nexus_mod_id }}" ]; then
+                    ARGS+=( --core-mod-id "${{ github.event.inputs.nexus_mod_id }}" )
+                  fi
+                  if [ -n "${{ github.event.inputs.mod_filename }}" ]; then
+                    ARGS+=( --core-filename "${{ github.event.inputs.mod_filename }}" )
+                  fi
+                  if [ -n "${{ github.event.inputs.artifact_pattern }}" ]; then
+                    ARGS+=( --core-artifact-pattern "${{ github.event.inputs.artifact_pattern }}" )
+                  fi
+                  python tools/feature_version_audit.py "${ARGS[@]}"
+                  python -c "
+                  import json
+                  with open('nexus-matrix-raw.json') as f:
+                      data = json.load(f)
+                  # Full matrix for artifact prep; upload matrix excludes auto_upload=false
+                  upload_data = [row for row in data if row.get('auto_upload', True)]
+                  has_uploads = bool(upload_data)
+                  with open('nexus-matrix.json', 'w') as f:
+                      json.dump({'include': data}, f)
+                  with open('nexus-upload-matrix.json', 'w') as f:
+                      json.dump({'include': upload_data or [{'name': '_empty', 'skip': True}]}, f)
+                  with open('nexus-upload-state.json', 'w') as f:
+                      json.dump({'has_uploads': has_uploads}, f)
+                  "
+                  echo "matrix<<EOF" >> $GITHUB_OUTPUT
+                  cat nexus-matrix.json >> $GITHUB_OUTPUT
+                  echo "EOF" >> $GITHUB_OUTPUT
+                  echo "upload_matrix<<EOF" >> $GITHUB_OUTPUT
+                  cat nexus-upload-matrix.json >> $GITHUB_OUTPUT
+                  echo "EOF" >> $GITHUB_OUTPUT
+                  echo "has_uploads=$(python -c \"import json; print('true' if json.load(open('nexus-upload-state.json')).get('has_uploads') else 'false')\")" >> $GITHUB_OUTPUT
+
+    prepare-artifacts:
+        needs: prepare-nexus-matrix
+        if: >
+            github.event_name == 'workflow_dispatch' ||
+            (
+              github.event_name == 'workflow_run' &&
+              github.event.workflow_run.conclusion == 'success'
+            )
+        runs-on: ubuntu-latest
+        strategy:
+            matrix: ${{ fromJson(needs.prepare-nexus-matrix.outputs.matrix) }}
+            fail-fast: false
+        steps:
+            - name: Download GitHub release assets
+              run: |
+                  mkdir -p release-assets
+                  gh release download "${{ needs.prepare-nexus-matrix.outputs.tag }}" --pattern "*.7z" --dir release-assets
+                  ls -lah release-assets
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Select release artifact
+              id: artifact
+              continue-on-error: true
+              run: |
+                  pattern='${{ matrix.artifact_pattern }}'
+                  echo "Searching for artifact matching: $pattern"
+                  asset=$(find release-assets -maxdepth 1 -name "$pattern" | sort | head -n 1)
+                  if [ -z "$asset" ]; then
+                    echo "ERROR: No release artifact matching pattern '$pattern' found for ${{ matrix.name }}" >&2
+                    echo "Available artifacts:"
+                    ls -1 release-assets/ | sed 's/^/  /'
+                    echo "artifact_found=false" >> $GITHUB_OUTPUT
+                    exit 0
+                  fi
+                  echo "Found artifact: $asset"
+                  echo "artifact_path=$asset" >> $GITHUB_OUTPUT
+                  echo "artifact_found=true" >> $GITHUB_OUTPUT
+
+            - name: Upload selected artifact as workflow artifact
+              if: steps.artifact.outputs.artifact_found == 'true'
+              uses: actions/upload-artifact@v7
+              with:
+                  name: nexus-upload-${{ matrix.name }}
+                  path: ${{ steps.artifact.outputs.artifact_path }}
+                  retention-days: 7
+
+            - name: Report planned Nexus upload
+              run: |
+                  DRY_RUN="${{ needs.prepare-nexus-matrix.outputs.dry_run }}"
+                  FOUND="${{ steps.artifact.outputs.artifact_found }}"
+                  if [ "$FOUND" != "true" ]; then
+                    echo "SKIPPED: No artifact found for ${{ matrix.name }}"
+                    echo "Pattern: ${{ matrix.artifact_pattern }}"
+                  else
+                    echo "Planned Nexus upload:"
+                    echo "  Nexus mod ID: ${{ matrix.nexus_mod_id }}"
+                    echo "  Artifact name: nexus-upload-${{ matrix.name }}"
+                    echo "  Release tag: ${{ needs.prepare-nexus-matrix.outputs.tag }}"
+                    echo "  Version: ${{ needs.prepare-nexus-matrix.outputs.version }}"
+                    echo "  Mod filename: ${{ matrix.mod_filename }}"
+                    echo "  Auto upload: ${{ matrix.auto_upload }}"
+                    if [ "$DRY_RUN" = "true" ]; then
+                      echo "Dry run enabled: skipping actual Nexus upload."
+                    fi
+                  fi
+
+    upload-to-nexus:
+        # Reusable workflow call: runs-on is intentionally omitted (runner is defined by the
+        # called workflow). IDE schema validators may flag this as an error — it is valid syntax.
+        # auto_upload=false items are pre-filtered from upload_matrix so no matrix-context
+        # filtering is needed in the if condition (matrix is not available in job-level if).
+        needs: [prepare-nexus-matrix, prepare-artifacts]
+        if: >
+            needs.prepare-nexus-matrix.outputs.dry_run != 'true' &&
+            needs.prepare-nexus-matrix.outputs.has_uploads == 'true' &&
+            (
+              github.event_name == 'workflow_dispatch' ||
+              (
+                github.event_name == 'workflow_run' &&
+                github.event.workflow_run.conclusion == 'success'
+              )
+            )
+        strategy:
+            matrix: ${{ fromJson(needs.prepare-nexus-matrix.outputs.upload_matrix) }}
+            fail-fast: false
+        continue-on-error: ${{ matrix.name != 'core' }}
+        uses: alandtse/nexus-workflows/.github/workflows/upload-nexus.yml@main
+        with:
+            nexus_game_id: ${{ github.event.inputs.nexus_game_id || 'skyrimspecialedition' }}
+            nexus_mod_id: ${{ matrix.nexus_mod_id }}
+            artifact_name: nexus-upload-${{ matrix.name }}
+            tag_name: ${{ needs.prepare-nexus-matrix.outputs.tag }}
+            mod_version: ${{ matrix.mod_version || needs.prepare-nexus-matrix.outputs.version }}
+            mod_filename: ${{ matrix.mod_filename }}
+            changelog: ${{ github.event.inputs.changelog || '' }}
+        secrets:
+            UNEX_NEXUSMODS_SESSION_COOKIE: ${{ secrets.UNEX_NEXUSMODS_SESSION_COOKIE }}
+            UNEX_APIKEY: ${{ secrets.UNEX_APIKEY }}
+
+    upload-summary:
+        name: Upload Summary
+        runs-on: ubuntu-latest
+        needs: [prepare-nexus-matrix, prepare-artifacts, upload-to-nexus]
+        if: always()
+        steps:
+            - name: Check upload status
+              run: |
+                  echo "## Nexus Upload Summary" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Workflow:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+                  echo "**Tag:** ${{ needs.prepare-nexus-matrix.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+                  echo "**Dry run:** ${{ needs.prepare-nexus-matrix.outputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+
+            - name: Report dry-run result
+              if: needs.prepare-nexus-matrix.outputs.dry_run == 'true'
+              run: |
+                  echo "ℹ️ Dry run — no files were uploaded to Nexus" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**To make a real upload:**" >> $GITHUB_STEP_SUMMARY
+                  echo "1. Re-run this workflow" >> $GITHUB_STEP_SUMMARY
+                  echo "2. Set \`dry_run: false\` in the workflow inputs" >> $GITHUB_STEP_SUMMARY
+
+            - name: Report upload result
+              if: needs.prepare-nexus-matrix.outputs.dry_run != 'true'
+              run: |
+                  RESULT="${{ needs.upload-to-nexus.result }}"
+                  if [ "$RESULT" = "success" ]; then
+                    echo "✓ All Nexus uploads completed successfully" >> $GITHUB_STEP_SUMMARY
+                    echo "" >> $GITHUB_STEP_SUMMARY
+                    echo "- [Community Shaders](https://www.nexusmods.com/skyrimspecialedition/mods/86492)" >> $GITHUB_STEP_SUMMARY
+                  else
+                    echo "⚠️ Some uploads failed or were skipped (result: $RESULT)" >> $GITHUB_STEP_SUMMARY
+                    echo "" >> $GITHUB_STEP_SUMMARY
+                    echo "**Recovery steps:**" >> $GITHUB_STEP_SUMMARY
+                    echo "1. Check the upload-to-nexus job logs for details" >> $GITHUB_STEP_SUMMARY
+                    echo "2. Verify credentials: UNEX_NEXUSMODS_SESSION_COOKIE, UNEX_APIKEY" >> $GITHUB_STEP_SUMMARY
+                    echo "3. Download failed artifacts from this workflow run and upload manually" >> $GITHUB_STEP_SUMMARY
+                    echo "4. Or re-run this workflow with the same tag to retry" >> $GITHUB_STEP_SUMMARY
+                  fi

--- a/.github/workflows/upload-nexus.yaml
+++ b/.github/workflows/upload-nexus.yaml
@@ -46,9 +46,12 @@ jobs:
             version: ${{ steps.resolve.outputs.version }}
             dry_run: ${{ steps.dryrun.outputs.dry_run }}
             has_uploads: ${{ steps.generate.outputs.has_uploads }}
+            skip: ${{ steps.resolve.outputs.skip }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
 
             - name: Setup Python
               uses: actions/setup-python@v5
@@ -58,48 +61,71 @@ jobs:
             - name: Resolve release tag
               id: resolve
               run: |
-                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-                    TAG='${{ github.event.inputs.tag }}'
+                  if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+                    TAG="$INPUT_TAG"
                   else
                     # Resolve the tag pointing at the head SHA of the triggering workflow run
-                    HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
-                    TAG=$(gh api repos/${{ github.repository }}/git/refs/tags \
+                    TAG=$(gh api "repos/$REPO/git/refs/tags" \
                       --jq ".[] | select(.object.sha == \"$HEAD_SHA\") | .ref | ltrimstr(\"refs/tags/\")" \
                       2>/dev/null | head -1)
                   fi
 
                   if [ -z "$TAG" ]; then
+                    if [ "$EVENT_NAME" = "workflow_run" ]; then
+                      echo 'No release tag for triggering workflow run; skipping Nexus upload.' >&2
+                      echo 'skip=true' >> $GITHUB_OUTPUT
+                      echo 'tag=' >> $GITHUB_OUTPUT
+                      echo 'version=' >> $GITHUB_OUTPUT
+                      exit 0
+                    fi
                     echo 'No tag found for Nexus upload' >&2
                     exit 1
                   fi
 
                   VERSION="${TAG#v}"
+                  echo "skip=false" >> $GITHUB_OUTPUT
                   echo "tag=$TAG" >> $GITHUB_OUTPUT
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  EVENT_NAME: ${{ github.event_name }}
+                  REPO: ${{ github.repository }}
+                  INPUT_TAG: ${{ github.event.inputs.tag || '' }}
+                  HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
 
             - name: Compute dry-run mode
               id: dryrun
+              if: steps.resolve.outputs.skip != 'true'
               run: |
-                  if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.dry_run }}" = "false" ]; then
+                  if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$INPUT_DRY_RUN" = "false" ]; then
                     echo "dry_run=false" >> $GITHUB_OUTPUT
                   else
                     echo "dry_run=true" >> $GITHUB_OUTPUT
                   fi
+              env:
+                  EVENT_NAME: ${{ github.event_name }}
+                  INPUT_DRY_RUN: ${{ github.event.inputs.dry_run || '' }}
 
             - name: Generate Nexus upload matrix
               id: generate
+              if: steps.resolve.outputs.skip != 'true'
               run: |
                   ARGS=( --export-nexus-matrix --matrix-output nexus-matrix-raw.json )
-                  if [ -n "${{ github.event.inputs.nexus_mod_id }}" ]; then
-                    ARGS+=( --core-mod-id "${{ github.event.inputs.nexus_mod_id }}" )
+                  PREVIOUS_TAG=$(git tag --merged "$RELEASE_TAG" --list 'v*.*.*' --sort=-v:refname 2>/dev/null \
+                    | awk -v current="$RELEASE_TAG" '$0 != current { print; exit }')
+                  if [ -n "$PREVIOUS_TAG" ]; then
+                    ARGS+=( --base "$PREVIOUS_TAG" )
+                  else
+                    ARGS+=( --all-features )
                   fi
-                  if [ -n "${{ github.event.inputs.mod_filename }}" ]; then
-                    ARGS+=( --core-filename "${{ github.event.inputs.mod_filename }}" )
+                  if [ -n "$INPUT_NEXUS_MOD_ID" ]; then
+                    ARGS+=( --core-mod-id "$INPUT_NEXUS_MOD_ID" )
                   fi
-                  if [ -n "${{ github.event.inputs.artifact_pattern }}" ]; then
-                    ARGS+=( --core-artifact-pattern "${{ github.event.inputs.artifact_pattern }}" )
+                  if [ -n "$INPUT_MOD_FILENAME" ]; then
+                    ARGS+=( --core-filename "$INPUT_MOD_FILENAME" )
+                  fi
+                  if [ -n "$INPUT_ARTIFACT_PATTERN" ]; then
+                    ARGS+=( --core-artifact-pattern "$INPUT_ARTIFACT_PATTERN" )
                   fi
                   python tools/feature_version_audit.py "${ARGS[@]}"
                   python -c "
@@ -123,14 +149,22 @@ jobs:
                   cat nexus-upload-matrix.json >> $GITHUB_OUTPUT
                   echo "EOF" >> $GITHUB_OUTPUT
                   echo "has_uploads=$(python -c \"import json; print('true' if json.load(open('nexus-upload-state.json')).get('has_uploads') else 'false')\")" >> $GITHUB_OUTPUT
+              env:
+                  RELEASE_TAG: ${{ steps.resolve.outputs.tag }}
+                  INPUT_NEXUS_MOD_ID: ${{ github.event.inputs.nexus_mod_id || '' }}
+                  INPUT_MOD_FILENAME: ${{ github.event.inputs.mod_filename || '' }}
+                  INPUT_ARTIFACT_PATTERN: ${{ github.event.inputs.artifact_pattern || '' }}
 
     prepare-artifacts:
         needs: prepare-nexus-matrix
         if: >
-            github.event_name == 'workflow_dispatch' ||
+            needs.prepare-nexus-matrix.outputs.skip != 'true' &&
             (
-              github.event_name == 'workflow_run' &&
-              github.event.workflow_run.conclusion == 'success'
+              github.event_name == 'workflow_dispatch' ||
+              (
+                github.event_name == 'workflow_run' &&
+                github.event.workflow_run.conclusion == 'success'
+              )
             )
         runs-on: ubuntu-latest
         strategy:
@@ -198,6 +232,7 @@ jobs:
         # filtering is needed in the if condition (matrix is not available in job-level if).
         needs: [prepare-nexus-matrix, prepare-artifacts]
         if: >
+            needs.prepare-nexus-matrix.outputs.skip != 'true' &&
             needs.prepare-nexus-matrix.outputs.dry_run != 'true' &&
             needs.prepare-nexus-matrix.outputs.has_uploads == 'true' &&
             (
@@ -228,7 +263,7 @@ jobs:
         name: Upload Summary
         runs-on: ubuntu-latest
         needs: [prepare-nexus-matrix, prepare-artifacts, upload-to-nexus]
-        if: always()
+        if: always() && needs.prepare-nexus-matrix.outputs.skip != 'true'
         steps:
             - name: Check upload status
               run: |
@@ -249,7 +284,7 @@ jobs:
                   echo "2. Set \`dry_run: false\` in the workflow inputs" >> $GITHUB_STEP_SUMMARY
 
             - name: Report upload result
-              if: needs.prepare-nexus-matrix.outputs.dry_run != 'true'
+              if: needs.prepare-nexus-matrix.outputs.dry_run != 'true' && needs.prepare-nexus-matrix.outputs.has_uploads == 'true'
               run: |
                   RESULT="${{ needs.upload-to-nexus.result }}"
                   if [ "$RESULT" = "success" ]; then

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,0 +1,42 @@
+const releaseType = process.env.RELEASE_TYPE || 'rc';
+
+module.exports = {
+  branches: [
+    {
+      name: 'dev',
+      ...(releaseType === 'rc' ? { prerelease: 'rc' } : {}),
+    },
+  ],
+  plugins: [
+    '@semantic-release/commit-analyzer',
+    '@semantic-release/release-notes-generator',
+    [
+      '@google/semantic-release-replace-plugin',
+      {
+        replacements: [
+          {
+            files: ['CMakeLists.txt'],
+            from: 'VERSION [0-9]+\\.[0-9]+\\.[0-9]+',
+            to: 'VERSION ${nextRelease.version}',
+            results: [
+              {
+                file: 'CMakeLists.txt',
+                hasChanged: true,
+                numReplacements: 1,
+                numMatches: 1,
+              },
+            ],
+            countMatches: true,
+          },
+        ],
+      },
+    ],
+    [
+      '@semantic-release/git',
+      {
+        assets: ['CMakeLists.txt', 'features/**/Shaders/Features/*.ini'],
+        message: 'chore(release): ${nextRelease.version} [skip ci]',
+      },
+    ],
+  ],
+};

--- a/features/Cloud Shadows/Shaders/Features/CloudShadows.ini
+++ b/features/Cloud Shadows/Shaders/Features/CloudShadows.ini
@@ -1,2 +1,7 @@
 [Info]
-Version = 1-3-0
+version = 1-3-0
+
+[Nexus]
+nexusmodid = 139185
+nexusfilename = Cloud Shadows
+autoupload = true

--- a/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
+++ b/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 2-3-0
+version = 2-3-0
+
+[Nexus]
+autoupload = false

--- a/features/Exponential Height Fog/Shaders/Features/ExponentialHeightFog.ini
+++ b/features/Exponential Height Fog/Shaders/Features/ExponentialHeightFog.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-0-0
+version = 1-0-0
+
+[Nexus]
+autoupload = false

--- a/features/Extended Materials/Shaders/Features/ExtendedMaterials.ini
+++ b/features/Extended Materials/Shaders/Features/ExtendedMaterials.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-2-0
+version = 1-2-0
+
+[Nexus]
+autoupload = false

--- a/features/Extended Translucency/Shaders/Features/ExtendedTranslucency.ini
+++ b/features/Extended Translucency/Shaders/Features/ExtendedTranslucency.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-0-0
+version = 1-0-0
+
+[Nexus]
+autoupload = false

--- a/features/Grass Collision/Shaders/Features/GrassCollision.ini
+++ b/features/Grass Collision/Shaders/Features/GrassCollision.ini
@@ -1,2 +1,7 @@
 [Info]
-Version = 3-0-3
+version = 3-0-3
+
+[Nexus]
+nexusmodid = 87816
+nexusfilename = Grass Collision
+autoupload = true

--- a/features/Grass Lighting/Shaders/Features/GrassLighting.ini
+++ b/features/Grass Lighting/Shaders/Features/GrassLighting.ini
@@ -1,2 +1,7 @@
 [Info]
-Version = 2-0-1
+version = 2-0-1
+
+[Nexus]
+nexusmodid = 86502
+nexusfilename = Grass Lighting
+autoupload = true

--- a/features/HDR Display/Shaders/Features/HDRDisplay.ini
+++ b/features/HDR Display/Shaders/Features/HDRDisplay.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-0-0
+version = 1-0-0
+
+[Nexus]
+autoupload = false

--- a/features/Hair Specular/Shaders/Features/HairSpecular.ini
+++ b/features/Hair Specular/Shaders/Features/HairSpecular.ini
@@ -1,2 +1,7 @@
 [Info]
-Version = 1-1-0
+version = 1-1-0
+
+[Nexus]
+nexusmodid = 149011
+nexusfilename = Hair Specular
+autoupload = true

--- a/features/IBL/Shaders/Features/ImageBasedLighting.ini
+++ b/features/IBL/Shaders/Features/ImageBasedLighting.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-1-0
+version = 1-1-0
+
+[Nexus]
+autoupload = false

--- a/features/Interior Sun/Shaders/Features/InteriorSun.ini
+++ b/features/Interior Sun/Shaders/Features/InteriorSun.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-0-0
+version = 1-0-0
+
+[Nexus]
+autoupload = false

--- a/features/Inverse Square Lighting/Shaders/Features/InverseSquareLighting.ini
+++ b/features/Inverse Square Lighting/Shaders/Features/InverseSquareLighting.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-2-0
+version = 1-2-0
+
+[Nexus]
+autoupload = false

--- a/features/LOD Blending/Shaders/Features/LODBlending.ini
+++ b/features/LOD Blending/Shaders/Features/LODBlending.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-0-0
+version = 1-0-0
+
+[Nexus]
+autoupload = false

--- a/features/Light Limit Fix/Shaders/Features/LightLimitFix.ini
+++ b/features/Light Limit Fix/Shaders/Features/LightLimitFix.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 3-0-2
+version = 3-0-2
+
+[Nexus]
+autoupload = false

--- a/features/Linear Lighting/Shaders/Features/LinearLighting.ini
+++ b/features/Linear Lighting/Shaders/Features/LinearLighting.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-1-0
+version = 1-1-0
+
+[Nexus]
+autoupload = false

--- a/features/Performance Overlay/Shaders/Features/PerformanceOverlay.ini
+++ b/features/Performance Overlay/Shaders/Features/PerformanceOverlay.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-1-0
+version = 1-1-0
+
+[Nexus]
+autoupload = false

--- a/features/RenderDoc/Shaders/Features/RenderDoc.ini
+++ b/features/RenderDoc/Shaders/Features/RenderDoc.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-0-1
+version = 1-0-1
+
+[Nexus]
+autoupload = false

--- a/features/Screen Space GI/Shaders/Features/ScreenSpaceGI.ini
+++ b/features/Screen Space GI/Shaders/Features/ScreenSpaceGI.ini
@@ -1,2 +1,7 @@
 [Info]
-Version = 4-1-0
+version = 4-1-0
+
+[Nexus]
+nexusmodid = 130375
+nexusfilename = Screen Space GI
+autoupload = true

--- a/features/Screen-Space Shadows/Shaders/Features/ScreenSpaceShadows.ini
+++ b/features/Screen-Space Shadows/Shaders/Features/ScreenSpaceShadows.ini
@@ -1,2 +1,7 @@
 [Info]
-Version = 2-1-0
+version = 2-1-0
+
+[Nexus]
+nexusmodid = 93209
+nexusfilename = Screen Space Shadows
+autoupload = true

--- a/features/Sky Sync/Shaders/Features/SkySync.ini
+++ b/features/Sky Sync/Shaders/Features/SkySync.ini
@@ -1,2 +1,7 @@
 [Info]
-Version = 1-1-0
+version = 1-1-0
+
+[Nexus]
+nexusmodid = 153543
+nexusfilename = Sky Sync
+autoupload = true

--- a/features/Skylighting/Shaders/Features/Skylighting.ini
+++ b/features/Skylighting/Shaders/Features/Skylighting.ini
@@ -1,2 +1,7 @@
 [Info]
-Version = 1-2-4
+version = 1-2-4
+
+[Nexus]
+nexusmodid = 139352
+nexusfilename = Skylighting
+autoupload = true

--- a/features/Subsurface Scattering/Shaders/Features/SubsurfaceScattering.ini
+++ b/features/Subsurface Scattering/Shaders/Features/SubsurfaceScattering.ini
@@ -1,2 +1,7 @@
 [Info]
-Version = 3-0-1
+version = 3-0-1
+
+[Nexus]
+nexusmodid = 114114
+nexusfilename = Subsurface Scattering
+autoupload = true

--- a/features/Terrain Blending/Shaders/Features/TerrainBlending.ini
+++ b/features/Terrain Blending/Shaders/Features/TerrainBlending.ini
@@ -1,2 +1,7 @@
 [Info]
-Version = 1-0-2
+version = 1-0-2
+
+[Nexus]
+nexusmodid = 157076
+nexusfilename = Terrain Blending
+autoupload = true

--- a/features/Terrain Helper/Shaders/Features/TerrainHelper.ini
+++ b/features/Terrain Helper/Shaders/Features/TerrainHelper.ini
@@ -1,2 +1,7 @@
 [Info]
-Version = 1-0-0
+version = 1-0-0
+
+[Nexus]
+nexusmodid = 143149
+nexusfilename = Terrain Helper
+autoupload = true

--- a/features/Terrain Shadows/Shaders/Features/TerrainShadows.ini
+++ b/features/Terrain Shadows/Shaders/Features/TerrainShadows.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-1-0
+version = 1-1-0
+
+[Nexus]
+autoupload = false

--- a/features/Terrain Variation/Shaders/Features/TerrainVariation.ini
+++ b/features/Terrain Variation/Shaders/Features/TerrainVariation.ini
@@ -1,2 +1,7 @@
 [Info]
-Version = 1-0-1
+version = 1-0-1
+
+[Nexus]
+nexusmodid = 148123
+nexusfilename = Terrain Variation
+autoupload = true

--- a/features/Unified Water/Shaders/Features/UnifiedWater.ini
+++ b/features/Unified Water/Shaders/Features/UnifiedWater.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-0-1
+version = 1-0-1
+
+[Nexus]
+autoupload = false

--- a/features/Upscaling/Shaders/Features/Upscaling.ini
+++ b/features/Upscaling/Shaders/Features/Upscaling.ini
@@ -1,2 +1,7 @@
 [Info]
-Version = 1-3-0
+version = 1-3-0
+
+[Nexus]
+nexusmodid = 156952
+nexusfilename = Upscaling
+autoupload = true

--- a/features/VR/Shaders/Features/VR.ini
+++ b/features/VR/Shaders/Features/VR.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-1-0
+version = 1-1-0
+
+[Nexus]
+autoupload = false

--- a/features/Volumetric Lighting/Shaders/Features/VolumetricLighting.ini
+++ b/features/Volumetric Lighting/Shaders/Features/VolumetricLighting.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-1-0
+version = 1-1-0
+
+[Nexus]
+autoupload = false

--- a/features/Volumetric Shadows/Shaders/Features/VolumetricShadows.ini
+++ b/features/Volumetric Shadows/Shaders/Features/VolumetricShadows.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 2-0-0
+version = 2-0-0
+
+[Nexus]
+autoupload = false

--- a/features/Water Effects/Shaders/Features/WaterEffects.ini
+++ b/features/Water Effects/Shaders/Features/WaterEffects.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-1-0
+version = 1-1-0
+
+[Nexus]
+autoupload = false

--- a/features/Weather Editor/Shaders/Features/WeatherEditor.ini
+++ b/features/Weather Editor/Shaders/Features/WeatherEditor.ini
@@ -1,2 +1,5 @@
 [Info]
-Version = 1-1-0
+version = 1-1-0
+
+[Nexus]
+autoupload = false

--- a/features/Wetness Effects/Shaders/Features/WetnessEffects.ini
+++ b/features/Wetness Effects/Shaders/Features/WetnessEffects.ini
@@ -1,2 +1,7 @@
 [Info]
-Version = 3-1-0
+version = 3-1-0
+
+[Nexus]
+nexusmodid = 112739
+nexusfilename = Wetness Effects
+autoupload = true

--- a/tools/feature_version_audit.py
+++ b/tools/feature_version_audit.py
@@ -186,28 +186,33 @@ def get_feature_ini_metadata(feature_dir_or_ini_path):
     if not sections:
         sections = ['Info'] if parser.has_section('Info') else []
 
-    metadata = {}
+    metadata = {'auto_upload': False}
     for section in sections:
         if not parser.has_section(section):
             continue
         section_items = dict(parser.items(section))
         # ConfigParser converts keys to lowercase, so look for both variants
-        # Parse AutoUpload as boolean (defaults to false if not specified — opt-in)
-        auto_upload_str = section_items.get('autoupload') or section_items.get('auto_upload') or 'false'
-        auto_upload = auto_upload_str.lower() not in ('false', '0', 'no')
+        auto_upload_str = section_items.get('autoupload') or section_items.get('auto_upload')
+        if auto_upload_str is not None:
+            metadata['auto_upload'] = str(auto_upload_str).strip().lower() not in ('false', '0', 'no', 'off', '')
 
-        metadata.update({
+        section_metadata = {
             'mod_id': section_items.get('nexusmodid') or section_items.get('nexus_mod_id') or section_items.get('mod_id'),
             'mod_filename': section_items.get('nexusfilename') or section_items.get('nexus_filename') or section_items.get('nexusmodfilename') or section_items.get('nexus_mod_filename') or section_items.get('mod_filename') or section_items.get('modname') or section_items.get('name'),
             'mod_link': section_items.get('nexusmodlink') or section_items.get('nexus_mod_link') or section_items.get('mod_link') or section_items.get('link'),
             'description': section_items.get('nexusdescription') or section_items.get('nexus_description') or section_items.get('description'),
             'artifact_pattern': section_items.get('nexusartifactpattern') or section_items.get('nexus_artifact_pattern') or section_items.get('artifact_pattern'),
             'short_name': section_items.get('shortname') or section_items.get('short_name') or section_items.get('nexusshortname') or section_items.get('nexus_short_name'),
-            'auto_upload': auto_upload,
-        })
+        }
+        metadata.update({k: v for k, v in section_metadata.items() if v is not None and v != ""})
         key_features = section_items.get('nexuskeyfeatures') or section_items.get('nexus_key_features') or section_items.get('key_features') or section_items.get('keyfeatures')
         if key_features:
-            metadata['key_features'] = [k.strip() for k in re.split(r'[;,]', key_features) if k.strip()]
+            parsed_kf = [k.strip() for k in re.split(r'[;,]', key_features) if k.strip()]
+            existing_kf = metadata.get('key_features', [])
+            for kf in parsed_kf:
+                if kf not in existing_kf:
+                    existing_kf.append(kf)
+            metadata['key_features'] = existing_kf
 
     return {k: v for k, v in metadata.items() if v is not None and v != ""}
 
@@ -718,10 +723,11 @@ def analyze_features(FEATURES_DIR, feature_meta_map, base_ref, only_changed=Fals
                 if status == "A":
                     # Get the commit that added this file (not the latest commit)
                     try:
-                        add_commit = subprocess.check_output(
+                        add_commits = subprocess.check_output(
                             ["git", "log", "--follow", "--diff-filter=A", "--format=%H", f"{version_ref}..{HEAD_REF}", "--", f],
                             stderr=subprocess.DEVNULL
-                        ).decode("utf-8").strip().split("\n")[0]  # First (oldest) commit
+                        ).decode("utf-8").splitlines()
+                        add_commit = add_commits[-1].strip() if add_commits else None
                         if add_commit:
                             new_code_author = get_commit_author(add_commit)
                             if new_code_author:
@@ -923,36 +929,59 @@ def build_nexus_upload_matrix(feature_metadata, core_mod_id, core_filename, core
 
 
 def build_feature_actions(bump_suggestions, metadata_issues, new_features, get_commit_author, normalize_name):
-    feature_actions = {}
+    consolidated = {}
+    display_name_map = {}
+
     for suggestion in bump_suggestions:
         m = RE_BUMP_SUGGESTION.match(suggestion)
         if m:
             fname, ver, author = m.group(1), m.group(2), m.group(3)
-            if fname not in feature_actions:
-                feature_actions[fname] = {"actions": [], "author": author}
-            feature_actions[fname]["actions"].append(f"Bump INI version to `{ver}`")
+            norm = normalize_name(fname)
+            display_name_map.setdefault(norm, fname)
+            if ' ' in fname and ' ' not in display_name_map[norm]:
+                display_name_map[norm] = fname
+            if norm not in consolidated:
+                consolidated[norm] = {"actions": [], "author": author}
+            consolidated[norm]["actions"].append(f"Bump INI version to `{ver}`")
+            if author and not consolidated[norm]["author"]:
+                consolidated[norm]["author"] = author
+
     for name, fields in metadata_issues:
-        if name not in feature_actions:
-            feature_actions[name] = {"actions": [], "author": None}
-        feature_actions[name]["actions"].append(f"Update INI: add {', '.join(fields)}")
+        norm = normalize_name(name)
+        display_name_map.setdefault(norm, name)
+        if ' ' in name and ' ' not in display_name_map[norm]:
+            display_name_map[norm] = name
+        if norm not in consolidated:
+            consolidated[norm] = {"actions": [], "author": None}
+        consolidated[norm]["actions"].append(f"Update INI: add {', '.join(fields)}")
+
     # Add new features with authors
     for feat_name, _, commit in new_features:
+        norm = normalize_name(feat_name)
+        display_name_map.setdefault(norm, feat_name)
+        if ' ' in feat_name and ' ' not in display_name_map[norm]:
+            display_name_map[norm] = feat_name
         author = get_commit_author(commit) if commit else None
-        if feat_name not in feature_actions:
-            feature_actions[feat_name] = {"actions": [], "author": author}
-        if "New feature" not in "".join(feature_actions[feat_name]["actions"]):
-            feature_actions[feat_name]["actions"].append("New feature")
-            feature_actions[feat_name]["author"] = author
+        if norm not in consolidated:
+            consolidated[norm] = {"actions": [], "author": author}
+        if "New feature" not in "".join(consolidated[norm]["actions"]):
+            consolidated[norm]["actions"].append("New feature")
+        if author and not consolidated[norm]["author"]:
+            consolidated[norm]["author"] = author
+
+    feature_actions = {}
+    for norm, info in consolidated.items():
+        feature_actions[display_name_map[norm]] = info
 
     # Also assign authors to existing entries if not already set
     new_features_map = {normalize_name(n): (commit, get_commit_author(commit) if commit else None) for n, _, commit in new_features}
-    for name in feature_actions:
-        if not feature_actions[name]["author"]:
-            norm = normalize_name(name)
+    for disp, info in feature_actions.items():
+        if not info["author"]:
+            norm = normalize_name(disp)
             if norm in new_features_map:
                 commit, author = new_features_map[norm]
                 if author:
-                    feature_actions[name]["author"] = author
+                    info["author"] = author
     return feature_actions
 
 def build_author_stats(feature_analysis, feature_actions):
@@ -1031,7 +1060,6 @@ def main():
     parser.add_argument('--export-nexus-matrix', action='store_true', help='Export a JSON Nexus upload matrix and exit')
     parser.add_argument('--matrix-output', type=str, default='nexus-matrix.json', help='Output filename for Nexus matrix JSON')
     parser.add_argument('--nexus-metadata-file', type=str, help='Optional Nexus metadata JSON file exported from nexus_mods_api')
-    # NEXUS_API_KEY is read from the environment at runtime; never pass secrets on the CLI
     parser.add_argument('--all-features', action='store_true', help='Include all Nexus-capable features in export, not just version-changed ones')
     parser.add_argument('--core-mod-id', type=str, default='86492', help='Core Nexus mod ID for the generated upload matrix')
     parser.add_argument('--core-filename', type=str, default='Community Shaders', help='Core Nexus filename for the generated upload matrix')

--- a/tools/feature_version_audit.py
+++ b/tools/feature_version_audit.py
@@ -1,6 +1,8 @@
 import os
 import subprocess
 import re
+import json
+import configparser
 from pathlib import Path
 import datetime
 import sys
@@ -31,7 +33,7 @@ RE_FEATURE_SUMMARY_CPP = re.compile(r'GetFeatureSummary\s*\([^)]*\)\s*\{[^}]*?st
 RE_FEATURE_SUMMARY_CPP_MULTILINE = re.compile(r'GetFeatureSummary\s*\([^)]*\)\s*\{[^}]*?std::string description\s*=\s*((?:"[^"]*"\s*)+);\s*std::vector<std::string> keyFeatures\s*=\s*\{([^}]*)\}', re.DOTALL)
 RE_FEATURE_DESCRIPTION_DIRECT = re.compile(r'GetFeatureDescription\s*\([^)]*\)\s*\{\s*return\s*"([^"]+)";\s*\}')
 RE_IS_CORE = re.compile(r"IsCore\s*\(.*\)\s*const\s*override\s*\{\s*return true;\s*\}")
-RE_VERSION = re.compile(r"Version\s*=\s*([0-9]+)-([0-9]+)-([0-9]+)")
+RE_VERSION = re.compile(r"(?i)version\s*=\s*([0-9]+)-([0-9]+)-([0-9]+)")
 RE_BUMP_SUGGESTION = re.compile(r"- \*\*(.+?)\.ini\*\*: bump to `([\d-]+)`.*\[link\]\([^)]+\) ?(?:\(([^)]+)\))?")
 
 # Commit type regexes
@@ -57,14 +59,157 @@ def extract_regex(pattern, content, group=1):
     return m.group(group) if m else None
 
 def extract_multiline_strings(multiline):
-    return [d.replace("\n", " ").strip() for d in re.findall(r'"([^"]*)"', multiline) if d.strip()]
+    return [d.replace("\n", " ").strip() for d in re.findall(r'"([^\"]*)"', multiline) if d.strip()]
+
+def normalize_feature_key(name):
+    return ''.join(str(name or '').lower().replace('-', ' ').split())
+
+def load_nexus_metadata_file(path):
+    try:
+        raw = json.loads(Path(path).read_text(encoding='utf-8'))
+    except Exception as e:
+        raise RuntimeError(f"Failed to load Nexus metadata file {path}: {e}")
+
+    if isinstance(raw, dict):
+        if 'mods' in raw and isinstance(raw['mods'], list):
+            raw = raw['mods']
+        elif 'data' in raw and isinstance(raw['data'], list):
+            raw = raw['data']
+        elif 'features' in raw and isinstance(raw['features'], list):
+            raw = raw['features']
+        else:
+            candidates = []
+            for key, value in raw.items():
+                if isinstance(value, dict):
+                    value = dict(value)
+                    if 'name' not in value:
+                        value['name'] = key
+                    candidates.append(value)
+            if candidates:
+                raw = candidates
+
+    if not isinstance(raw, list):
+        raise RuntimeError(f"Expected JSON list or object containing a feature list in {path}")
+
+    nexus_metadata = {}
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        name = item.get('name') or item.get('mod_name') or item.get('modFilename') or item.get('mod_filename') or item.get('file_name')
+        if not name:
+            continue
+        key = normalize_feature_key(name)
+        mod_id = item.get('nexus_mod_id') or item.get('mod_id') or item.get('modId') or item.get('id')
+        if isinstance(mod_id, int):
+            mod_id = str(mod_id)
+        mod_filename = item.get('mod_filename') or item.get('modFilename') or item.get('file_name') or item.get('fileName')
+        mod_link = item.get('mod_link') or item.get('modLink') or item.get('url') or item.get('link')
+        description = item.get('description') or item.get('summary') or item.get('details') or ""
+        key_features = item.get('key_features') or item.get('keyFeatures') or item.get('features') or []
+        if isinstance(key_features, str):
+            key_features = [k.strip() for k in key_features.split(',') if k.strip()]
+        elif not isinstance(key_features, list):
+            key_features = []
+        artifact_pattern = item.get('artifact_pattern') or item.get('artifactPattern')
+        short_name = item.get('short_name') or item.get('shortName')
+
+        nexus_metadata[key] = {
+            'name': name,
+            'mod_id': mod_id,
+            'mod_filename': mod_filename,
+            'mod_link': mod_link,
+            'description': description,
+            'key_features': key_features,
+            'artifact_pattern': artifact_pattern,
+            'short_name': short_name,
+        }
+    return nexus_metadata
+
+def find_feature_dir(feature_name):
+    """Find the feature directory matching the given name, with fuzzy matching support."""
+    base_dir = FEATURES_DIR / feature_name
+    if base_dir.exists():
+        return base_dir
+
+    # Fuzzy search: try removing spaces/hyphens and matching case-insensitively
+    normalized_name = normalize_feature_key(feature_name)
+    for entry in FEATURES_DIR.iterdir():
+        if entry.is_dir() and normalize_feature_key(entry.name) == normalized_name:
+            return entry
+
+    return None
 
 def get_feature_ini(feature_path):
+    # Support both direct paths and feature names (strings)
+    if isinstance(feature_path, str):
+        feature_path = find_feature_dir(feature_path)
+        if not feature_path:
+            return None
+
     ini_dir = feature_path / "Shaders" / "Features"
     if ini_dir.exists():
         for f in ini_dir.glob("*.ini"):
             return f
     return None
+
+def get_feature_mod_id_from_ini(feature_dir):
+    ini_path = get_feature_ini(feature_dir)
+    if not ini_path:
+        return None
+    try:
+        content = ini_path.read_text(encoding='utf-8')
+    except Exception:
+        return None
+    m = RE_MOD_ID.search(content)
+    return m.group(1) if m else None
+
+def get_feature_ini_metadata(feature_dir_or_ini_path):
+    # Accept both directory and direct INI path
+    if isinstance(feature_dir_or_ini_path, (str, Path)):
+        path = Path(feature_dir_or_ini_path)
+        if path.suffix == '.ini':
+            ini_path = path
+        else:
+            ini_path = get_feature_ini(feature_dir_or_ini_path)
+    else:
+        ini_path = get_feature_ini(feature_dir_or_ini_path)
+
+    if not ini_path:
+        return {}
+    parser = configparser.ConfigParser()
+    try:
+        parser.read(ini_path, encoding='utf-8')
+    except Exception:
+        return {}
+
+    sections = [s for s in parser.sections() if s.lower() in {'info', 'nexus'}]
+    if not sections:
+        sections = ['Info'] if parser.has_section('Info') else []
+
+    metadata = {}
+    for section in sections:
+        if not parser.has_section(section):
+            continue
+        section_items = dict(parser.items(section))
+        # ConfigParser converts keys to lowercase, so look for both variants
+        # Parse AutoUpload as boolean (defaults to false if not specified — opt-in)
+        auto_upload_str = section_items.get('autoupload') or section_items.get('auto_upload') or 'false'
+        auto_upload = auto_upload_str.lower() not in ('false', '0', 'no')
+
+        metadata.update({
+            'mod_id': section_items.get('nexusmodid') or section_items.get('nexus_mod_id') or section_items.get('mod_id'),
+            'mod_filename': section_items.get('nexusfilename') or section_items.get('nexus_filename') or section_items.get('nexusmodfilename') or section_items.get('nexus_mod_filename') or section_items.get('mod_filename') or section_items.get('modname') or section_items.get('name'),
+            'mod_link': section_items.get('nexusmodlink') or section_items.get('nexus_mod_link') or section_items.get('mod_link') or section_items.get('link'),
+            'description': section_items.get('nexusdescription') or section_items.get('nexus_description') or section_items.get('description'),
+            'artifact_pattern': section_items.get('nexusartifactpattern') or section_items.get('nexus_artifact_pattern') or section_items.get('artifact_pattern'),
+            'short_name': section_items.get('shortname') or section_items.get('short_name') or section_items.get('nexusshortname') or section_items.get('nexus_short_name'),
+            'auto_upload': auto_upload,
+        })
+        key_features = section_items.get('nexuskeyfeatures') or section_items.get('nexus_key_features') or section_items.get('key_features') or section_items.get('keyfeatures')
+        if key_features:
+            metadata['key_features'] = [k.strip() for k in re.split(r'[;,]', key_features) if k.strip()]
+
+    return {k: v for k, v in metadata.items() if v is not None and v != ""}
 
 def get_version_from_ini(ini_path, content=None):
     if content is None:
@@ -172,8 +317,13 @@ def apply_version_bump(ini_path, proposed_ver_str):
         with open(ini_path, "r", encoding="utf-8") as f:
             content = f.read()
 
-        # Replace Version = X-X-X with Version = proposed_ver_str
-        new_content = RE_VERSION.sub(f"Version = {proposed_ver_str}", content, count=1)
+        # Replace version = X-X-X preserving original key casing
+        new_content = re.sub(
+            r"(?i)(version\s*=\s*)[0-9]+-[0-9]+-[0-9]+",
+            lambda m: f"{m.group(1)}{proposed_ver_str}",
+            content,
+            count=1,
+        )
 
         if new_content != content:
             with open(ini_path, "w", encoding="utf-8") as f:
@@ -225,7 +375,8 @@ def parse_feature_metadata_file(path, mod_id=None, is_core=False):
         "key_features": key_features
     }
 
-def extract_feature_metadata(feature_headers_dir):
+def extract_feature_metadata(feature_headers_dir, nexus_metadata=None):
+    nexus_metadata = nexus_metadata or {}
     feature_info = []
     for header in sorted(feature_headers_dir.glob("*.h")):
         name = header.stem
@@ -251,14 +402,86 @@ def extract_feature_metadata(feature_headers_dir):
         mod_link = h_meta["mod_link"] or cpp_meta["mod_link"]
         description = h_meta["description"] or cpp_meta["description"]
         key_features = h_meta["key_features"] or cpp_meta["key_features"]
-        feature_info.append({
-            "name": name,
-            "short_name": short_name,
-            "is_core": is_core,
-            "mod_link": mod_link,
-            "description": description,
-            "key_features": key_features
-        })
+        feature_dir = FEATURES_DIR / name
+        ini_meta = get_feature_ini_metadata(feature_dir) if feature_dir.exists() else {}
+        if not mod_id:
+            mod_id = ini_meta.get('mod_id')
+
+        if ini_meta.get('mod_link'):
+            mod_link = ini_meta['mod_link']
+        if ini_meta.get('description') and not description:
+            description = ini_meta['description']
+        if ini_meta.get('key_features') and not key_features:
+            key_features = ini_meta['key_features']
+        if ini_meta.get('short_name'):
+            short_name = ini_meta['short_name']
+        if ini_meta.get('artifact_pattern'):
+            artifact_pattern = ini_meta['artifact_pattern']
+        else:
+            artifact_pattern = None
+        if ini_meta.get('mod_filename'):
+            mod_filename = ini_meta['mod_filename']
+        else:
+            mod_filename = None
+
+        # Fallback: if exact match failed, try fuzzy matching
+        if not feature_dir.exists():
+            # Try to find directory by normalizing names (ScreenSpaceGI -> screen space gi)
+            normalized_name = normalize_feature_key(name)
+            for candidate_dir in FEATURES_DIR.iterdir():
+                if candidate_dir.is_dir() and normalize_feature_key(candidate_dir.name) == normalized_name:
+                    feature_dir = candidate_dir
+                    ini_meta = get_feature_ini_metadata(candidate_dir)
+                    break
+
+        # Update mod_id from INI if still missing
+        if not mod_id:
+            mod_id = ini_meta.get('mod_id')
+        if ini_meta.get('mod_link'):
+            mod_link = ini_meta['mod_link']
+        if ini_meta.get('description') and not description:
+            description = ini_meta['description']
+        if ini_meta.get('key_features') and not key_features:
+            key_features = ini_meta['key_features']
+        if ini_meta.get('short_name'):
+            short_name = ini_meta['short_name']
+        if ini_meta.get('artifact_pattern'):
+            artifact_pattern = ini_meta['artifact_pattern']
+        if ini_meta.get('mod_filename'):
+            mod_filename = ini_meta['mod_filename']
+
+        key = normalize_feature_key(name)
+        nexus_meta = nexus_metadata.get(key, {})
+        if nexus_meta:
+            mod_id = nexus_meta.get('mod_id') or mod_id
+            mod_filename = nexus_meta.get('mod_filename') or mod_filename
+            artifact_pattern = nexus_meta.get('artifact_pattern') or artifact_pattern
+            mod_link = nexus_meta.get('mod_link') or mod_link
+            description = nexus_meta.get('description') or description
+            if nexus_meta.get('key_features'):
+                key_features = nexus_meta.get('key_features')
+            if nexus_meta.get('short_name'):
+                short_name = nexus_meta.get('short_name')
+
+        if not mod_link and not is_core and mod_id:
+            mod_link = DEFAULT_NEXUS_BASE_URL + mod_id
+
+        if not mod_filename:
+            mod_filename = name
+
+        # Only include if a feature directory exists (or will be found by fuzzy match)
+        if feature_dir.exists() or ini_meta.get('mod_id'):
+            feature_info.append({
+                "name": name,
+                "short_name": short_name,
+                "is_core": is_core,
+                "mod_id": mod_id,
+                "mod_link": mod_link,
+                "description": description,
+                "key_features": key_features,
+                "artifact_pattern": artifact_pattern,
+                "mod_filename": mod_filename,
+            })
     return feature_info
 
 def get_latest_release_tag(ref="HEAD"):
@@ -311,6 +534,7 @@ def propose_new_version(prior_version, commits):
 def analyze_features(FEATURES_DIR, feature_meta_map, base_ref, only_changed=False, release_ref=None):
     bump_suggestions = []
     new_features = []
+    new_code_features = []  # Features with new code added (not entirely new)
     actionable = False
     feature_actions = {}
     feature_analysis = []
@@ -401,6 +625,14 @@ def analyze_features(FEATURES_DIR, feature_meta_map, base_ref, only_changed=Fals
                 changes.extend(get_changed_files(cpp_path, base_ref, file_types=cpp_types))
             if feature_src_dir.exists() and feature_src_dir.is_dir():
                 changes.extend(get_changed_files(feature_src_dir, base_ref, file_types=cpp_types))
+            # Special case: VR feature includes VRStereoOptimizations
+            if meta['name'] == 'VR':
+                vr_stereo_h = DEFAULT_FEATURE_HEADERS_DIR / "VRStereoOptimizations.h"
+                vr_stereo_cpp = DEFAULT_FEATURE_HEADERS_DIR / "VRStereoOptimizations.cpp"
+                if vr_stereo_h.exists():
+                    changes.extend(get_changed_files(vr_stereo_h, base_ref, file_types=cpp_types))
+                if vr_stereo_cpp.exists():
+                    changes.extend(get_changed_files(vr_stereo_cpp, base_ref, file_types=cpp_types))
         changes = list(set(changes))
 
         # Release-scoped changes: all changes since last release, used to propose the correct
@@ -416,6 +648,14 @@ def analyze_features(FEATURES_DIR, feature_meta_map, base_ref, only_changed=Fals
                 release_changes.extend(get_changed_files(cpp_path, version_ref, file_types=cpp_types))
             if feature_src_dir.exists() and feature_src_dir.is_dir():
                 release_changes.extend(get_changed_files(feature_src_dir, version_ref, file_types=cpp_types))
+            # Special case: VR feature includes VRStereoOptimizations
+            if meta['name'] == 'VR':
+                vr_stereo_h = DEFAULT_FEATURE_HEADERS_DIR / "VRStereoOptimizations.h"
+                vr_stereo_cpp = DEFAULT_FEATURE_HEADERS_DIR / "VRStereoOptimizations.cpp"
+                if vr_stereo_h.exists():
+                    release_changes.extend(get_changed_files(vr_stereo_h, version_ref, file_types=cpp_types))
+                if vr_stereo_cpp.exists():
+                    release_changes.extend(get_changed_files(vr_stereo_cpp, version_ref, file_types=cpp_types))
         release_changes = list(set(release_changes))
 
         change_types = set(os.path.splitext(f)[1].lower() for _, f in changes)
@@ -469,6 +709,27 @@ def analyze_features(FEATURES_DIR, feature_meta_map, base_ref, only_changed=Fals
             new_features.append((feature_dir.name, "-", bump_commit))
             is_attention = True
 
+        # Detect new code added to existing feature (not entirely new since last release)
+        # Feature existed before version_ref (has non-"A" release_changes) AND has new files
+        if (not (release_changes and all(s == "A" for s, _ in release_changes)) and  # Not brand new since last release
+            release_changes and any(s == "A" for s, _ in release_changes)):  # Has new files added
+            # Find author of the commit that added the file (first commit touching it since version_ref)
+            for status, f in release_changes:
+                if status == "A":
+                    # Get the commit that added this file (not the latest commit)
+                    try:
+                        add_commit = subprocess.check_output(
+                            ["git", "log", "--follow", "--diff-filter=A", "--format=%H", f"{version_ref}..{HEAD_REF}", "--", f],
+                            stderr=subprocess.DEVNULL
+                        ).decode("utf-8").strip().split("\n")[0]  # First (oldest) commit
+                        if add_commit:
+                            new_code_author = get_commit_author(add_commit)
+                            if new_code_author:
+                                new_code_features.append((feature_dir.name, new_code_author))
+                                break
+                    except Exception:
+                        pass
+
         if needs_bump:
             is_attention = True
         if is_attention:
@@ -491,7 +752,8 @@ def analyze_features(FEATURES_DIR, feature_meta_map, base_ref, only_changed=Fals
             'note': note,
             'commit_link': commit_link,
             'is_attention': is_attention,
-            'ini_path': str(ini_path) if ini_path else None
+            'ini_path': str(ini_path) if ini_path else None,
+            'author': bump_author
         })
         if needs_bump:
             bump_suggestions.append(f"- **{os.path.basename(ini_path)}**: bump to `{proposed_ver_str}` {commit_link}")
@@ -502,7 +764,7 @@ def analyze_features(FEATURES_DIR, feature_meta_map, base_ref, only_changed=Fals
             if needs_bump:
                 feat_act["actions"].append(f"Needs version bump to {proposed_ver_str}")
 
-    return feature_analysis, bump_suggestions, new_features, actionable, feature_actions
+    return feature_analysis, bump_suggestions, new_features, new_code_features, actionable, feature_actions
 
 def print_actionable_suggestions(feature_actions):
     if feature_actions:
@@ -517,11 +779,11 @@ def format_author_stats(author_stats):
     lines = []
     if author_stats:
         lines.append("\n### Author Stats\n")
-        lines.append("| Author | New Features | Updated Features | Metadata Issues | Total Actionable |")
-        lines.append("|--------|--------------|------------------|----------------|------------------|")
-        for author, stat in sorted(author_stats.items(), key=lambda x: (-(x[1].get('new',0)+x[1].get('bump',0)+x[1].get('meta',0)), x[0])):
-            total = stat.get('new',0) + stat.get('bump',0) + stat.get('meta',0)
-            lines.append(f"| {author} | {stat.get('new',0)} | {stat.get('bump',0)} | {stat.get('meta',0)} | {total} |")
+        lines.append("| Author | Changed Features | New Features | Version Bumps | Metadata Issues | Total Actionable |")
+        lines.append("|--------|------------------|--------------|---------------|-----------------|------------------|")
+        for author, stat in sorted(author_stats.items(), key=lambda x: (-(x[1].get('total_changed',0)), x[0])):
+            total_actionable = stat.get('new',0) + stat.get('bump',0) + stat.get('meta',0)
+            lines.append(f"| {author} | {stat.get('total_changed',0)} | {stat.get('new',0)} | {stat.get('bump',0)} | {stat.get('meta',0)} | {total_actionable} |")
     return lines
 
 def format_actionable_lines(feature_actions):
@@ -568,6 +830,16 @@ def format_new_features_table(new_features, feature_meta_map, get_commit_author,
             lines.append(f"| {boldmeta(name)} | {boldmeta(ver)} | {nexus_link} | {commit_link} |")
     return lines
 
+def format_new_code_table(new_code_features):
+    lines = []
+    if new_code_features:
+        lines.append(f"### New Code Added to Existing Features ({len(new_code_features)})\n")
+        lines.append("| Feature | Author |")
+        lines.append("|---------|--------|")
+        for name, author in new_code_features:
+            lines.append(f"| {name} | {author} |")
+    return lines
+
 def format_metadata_summary(feature_metadata):
     lines = []
     lines.append("\n## Feature Metadata Summary\n")
@@ -596,6 +868,60 @@ def format_metadata_summary(feature_metadata):
             metadata_issues.append((info['name'], missing_fields))
     return lines, metadata_issues
 
+
+def build_nexus_upload_matrix(feature_metadata, core_mod_id, core_filename, core_artifact_pattern):
+    rows = [
+        {
+            'name': 'core',
+            'artifact_pattern': core_artifact_pattern,
+            'artifact_name': 'nexus-upload-core',
+            'nexus_mod_id': core_mod_id,
+            'mod_filename': core_filename,
+        }
+    ]
+    def sanitize_name(name):
+        return re.sub(r'[^A-Za-z0-9_-]+', '_', name.strip())
+
+    for info in sorted(feature_metadata, key=lambda x: x['name']):
+        if info.get('is_core'):
+            continue
+        mod_id = info.get('mod_id')
+        if not mod_id:
+            continue
+        name = info['name']
+        artifact_pattern = info.get('artifact_pattern') or f'{name}-*.7z'
+
+        # Read INI metadata (version, filename, etc.)
+        ini_path = get_feature_ini(name)  # Pass name as string for fuzzy matching
+        ini_metadata = {}
+        mod_version = None
+        if ini_path:
+            ini_metadata = get_feature_ini_metadata(ini_path)
+            version_tuple = get_version_from_ini(ini_path)
+            if version_tuple:
+                mod_version = '.'.join(str(v) for v in version_tuple)
+
+        # Use mod_filename from INI if available, else from feature metadata, else use name
+        mod_filename = ini_metadata.get('mod_filename') or info.get('mod_filename') or name
+
+        # Auto-upload is opt-in; missing metadata should not enable uploads.
+        auto_upload = ini_metadata.get('auto_upload', False)
+
+        row = {
+            'name': name,
+            'artifact_pattern': artifact_pattern,
+            'artifact_name': f'nexus-upload-{sanitize_name(name)}',
+            'nexus_mod_id': mod_id,
+            'mod_filename': mod_filename,
+            'auto_upload': auto_upload,
+        }
+        if mod_version:
+            row['mod_version'] = mod_version
+
+        rows.append(row)
+    return rows
+
+
 def build_feature_actions(bump_suggestions, metadata_issues, new_features, get_commit_author, normalize_name):
     feature_actions = {}
     for suggestion in bump_suggestions:
@@ -608,8 +934,17 @@ def build_feature_actions(bump_suggestions, metadata_issues, new_features, get_c
     for name, fields in metadata_issues:
         if name not in feature_actions:
             feature_actions[name] = {"actions": [], "author": None}
-        feature_actions[name]["actions"].append(f"Add: {', '.join(fields)}")
-    # Mapping new features to authors
+        feature_actions[name]["actions"].append(f"Update INI: add {', '.join(fields)}")
+    # Add new features with authors
+    for feat_name, _, commit in new_features:
+        author = get_commit_author(commit) if commit else None
+        if feat_name not in feature_actions:
+            feature_actions[feat_name] = {"actions": [], "author": author}
+        if "New feature" not in "".join(feature_actions[feat_name]["actions"]):
+            feature_actions[feat_name]["actions"].append("New feature")
+            feature_actions[feat_name]["author"] = author
+
+    # Also assign authors to existing entries if not already set
     new_features_map = {normalize_name(n): (commit, get_commit_author(commit) if commit else None) for n, _, commit in new_features}
     for name in feature_actions:
         if not feature_actions[name]["author"]:
@@ -620,21 +955,33 @@ def build_feature_actions(bump_suggestions, metadata_issues, new_features, get_c
                     feature_actions[name]["author"] = author
     return feature_actions
 
-def build_author_stats(feature_actions):
+def build_author_stats(feature_analysis, feature_actions):
+    # Count all features per author from feature_analysis
     author_stats = {}
+    for fa in feature_analysis:
+        author = fa.get('author')
+        if not author:
+            continue
+        if author not in author_stats:
+            author_stats[author] = {'new': 0, 'bump': 0, 'meta': 0, 'total_changed': 0}
+        # Count each feature once per author
+        author_stats[author]['total_changed'] += 1
+
+    # Then, count actionable items for authors who have them (from feature_actions)
     for fname, info in feature_actions.items():
         author = info["author"]
         if not author:
             continue
         if author not in author_stats:
-            author_stats[author] = {'new': 0, 'bump': 0, 'meta': 0}
+            author_stats[author] = {'new': 0, 'bump': 0, 'meta': 0, 'total_changed': 0}
         for action in info["actions"]:
             if action.startswith("Bump INI version"):
                 author_stats[author]['bump'] += 1
-            elif action.startswith("Add: "):
+            elif action.startswith("Update INI"):
                 author_stats[author]['meta'] += 1
-            elif "new feature" in action.lower():
+            elif "new feature" in action.lower() or "new ini" in action.lower():
                 author_stats[author]['new'] += 1
+
     return author_stats
 
 def generate_audit_report(
@@ -644,6 +991,7 @@ def generate_audit_report(
     now,
     feature_analysis,
     new_features,
+    new_code_features,
     feature_meta_map,
     get_commit_author,
     normalize_name,
@@ -659,10 +1007,11 @@ def generate_audit_report(
     lines.extend(format_feature_table(feature_analysis))
     lines.append("\n## Critical Information Summary\n")
     lines.extend(format_new_features_table(new_features, feature_meta_map, get_commit_author, normalize_name))
+    lines.extend(format_new_code_table(new_code_features))
     metadata_lines, metadata_issues = format_metadata_summary(feature_metadata)
     lines.extend(metadata_lines)
     feature_actions = build_feature_actions(bump_suggestions, metadata_issues, new_features, get_commit_author, normalize_name)
-    author_stats = build_author_stats(feature_actions)
+    author_stats = build_author_stats(feature_analysis, feature_actions)
     author_stats_lines = format_author_stats(author_stats)
     actionable_lines = format_actionable_lines(feature_actions)
     output = "\n".join(lines)
@@ -679,6 +1028,14 @@ def main():
     parser.add_argument('--fail-on-actionable', action='store_true', help='Exit 1 if actionable items found (alias for --ci)')
     parser.add_argument('--pr-check', action='store_true', help='Only show actionable items for changes since base')
     parser.add_argument('--apply-bumps', action='store_true', help='Automatically apply suggested version bumps')
+    parser.add_argument('--export-nexus-matrix', action='store_true', help='Export a JSON Nexus upload matrix and exit')
+    parser.add_argument('--matrix-output', type=str, default='nexus-matrix.json', help='Output filename for Nexus matrix JSON')
+    parser.add_argument('--nexus-metadata-file', type=str, help='Optional Nexus metadata JSON file exported from nexus_mods_api')
+    # NEXUS_API_KEY is read from the environment at runtime; never pass secrets on the CLI
+    parser.add_argument('--all-features', action='store_true', help='Include all Nexus-capable features in export, not just version-changed ones')
+    parser.add_argument('--core-mod-id', type=str, default='86492', help='Core Nexus mod ID for the generated upload matrix')
+    parser.add_argument('--core-filename', type=str, default='Community Shaders', help='Core Nexus filename for the generated upload matrix')
+    parser.add_argument('--core-artifact-pattern', type=str, default='CommunityShaders-*.7z', help='Core artifact pattern for the generated upload matrix')
     args = parser.parse_args()
 
     global HEAD_REF
@@ -722,11 +1079,37 @@ def main():
     if base_date_iso:
         print(f"Base commit date: {base_date_iso} ({base_date_human})", file=sys.stderr)
 
-    feature_metadata = extract_feature_metadata(DEFAULT_FEATURE_HEADERS_DIR)
-    def normalize_name(name): return ''.join(name.lower().split())
+    nexus_metadata = load_nexus_metadata_file(args.nexus_metadata_file) if args.nexus_metadata_file else None
+    feature_metadata = extract_feature_metadata(DEFAULT_FEATURE_HEADERS_DIR, nexus_metadata=nexus_metadata)
+    def normalize_name(name): return normalize_feature_key(name)
     feature_meta_map = {normalize_name(f['name']): f for f in feature_metadata}
 
-    feature_analysis, bump_suggestions, new_features, actionable, feature_actions = analyze_features(
+    def feature_changed_versions(metadata_item):
+        ini_path = get_feature_ini(metadata_item['name'])  # Use fuzzy matching
+        if not ini_path:
+            return False
+        prior_ver = get_prior_version(ini_path, base_ref)
+        new_ver = get_version_from_ini(ini_path)
+        return new_ver is not None and prior_ver != new_ver
+
+    if args.export_nexus_matrix:
+        export_features = feature_metadata
+        if not args.all_features:
+            export_features = [f for f in feature_metadata if f.get('is_core') or feature_changed_versions(f)]
+        matrix = build_nexus_upload_matrix(
+            export_features,
+            args.core_mod_id,
+            args.core_filename,
+            args.core_artifact_pattern,
+        )
+        output_path = args.matrix_output
+        with open(output_path, 'w', encoding='utf-8') as f:
+            json.dump(matrix, f, indent=2)
+        visibility = 'all features' if args.all_features else 'version-changed only'
+        print(f'Wrote Nexus matrix to {output_path} ({visibility})')
+        sys.exit(0)
+
+    feature_analysis, bump_suggestions, new_features, new_code_features, actionable, feature_actions = analyze_features(
         FEATURES_DIR, feature_meta_map, base_ref, only_changed=args.pr_check, release_ref=release_ref)
 
     now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
@@ -772,7 +1155,7 @@ def main():
         print_actionable_suggestions(feature_actions)
     else:
         output = generate_audit_report(base_ref, base_date_iso, base_date_human, now,
-                                      feature_analysis, new_features, feature_meta_map,
+                                      feature_analysis, new_features, new_code_features, feature_meta_map,
                                       get_commit_author, normalize_name, feature_metadata, bump_suggestions)
         if output_file:
             with open(output_file, "w", encoding="utf-8") as f: f.write(output)


### PR DESCRIPTION
Standardize feature metadata via INI files and add automated release:

- Add semantic-release configuration for dev branch with RC prerelease support
- Create release.yaml workflow for version bumping and changelog generation
- Create upload-nexus.yaml for parallel feature uploads with dry-run and recovery
- Extend feature_version_audit.py with fuzzy directory matching and AutoUpload support
- Standardize all 34 feature INI files to [Info] + [Nexus] format
  - Core features: empty [Nexus] section (AutoUpload implicit false)
  - Independent mods: [Nexus] with NexusModID, NexusFileName, AutoUpload=true
- Support dry-run mode and graceful failure handling (core strict, features optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized feature metadata across many shaders (normalized version key, trailing newlines) and added Nexus upload metadata where applicable.
  * Added CI release workflow (manual trigger with release type) and semantic-release configuration to automate releases.
  * Added an automated Nexus upload workflow with artifact resolution, matrix-driven uploads, dry-run support and upload summaries.

* **New Features**
  * Enhanced feature-audit tooling: Nexus metadata ingestion/normalization, new-code detection and author stats, and a CLI option to export Nexus upload matrices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->