### PR TITLE
fix(PBR): use-after-free CTD

### DIFF
--- a/src/TruePBR/BSLightingShaderMaterialPBR.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBR.cpp
@@ -20,7 +20,10 @@ BSLightingShaderMaterialPBR* BSLightingShaderMaterialPBR::Make()
 
 RE::BSShaderMaterial* BSLightingShaderMaterialPBR::Create()
 {
-	return Make();
+	// Must use regular heap (not scrap heap like Make()). BSLightingShaderProperty::LinkObject
+	// calls ScrapHeap::Free() after LinkMaterial — if Create() used scrap heap, it would pop
+	// the canonical off the stack, causing immediate use-after-free in property->material.
+	return new BSLightingShaderMaterialPBR();
 }
 
 void BSLightingShaderMaterialPBR::CopyMembers(RE::BSShaderMaterial* that)

--- a/src/TruePBR/BSLightingShaderMaterialPBR.h
+++ b/src/TruePBR/BSLightingShaderMaterialPBR.h
@@ -54,6 +54,10 @@ public:
 	~BSLightingShaderMaterialPBR();
 
 	// override (BSLightingShaderMaterialBase)
+	// Called by BSShaderMaterialHashMap::Link to produce the heap-allocated canonical copy.
+	// MUST use regular heap (new), NOT Make()/scrap heap. BSLightingShaderProperty::LinkObject
+	// calls ScrapHeap::Free() immediately after Link — a scrap-heap canonical would be popped
+	// off the stack and freed while property->material still points to it (use-after-free).
 	RE::BSShaderMaterial* Create() override;                                                                                      // 01
 	void CopyMembers(RE::BSShaderMaterial* that) override;                                                                        // 02
 	std::uint32_t ComputeCRC32(uint32_t srcHash) override;                                                                        // 04
@@ -64,6 +68,10 @@ public:
 	uint32_t GetTextures(RE::NiSourceTexture** textures) override;                                                                // 0B
 	void LoadBinary(RE::NiStream& stream) override;                                                                               // 0D
 
+	// Allocates a scrap-heap temp for use during BSLightingShaderProperty::LoadBinary.
+	// The temp is direct-assigned to property->material so that BSLightingShaderProperty::LinkObject
+	// (NiStream link phase) can find it, call BSShaderMaterialHashMap::Link to produce the canonical,
+	// then ScrapHeap::Free() to pop this temp. Never use Make() as the Create() implementation.
 	static BSLightingShaderMaterialPBR* Make();
 
 	void ApplyTextureSetData(const TruePBR::PBRTextureSetData& textureSetData);

--- a/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBRLandscape.cpp
@@ -26,7 +26,10 @@ BSLightingShaderMaterialPBRLandscape* BSLightingShaderMaterialPBRLandscape::Make
 
 RE::BSShaderMaterial* BSLightingShaderMaterialPBRLandscape::Create()
 {
-	return Make();
+	// Must use regular heap (not scrap heap like Make()). BSLightingShaderProperty::LinkObject
+	// calls ScrapHeap::Free() after LinkMaterial — if Create() used scrap heap, it would pop
+	// the canonical off the stack, causing immediate use-after-free in property->material.
+	return new BSLightingShaderMaterialPBRLandscape();
 }
 
 void BSLightingShaderMaterialPBRLandscape::CopyMembers(RE::BSShaderMaterial* that)

--- a/src/TruePBR/BSLightingShaderMaterialPBRLandscape.h
+++ b/src/TruePBR/BSLightingShaderMaterialPBRLandscape.h
@@ -18,6 +18,10 @@ public:
 	~BSLightingShaderMaterialPBRLandscape();
 
 	// override (BSLightingShaderMaterialBase)
+	// Called by BSShaderMaterialHashMap::Link to produce the heap-allocated canonical copy.
+	// MUST use regular heap (new), NOT Make()/scrap heap. BSLightingShaderProperty::LinkObject
+	// calls ScrapHeap::Free() immediately after Link — a scrap-heap canonical would be popped
+	// off the stack and freed while property->material still points to it (use-after-free).
 	RE::BSShaderMaterial* Create() override;                                                                                      // 01
 	void CopyMembers(RE::BSShaderMaterial* that) override;                                                                        // 02
 	Feature GetFeature() const override;                                                                                          // 06
@@ -25,6 +29,10 @@ public:
 	void ReceiveValuesFromRootMaterial(bool skinned, bool rimLighting, bool softLighting, bool backLighting, bool MSN) override;  // 0A
 	uint32_t GetTextures(RE::NiSourceTexture** textures) override;                                                                // 0B
 
+	// Allocates a scrap-heap temp for use during BSLightingShaderProperty::LoadBinary.
+	// The temp is direct-assigned to property->material so that BSLightingShaderProperty::LinkObject
+	// (NiStream link phase) can find it, call BSShaderMaterialHashMap::Link to produce the canonical,
+	// then ScrapHeap::Free() to pop this temp. Never use Make() as the Create() implementation.
 	static BSLightingShaderMaterialPBRLandscape* Make();
 
 	bool HasGlint() const;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory allocation and lifetime management issues in shader materials that could cause crashes.

* **Documentation**
  * Added clarification on allocation strategies for shader material creation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->