### PR TITLE
refactor(skylighting): simplify skylightingSH initialization

### DIFF
--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -757,8 +757,6 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float3 directionalAmbientColor = Color::Ambient(max(0, SharedData::GetAmbient(normal)));
 
 #				if defined(SKYLIGHTING)
-	const static sh2 unitSH_grass1 = float4(sqrt(4.0 * Math::PI), 0, 0, 0);
-	sh2 skylightingSH = unitSH_grass1;
 	float skylightingDiffuse = 1.0;
 	if (!SharedData::InInterior) {
 #					if defined(VR)
@@ -766,7 +764,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #					else
 		float3 positionMSSkylight = input.WorldPosition.xyz;
 #					endif
-		skylightingSH = Skylighting::sample(SharedData::skylightingSettings, Skylighting::SkylightingProbeArray, Skylighting::stbn_vec3_2Dx1D_128x128x64, input.HPosition.xy, positionMSSkylight, normal);
+		sh2 skylightingSH = Skylighting::sample(SharedData::skylightingSettings, Skylighting::SkylightingProbeArray, Skylighting::stbn_vec3_2Dx1D_128x128x64, input.HPosition.xy, positionMSSkylight, normal);
 		skylightingDiffuse = SphericalHarmonics::FuncProductIntegral(skylightingSH, SphericalHarmonics::EvaluateCosineLobe(normal)) / Math::PI;
 		skylightingDiffuse = saturate(skylightingDiffuse);
 		skylightingDiffuse = lerp(1.0, skylightingDiffuse, skylightingFadeOutFactor);
@@ -950,8 +948,6 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 directionalAmbientColor = Color::Ambient(max(0, SharedData::GetAmbient(normal)));
 
 #			if defined(SKYLIGHTING)
-	const static sh2 unitSH_grass2 = float4(sqrt(4.0 * Math::PI), 0, 0, 0);
-	sh2 skylightingSH = unitSH_grass2;
 	float skylightingDiffuse = 1.0;
 	if (!SharedData::InInterior) {
 #				if defined(VR)
@@ -959,7 +955,7 @@ PS_OUTPUT main(PS_INPUT input)
 #				else
 		float3 positionMSSkylight = input.WorldPosition.xyz;
 #				endif
-		skylightingSH = Skylighting::sample(SharedData::skylightingSettings, Skylighting::SkylightingProbeArray, Skylighting::stbn_vec3_2Dx1D_128x128x64, input.HPosition.xy, positionMSSkylight, normal);
+		sh2 skylightingSH = Skylighting::sample(SharedData::skylightingSettings, Skylighting::SkylightingProbeArray, Skylighting::stbn_vec3_2Dx1D_128x128x64, input.HPosition.xy, positionMSSkylight, normal);
 		skylightingDiffuse = SphericalHarmonics::FuncProductIntegral(skylightingSH, SphericalHarmonics::EvaluateCosineLobe(normal)) / Math::PI;
 		skylightingDiffuse = saturate(skylightingDiffuse);
 		skylightingDiffuse = lerp(1.0, skylightingDiffuse, skylightingFadeOutFactor);


### PR DESCRIPTION
This pull request refactors how the `skylightingSH` variable is initialized and used in the `RunGrass.hlsl` shader. The main improvement is to only declare and assign `skylightingSH` when skylighting is actually sampled, simplifying the code and reducing unnecessary variable declarations.

**Shader logic simplification:**

* Removed the static initialization of `skylightingSH` (`unitSH_grass1` and `unitSH_grass2`) and now declares and assigns `skylightingSH` only when skylighting is sampled, making the code cleaner and reducing unnecessary assignments. (`package/Shaders/RunGrass.hlsl`, [[1]](diffhunk://#diff-eec9fbd5eed4cf5cb24e394ce938975405b77a79250582d1fb804c70bb4b085cL760-R767) [[2]](diffhunk://#diff-eec9fbd5eed4cf5cb24e394ce938975405b77a79250582d1fb804c70bb4b085cL953-R958)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grass skylighting calculation to ensure proper lighting in interior and exterior areas.

* **Refactor**
  * Optimized shader code structure for grass skylighting computation with reduced memory overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->