### PR TITLE
fix(llf): guard against null bsLight/niLight

### DIFF
--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -222,9 +222,14 @@ void LightLimitFix::BSLightingShader_SetupGeometry_GeometrySetupConstantPointLig
 
 	strictLightDataTemp.NumStrictLights = inWorld ? 0 : (a_pass->numLights - 1);
 
+	uint32_t writeIdx = 0;
 	for (uint32_t i = 0; i < strictLightDataTemp.NumStrictLights; i++) {
 		auto bsLight = a_pass->sceneLights[i + 1];
+		if (!bsLight)
+			continue;
 		auto niLight = bsLight->light.get();
+		if (!niLight)
+			continue;
 
 		auto& runtimeData = niLight->GetLightRuntimeData();
 
@@ -251,14 +256,17 @@ void LightLimitFix::BSLightingShader_SetupGeometry_GeometrySetupConstantPointLig
 			light.lightFlags.set(LightFlags::Shadow);
 		}
 
-		strictLightDataTemp.StrictLights[i] = light;
+		strictLightDataTemp.StrictLights[writeIdx++] = light;
 	}
+	strictLightDataTemp.NumStrictLights = writeIdx;
 
 	for (uint32_t i = 0; i < a_pass->numShadowLights; i++) {
 		auto bsLight = a_pass->sceneLights[i + 1];
+		if (!bsLight)
+			continue;
 		auto* shadowLight = static_cast<RE::BSShadowLight*>(bsLight);
 		GET_INSTANCE_MEMBER(maskIndex, shadowLight);
-		strictLightDataTemp.ShadowBitMask |= (1 << maskIndex);
+		strictLightDataTemp.ShadowBitMask |= (1u << maskIndex);
 	}
 }
 


### PR DESCRIPTION
Null-check bsLight and niLight before dereferencing in BSLightingShader_SetupGeometry_GeometrySetupConstantPointLights. Use a write index so StrictLights[] stays contiguous when entries are skipped, and update NumStrictLights to the actual written count. Also guard the ShadowBitMask loop against null bsLight.

A BSLight can have a null NiLight smart pointer when the underlying light object is destroyed while still referenced in a render pass. Observed crash: RSI=null (niLight), RCX=0x110 (GetLightRuntimeData SE offset), +0x0C (diffuse) -> access at 0x11C.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed light rendering to properly handle complex lighting scenarios and prevent visual artifacts.
  * Improved shadow mask computation for more accurate lighting calculations across diverse scene conditions.
  * Enhanced overall rendering stability and quality in light-intensive environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->