### PR TITLE
ci: fix early exit and timing issues

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -551,6 +551,8 @@ jobs:
             startsWith(github.ref, 'refs/tags/v') ||
             (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
         runs-on: windows-2025
+        outputs:
+            release_tag: ${{ steps.combined_notes.outputs.release_tag }}
         permissions:
             contents: write
         steps:
@@ -597,6 +599,7 @@ jobs:
                   echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
 
             - name: Create or Update Release
+              id: create_release
               uses: ncipollo/release-action@v1
               with:
                   name: "Community Shaders ${{ steps.combined_notes.outputs.release_tag }}"
@@ -608,3 +611,15 @@ jobs:
                   replacesArtifacts: true
                   removeArtifacts: true
                   allowUpdates: true
+
+    nexus-upload:
+        name: Nexus Upload (dry run)
+        needs: release
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+        uses: ./.github/workflows/upload-nexus.yaml
+        with:
+            tag: ${{ needs.release.outputs.release_tag }}
+            dry_run: "true"
+        secrets:
+            UNEX_NEXUSMODS_SESSION_COOKIE: ${{ secrets.UNEX_NEXUSMODS_SESSION_COOKIE }}
+            UNEX_APIKEY: ${{ secrets.UNEX_APIKEY }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -615,7 +615,11 @@ jobs:
     nexus-upload:
         name: Nexus Upload (dry run)
         needs: release
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+        if: >
+            always() &&
+            needs.release.result == 'success' &&
+            startsWith(github.ref, 'refs/tags/v') &&
+            !contains(github.ref_name, '-')
         uses: ./.github/workflows/upload-nexus.yaml
         with:
             tag: ${{ needs.release.outputs.release_tag }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -619,6 +619,7 @@ jobs:
         uses: ./.github/workflows/upload-nexus.yaml
         with:
             tag: ${{ needs.release.outputs.release_tag }}
+            artifact_pattern: "CommunityShaders-*.7z"
             dry_run: "true"
         secrets:
             UNEX_NEXUSMODS_SESSION_COOKIE: ${{ secrets.UNEX_NEXUSMODS_SESSION_COOKIE }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,21 +7,13 @@ on:
                 description: "Release type: rc or stable"
                 required: true
                 default: "rc"
-            dry_run:
-                description: "Dry-run for downstream Nexus upload (true uploads nothing)"
-                required: false
-                default: "true"
 
 permissions:
     contents: write
-    actions: write
 
 jobs:
     release:
         runs-on: ubuntu-latest
-        outputs:
-            new_release_published: ${{ steps.semantic.outputs.new_release_published }}
-            new_release_version: ${{ steps.semantic.outputs.new_release_version }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
@@ -32,7 +24,6 @@ jobs:
               run: |
                   python tools/feature_version_audit.py \
                     --apply-bumps \
-                    --ci \
                     --output /tmp/feature-version-audit.txt
 
             - name: Semantic Release
@@ -46,32 +37,3 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   RELEASE_TYPE: ${{ github.event.inputs.release_type }}
-
-    dispatch-upload:
-        name: Trigger Nexus upload workflow
-        runs-on: ubuntu-latest
-        needs: release
-        if: needs.release.outputs.new_release_published == 'true'
-        steps:
-            - name: Dispatch upload-nexus.yaml
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  REPO: ${{ github.repository }}
-                  RELEASE_TAG: v${{ needs.release.outputs.new_release_version }}
-                  DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
-              run: |
-                  gh workflow run upload-nexus.yaml \
-                    --repo "$REPO" \
-                    --ref "${GITHUB_REF_NAME}" \
-                    -f tag="$RELEASE_TAG" \
-                    -f dry_run="$DRY_RUN"
-
-            - name: Create job summary
-              env:
-                  RELEASE_TAG: v${{ needs.release.outputs.new_release_version }}
-                  DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
-              run: |
-                  echo "## Release Complete - Nexus Upload Dispatched" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "✓ Release **$RELEASE_TAG** created successfully" >> $GITHUB_STEP_SUMMARY
-                  echo "✓ Dispatched [upload-nexus.yaml](https://github.com/${{ github.repository }}/actions/workflows/upload-nexus.yaml) with tag \`$RELEASE_TAG\` (dry_run=\`$DRY_RUN\`)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/upload-nexus.yaml
+++ b/.github/workflows/upload-nexus.yaml
@@ -29,6 +29,41 @@ on:
             changelog:
                 description: "Optional release notes or changelog for Nexus"
                 required: false
+    workflow_call:
+        inputs:
+            tag:
+                description: "Release tag to upload to Nexus"
+                required: true
+                type: string
+            nexus_game_id:
+                required: false
+                type: string
+                default: "skyrimspecialedition"
+            nexus_mod_id:
+                required: false
+                type: string
+                default: "86492"
+            artifact_pattern:
+                required: false
+                type: string
+                default: "CommunityShaders-*.7z"
+            mod_filename:
+                required: false
+                type: string
+                default: "Community Shaders"
+            dry_run:
+                required: false
+                type: string
+                default: "true"
+            changelog:
+                required: false
+                type: string
+                default: ""
+        secrets:
+            UNEX_NEXUSMODS_SESSION_COOKIE:
+                required: false
+            UNEX_APIKEY:
+                required: false
 
 jobs:
     prepare-nexus-matrix:
@@ -59,11 +94,15 @@ jobs:
                     echo 'No tag provided for Nexus upload' >&2
                     exit 1
                   fi
+                  if [[ "$TAG" == *-* ]]; then
+                    echo "ERROR: '$TAG' is a pre-release tag. Only stable releases are uploaded to Nexus." >&2
+                    exit 1
+                  fi
                   VERSION="${TAG#v}"
                   echo "tag=$TAG" >> $GITHUB_OUTPUT
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
               env:
-                  INPUT_TAG: ${{ github.event.inputs.tag || '' }}
+                  INPUT_TAG: ${{ inputs.tag || '' }}
 
             - name: Compute dry-run mode
               id: dryrun
@@ -74,7 +113,7 @@ jobs:
                     echo "dry_run=true" >> $GITHUB_OUTPUT
                   fi
               env:
-                  INPUT_DRY_RUN: ${{ github.event.inputs.dry_run || '' }}
+                  INPUT_DRY_RUN: ${{ inputs.dry_run || '' }}
 
             - name: Generate Nexus upload matrix
               id: generate
@@ -120,9 +159,9 @@ jobs:
                   echo "has_uploads=$(python -c \"import json; print('true' if json.load(open('nexus-upload-state.json')).get('has_uploads') else 'false')\")" >> $GITHUB_OUTPUT
               env:
                   RELEASE_TAG: ${{ steps.resolve.outputs.tag }}
-                  INPUT_NEXUS_MOD_ID: ${{ github.event.inputs.nexus_mod_id || '' }}
-                  INPUT_MOD_FILENAME: ${{ github.event.inputs.mod_filename || '' }}
-                  INPUT_ARTIFACT_PATTERN: ${{ github.event.inputs.artifact_pattern || '' }}
+                  INPUT_NEXUS_MOD_ID: ${{ inputs.nexus_mod_id || '' }}
+                  INPUT_MOD_FILENAME: ${{ inputs.mod_filename || '' }}
+                  INPUT_ARTIFACT_PATTERN: ${{ inputs.artifact_pattern || '' }}
 
     prepare-artifacts:
         needs: prepare-nexus-matrix
@@ -200,13 +239,13 @@ jobs:
         continue-on-error: ${{ matrix.name != 'core' }}
         uses: alandtse/nexus-workflows/.github/workflows/upload-nexus.yml@main
         with:
-            nexus_game_id: ${{ github.event.inputs.nexus_game_id || 'skyrimspecialedition' }}
+            nexus_game_id: ${{ inputs.nexus_game_id || 'skyrimspecialedition' }}
             nexus_mod_id: ${{ matrix.nexus_mod_id }}
             artifact_name: nexus-upload-${{ matrix.name }}
             tag_name: ${{ needs.prepare-nexus-matrix.outputs.tag }}
             mod_version: ${{ matrix.mod_version || needs.prepare-nexus-matrix.outputs.version }}
             mod_filename: ${{ matrix.mod_filename }}
-            changelog: ${{ github.event.inputs.changelog || '' }}
+            changelog: ${{ inputs.changelog || '' }}
         secrets:
             UNEX_NEXUSMODS_SESSION_COOKIE: ${{ secrets.UNEX_NEXUSMODS_SESSION_COOKIE }}
             UNEX_APIKEY: ${{ secrets.UNEX_APIKEY }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable, tag-triggered upload job to forward build artifacts to the external mod host (invoked with a computed release tag; dry-run enabled by default).
* **Bug Fixes**
  * Validation prevents pre-release (hyphenated) tags from being uploaded.
* **Chores**
  * Simplified release workflow inputs/outputs, removed an interactive dry-run input and write permission, and removed an older dispatch/upload handoff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->