### PR TITLE
fix(VR): hmd mask while upscaling

### DIFF
--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/blur.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/blur.cs.hlsl
@@ -102,6 +102,10 @@ float2x2 getRotationMatrix(float noise)
 	const float2 screenPos = Stereo::ConvertFromStereoUV(uv, eyeIndex);
 
 	float depth = READ_DEPTH(srcDepth, dtid);
+#if defined(VR)
+	if (depth == 0.0)  // depth sentinel: ClearHMDMaskCS writes 0 at hidden-area pixels
+		return;
+#endif
 	float3 pos = ScreenToViewPosition(screenPos, depth, eyeIndex);
 	float3 normal = GBuffer::DecodeNormal(FULLRES_LOAD(srcNormalRoughness, dtid, uv, samplerLinearClamp).xy);
 

--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
@@ -342,8 +342,11 @@ void CalculateGI(
 
 	float2 uv = (pxCoord + .5) * RCP_OUT_FRAME_DIM;
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
-
 	float viewspaceZ = READ_DEPTH(srcWorkingDepth, pxCoord);
+#if defined(VR)
+	if (viewspaceZ == 0.0)  // depth sentinel: ClearHMDMaskCS writes 0 at hidden-area pixels
+		return;
+#endif
 
 	float2 normalSample = FULLRES_LOAD(srcNormalRoughness, pxCoord, uv * frameScale, samplerLinearClamp).xy;
 	float3 viewspaceNormal = GBuffer::DecodeNormal(normalSample);

--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
@@ -342,6 +342,7 @@ void CalculateGI(
 
 	float2 uv = (pxCoord + .5) * RCP_OUT_FRAME_DIM;
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
+
 	float viewspaceZ = READ_DEPTH(srcWorkingDepth, pxCoord);
 #if defined(VR)
 	if (viewspaceZ == 0.0)  // depth sentinel: ClearHMDMaskCS writes 0 at hidden-area pixels

--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/prefilterDepths.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/prefilterDepths.cs.hlsl
@@ -53,13 +53,25 @@ groupshared float g_scratchDepths[8][8];
 	// MIP 0
 	const uint2 baseCoord = dispatchThreadID;
 	const uint2 pixCoord = baseCoord * 2;
+#if defined(VR)
+	// Use the depth sentinel instead of t21: ClearHMDMaskCS writes NDC depth=0 at hidden-area pixels.
+	const bool isHiddenPixel = (srcNDCDepth.Load(int3(pixCoord, 0)) == 0.0);
+#else
+	const bool isHiddenPixel = false;
+#endif
 	const float2 uv = (pixCoord + .5) * RcpFrameDim;
 
-	float4 depths4 = srcNDCDepth.GatherRed(samplerPointClamp, uv * frameScale);
-	float depth0 = ClampDepth(depths4.w);
-	float depth1 = ClampDepth(depths4.z);
-	float depth2 = ClampDepth(depths4.x);
-	float depth3 = ClampDepth(depths4.y);
+	float depth0 = 0.0;
+	float depth1 = 0.0;
+	float depth2 = 0.0;
+	float depth3 = 0.0;
+	if (!isHiddenPixel) {
+		float4 depths4 = srcNDCDepth.GatherRed(samplerPointClamp, uv * frameScale);
+		depth0 = ClampDepth(depths4.w);
+		depth1 = ClampDepth(depths4.z);
+		depth2 = ClampDepth(depths4.x);
+		depth3 = ClampDepth(depths4.y);
+	}
 	outDepth0[pixCoord + uint2(0, 0)] = depth0;
 	outDepth0[pixCoord + uint2(1, 0)] = depth1;
 	outDepth0[pixCoord + uint2(0, 1)] = depth2;

--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/prefilterRadiance.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/prefilterRadiance.cs.hlsl
@@ -36,16 +36,27 @@ groupshared float3 g_scratchRadiance[8][8];
 	// MIP 0
 	const uint2 baseCoord = dispatchThreadID;
 	const uint2 pixCoord = baseCoord * 2;
+#if defined(VR)
+	// No depth input in this shader; use t21 stencil texture for the hidden-pixel check.
+	const bool isHiddenPixel = HMDMask::IsHiddenPixel(pixCoord);
+#else
+	const bool isHiddenPixel = false;
+#endif
 	const float2 uv = (pixCoord + .5) * RcpFrameDim;
 
-	float4 rad0 = srcRadiance.GatherRed(samplerPointClamp, uv * frameScale);
-	float4 rad1 = srcRadiance.GatherGreen(samplerPointClamp, uv * frameScale);
-	float4 rad2 = srcRadiance.GatherBlue(samplerPointClamp, uv * frameScale);
-
-	float3 radiance0 = float3(rad0.w, rad1.w, rad2.w);
-	float3 radiance1 = float3(rad0.z, rad1.z, rad2.z);
-	float3 radiance2 = float3(rad0.x, rad1.x, rad2.x);
-	float3 radiance3 = float3(rad0.y, rad1.y, rad2.y);
+	float3 radiance0 = 0.0;
+	float3 radiance1 = 0.0;
+	float3 radiance2 = 0.0;
+	float3 radiance3 = 0.0;
+	if (!isHiddenPixel) {
+		float4 rad0 = srcRadiance.GatherRed(samplerPointClamp, uv * frameScale);
+		float4 rad1 = srcRadiance.GatherGreen(samplerPointClamp, uv * frameScale);
+		float4 rad2 = srcRadiance.GatherBlue(samplerPointClamp, uv * frameScale);
+		radiance0 = float3(rad0.w, rad1.w, rad2.w);
+		radiance1 = float3(rad0.z, rad1.z, rad2.z);
+		radiance2 = float3(rad0.x, rad1.x, rad2.x);
+		radiance3 = float3(rad0.y, rad1.y, rad2.y);
+	}
 
 	outRadiance0[pixCoord + uint2(0, 0)] = radiance0;
 	outRadiance0[pixCoord + uint2(1, 0)] = radiance1;

--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/radianceDisocc.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/radianceDisocc.cs.hlsl
@@ -76,6 +76,12 @@ void readHistory(
 
 	const float2 uv = (pixCoord + .5) * RCP_OUT_FRAME_DIM;
 	const uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
+#if defined(VR)
+	// Use the depth sentinel instead of t21: ClearHMDMaskCS writes 0 at hidden-area pixels.
+	// The READ_DEPTH below re-reads the same pixel; GPU L1 cache makes this essentially free.
+	if (READ_DEPTH(srcCurrDepth, pixCoord) == 0.0)
+		return;
+#endif
 	const float2 screen_pos = Stereo::ConvertFromStereoUV(uv, eyeIndex);
 
 	float2 prev_screen_pos = screen_pos;

--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/stereoSync.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/stereoSync.cs.hlsl
@@ -58,10 +58,13 @@ float4 SampleCrossDepths(float2 centerUV, float2 step, float2 texScale, uint eye
 	float2 uv = (dtid + 0.5) / outFrameDim;
 
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
-
 	// SSGI working depth is linear view-space Z.
 	// 0.0 = mask (outside lens area). FP_Z = first-person hands threshold (~18.0).
 	float depth = srcDepth.SampleLevel(samplerPointClamp, uv * frameScale, RES_MIP);
+#	if defined(VR)
+	if (depth < kMaskDepth)  // depth sentinel: ClearHMDMaskCS writes 0 at hidden-area pixels
+		return;
+#	endif
 	if (depth < FP_Z) {
 		Passthrough(dtid);
 		return;

--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/stereoSync.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/stereoSync.cs.hlsl
@@ -58,6 +58,7 @@ float4 SampleCrossDepths(float2 centerUV, float2 step, float2 texScale, uint eye
 	float2 uv = (dtid + 0.5) / outFrameDim;
 
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
+
 	// SSGI working depth is linear view-space Z.
 	// 0.0 = mask (outside lens area). FP_Z = first-person hands threshold (~18.0).
 	float depth = srcDepth.SampleLevel(samplerPointClamp, uv * frameScale, RES_MIP);

--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/upsample.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/upsample.cs.hlsl
@@ -23,6 +23,11 @@ RWTexture2D<half4> outGiSpecular : register(u3);
 	// Early exit if dispatch thread is outside frame bounds
 	if (any(dtid >= uint2(FrameDim)))
 		return;
+#if defined(VR)
+	// Use the depth sentinel instead of t21: ClearHMDMaskCS writes 0 at hidden-area pixels.
+	if (srcDepth.Load(int3(dtid, RES_MIP)) == 0.0)
+		return;
+#endif
 #ifdef HALF_RES
 	int2 px00 = (dtid >> 1) + (dtid & 1) - 1;
 #else  // QUARTER_RES

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/StereoSyncCS.hlsl
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/StereoSyncCS.hlsl
@@ -85,14 +85,13 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 [numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
 	if (any(dtid >= uint2(FrameDim)))
 		return;
-
 	float2 uv = (dtid + 0.5) * RcpFrameDim;
 
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);
 
 	float depth = SrcDepthTexture[dtid];
 
-	// depth == 0: VR HMD mask; depth == 1: sky/far plane
+	// depth == 0: VR HMD hidden-area sentinel (ClearHMDMaskCS); depth == 1: sky/far plane
 	if (depth < 1e-5 || depth >= 1.0) {
 		OutShadowTexture[dtid] = SrcShadowTexture[dtid];
 		return;

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/StereoSyncCS.hlsl
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/StereoSyncCS.hlsl
@@ -85,6 +85,7 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 [numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
 	if (any(dtid >= uint2(FrameDim)))
 		return;
+
 	float2 uv = (dtid + 0.5) * RcpFrameDim;
 
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(uv);

--- a/features/Subsurface Scattering/Shaders/Features/SubsurfaceScattering.ini
+++ b/features/Subsurface Scattering/Shaders/Features/SubsurfaceScattering.ini
@@ -1,5 +1,5 @@
 [Info]
-version = 3-0-1
+version = 3-0-2
 
 [Nexus]
 nexusmodid = 114114

--- a/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSSCS.hlsl
+++ b/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSSCS.hlsl
@@ -34,6 +34,10 @@ cbuffer PerFrameSSS : register(b1)
 	// Early exit if dispatch thread is outside screen bounds
 	if (any(DTid.xy >= uint2(SharedData::BufferDim.xy)))
 		return;
+#if defined(VR)
+	if (HMDMask::IsHiddenPixel(DTid.xy))
+		return;
+#endif
 
 	float2 texCoord = (DTid.xy + 0.5) * SharedData::BufferDim.zw;
 	uint eyeIndex = Stereo::GetEyeIndexFromTexCoord(texCoord);

--- a/features/Upscaling/Shaders/Upscaling/ApplyHMDMaskCS.hlsl
+++ b/features/Upscaling/Shaders/Upscaling/ApplyHMDMaskCS.hlsl
@@ -1,0 +1,87 @@
+// Applies a pre-rasterized HMD hidden area mask to upscaler inputs or outputs.
+//
+// MaskTex (t0): R8_UNORM texture, 1=hidden, 0=visible. Rasterized from the OpenVR
+//   GetHiddenAreaMesh() at the target resolution so the boundary is resolution-exact.
+//
+// ColorInOut (u0): zeroed where exactly masked — prevents the upscaler from temporally
+//   accumulating sky/ambient color at the hidden area boundary.
+//
+// When UPDATE_REACTIVE is defined (pre-upscale pass only):
+//   ReactiveOut (u1): set to 1.0 where masked OR within dilationRadius pixels of the
+//     mask boundary. The dilation covers the temporal reconstruction neighborhood so
+//     DLSS/FSR does not blend historical sky-blue into the boundary ring during fast
+//     head movement. Color is only zeroed for exactly-masked pixels; boundary pixels
+//     keep their actual scene color but discard temporal history.
+//   TransparencyOut (u2): set to 0.0 where masked (exact, not dilated).
+
+Texture2D<float> MaskTex : register(t0);
+
+RWTexture2D<float4> ColorInOut : register(u0);
+#if defined(UPDATE_REACTIVE)
+RWTexture2D<float> ReactiveOut : register(u1);
+RWTexture2D<float> TransparencyOut : register(u2);
+
+// Velocity-adaptive dilation radius set by the CPU each frame from HMD angular velocity.
+// Covers the expected boundary shift per frame: ceil(angVel_rad_per_frame * px_per_rad).
+// Separable (horizontal then vertical) 1D max-filter: O(r) per pixel instead of O(r^2).
+//
+// velocityFactor [0,1]: global reactive weight applied to ALL visible pixels.
+// At 0 (stationary) only the dilated boundary ring is reactive.  At 1 (fast rotation)
+// every visible pixel gets reactive=1, forcing the upscaler to trust current-frame data
+// and preventing sky-history ghosting during rapid head movements.
+cbuffer DilationCB : register(b0)
+{
+	uint dilationRadius;
+	float velocityFactor;
+	uint2 pad;
+};
+#endif
+
+[numthreads(8, 8, 1)] void main(uint3 id : SV_DispatchThreadID) {
+	uint w, h;
+	ColorInOut.GetDimensions(w, h);
+	if (id.x >= w || id.y >= h)
+		return;
+
+	bool exactMasked = MaskTex[id.xy] > 0.5;
+
+	if (exactMasked) {
+		ColorInOut[id.xy] = float4(0.0, 0.0, 0.0, 0.0);
+	}
+
+#if defined(UPDATE_REACTIVE)
+	// Separable 1D dilation: scan horizontal row then vertical column.
+	// Equivalent to a rhombus-shaped dilation (L1 distance), cheaper than square for large r.
+	int dr = (int)dilationRadius;
+	bool dilatedMasked = exactMasked;
+	if (!dilatedMasked) {
+		[loop] for (int dx = -dr; dx <= dr && !dilatedMasked; ++dx)
+		{
+			int sx = clamp((int)id.x + dx, 0, (int)w - 1);
+			if (MaskTex[int2(sx, id.y)] > 0.5)
+				dilatedMasked = true;
+		}
+	}
+	if (!dilatedMasked) {
+		[loop] for (int dy = -dr; dy <= dr && !dilatedMasked; ++dy)
+		{
+			int sy = clamp((int)id.y + dy, 0, (int)h - 1);
+			if (MaskTex[int2(id.x, sy)] > 0.5)
+				dilatedMasked = true;
+		}
+	}
+
+	if (dilatedMasked) {
+		ReactiveOut[id.xy] = 1.0;
+		if (exactMasked)
+			TransparencyOut[id.xy] = 0.0;
+	} else {
+		// Velocity-proportional reactive weight for pixels far from the boundary.
+		// During rapid head rotation, the upscaler accumulates sky-tinted history at pixels
+		// that previously faced the sky.  Scaling reactive weight with angular velocity
+		// forces the upscaler to discard stale history at interior pixels too, eliminating
+		// sky ghosting without sacrificing temporal smoothness when the head is still.
+		ReactiveOut[id.xy] = velocityFactor;
+	}
+#endif
+}

--- a/features/Upscaling/Shaders/Upscaling/BuildStereoMaskCS.hlsl
+++ b/features/Upscaling/Shaders/Upscaling/BuildStereoMaskCS.hlsl
@@ -1,0 +1,33 @@
+// Composites two per-eye R8 HMD masks into a single full-stereo R8 mask at t21 resolution.
+//
+// Output layout matches the SBS render-res stereo buffer: left eye at [0, renderW-1],
+// right eye at [renderW, 2*renderW-1].  This matches the coordinate space seen by
+// deferred compute shaders, so IsHiddenPixel can sample directly without any remapping.
+//
+// Only needs to run when the resolution or HMD mesh changes (not every frame).
+
+Texture2D<float> EyeMask0 : register(t0);  // left-eye  R8 mask at renderW x renderH
+Texture2D<float> EyeMask1 : register(t1);  // right-eye R8 mask at renderW x renderH
+
+RWTexture2D<float> StereoMask : register(u0);  // output: renderW*2 x renderH
+
+cbuffer BuildStereoMaskCB : register(b0)
+{
+	uint renderW;  // per-eye rendered width
+	uint renderH;  // per-eye rendered height
+	uint pad0;
+	uint pad1;
+};
+
+[numthreads(8, 8, 1)] void main(uint3 DTid : SV_DispatchThreadID) {
+	uint w, h;
+	StereoMask.GetDimensions(w, h);
+	if (DTid.x >= w || DTid.y >= h)
+		return;
+
+	// Right eye starts immediately after left eye, matching SBS render-res layout.
+	uint eyeIdx = (DTid.x >= renderW) ? 1 : 0;
+	uint eyeX = DTid.x - eyeIdx * renderW;
+
+	StereoMask[DTid.xy] = eyeIdx == 0 ? EyeMask0[int2(eyeX, DTid.y)] : EyeMask1[int2(eyeX, DTid.y)];
+}

--- a/features/Upscaling/Shaders/Upscaling/ClearHMDMaskCS.hlsl
+++ b/features/Upscaling/Shaders/Upscaling/ClearHMDMaskCS.hlsl
@@ -4,6 +4,12 @@
 // depth == 0.0 is the unrendered/hidden area value (Skyrim reversed-Z: far plane = 0).
 // DepthIn is the combined stereo depth buffer; DepthOffsetX selects the eye's half.
 // ColorInOut is the isolated per-eye buffer; ColorOffsetX is always 0.
+//
+// NOTE: depth == 0.0 also matches sky pixels (reversed-Z far plane). We intentionally
+// do NOT set the reactive mask here — setting reactive=1.0 for sky would prevent the
+// upscaler from using temporal history for sky, causing permanently black sky.
+// Reactive mask is only set via the mesh-based path (ApplyHMDMaskCS.hlsl), which is
+// resolution-exact and covers only the true hidden-area corners.
 
 cbuffer ClearHMDMaskCB : register(b0)
 {

--- a/features/Upscaling/Shaders/Upscaling/HMDMaskRasterPS.hlsl
+++ b/features/Upscaling/Shaders/Upscaling/HMDMaskRasterPS.hlsl
@@ -1,0 +1,7 @@
+// Pixel shader for rasterizing the OpenVR hidden area mesh.
+// Outputs 1.0 into an R8_UNORM render target to mark hidden pixels.
+
+float4 main() : SV_Target
+{
+	return float4(1.0, 0.0, 0.0, 0.0);
+}

--- a/features/Upscaling/Shaders/Upscaling/HMDMaskRasterVS.hlsl
+++ b/features/Upscaling/Shaders/Upscaling/HMDMaskRasterVS.hlsl
@@ -1,0 +1,10 @@
+// Vertex shader for rasterizing the OpenVR hidden area mesh into an R8 mask texture.
+// Vertices are stored as a StructuredBuffer<float2> in NDC space (no input layout needed).
+// The CPU converts OpenVR UV [0,1] -> NDC [-1,1] before uploading.
+
+StructuredBuffer<float2> MeshVerts : register(t0);
+
+float4 main(uint vertexId : SV_VertexID) : SV_POSITION
+{
+	return float4(MeshVerts[vertexId], 0.0, 1.0);
+}

--- a/package/Shaders/Common/VR.hlsli
+++ b/package/Shaders/Common/VR.hlsli
@@ -21,7 +21,22 @@ cbuffer VRValues : register(b13)
 	float2 EyeOffsetScale : packoffset(c0.z);
 	float4 EyeClipEdge[2] : packoffset(c1);
 }
-#endif
+
+// Full-stereo R8 HMD mask: 1.0=hidden, 0.0=visible.
+// Built from the OpenVR GetHiddenAreaMesh() at render resolution; gap columns and rows
+// below render height are also marked 1.0.  More accurate than the game's D24S8 stencil,
+// which does not cover all OpenVR-hidden pixels after a resolution change.
+// Bound by Upscaling::BindVRHMDStencil() into t21 before each VR deferred CS pass.
+#	if defined(CSHADER) || defined(COMPUTESHADER)
+Texture2D<float> VRHMDStencil : register(t21);
+
+namespace HMDMask
+{
+	// Returns true when pos is inside the HMD hidden area and should produce no output.
+	bool IsHiddenPixel(uint2 pos) { return VRHMDStencil.Load(int3(pos, 0)) > 0.5f; }
+}
+#	endif  // CSHADER
+#endif      // VR
 
 namespace Stereo
 {

--- a/package/Shaders/VR/StereoBlendCS.hlsl
+++ b/package/Shaders/VR/StereoBlendCS.hlsl
@@ -75,7 +75,6 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 [numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
 	if (any(dtid >= uint2(FrameDim)))
 		return;
-
 #ifdef STEREO_OVERWRITE
 	// =========================================================================
 	// Mode-driven stereo merge: reads per-pixel classification from StencilCS
@@ -88,8 +87,9 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 
 	float centerDepth = DepthTexture[dtid];
 
-	// HMD mask pixels (depth >= 1.0 in reversed-Z) — always skip
-	if (centerDepth >= 1.0)
+	// HMD hidden-area: ClearHMDMaskCS writes reversed-Z far-plane (0.0) at masked pixels.
+	// Near-clip geometry (depth >= 1.0) is also degenerate — skip both.
+	if (centerDepth == 0.0 || centerDepth >= 1.0)
 		return;
 
 	uint pixelMode = ModeTexture[dtid];

--- a/package/Shaders/VR/StereoBlendCS.hlsl
+++ b/package/Shaders/VR/StereoBlendCS.hlsl
@@ -75,6 +75,7 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 [numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
 	if (any(dtid >= uint2(FrameDim)))
 		return;
+
 #ifdef STEREO_OVERWRITE
 	// =========================================================================
 	// Mode-driven stereo merge: reads per-pixel classification from StencilCS

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -3,7 +3,9 @@
 #include <DirectXTex.h>
 
 #include "Deferred.h"
+#include "Globals.h"
 #include "State.h"
+#include "Upscaling.h"
 #include "Util.h"
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
@@ -752,6 +754,9 @@ void ScreenSpaceGI::DrawSSGI()
 	context->CSSetConstantBuffers(5, 1, &sharedDataBuf);
 	context->CSSetSamplers(0, (uint)samplers.size(), samplers.data());
 
+	if (globals::game::isVR)
+		globals::features::upscaling.BindVRHMDStencil();  // stencil SRV at t21 for CS HMD culling
+
 	// prefilter depths
 	{
 		TracyD3D11Zone(globals::state->tracyCtx, "SSGI - Prefilter Depths");
@@ -935,6 +940,9 @@ void ScreenSpaceGI::DrawSSGI()
 
 	// cleanup
 	resetViews();
+
+	if (globals::game::isVR)
+		globals::features::upscaling.UnbindVRHMDStencil();  // t21
 
 	samplers.fill(nullptr);
 	cb = nullptr;

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -1,5 +1,6 @@
 #include "ScreenSpaceShadows.h"
 
+#include "Globals.h"
 #include "State.h"
 
 #pragma warning(push)

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -1,6 +1,5 @@
 #include "ScreenSpaceShadows.h"
 
-#include "Globals.h"
 #include "State.h"
 
 #pragma warning(push)

--- a/src/Features/SubsurfaceScattering.cpp
+++ b/src/Features/SubsurfaceScattering.cpp
@@ -1,8 +1,10 @@
 #include "SubsurfaceScattering.h"
 
 #include "Deferred.h"
+#include "Globals.h"
 #include "ShaderCache.h"
 #include "State.h"
+#include "Upscaling.h"
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(SubsurfaceScattering::DiffusionProfile,
 	BlurRadius, Thickness, Strength, Falloff)
@@ -225,6 +227,9 @@ void SubsurfaceScattering::DrawSSS()
 	auto renderer = globals::game::renderer;
 	auto context = globals::d3d::context;
 
+	if (globals::game::isVR)
+		globals::features::upscaling.BindVRHMDStencil();  // stencil SRV at t21 for CS HMD culling
+
 	{
 		ID3D11Buffer* buffer[1] = { blurCB->CB() };
 		context->CSSetConstantBuffers(1, 1, buffer);
@@ -290,6 +295,9 @@ void SubsurfaceScattering::DrawSSS()
 			}
 		}
 	}
+
+	if (globals::game::isVR)
+		globals::features::upscaling.UnbindVRHMDStencil();  // t21
 
 	ID3D11Buffer* buffer = nullptr;
 	context->CSSetConstantBuffers(1, 1, &buffer);

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -8,12 +8,14 @@
 #include "Upscaling/FidelityFX.h"
 #include "Upscaling/Streamline.h"
 #include "Utils/UI.h"
+#include "Utils/VRUtils.h"
 #include <Windows.h>
 #include <algorithm>
 #include <cfloat>
 #include <cmath>
 #include <directx/d3dx12.h>
 #include <format>
+#include <openvr.h>
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	Upscaling::Settings,
@@ -939,7 +941,7 @@ void Upscaling::CreateVRIntermediateTextures(uint32_t inWidth, uint32_t inHeight
 		std::string suffix = (i == 0) ? "Left" : "Right";
 
 		vrIntermediateColorIn[i] = CreateTextureFromSource(colorSrc, inWidth, inHeight, false, true, true, ("Upscale_ColorIn_" + suffix).c_str());
-		vrIntermediateColorOut[i] = CreateTextureFromSource(colorSrc, outWidth, outHeight, false, true, false, ("Upscale_ColorOut_" + suffix).c_str());
+		vrIntermediateColorOut[i] = CreateTextureFromSource(colorSrc, outWidth, outHeight, false, true, true, ("Upscale_ColorOut_" + suffix).c_str());
 
 		// Depth: R24G8_TYPELESS matches the game's D24S8_TYPELESS cast group so that
 		// CopySubresourceRegion can copy from the game depth buffer without format errors.
@@ -1002,6 +1004,15 @@ void Upscaling::CreateVRIntermediateTextures(uint32_t inWidth, uint32_t inHeight
 		vrIntermediateTransparencyMask[i] = CreateTextureFromSource(transparencySrc, inWidth, inHeight, false, true, true, ("Upscale_Transparency_" + suffix).c_str());
 	}
 
+	// Build HMD mesh once; rasterize masks whenever resolution changes.
+	if (!vrHMDMeshBuilt)
+		BuildHMDMesh();
+	// The VR stereo buffer is over-allocated in height: Skyrim only renders into the top
+	// min(inHeight, outHeight) rows regardless of quality mode. OpenVR mesh UV [0,1] spans
+	// that content region, so the render-res mask must use the smaller of the two heights.
+	// The display-res mask uses outHeight directly since the upscaler fills the full output.
+	RasterizeHMDMasks(inWidth, std::min(inHeight, outHeight), outWidth, outHeight);
+
 	logger::info("[Upscaling] Created VR intermediate textures: per-eye in {}x{}, out {}x{}",
 		inWidth, inHeight, outWidth, outHeight);
 }
@@ -1020,7 +1031,8 @@ void Upscaling::EnsureVRIntermediateTextures()
 	uint32_t eyeWidthIn = (uint32_t)(renderSize.x / 2);
 	uint32_t eyeHeightIn = (uint32_t)renderSize.y;
 
-	bool needsRecreate = !vrIntermediateColorIn[0] || !vrIntermediateColorOut[0] || !vrIntermediateLinearDepth[0];
+	bool needsRecreate = !vrIntermediateColorIn[0] || !vrIntermediateColorOut[0] || !vrIntermediateLinearDepth[0] ||
+	                     !vrHMDMaskRenderRes[0] || !vrHMDMaskDisplayRes[0] || !vrHMDMaskStereoRenderRes;
 	if (!needsRecreate) {
 		needsRecreate = (vrIntermediateColorIn[0]->desc.Width != eyeWidthIn ||
 						 vrIntermediateColorIn[0]->desc.Height != eyeHeightIn ||
@@ -1051,6 +1063,25 @@ void Upscaling::PreparePerEyeInputs(ID3D11Resource* colorSrc, ID3D11Resource* de
 	uint32_t eyeWidthIn = (uint32_t)(renderSize.x / 2);
 	uint32_t eyeHeightIn = (uint32_t)renderSize.y;
 
+	// Update velocity-adaptive dilation radius from current HMD angular velocity.
+	// radius = ceil(angVel_rad_per_sec * deltaTime * renderW / hFOV_rad), clamped to [4, 64].
+	// TryGetLastHMDPose uses compositor GetLastPoses only (non-blocking, cached last-frame pose).
+	// On failure the previous vrDilationRadius is kept — acceptable for a smoothly changing value.
+	{
+		vr::TrackedDevicePose_t hmdPose{};
+		if (Util::TryGetLastHMDPose(hmdPose) && hmdPose.bPoseIsValid) {
+			const auto& av = hmdPose.vAngularVelocity;  // rad/sec
+			float angSpeed = sqrtf(av.v[0] * av.v[0] + av.v[1] * av.v[1] + av.v[2] * av.v[2]);
+			float angPerFrame = angSpeed * (*globals::game::deltaTime);
+			float hFOVRad = Util::GetPerEyeHorizontalFOVRad(0);
+			if (hFOVRad <= 0.0f)
+				hFOVRad = 1.5708f;  // 90° fallback
+			float pxPerRad = vrRenderPerEyeW > 0 ? static_cast<float>(vrRenderPerEyeW) / hFOVRad : 1000.0f;
+			uint32_t r = static_cast<uint32_t>(ceilf(angPerFrame * pxPerRad));
+			vrDilationRadius = std::clamp(r, 4u, 64u);
+		}
+	}
+
 	// Textures guaranteed to exist: EnsureVRIntermediateTextures() was called in Upscale()
 	// Read the original game depth SRV for ClearHMDMask — the combined stereo buffer is
 	// definitively valid here, whereas the per-eye copy may silently produce zeros on some
@@ -1072,9 +1103,17 @@ void Upscaling::PreparePerEyeInputs(ID3D11Resource* colorSrc, ID3D11Resource* de
 		if (GetUpscaleMethod() != UpscaleMethod::kDLSS)
 			context->CopySubresourceRegion(vrIntermediateMotionVectors[i]->resource.get(), 0, 0, 0, 0, motionVectorRT.texture, 0, &srcBox);
 
-		uint32_t depthOffset = (i == 1) ? eyeWidthIn : 0;
-		ClearHMDMask(vrIntermediateColorIn[i]->uav.get(), depthTexture.depthSRV,
-			eyeWidthIn, eyeHeightIn, depthOffset, 0);
+		// Apply HMD hidden area mask: zero color and mark reactive to prevent temporal bleed.
+		// Mesh path (OpenVR GetHiddenAreaMesh) is resolution-exact and safe for reactive marking.
+		// Depth fallback (depth==0) zeros color only — depth==0 also matches sky (reversed-Z far
+		// plane), so setting reactive there would black out the sky.
+		if (vrHMDMeshVertCount[i] > 0 && vrHMDMaskRenderRes[i]) {
+			ApplyHMDMaskToEyeInputs(i, eyeWidthIn, eyeHeightIn);
+		} else {
+			uint32_t depthOffset = (i == 1) ? eyeWidthIn : 0;
+			ClearHMDMask(vrIntermediateColorIn[i]->uav.get(), depthTexture.depthSRV,
+				eyeWidthIn, eyeHeightIn, depthOffset, 0);
+		}
 	}
 
 	if (state->frameAnnotations)
@@ -1098,6 +1137,14 @@ void Upscaling::FinalizePerEyeOutputs(ID3D11Resource* colorDst)
 
 	uint32_t eyeWidthOut = (uint32_t)(screenSize.x / 2);
 	uint32_t eyeHeightOut = (uint32_t)screenSize.y;
+
+	// Re-zero the hidden area in upscaled outputs at display resolution before copying back.
+	// The upscaler may have accumulated or interpolated across the render-res mask boundary;
+	// rasterizing the OpenVR mesh at display-res gives the exact boundary.
+	for (uint32_t i = 0; i < 2; ++i) {
+		if (vrHMDMeshVertCount[i] > 0 && vrHMDMaskDisplayRes[i])
+			ApplyHMDMaskToEyeOutput(i, eyeWidthOut, eyeHeightOut);
+	}
 
 	// Write upscaled outputs back
 	for (uint32_t i = 0; i < 2; ++i) {
@@ -1163,6 +1210,438 @@ void Upscaling::ClearHMDMask(ID3D11UnorderedAccessView* colorUAV, ID3D11ShaderRe
 		context->CSSetConstantBuffers(0, 1, nullCB);
 		context->CSSetShader(nullptr, nullptr, 0);
 	}
+}
+
+void Upscaling::BuildHMDMesh()
+{
+	vrHMDMeshBuilt = true;
+
+	if (!globals::game::isVR)
+		return;
+
+	Util::OpenVRContext ctx;
+	if (!ctx.IsValid()) {
+		logger::warn("[Upscaling] BuildHMDMesh: OpenVR not available, HMD mask will use depth fallback");
+		return;
+	}
+
+	// Bypass openvr->vrSystem — other mods (e.g. HookVRSystem) may hook that pointer and
+	// return null or garbage from GetHiddenAreaMesh. VR_GetGenericInterface goes straight
+	// to the runtime, same approach as BSOpenVR::GetCleanIVROverlay.
+	typedef void* (*pfnVRGetGenericInterface)(const char*, vr::EVRInitError*);
+	vr::IVRSystem* system = ctx.system;  // fallback: use whatever the game has
+	REX::W32::HMODULE openvr_mod = REX::W32::GetModuleHandleA("openvr_api.dll");
+	if (openvr_mod) {
+		auto fn = reinterpret_cast<pfnVRGetGenericInterface>(
+			reinterpret_cast<void*>(REX::W32::GetProcAddress(openvr_mod, "VR_GetGenericInterface")));
+		if (fn) {
+			vr::EVRInitError err = vr::VRInitError_None;
+			auto* clean = reinterpret_cast<vr::IVRSystem*>(fn(vr::IVRSystem_Version, &err));
+			if (err == vr::VRInitError_None && clean) {
+				system = clean;
+				logger::info("[Upscaling] BuildHMDMesh: obtained clean IVRSystem via VR_GetGenericInterface");
+			}
+		}
+	}
+
+	if (!system) {
+		logger::warn("[Upscaling] BuildHMDMesh: no IVRSystem available, using depth fallback");
+		return;
+	}
+
+	for (int eye = 0; eye < 2; ++eye) {
+		vr::EVREye vrEye = (eye == 0) ? vr::Eye_Left : vr::Eye_Right;
+		vr::HiddenAreaMesh_t mesh = system->GetHiddenAreaMesh(vrEye, vr::k_eHiddenAreaMesh_Standard);
+
+		if (!mesh.pVertexData || mesh.unTriangleCount == 0) {
+			logger::info("[Upscaling] BuildHMDMesh: no hidden area mesh for eye {}, using depth fallback", eye);
+			continue;
+		}
+
+		// OpenVR GetHiddenAreaMesh returns UVs with v=0 at BOTTOM (GL convention), not top.
+		// D3D NDC has y=-1 at bottom, so both X and Y map with `v * 2 - 1` (no flip).
+		// (A Y-flip here was measured to invert the mask: captured mask had its wide hidden
+		// strip on the bottom-left while the game's drawn region shows the top-left
+		// as the more-clipped area.)
+		auto toNDC = [](const vr::HmdVector2_t& uv) -> float2 {
+			return { uv.v[0] * 2.0f - 1.0f, uv.v[1] * 2.0f - 1.0f };
+		};
+
+		// Validate pVertexData before any access.
+		//
+		// Hooked VR systems (e.g. HookVRSystem from other mods) or buggy runtimes can return
+		// a garbage pointer — including addresses inside DLL code sections (MEM_IMAGE type).
+		// Reading from those would either produce junk or crash far into the image.
+		// Reject any pointer that is not in private/mapped heap memory.
+		MEMORY_BASIC_INFORMATION mbi{};
+		size_t validBytes = 0;
+		// Whitelist only explicitly readable page protections.
+		// PAGE_EXECUTE alone is not readable on x64 (DEP); PAGE_NOACCESS/PAGE_GUARD trap.
+		constexpr DWORD kReadableProtect =
+			PAGE_READONLY | PAGE_READWRITE | PAGE_WRITECOPY |
+			PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
+		if (VirtualQuery(mesh.pVertexData, &mbi, sizeof(mbi)) &&
+			mbi.State == MEM_COMMIT &&
+			mbi.Type != MEM_IMAGE &&           // code/data section of a PE: not valid mesh data
+			(mbi.Protect & kReadableProtect))  // must be explicitly readable
+		{
+			validBytes = (static_cast<const char*>(mbi.BaseAddress) + mbi.RegionSize) -
+			             reinterpret_cast<const char*>(mesh.pVertexData);
+		}
+
+		if (validBytes == 0) {
+			logger::warn(
+				"[Upscaling] BuildHMDMesh: eye {} — pVertexData {:p} is not valid heap memory "
+				"(State={:#x} Type={:#x}), skipping (hooked/buggy VR runtime?)",
+				eye, static_cast<const void*>(mesh.pVertexData), mbi.State, mbi.Type);
+			continue;
+		}
+
+		uint32_t maxSafeVerts = static_cast<uint32_t>(
+			std::min(validBytes / sizeof(vr::HmdVector2_t), static_cast<size_t>(UINT32_MAX)));
+
+		// Hard cap: no legitimate HMD mask needs more than 64 K verts.
+		// Prevents enormous allocations from a misbehaving runtime.
+		constexpr uint32_t kMaxHMDMaskVerts = 65536;
+
+		// Determine whether the runtime returned a true triangle mesh or a line-loop polygon.
+		//
+		// Oculus/Meta runtimes (Quest 2/3, Rift S) return a line-loop when
+		// k_eHiddenAreaMesh_Standard is requested: unTriangleCount = polygon vertex count,
+		// buffer holds exactly that many float2 entries — NOT unTriangleCount*3.
+		//
+		// Two independent checks — either is sufficient to fan-triangulate:
+		//   1. k_eHiddenAreaMesh_LineLoop query: if the line-loop mesh has the same vertex
+		//      count as the "standard" mesh, the runtime returned line-loop data for both.
+		//   2. VirtualQuery: buffer too small to hold unTriangleCount*3 entries → line-loop.
+
+		vr::HiddenAreaMesh_t loopMesh = system->GetHiddenAreaMesh(vrEye, vr::k_eHiddenAreaMesh_LineLoop);
+		bool lineLoopByQuery = (loopMesh.pVertexData && loopMesh.unTriangleCount == mesh.unTriangleCount);
+		// Use uint64_t to avoid overflow when unTriangleCount is near UINT32_MAX.
+		bool lineLoopByMemory = (static_cast<uint64_t>(mesh.unTriangleCount) * 3 > maxSafeVerts);
+		bool isLineLoop = lineLoopByQuery || lineLoopByMemory;
+
+		std::vector<float2> ndcVerts;
+		uint32_t vertCount = 0;
+
+		if (!isLineLoop) {
+			// Standard triangle mesh (SteamVR / WMR / Pimax normal case)
+			uint64_t safeProduct = static_cast<uint64_t>(mesh.unTriangleCount) * 3;
+			vertCount = static_cast<uint32_t>(std::min<uint64_t>(safeProduct, std::min<uint64_t>(maxSafeVerts, kMaxHMDMaskVerts)));
+			ndcVerts.resize(vertCount);
+			for (uint32_t v = 0; v < vertCount; ++v)
+				ndcVerts[v] = toNDC(mesh.pVertexData[v]);
+		} else {
+			// Line-loop (convex polygon) — seen on Oculus/Meta runtimes.
+			// unTriangleCount is the polygon vertex count; clamp to safe limits.
+			uint32_t polyVerts = std::min({ mesh.unTriangleCount, maxSafeVerts, kMaxHMDMaskVerts });
+			if (polyVerts < 3) {
+				logger::warn("[Upscaling] BuildHMDMesh: eye {} mesh too small ({} verts), skipping", eye, polyVerts);
+				continue;
+			}
+			logger::info(
+				"[Upscaling] BuildHMDMesh: eye {} — line-loop mesh detected "
+				"({} poly-verts, capped to {}, lineLoopByQuery={}, lineLoopByMemory={}), fan-triangulating",
+				eye, mesh.unTriangleCount, polyVerts, lineLoopByQuery, lineLoopByMemory);
+
+			vertCount = (polyVerts - 2) * 3;  // safe: polyVerts <= 65536, product <= 196602
+			ndcVerts.resize(vertCount);
+			float2 hub = toNDC(mesh.pVertexData[0]);
+			uint32_t out = 0;
+			for (uint32_t v = 1; v + 1 < polyVerts; ++v) {
+				ndcVerts[out++] = hub;
+				ndcVerts[out++] = toNDC(mesh.pVertexData[v]);
+				ndcVerts[out++] = toNDC(mesh.pVertexData[v + 1]);
+			}
+		}
+
+		D3D11_BUFFER_DESC bd = {};
+		bd.ByteWidth = vertCount * sizeof(float2);
+		bd.Usage = D3D11_USAGE_IMMUTABLE;
+		bd.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+		bd.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
+		bd.StructureByteStride = sizeof(float2);
+
+		D3D11_SUBRESOURCE_DATA init = { ndcVerts.data(), 0, 0 };
+		DX::ThrowIfFailed(globals::d3d::device->CreateBuffer(&bd, &init, vrHMDMeshVB[eye].put()));
+
+		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Format = DXGI_FORMAT_UNKNOWN;
+		srvDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
+		srvDesc.Buffer.FirstElement = 0;
+		srvDesc.Buffer.NumElements = vertCount;
+		DX::ThrowIfFailed(globals::d3d::device->CreateShaderResourceView(vrHMDMeshVB[eye].get(), &srvDesc, vrHMDMeshVBSRV[eye].put()));
+
+		vrHMDMeshVertCount[eye] = vertCount;
+		logger::info("[Upscaling] BuildHMDMesh: eye {} — {} triangles, first 3 NDC verts: ({:.3f},{:.3f}) ({:.3f},{:.3f}) ({:.3f},{:.3f})",
+			eye, mesh.unTriangleCount,
+			ndcVerts[0].x, ndcVerts[0].y,
+			ndcVerts[1].x, ndcVerts[1].y,
+			ndcVerts[2].x, ndcVerts[2].y);
+	}
+}
+
+void Upscaling::RasterizeHMDMasks(uint32_t renderW, uint32_t renderH, uint32_t displayW, uint32_t displayH)
+{
+	vrRenderPerEyeW = renderW;
+	vrRenderPerEyeH = renderH;
+	auto context = globals::d3d::context;
+	const float clearBlack[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+
+	auto CreateMaskTex = [&](uint32_t w, uint32_t h, const char* name) -> eastl::unique_ptr<Texture2D> {
+		D3D11_TEXTURE2D_DESC desc = {};
+		desc.Width = w;
+		desc.Height = h;
+		desc.MipLevels = 1;
+		desc.ArraySize = 1;
+		desc.Format = DXGI_FORMAT_R8_UNORM;
+		desc.SampleDesc.Count = 1;
+		desc.Usage = D3D11_USAGE_DEFAULT;
+		desc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+		auto tex = eastl::make_unique<Texture2D>(desc);
+		Util::SetResourceName(tex->resource.get(), name);
+		D3D11_RENDER_TARGET_VIEW_DESC rtvDesc = {};
+		rtvDesc.Format = DXGI_FORMAT_R8_UNORM;
+		rtvDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+		tex->CreateRTV(rtvDesc);
+		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Format = DXGI_FORMAT_R8_UNORM;
+		srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
+		tex->CreateSRV(srvDesc);
+		// Clear to black immediately — GPU memory is undefined at creation.
+		// This ensures a safe "no mask" state even if rasterization is skipped.
+		context->ClearRenderTargetView(tex->rtv.get(), clearBlack);
+		return tex;
+	};
+
+	for (int eye = 0; eye < 2; ++eye) {
+		std::string s = (eye == 0) ? "Left" : "Right";
+		vrHMDMaskRenderRes[eye] = CreateMaskTex(renderW, renderH, ("HMDMask_RenderRes_" + s).c_str());
+		vrHMDMaskDisplayRes[eye] = CreateMaskTex(displayW, displayH, ("HMDMask_DisplayRes_" + s).c_str());
+	}
+
+	// Unbind RTVs left from the clears above before compiling shaders
+	ID3D11RenderTargetView* nullRTV = nullptr;
+	context->OMSetRenderTargets(1, &nullRTV, nullptr);
+
+	if (!vrHMDMaskRasterVS) {
+		vrHMDMaskRasterVS.attach((ID3D11VertexShader*)Util::CompileShader(L"Data/Shaders/Upscaling/HMDMaskRasterVS.hlsl", {}, "vs_5_0"));
+		vrHMDMaskRasterPS.attach((ID3D11PixelShader*)Util::CompileShader(L"Data/Shaders/Upscaling/HMDMaskRasterPS.hlsl", {}, "ps_5_0"));
+	}
+
+	if (!vrHMDMaskRasterVS || !vrHMDMaskRasterPS) {
+		logger::warn("[Upscaling] RasterizeHMDMasks: shader compile failed, HMD mask left as all-black (no masking)");
+		return;
+	}
+
+	context->IASetInputLayout(nullptr);
+	context->IASetVertexBuffers(0, 0, nullptr, nullptr, nullptr);
+	context->IASetIndexBuffer(nullptr, DXGI_FORMAT_UNKNOWN, 0);
+	context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	context->VSSetShader(vrHMDMaskRasterVS.get(), nullptr, 0);
+	context->PSSetShader(vrHMDMaskRasterPS.get(), nullptr, 0);
+	context->RSSetState(upscaleRasterizerState.get());
+	context->OMSetBlendState(upscaleBlendState.get(), nullptr, 0xffffffff);
+	context->OMSetDepthStencilState(nullptr, 0);
+
+	auto RasterForEye = [&](int eye, Texture2D* maskTex, uint32_t w, uint32_t h) {
+		if (vrHMDMeshVertCount[eye] == 0 || !vrHMDMeshVBSRV[eye])
+			return;
+
+		D3D11_VIEWPORT vp = { 0.0f, 0.0f, (float)w, (float)h, 0.0f, 1.0f };
+		context->RSSetViewports(1, &vp);
+
+		ID3D11RenderTargetView* rtv = maskTex->rtv.get();
+		context->OMSetRenderTargets(1, &rtv, nullptr);
+
+		ID3D11ShaderResourceView* srv = vrHMDMeshVBSRV[eye].get();
+		context->VSSetShaderResources(0, 1, &srv);
+
+		context->Draw(vrHMDMeshVertCount[eye], 0);
+	};
+
+	for (int eye = 0; eye < 2; ++eye) {
+		RasterForEye(eye, vrHMDMaskRenderRes[eye].get(), renderW, renderH);
+		RasterForEye(eye, vrHMDMaskDisplayRes[eye].get(), displayW, displayH);
+	}
+
+	// Unbind rasterizer state
+	context->OMSetRenderTargets(1, &nullRTV, nullptr);
+	ID3D11ShaderResourceView* nullSRV = nullptr;
+	context->VSSetShaderResources(0, 1, &nullSRV);
+	context->VSSetShader(nullptr, nullptr, 0);
+	context->PSSetShader(nullptr, nullptr, 0);
+
+	// Build full-stereo render-res mask for t21 binding.
+	// Layout matches the SBS render-res buffer: left eye at [0, renderW-1], right eye
+	// at [renderW, 2*renderW-1].  IsHiddenPixel can then sample directly without remapping.
+	{
+		uint32_t stereoW = renderW * 2;
+
+		D3D11_TEXTURE2D_DESC stDesc = {};
+		stDesc.Width = stereoW;
+		stDesc.Height = renderH;
+		stDesc.MipLevels = 1;
+		stDesc.ArraySize = 1;
+		stDesc.Format = DXGI_FORMAT_R8_UNORM;
+		stDesc.SampleDesc.Count = 1;
+		stDesc.Usage = D3D11_USAGE_DEFAULT;
+		stDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
+		vrHMDMaskStereoRenderRes = eastl::make_unique<Texture2D>(stDesc);
+		Util::SetResourceName(vrHMDMaskStereoRenderRes->resource.get(), "HMDMask_StereoRenderRes");
+
+		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Format = DXGI_FORMAT_R8_UNORM;
+		srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
+		vrHMDMaskStereoRenderRes->CreateSRV(srvDesc);
+
+		D3D11_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+		uavDesc.Format = DXGI_FORMAT_R8_UNORM;
+		uavDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D;
+		vrHMDMaskStereoRenderRes->CreateUAV(uavDesc);
+
+		// Zero the stereo mask so BindVRHMDStencil never serves undefined data if the
+		// BuildStereoMaskCS dispatch below is skipped (compile failure, cbuffer failure).
+		{
+			const UINT zero[4] = { 0, 0, 0, 0 };
+			context->ClearUnorderedAccessViewUint(vrHMDMaskStereoRenderRes->uav.get(), zero);
+		}
+
+		if (!vrBuildStereoMaskCS) {
+			vrBuildStereoMaskCS.attach((ID3D11ComputeShader*)Util::CompileShader(
+				L"Data/Shaders/Upscaling/BuildStereoMaskCS.hlsl", {}, "cs_5_0"));
+		}
+
+		if (vrBuildStereoMaskCS) {
+			struct BuildCB
+			{
+				uint32_t renderW, renderH, pad0, pad1;
+			};
+			BuildCB cbData{ renderW, renderH, 0, 0 };
+			D3D11_BUFFER_DESC cbDesc = {};
+			cbDesc.ByteWidth = sizeof(BuildCB);
+			cbDesc.Usage = D3D11_USAGE_IMMUTABLE;
+			cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+			D3D11_SUBRESOURCE_DATA cbInit = { &cbData };
+			winrt::com_ptr<ID3D11Buffer> cb;
+			if (FAILED(globals::d3d::device->CreateBuffer(&cbDesc, &cbInit, cb.put()))) {
+				logger::warn("[Upscaling] BuildStereoMaskCS cbuffer creation failed — t21 will be all-zero");
+				return;
+			}
+
+			ID3D11ShaderResourceView* srvs[2] = {
+				vrHMDMaskRenderRes[0] ? vrHMDMaskRenderRes[0]->srv.get() : nullptr,
+				vrHMDMaskRenderRes[1] ? vrHMDMaskRenderRes[1]->srv.get() : nullptr
+			};
+			ID3D11UnorderedAccessView* uav = vrHMDMaskStereoRenderRes->uav.get();
+			ID3D11Buffer* cbBuf = cb.get();
+
+			context->CSSetShader(vrBuildStereoMaskCS.get(), nullptr, 0);
+			context->CSSetShaderResources(0, 2, srvs);
+			context->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
+			context->CSSetConstantBuffers(0, 1, &cbBuf);
+			context->Dispatch((stereoW + 7) / 8, (renderH + 7) / 8, 1);
+
+			ID3D11ShaderResourceView* nullSRVs[2] = { nullptr, nullptr };
+			ID3D11UnorderedAccessView* nullUAV = nullptr;
+			ID3D11Buffer* nullCB = nullptr;
+			context->CSSetShaderResources(0, 2, nullSRVs);
+			context->CSSetUnorderedAccessViews(0, 1, &nullUAV, nullptr);
+			context->CSSetConstantBuffers(0, 1, &nullCB);
+			context->CSSetShader(nullptr, nullptr, 0);
+		} else {
+			logger::warn("[Upscaling] BuildStereoMaskCS compile failed — t21 binding unavailable");
+		}
+	}
+}
+
+void Upscaling::ApplyHMDMaskToEyeInputs(uint32_t eye, uint32_t eyeWidth, uint32_t eyeHeight)
+{
+	if (!vrApplyHMDMaskWithReactiveCS) {
+		vrApplyHMDMaskWithReactiveCS.attach((ID3D11ComputeShader*)Util::CompileShader(
+			L"Data/Shaders/Upscaling/ApplyHMDMaskCS.hlsl", { { "UPDATE_REACTIVE", "" } }, "cs_5_0"));
+	}
+	if (!vrApplyHMDMaskWithReactiveCS)
+		return;
+
+	auto context = globals::d3d::context;
+	context->CSSetShader(vrApplyHMDMaskWithReactiveCS.get(), nullptr, 0);
+
+	// Create dilation cbuffer lazily
+	if (!vrDilationCB) {
+		D3D11_BUFFER_DESC cbDesc = {};
+		cbDesc.ByteWidth = 16;
+		cbDesc.Usage = D3D11_USAGE_DYNAMIC;
+		cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+		cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+		DX::ThrowIfFailed(globals::d3d::device->CreateBuffer(&cbDesc, nullptr, vrDilationCB.put()));
+	}
+	{
+		D3D11_MAPPED_SUBRESOURCE mapped{};
+		context->Map(vrDilationCB.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
+		// velocityFactor: ramp from 0 (r=4, stationary) to 1 (r=52+, fast rotation).
+		// Reaches 1.0 at ~48 px/frame displacement — roughly 2 rad/s at native resolution.
+		float vf = (vrDilationRadius > 4u) ? std::clamp((float)(vrDilationRadius - 4u) / 48.0f, 0.0f, 1.0f) : 0.0f;
+		struct
+		{
+			uint32_t dilRadius;
+			float velFactor;
+			uint32_t pad[2];
+		} cbData{ vrDilationRadius, vf, {} };
+		memcpy(mapped.pData, &cbData, sizeof(cbData));
+		context->Unmap(vrDilationCB.get(), 0);
+	}
+	ID3D11Buffer* cb = vrDilationCB.get();
+	context->CSSetConstantBuffers(0, 1, &cb);
+
+	ID3D11ShaderResourceView* srv = vrHMDMaskRenderRes[eye]->srv.get();
+	context->CSSetShaderResources(0, 1, &srv);
+
+	ID3D11UnorderedAccessView* uavs[3] = {
+		vrIntermediateColorIn[eye]->uav.get(),
+		vrIntermediateReactiveMask[eye]->uav.get(),
+		vrIntermediateTransparencyMask[eye]->uav.get()
+	};
+	context->CSSetUnorderedAccessViews(0, 3, uavs, nullptr);
+
+	context->Dispatch((eyeWidth + 7) / 8, (eyeHeight + 7) / 8, 1);
+
+	ID3D11Buffer* nullCB = nullptr;
+	ID3D11ShaderResourceView* nullSRV = nullptr;
+	ID3D11UnorderedAccessView* nullUAVs[3] = { nullptr, nullptr, nullptr };
+	context->CSSetConstantBuffers(0, 1, &nullCB);
+	context->CSSetShaderResources(0, 1, &nullSRV);
+	context->CSSetUnorderedAccessViews(0, 3, nullUAVs, nullptr);
+	context->CSSetShader(nullptr, nullptr, 0);
+}
+
+void Upscaling::ApplyHMDMaskToEyeOutput(uint32_t eye, uint32_t eyeWidth, uint32_t eyeHeight)
+{
+	if (!vrApplyHMDMaskCS) {
+		vrApplyHMDMaskCS.attach((ID3D11ComputeShader*)Util::CompileShader(
+			L"Data/Shaders/Upscaling/ApplyHMDMaskCS.hlsl", {}, "cs_5_0"));
+	}
+	if (!vrApplyHMDMaskCS)
+		return;
+
+	auto context = globals::d3d::context;
+	context->CSSetShader(vrApplyHMDMaskCS.get(), nullptr, 0);
+
+	ID3D11ShaderResourceView* srv = vrHMDMaskDisplayRes[eye]->srv.get();
+	context->CSSetShaderResources(0, 1, &srv);
+
+	ID3D11UnorderedAccessView* uav = vrIntermediateColorOut[eye]->uav.get();
+	context->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
+
+	context->Dispatch((eyeWidth + 7) / 8, (eyeHeight + 7) / 8, 1);
+
+	ID3D11ShaderResourceView* nullSRV = nullptr;
+	ID3D11UnorderedAccessView* nullUAV = nullptr;
+	context->CSSetShaderResources(0, 1, &nullSRV);
+	context->CSSetUnorderedAccessViews(0, 1, &nullUAV, nullptr);
+	context->CSSetShader(nullptr, nullptr, 0);
 }
 
 int32_t GetJitterPhaseCount(int32_t renderWidth, int32_t displayWidth)
@@ -1360,16 +1839,53 @@ void Upscaling::SetupResources()
 	}
 }
 
+void Upscaling::BindVRHMDStencil()
+{
+	if (!vrHMDMaskStereoRenderRes) {
+		// Explicitly unbind t21 so shaders never see a stale SRV from a previous frame.
+		ID3D11ShaderResourceView* nullSRV = nullptr;
+		globals::d3d::context->CSSetShaderResources(21, 1, &nullSRV);
+		static bool warnedOnce = false;
+		if (!warnedOnce) {
+			warnedOnce = true;
+			logger::warn("[Upscaling] BindVRHMDStencil: stereo mask not ready — t21 unbound");
+		}
+		return;
+	}
+	ID3D11ShaderResourceView* srv = vrHMDMaskStereoRenderRes->srv.get();
+	globals::d3d::context->CSSetShaderResources(21, 1, &srv);
+}
+
+void Upscaling::UnbindVRHMDStencil()
+{
+	ID3D11ShaderResourceView* nullSRV = nullptr;
+	globals::d3d::context->CSSetShaderResources(21, 1, &nullSRV);
+}
+
 void Upscaling::ClearShaderCache()
 {
 	for (int i = 0; i < 5; ++i) {
-		encodeTexturesCS[i] = nullptr;  // com_ptr automatically releases
+		encodeTexturesCS[i] = nullptr;
 	}
 	encodeTexturesCSDepthOutput = nullptr;
 
-	depthRefractionUpscalePS = nullptr;  // com_ptr automatically releases
-	underwaterMaskUpscalePS = nullptr;   // com_ptr automatically releases
-	upscaleVS = nullptr;                 // com_ptr automatically releases
+	depthRefractionUpscalePS = nullptr;
+	underwaterMaskUpscalePS = nullptr;
+	upscaleVS = nullptr;
+	vrClearHMDMaskCS = nullptr;
+	vrHMDMaskRasterVS = nullptr;
+	vrHMDMaskRasterPS = nullptr;
+	vrApplyHMDMaskCS = nullptr;
+	vrApplyHMDMaskWithReactiveCS = nullptr;
+	vrDilationCB = nullptr;
+	vrBuildStereoMaskCS = nullptr;
+	vrHMDMaskStereoRenderRes = nullptr;
+	vrHMDMaskRenderRes[0].reset();
+	vrHMDMaskRenderRes[1].reset();
+	vrHMDMaskDisplayRes[0].reset();
+	vrHMDMaskDisplayRes[1].reset();
+	vrRenderPerEyeW = 0;
+	vrRenderPerEyeH = 0;
 }
 
 void Upscaling::CopySharedD3D12Resources()

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -140,12 +140,59 @@ public:
 	winrt::com_ptr<ID3D11BlendState> upscaleBlendState;
 	winrt::com_ptr<ID3D11RasterizerState> upscaleRasterizerState;
 
-	// Shared VR HMD Mask Clearing
+	// Shared VR HMD Mask Clearing (depth-based fallback — used when no OpenVR mesh is available)
 	winrt::com_ptr<ID3D11ComputeShader> vrClearHMDMaskCS;
 	winrt::com_ptr<ID3D11Buffer> vrClearHMDMaskCB;
-	// Helper to dispatch mask clearing for a single eye region
 	void ClearHMDMask(ID3D11UnorderedAccessView* colorUAV, ID3D11ShaderResourceView* depthSRV,
 		uint32_t eyeWidth, uint32_t eyeHeight, uint32_t depthOffsetX, uint32_t colorOffsetX);
+
+	// Per-eye render resolution (eye content, not the padded texture allocation height).
+	// Set by RasterizeHMDMasks. Zero until the first VR upscale frame.
+	uint32_t vrRenderPerEyeW = 0;
+	uint32_t vrRenderPerEyeH = 0;
+
+	// HMD hidden area mesh — queried once from OpenVR at first VR upscale setup.
+	// Vertices are stored in NDC space (CPU converts from OpenVR UV [0,1]).
+	// vrHMDMeshVertCount[eye] == 0 means no mesh available; fall back to depth heuristic.
+	bool vrHMDMeshBuilt = false;
+	winrt::com_ptr<ID3D11Buffer> vrHMDMeshVB[2];
+	winrt::com_ptr<ID3D11ShaderResourceView> vrHMDMeshVBSRV[2];
+	uint32_t vrHMDMeshVertCount[2] = { 0, 0 };
+
+	// Per-eye R8_UNORM mask textures rasterized from the HMD mesh.
+	// RenderRes: at per-eye render resolution — used to clean upscaler inputs.
+	// DisplayRes: at per-eye display resolution — re-zeroes upscaler output at the exact boundary.
+	eastl::unique_ptr<Texture2D> vrHMDMaskRenderRes[2];
+	eastl::unique_ptr<Texture2D> vrHMDMaskDisplayRes[2];
+
+	// Shaders for HMD mesh rasterization and mask application
+	winrt::com_ptr<ID3D11VertexShader> vrHMDMaskRasterVS;
+	winrt::com_ptr<ID3D11PixelShader> vrHMDMaskRasterPS;
+	winrt::com_ptr<ID3D11ComputeShader> vrApplyHMDMaskCS;              // color only (post-upscale)
+	winrt::com_ptr<ID3D11ComputeShader> vrApplyHMDMaskWithReactiveCS;  // color + reactive + transparency (pre-upscale)
+	winrt::com_ptr<ID3D11Buffer> vrDilationCB;                         // cbuffer carrying per-frame dilation radius
+	uint32_t vrDilationRadius = 32;                                    // pixels; updated each frame from HMD angular velocity
+	// Full-stereo R8 mask at renderW*2 x renderH; 1=hidden, 0=visible.
+	// Layout matches the SBS render-res stereo buffer (left eye [0,renderW-1], right eye
+	// [renderW,2*renderW-1]), so IsHiddenPixel can sample without coordinate remapping.
+	// Built from per-eye render-res masks by BuildStereoMaskCS.
+	eastl::unique_ptr<Texture2D> vrHMDMaskStereoRenderRes;
+	winrt::com_ptr<ID3D11ComputeShader> vrBuildStereoMaskCS;
+
+	/// Binds vrHMDMaskStereoRenderRes as a CS SRV at t21 so deferred compute shaders can
+	/// early-exit for HMD hidden pixels via HMDMask::IsHiddenPixel.
+	void BindVRHMDStencil();
+	/// Unbinds t21.
+	void UnbindVRHMDStencil();
+
+	/// Queries GetHiddenAreaMesh() for both eyes, converts UV→NDC, builds structured buffer VBs.
+	void BuildHMDMesh();
+	/// Rasterizes the HMD mesh into R8 mask textures at render-res and display-res.
+	void RasterizeHMDMasks(uint32_t renderW, uint32_t renderH, uint32_t displayW, uint32_t displayH);
+	/// Zeros per-eye color input and marks reactive/transparency masks where hidden.
+	void ApplyHMDMaskToEyeInputs(uint32_t eye, uint32_t eyeWidth, uint32_t eyeHeight);
+	/// Zeros per-eye color output where hidden, preventing upscaler boundary bleed.
+	void ApplyHMDMaskToEyeOutput(uint32_t eye, uint32_t eyeWidth, uint32_t eyeHeight);
 
 	// Shared VR Per-Eye Intermediate Buffers
 	// Owned here so both Streamline (DLSS) and FidelityFX (FSR) can use them.

--- a/src/Features/Upscaling/FidelityFX.cpp
+++ b/src/Features/Upscaling/FidelityFX.cpp
@@ -199,7 +199,9 @@ void FidelityFX::Present(bool a_useFrameGeneration, bool a_isHDR)
 		dispatchParameters.cameraFar = *globals::game::cameraFar;
 		dispatchParameters.cameraNear = *globals::game::cameraNear;
 
-		dispatchParameters.cameraFovAngleVertical = Util::GetVerticalFOVRad();
+		// Frame generation is DX12-only and operates on a single combined frame, not per-eye.
+		// VR never enables frame generation (OpenVR owns the swapchain), so eye 0 is always correct here.
+		dispatchParameters.cameraFovAngleVertical = Util::GetVerticalFOVRad(0);
 		dispatchParameters.viewSpaceToMetersFactor = 0.01428222656f;
 
 		dispatchParameters.frameID = frameID;
@@ -391,7 +393,7 @@ void FidelityFX::Upscale(ID3D11Resource* a_upscalingTexture, ID3D11Resource* a_r
 		dispatchParameters.cameraNear = *globals::game::cameraNear;
 		dispatchParameters.enableSharpening = true;
 		dispatchParameters.sharpness = a_sharpness;
-		dispatchParameters.cameraFovAngleVertical = Util::GetVerticalFOVRad();
+		dispatchParameters.cameraFovAngleVertical = Util::GetVerticalFOVRad(contextIndex);
 		dispatchParameters.viewSpaceToMetersFactor = 0.01428222656f;
 		dispatchParameters.reset = false;
 		dispatchParameters.preExposure = 1.0f;

--- a/src/Features/Upscaling/Streamline.cpp
+++ b/src/Features/Upscaling/Streamline.cpp
@@ -352,7 +352,7 @@ bool Streamline::CheckFrameConstants(sl::ViewportHandle p_viewport, uint32_t eye
 	float eyeWidth = state->screenSize.x * (globals::game::isVR ? 0.5f : 1.0f);
 	slConstants.cameraAspectRatio = eyeWidth / state->screenSize.y;
 
-	slConstants.cameraFOV = Util::GetVerticalFOVRad();
+	slConstants.cameraFOV = Util::GetVerticalFOVRad(eyeIndex);
 	slConstants.cameraNear = *globals::game::cameraNear;
 	slConstants.cameraFar = *globals::game::cameraFar;
 

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -79,6 +79,8 @@ void VR::RestoreDefaultSettings()
 
 void VR::SetupResources()
 {
+	RefreshPerEyeProjectionFOV();
+
 	// Compile stereo blend compute shader and create copy texture
 	std::vector<std::pair<const char*, const char*>> defines = { { "VR", "" }, { "FRAMEBUFFER", "" } };
 	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", defines, "cs_5_0")))
@@ -230,6 +232,53 @@ bool VR::IsWelcomeOverlayVisible() const
 	       !globals::menu->IsEnabled;
 }
 
+float VR::GetPerEyeVerticalFOVRad(uint32_t eyeIndex)
+{
+	if (eyeIndex > 1) {
+		return 0.0f;
+	}
+
+	if (vrPerEyeVFOVRad[eyeIndex] <= 0.0f) {
+		RefreshPerEyeProjectionFOV();
+	}
+
+	return vrPerEyeVFOVRad[eyeIndex];
+}
+
+float VR::GetPerEyeHorizontalFOVRad(uint32_t eyeIndex)
+{
+	if (eyeIndex > 1) {
+		return 0.0f;
+	}
+
+	if (vrPerEyeHFOVRad[eyeIndex] <= 0.0f) {
+		RefreshPerEyeProjectionFOV();
+	}
+
+	return vrPerEyeHFOVRad[eyeIndex];
+}
+
+void VR::RefreshPerEyeProjectionFOV()
+{
+	if (!globals::game::isVR) {
+		return;
+	}
+
+	Util::OpenVRContext ctx;
+	if (!(ctx.IsValid() && ctx.system)) {
+		return;
+	}
+
+	for (int eye = 0; eye < 2; ++eye) {
+		float l, r, b, t;
+		// Note: OpenVR GetProjectionRaw has a known bug (Valve #110): the parameter named
+		// "pTop" (3rd) actually returns the bottom tangent, "pBottom" (4th) returns top.
+		ctx.system->GetProjectionRaw(eye == 0 ? vr::Eye_Left : vr::Eye_Right, &l, &r, &b, &t);
+		vrPerEyeVFOVRad[eye] = atanf(t) + atanf(-b);
+		vrPerEyeHFOVRad[eye] = atanf(r) + atanf(-l);
+	}
+}
+
 void VR::SubmitOverlayFrame()
 {
 	InstallSubmitHook();
@@ -313,5 +362,9 @@ bool VR::IsOpenVRCompatible() const
 
 void VR::Reset()
 {
+	vrPerEyeVFOVRad[0] = 0.0f;
+	vrPerEyeVFOVRad[1] = 0.0f;
+	vrPerEyeHFOVRad[0] = 0.0f;
+	vrPerEyeHFOVRad[1] = 0.0f;
 	stereoOpt.Reset();
 }

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -302,6 +302,8 @@ public:
 	void RecreateOverlayTexturesIfNeeded();
 	void SubmitOverlayFrame();
 	bool IsWelcomeOverlayVisible() const;
+	float GetPerEyeVerticalFOVRad(uint32_t eyeIndex);
+	float GetPerEyeHorizontalFOVRad(uint32_t eyeIndex);
 
 	/**
 	 * @brief Context for rendering VR overlays with render target management
@@ -495,6 +497,11 @@ public:
 		bool probingSucceeded = false;
 	} openVRInfo;
 
+	// Cached per-eye OpenVR projection FOV values.
+	// Values are 0 until successfully queried from OpenVR.
+	float vrPerEyeVFOVRad[2] = { 0.0f, 0.0f };
+	float vrPerEyeHFOVRad[2] = { 0.0f, 0.0f };
+
 	RE::NiPoint3 savedPlayerWorldPos = RE::NiPoint3();  // Used for auto-reset distance check
 
 	// Wand pointing state
@@ -551,6 +558,8 @@ private:
 	//=============================================================================
 	// PRIVATE HELPERS
 	//=============================================================================
+
+	void RefreshPerEyeProjectionFOV();
 
 	bool GetGripPressed(bool isLeft, bool isRight) const;
 	void ResetComboRecording();

--- a/src/Features/VR/StereoBlend.cpp
+++ b/src/Features/VR/StereoBlend.cpp
@@ -4,6 +4,7 @@
 #include "Features/DynamicCubemaps.h"
 #include "Features/ScreenSpaceGI.h"
 #include "Features/ScreenSpaceShadows.h"
+#include "Globals.h"
 #include "State.h"
 #include "Utils/D3D.h"
 

--- a/src/Utils/Game.cpp
+++ b/src/Utils/Game.cpp
@@ -1,6 +1,7 @@
 #include "Game.h"
-
+#include "Globals.h"
 #include "State.h"
+#include "VRUtils.h"
 
 namespace Util
 {
@@ -138,8 +139,15 @@ namespace Util
 		return (!REL::Module::IsVR() ? imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA->taaEnabled : imageSpaceManager->GetVRRuntimeData().BSImagespaceShaderISTemporalAA->taaEnabled);
 	}
 
-	float GetVerticalFOVRad()
+	float GetVerticalFOVRad(uint32_t eyeIndex)
 	{
+		// VR: use per-eye vertical FOV from OpenVR projection when available (via core VR feature).
+		// Fallback remains the game's flat-screen FOV conversion.
+		if (globals::game::isVR) {
+			float vfov = Util::GetPerEyeVerticalFOVRad(eyeIndex);
+			if (vfov > 0.0f)
+				return vfov;
+		}
 		static float& cameraFOVDeg = (*(float*)(REL::RelocationID(513786, 388785).address()));  // FOV degrees
 		float hFOVRad = cameraFOVDeg * (3.14159265359f / 180.0f);
 		float unitHalfWidth = tan(hFOVRad / 2);                                                                // This is same as camera frustum RL

--- a/src/Utils/Game.h
+++ b/src/Utils/Game.h
@@ -35,7 +35,7 @@ namespace Util
 	float4 TryGetWaterData(float offsetX, float offsetY);
 	float4 GetCameraData();
 	bool GetTemporal();
-	float GetVerticalFOVRad();
+	float GetVerticalFOVRad(uint32_t eyeIndex = 0);
 
 	RE::NiPoint3 GetAverageEyePosition();
 	RE::NiPoint3 GetEyePosition(int eyeIndex);

--- a/src/Utils/VRUtils.cpp
+++ b/src/Utils/VRUtils.cpp
@@ -6,6 +6,16 @@
 
 namespace Util
 {
+	float GetPerEyeVerticalFOVRad(uint32_t eyeIndex)
+	{
+		return globals::features::vr.GetPerEyeVerticalFOVRad(eyeIndex);
+	}
+
+	float GetPerEyeHorizontalFOVRad(uint32_t eyeIndex)
+	{
+		return globals::features::vr.GetPerEyeHorizontalFOVRad(eyeIndex);
+	}
+
 	void DrawButtonCombo(const std::vector<ButtonCombo>& combo, bool showControllerLabels)
 	{
 		bool anyDrawn = false;
@@ -236,6 +246,30 @@ namespace Util
 
 		// If compositor methods failed, return false rather than using the problematic direct call
 		return false;
+	}
+
+	bool TryGetLastHMDPose(vr::TrackedDevicePose_t& outPose)
+	{
+		OpenVRContext ctx;
+		if (!ctx.IsValid())
+			return false;
+
+		auto* compositor = RE::BSOpenVR::GetIVRCompositor();
+		if (!compositor && ctx.openvr)
+			compositor = ctx.openvr->vrContext.vrCompositor;
+		if (!compositor)
+			return false;
+
+		vr::TrackedDevicePose_t poses[vr::k_unTrackedDeviceIndex_Hmd + 1];
+		auto err = compositor->GetLastPoses(poses, vr::k_unTrackedDeviceIndex_Hmd + 1, nullptr, 0);
+		if (err != vr::VRCompositorError_None)
+			return false;
+
+		if (!poses[vr::k_unTrackedDeviceIndex_Hmd].bPoseIsValid)
+			return false;
+
+		outPose = poses[vr::k_unTrackedDeviceIndex_Hmd];
+		return true;
 	}
 
 }

--- a/src/Utils/VRUtils.h
+++ b/src/Utils/VRUtils.h
@@ -36,6 +36,9 @@ namespace Util
 	inline ImVec4 GetControllerBothColor() { return Colors::Both; }
 	inline ImVec4 GetControllerDefaultColor() { return Colors::Default; }
 
+	float GetPerEyeVerticalFOVRad(uint32_t eyeIndex);
+	float GetPerEyeHorizontalFOVRad(uint32_t eyeIndex);
+
 	/**
 	 * @brief Draws a button combination in the ImGui interface with color coding
 	 * @param combo Vector of ButtonCombo structures representing the key combination
@@ -135,6 +138,11 @@ namespace Util
 	 * when available for better OpenComposite compatibility.
 	 */
 	bool GetDeviceToAbsoluteTrackingPoseCompatible(vr::ETrackingUniverseOrigin eOrigin, float fPredictedSecondsToPhotonsFromNow, vr::TrackedDevicePose_t* pTrackedDevicePoseArray, uint32_t unTrackedDevicePoseArrayCount);
+
+	/// Non-blocking HMD pose query: uses compositor GetLastPoses only — never WaitGetPoses.
+	/// Returns false (leaving pose unchanged) if no cached pose is available.
+	/// Safe to call from the render hot path; use for best-effort data like angular velocity.
+	bool TryGetLastHMDPose(vr::TrackedDevicePose_t& outPose);
 
 	//=============================================================================
 	// MATRIX CONVERSION UTILITIES


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full OpenVR hidden-area masking pipeline: mesh rasterization, stereo-mask generation, compute pass to apply per-eye masks with reactive/transparency support and dilation; upscaling APIs to bind/unbind and manage masks
  * Per-eye FOV accessors for VR workflows

* **Performance Improvements**
  * VR hidden-pixel early-culling added across GI, shadows, subsurface scattering, stereo sync/blending and upscaling to skip work for masked pixels
  * Masked regions zeroed in upscaled outputs to avoid wasted work and visual artifacts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->