### PR TITLE
fix(VR): skip wasted overlay rendering in game

### DIFF
--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -221,6 +221,15 @@ void VR::RecreateOverlayTexturesIfNeeded()
 	Util::CreateOverlayTextureAndRTV(globals::d3d::device, Config::kOverlayWidth, Config::kOverlayHeight, menuTexture.put(), menuRTV.put());
 }
 
+bool VR::IsWelcomeOverlayVisible() const
+{
+	return settings.kAutoHideSeconds > 0 &&
+	       globals::game::ui &&
+	       globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) &&
+	       globals::menu &&
+	       !globals::menu->IsEnabled;
+}
+
 void VR::SubmitOverlayFrame()
 {
 	InstallSubmitHook();
@@ -233,7 +242,7 @@ void VR::SubmitOverlayFrame()
 	auto& enabled = globals::menu->IsEnabled;
 	auto& overlayVisible = globals::menu->overlayVisible;
 
-	if ((enabled || overlayVisible || settings.kAutoHideSeconds > 0) && menuTexture.get() && menuRTV.get()) {
+	if ((enabled || overlayVisible || IsWelcomeOverlayVisible()) && menuTexture.get() && menuRTV.get()) {
 		UpdateFixedWorldPositioning();
 		UpdateOverlayDrag();
 

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -301,6 +301,7 @@ public:
 
 	void RecreateOverlayTexturesIfNeeded();
 	void SubmitOverlayFrame();
+	bool IsWelcomeOverlayVisible() const;
 
 	/**
 	 * @brief Context for rendering VR overlays with render target management

--- a/src/Features/VR/InSceneOverlay.cpp
+++ b/src/Features/VR/InSceneOverlay.cpp
@@ -230,6 +230,10 @@ void VR::InitInSceneResources()
 
 void VR::RenderInSceneOverlay(vr::EVREye eye, ID3D11Texture2D* targetTexture, const vr::VRTextureBounds_t* bounds)
 {
+	if (!globals::menu || !(globals::menu->IsEnabled || globals::menu->overlayVisible || globals::features::vr.IsWelcomeOverlayVisible()) || settings.attachMode == AttachMode::None || !menuTexture) {
+		return;
+	}
+
 	auto context = globals::d3d::context;
 	winrt::com_ptr<ID3DUserDefinedAnnotation> perf;
 	context->QueryInterface(__uuidof(ID3DUserDefinedAnnotation), perf.put_void());
@@ -241,25 +245,6 @@ void VR::RenderInSceneOverlay(vr::EVREye eye, ID3D11Texture2D* targetTexture, co
 	if (!inSceneResources.initialized)
 		InitInSceneResources();
 	if (!inSceneResources.initialized) {
-		if (perf)
-			perf->EndEvent();
-		return;
-	}
-
-	// Only render if overlay should be visible
-	if (!globals::menu || !(globals::menu->IsEnabled || globals::menu->overlayVisible || settings.kAutoHideSeconds > 0)) {
-		if (perf)
-			perf->EndEvent();
-		return;
-	}
-	if (!menuTexture) {
-		if (perf)
-			perf->EndEvent();
-		return;
-	}
-
-	// Skip rendering when attach mode is None (disabled)
-	if (settings.attachMode == AttachMode::None) {
 		if (perf)
 			perf->EndEvent();
 		return;

--- a/src/Features/VR/InSceneOverlay.cpp
+++ b/src/Features/VR/InSceneOverlay.cpp
@@ -230,7 +230,7 @@ void VR::InitInSceneResources()
 
 void VR::RenderInSceneOverlay(vr::EVREye eye, ID3D11Texture2D* targetTexture, const vr::VRTextureBounds_t* bounds)
 {
-	if (!globals::menu || !(globals::menu->IsEnabled || globals::menu->overlayVisible || globals::features::vr.IsWelcomeOverlayVisible()) || settings.attachMode == AttachMode::None || !menuTexture) {
+	if (!globals::menu || !(globals::menu->IsEnabled || globals::menu->overlayVisible || IsWelcomeOverlayVisible()) || settings.attachMode == AttachMode::None || !menuTexture) {
 		return;
 	}
 

--- a/src/Features/VR/SettingsUI.cpp
+++ b/src/Features/VR/SettingsUI.cpp
@@ -73,7 +73,7 @@ void VR::DrawOverlay()
 	static LARGE_INTEGER overlayShowStart = { 0 };
 	static LARGE_INTEGER freq = { 0 };
 
-	bool shouldShow = settings.kAutoHideSeconds > 0 && globals::game::ui && globals::game::ui->IsMenuOpen(RE::MainMenu::MENU_NAME) && globals::menu && !globals::menu->IsEnabled;
+	bool shouldShow = IsWelcomeOverlayVisible();
 
 	if (!shouldShow) {
 		overlayShowStart.QuadPart = 0;


### PR DESCRIPTION
Even without a VR menu open, the overlay would render into the HMD. This now correctly skips any rendering in the HMD for the menu when not visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VR welcome overlay visibility so it appears and hides correctly based on menu state and auto-hide settings.

* **Refactor**
  * Centralized overlay visibility logic into a single helper to simplify and streamline rendering and early-exit checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->