### PR TITLE
perf(dynamic cubemaps): encode to b6h

### DIFF
--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/BC6HEncodeCS.hlsl
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/BC6HEncodeCS.hlsl
@@ -30,7 +30,7 @@
 //   - cbuffer simplified to only fields needed for compression
 //   - QUALITY forced to 0 (fast P1-only mode)
 
-#pragma warning(disable : 3078)
+#pragma warning(disable: 3078)
 
 // Fast mode: P1 only (single endpoint pair, 4-bit indices). No P2.
 #define QUALITY 0
@@ -315,10 +315,8 @@ void EncodeP1(inout uint4 block, inout float blockMSLE, float3 texels[16])
 	block.w |= indices[15] << 28;
 }
 
-[numthreads(8, 8, 1)]
-void main(
-	uint3 dispatchThreadID : SV_DispatchThreadID)
-{
+[numthreads(8, 8, 1)] void main(
+	uint3 dispatchThreadID : SV_DispatchThreadID) {
 	uint2 blockCoord = dispatchThreadID.xy;
 	uint faceIndex = dispatchThreadID.z;
 
@@ -326,7 +324,8 @@ void main(
 		int2 texelBase = int2(blockCoord) * 4;
 
 		float3 texels[16];
-		[unroll] for (int i = 0; i < 16; i++) {
+		[unroll] for (int i = 0; i < 16; i++)
+		{
 			int tx = i % 4;
 			int ty = i / 4;
 			texels[i] = SrcTexture.Load(int4(texelBase.x + tx, texelBase.y + ty, int(faceIndex), int(MipLevel))).rgb;

--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/BC6HEncodeCS.hlsl
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/BC6HEncodeCS.hlsl
@@ -1,0 +1,372 @@
+// BC6H real-time GPU encoder compute shader.
+// Adapted from GPURealTimeBC6H by Krzysztof Narkowicz.
+// Source: https://github.com/knarkowicz/GPURealTimeBC6H
+//
+// MIT License
+//
+// Copyright (c) 2015 Krzysztof Narkowicz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Modifications for Community Shaders:
+//   - Input changed from Texture2D to Texture2DArray to process all 6 cubemap faces in one dispatch
+//   - Output changed from RWTexture2D to RWTexture2DArray accordingly
+//   - cbuffer simplified to only fields needed for compression
+//   - QUALITY forced to 0 (fast P1-only mode)
+
+#pragma warning(disable : 3078)
+
+// Fast mode: P1 only (single endpoint pair, 4-bit indices). No P2.
+#define QUALITY 0
+#define ENCODE_P2 0
+
+#define INSET_COLOR_BBOX 1
+#define OPTIMIZE_ENDPOINTS 1
+#define LUMINANCE_WEIGHTS 1
+
+static const float HALF_MAX = 65504.0f;
+static const uint PATTERN_NUM = 32;
+
+Texture2DArray<float4> SrcTexture : register(t0);
+RWTexture2DArray<uint4> OutputTexture : register(u0);
+SamplerState PointSampler : register(s0);
+
+cbuffer BC6HEncodeCB : register(b0)
+{
+	uint2 TextureSizeInBlocks;
+	float2 TextureSizeRcp;
+};
+
+float CalcMSLE(float3 a, float3 b)
+{
+	float3 delta = log2((b + 1.0f) / (a + 1.0f));
+	float3 deltaSq = delta * delta;
+
+#if LUMINANCE_WEIGHTS
+	float3 luminanceWeights = float3(0.299f, 0.587f, 0.114f);
+	deltaSq *= luminanceWeights;
+#endif
+
+	return deltaSq.x + deltaSq.y + deltaSq.z;
+}
+
+uint PatternFixupID(uint i)
+{
+	uint ret = 15;
+	ret = ((3441033216 >> i) & 0x1) ? 2 : ret;
+	ret = ((845414400 >> i) & 0x1) ? 8 : ret;
+	return ret;
+}
+
+uint Pattern(uint p, uint i)
+{
+	uint p2 = p / 2;
+	uint p3 = p - p2 * 2;
+
+	uint enc = 0;
+	enc = p2 == 0 ? 2290666700 : enc;
+	enc = p2 == 1 ? 3972591342 : enc;
+	enc = p2 == 2 ? 4276930688 : enc;
+	enc = p2 == 3 ? 3967876808 : enc;
+	enc = p2 == 4 ? 4293707776 : enc;
+	enc = p2 == 5 ? 3892379264 : enc;
+	enc = p2 == 6 ? 4278255592 : enc;
+	enc = p2 == 7 ? 4026597360 : enc;
+	enc = p2 == 8 ? 9369360 : enc;
+	enc = p2 == 9 ? 147747072 : enc;
+	enc = p2 == 10 ? 1930428556 : enc;
+	enc = p2 == 11 ? 2362323200 : enc;
+	enc = p2 == 12 ? 823134348 : enc;
+	enc = p2 == 13 ? 913073766 : enc;
+	enc = p2 == 14 ? 267393000 : enc;
+	enc = p2 == 15 ? 966553998 : enc;
+
+	enc = p3 ? enc >> 16 : enc;
+	uint ret = (enc >> i) & 0x1;
+	return ret;
+}
+
+float3 Quantize7(float3 x)
+{
+	return (f32tof16(x) * 128.0f) / (0x7bff + 1.0f);
+}
+
+float3 Quantize9(float3 x)
+{
+	return (f32tof16(x) * 512.0f) / (0x7bff + 1.0f);
+}
+
+float3 Quantize10(float3 x)
+{
+	return (f32tof16(x) * 1024.0f) / (0x7bff + 1.0f);
+}
+
+float3 Unquantize7(float3 x)
+{
+	return (x * 65536.0f + 0x8000) / 128.0f;
+}
+
+float3 Unquantize9(float3 x)
+{
+	return (x * 65536.0f + 0x8000) / 512.0f;
+}
+
+float3 Unquantize10(float3 x)
+{
+	return (x * 65536.0f + 0x8000) / 1024.0f;
+}
+
+float3 FinishUnquantize(float3 endpoint0Unq, float3 endpoint1Unq, float weight)
+{
+	float3 comp = (endpoint0Unq * (64.0f - weight) + endpoint1Unq * weight + 32.0f) * (31.0f / 4096.0f);
+	return f16tof32(uint3(comp));
+}
+
+void Swap(inout float3 a, inout float3 b)
+{
+	float3 tmp = a;
+	a = b;
+	b = tmp;
+}
+
+void Swap(inout float a, inout float b)
+{
+	float tmp = a;
+	a = b;
+	b = tmp;
+}
+
+uint ComputeIndex3(float texelPos, float endPoint0Pos, float endPoint1Pos)
+{
+	float r = (texelPos - endPoint0Pos) / (endPoint1Pos - endPoint0Pos);
+	return (uint)clamp(r * 6.98182f + 0.00909f + 0.5f, 0.0f, 7.0f);
+}
+
+uint ComputeIndex4(float texelPos, float endPoint0Pos, float endPoint1Pos)
+{
+	float r = (texelPos - endPoint0Pos) / (endPoint1Pos - endPoint0Pos);
+	return (uint)clamp(r * 14.93333f + 0.03333f + 0.5f, 0.0f, 15.0f);
+}
+
+void SignExtend(inout float3 v1, uint mask, uint signFlag)
+{
+	int3 v = (int3)v1;
+	v.x = (v.x & mask) | (v.x < 0 ? signFlag : 0);
+	v.y = (v.y & mask) | (v.y < 0 ? signFlag : 0);
+	v.z = (v.z & mask) | (v.z < 0 ? signFlag : 0);
+	v1 = v;
+}
+
+void InsetColorBBoxP1(float3 texels[16], inout float3 blockMin, inout float3 blockMax)
+{
+	float3 refinedBlockMin = blockMax;
+	float3 refinedBlockMax = blockMin;
+
+	for (uint i = 0; i < 16; ++i) {
+		refinedBlockMin = min(refinedBlockMin, texels[i] == blockMin ? refinedBlockMin : texels[i]);
+		refinedBlockMax = max(refinedBlockMax, texels[i] == blockMax ? refinedBlockMax : texels[i]);
+	}
+
+	float3 logRefinedBlockMax = log2(refinedBlockMax + 1.0f);
+	float3 logRefinedBlockMin = log2(refinedBlockMin + 1.0f);
+
+	float3 logBlockMax = log2(blockMax + 1.0f);
+	float3 logBlockMin = log2(blockMin + 1.0f);
+	float3 logBlockMaxExt = (logBlockMax - logBlockMin) * (1.0f / 32.0f);
+
+	logBlockMin += min(logRefinedBlockMin - logBlockMin, logBlockMaxExt);
+	logBlockMax -= min(logBlockMax - logRefinedBlockMax, logBlockMaxExt);
+
+	blockMin = exp2(logBlockMin) - 1.0f;
+	blockMax = exp2(logBlockMax) - 1.0f;
+}
+
+void OptimizeEndpointsP1(float3 texels[16], inout float3 blockMin, inout float3 blockMax, in float3 blockMinNonInset, in float3 blockMaxNonInset)
+{
+	float3 blockDir = blockMax - blockMin;
+	blockDir = blockDir / (blockDir.x + blockDir.y + blockDir.z);
+
+	float endPoint0Pos = f32tof16(dot(blockMin, blockDir));
+	float endPoint1Pos = f32tof16(dot(blockMax, blockDir));
+
+	float3 alphaTexelSum = 0.0f;
+	float3 betaTexelSum = 0.0f;
+	float alphaBetaSum = 0.0f;
+	float alphaSqSum = 0.0f;
+	float betaSqSum = 0.0f;
+
+	for (int i = 0; i < 16; i++) {
+		float texelPos = f32tof16(dot(texels[i], blockDir));
+		uint texelIndex = ComputeIndex4(texelPos, endPoint0Pos, endPoint1Pos);
+
+		float beta = saturate(texelIndex / 15.0f);
+		float alpha = 1.0f - beta;
+
+		float3 texelF16 = f32tof16(texels[i].xyz);
+		alphaTexelSum += alpha * texelF16;
+		betaTexelSum += beta * texelF16;
+
+		alphaBetaSum += alpha * beta;
+		alphaSqSum += alpha * alpha;
+		betaSqSum += beta * beta;
+	}
+
+	float det = alphaSqSum * betaSqSum - alphaBetaSum * alphaBetaSum;
+
+	if (abs(det) > 0.00001f) {
+		float detRcp = rcp(det);
+		blockMin = clamp(f16tof32(clamp(detRcp * (alphaTexelSum * betaSqSum - betaTexelSum * alphaBetaSum), 0.0f, HALF_MAX)), blockMinNonInset, blockMaxNonInset);
+		blockMax = clamp(f16tof32(clamp(detRcp * (betaTexelSum * alphaSqSum - alphaTexelSum * alphaBetaSum), 0.0f, HALF_MAX)), blockMinNonInset, blockMaxNonInset);
+	}
+}
+
+void EncodeP1(inout uint4 block, inout float blockMSLE, float3 texels[16])
+{
+	float3 blockMin = texels[0];
+	float3 blockMax = texels[0];
+	for (uint i = 1; i < 16; ++i) {
+		blockMin = min(blockMin, texels[i]);
+		blockMax = max(blockMax, texels[i]);
+	}
+
+	float3 blockMinNonInset = blockMin;
+	float3 blockMaxNonInset = blockMax;
+#if INSET_COLOR_BBOX
+	InsetColorBBoxP1(texels, blockMin, blockMax);
+#endif
+
+#if OPTIMIZE_ENDPOINTS
+	OptimizeEndpointsP1(texels, blockMin, blockMax, blockMinNonInset, blockMaxNonInset);
+#endif
+
+	float3 blockDir = blockMax - blockMin;
+	blockDir = blockDir / (blockDir.x + blockDir.y + blockDir.z);
+
+	float3 endpoint0 = Quantize10(blockMin);
+	float3 endpoint1 = Quantize10(blockMax);
+	float endPoint0Pos = f32tof16(dot(blockMin, blockDir));
+	float endPoint1Pos = f32tof16(dot(blockMax, blockDir));
+
+	float fixupTexelPos = f32tof16(dot(texels[0], blockDir));
+	uint fixupIndex = ComputeIndex4(fixupTexelPos, endPoint0Pos, endPoint1Pos);
+	if (fixupIndex > 7) {
+		Swap(endPoint0Pos, endPoint1Pos);
+		Swap(endpoint0, endpoint1);
+	}
+
+	uint indices[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+	for (uint i = 0; i < 16; ++i) {
+		float texelPos = f32tof16(dot(texels[i], blockDir));
+		indices[i] = ComputeIndex4(texelPos, endPoint0Pos, endPoint1Pos);
+	}
+
+	float3 endpoint0Unq = Unquantize10(endpoint0);
+	float3 endpoint1Unq = Unquantize10(endpoint1);
+	float msle = 0.0f;
+	for (uint i = 0; i < 16; ++i) {
+		float weight = floor((indices[i] * 64.0f) / 15.0f + 0.5f);
+		float3 texelUnc = FinishUnquantize(endpoint0Unq, endpoint1Unq, weight);
+		msle += CalcMSLE(texels[i], texelUnc);
+	}
+
+	blockMSLE = msle;
+	block.x = 0x03;
+
+	block.x |= (uint)endpoint0.x << 5;
+	block.x |= (uint)endpoint0.y << 15;
+	block.x |= (uint)endpoint0.z << 25;
+	block.y |= (uint)endpoint0.z >> 7;
+	block.y |= (uint)endpoint1.x << 3;
+	block.y |= (uint)endpoint1.y << 13;
+	block.y |= (uint)endpoint1.z << 23;
+	block.z |= (uint)endpoint1.z >> 9;
+
+	block.z |= indices[0] << 1;
+	block.z |= indices[1] << 4;
+	block.z |= indices[2] << 8;
+	block.z |= indices[3] << 12;
+	block.z |= indices[4] << 16;
+	block.z |= indices[5] << 20;
+	block.z |= indices[6] << 24;
+	block.z |= indices[7] << 28;
+	block.w |= indices[8] << 0;
+	block.w |= indices[9] << 4;
+	block.w |= indices[10] << 8;
+	block.w |= indices[11] << 12;
+	block.w |= indices[12] << 16;
+	block.w |= indices[13] << 20;
+	block.w |= indices[14] << 24;
+	block.w |= indices[15] << 28;
+}
+
+[numthreads(8, 8, 1)]
+void CSMain(
+	uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+	uint2 blockCoord = dispatchThreadID.xy;
+	uint faceIndex = dispatchThreadID.z;
+
+	if (all(blockCoord < TextureSizeInBlocks)) {
+		// UV coords to sample the center of the 4x4 block's top-left 2x2 texels
+		float2 uv = blockCoord * TextureSizeRcp * 4.0f + TextureSizeRcp;
+		float2 block0UV = uv;
+		float2 block1UV = uv + float2(2.0f * TextureSizeRcp.x, 0.0f);
+		float2 block2UV = uv + float2(0.0f, 2.0f * TextureSizeRcp.y);
+		float2 block3UV = uv + float2(2.0f * TextureSizeRcp.x, 2.0f * TextureSizeRcp.y);
+
+		float fi = (float)faceIndex;
+		float4 block0X = SrcTexture.GatherRed(PointSampler, float3(block0UV, fi));
+		float4 block1X = SrcTexture.GatherRed(PointSampler, float3(block1UV, fi));
+		float4 block2X = SrcTexture.GatherRed(PointSampler, float3(block2UV, fi));
+		float4 block3X = SrcTexture.GatherRed(PointSampler, float3(block3UV, fi));
+		float4 block0Y = SrcTexture.GatherGreen(PointSampler, float3(block0UV, fi));
+		float4 block1Y = SrcTexture.GatherGreen(PointSampler, float3(block1UV, fi));
+		float4 block2Y = SrcTexture.GatherGreen(PointSampler, float3(block2UV, fi));
+		float4 block3Y = SrcTexture.GatherGreen(PointSampler, float3(block3UV, fi));
+		float4 block0Z = SrcTexture.GatherBlue(PointSampler, float3(block0UV, fi));
+		float4 block1Z = SrcTexture.GatherBlue(PointSampler, float3(block1UV, fi));
+		float4 block2Z = SrcTexture.GatherBlue(PointSampler, float3(block2UV, fi));
+		float4 block3Z = SrcTexture.GatherBlue(PointSampler, float3(block3UV, fi));
+
+		float3 texels[16];
+		texels[0] = float3(block0X.w, block0Y.w, block0Z.w);
+		texels[1] = float3(block0X.z, block0Y.z, block0Z.z);
+		texels[2] = float3(block1X.w, block1Y.w, block1Z.w);
+		texels[3] = float3(block1X.z, block1Y.z, block1Z.z);
+		texels[4] = float3(block0X.x, block0Y.x, block0Z.x);
+		texels[5] = float3(block0X.y, block0Y.y, block0Z.y);
+		texels[6] = float3(block1X.x, block1Y.x, block1Z.x);
+		texels[7] = float3(block1X.y, block1Y.y, block1Z.y);
+		texels[8] = float3(block2X.w, block2Y.w, block2Z.w);
+		texels[9] = float3(block2X.z, block2Y.z, block2Z.z);
+		texels[10] = float3(block3X.w, block3Y.w, block3Z.w);
+		texels[11] = float3(block3X.z, block3Y.z, block3Z.z);
+		texels[12] = float3(block2X.x, block2Y.x, block2Z.x);
+		texels[13] = float3(block2X.y, block2Y.y, block2Z.y);
+		texels[14] = float3(block3X.x, block3Y.x, block3Z.x);
+		texels[15] = float3(block3X.y, block3Y.y, block3Z.y);
+
+		uint4 block = uint4(0, 0, 0, 0);
+		float blockMSLE = 0.0f;
+
+		EncodeP1(block, blockMSLE, texels);
+
+		OutputTexture[uint3(blockCoord, faceIndex)] = block;
+	}
+}

--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/BC6HEncodeCS.hlsl
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/BC6HEncodeCS.hlsl
@@ -45,12 +45,12 @@ static const uint PATTERN_NUM = 32;
 
 Texture2DArray<float4> SrcTexture : register(t0);
 RWTexture2DArray<uint4> OutputTexture : register(u0);
-SamplerState PointSampler : register(s0);
 
 cbuffer BC6HEncodeCB : register(b0)
 {
 	uint2 TextureSizeInBlocks;
-	float2 TextureSizeRcp;
+	uint MipLevel;
+	uint pad;
 };
 
 float CalcMSLE(float3 a, float3 b)
@@ -316,51 +316,21 @@ void EncodeP1(inout uint4 block, inout float blockMSLE, float3 texels[16])
 }
 
 [numthreads(8, 8, 1)]
-void CSMain(
+void main(
 	uint3 dispatchThreadID : SV_DispatchThreadID)
 {
 	uint2 blockCoord = dispatchThreadID.xy;
 	uint faceIndex = dispatchThreadID.z;
 
 	if (all(blockCoord < TextureSizeInBlocks)) {
-		// UV coords to sample the center of the 4x4 block's top-left 2x2 texels
-		float2 uv = blockCoord * TextureSizeRcp * 4.0f + TextureSizeRcp;
-		float2 block0UV = uv;
-		float2 block1UV = uv + float2(2.0f * TextureSizeRcp.x, 0.0f);
-		float2 block2UV = uv + float2(0.0f, 2.0f * TextureSizeRcp.y);
-		float2 block3UV = uv + float2(2.0f * TextureSizeRcp.x, 2.0f * TextureSizeRcp.y);
-
-		float fi = (float)faceIndex;
-		float4 block0X = SrcTexture.GatherRed(PointSampler, float3(block0UV, fi));
-		float4 block1X = SrcTexture.GatherRed(PointSampler, float3(block1UV, fi));
-		float4 block2X = SrcTexture.GatherRed(PointSampler, float3(block2UV, fi));
-		float4 block3X = SrcTexture.GatherRed(PointSampler, float3(block3UV, fi));
-		float4 block0Y = SrcTexture.GatherGreen(PointSampler, float3(block0UV, fi));
-		float4 block1Y = SrcTexture.GatherGreen(PointSampler, float3(block1UV, fi));
-		float4 block2Y = SrcTexture.GatherGreen(PointSampler, float3(block2UV, fi));
-		float4 block3Y = SrcTexture.GatherGreen(PointSampler, float3(block3UV, fi));
-		float4 block0Z = SrcTexture.GatherBlue(PointSampler, float3(block0UV, fi));
-		float4 block1Z = SrcTexture.GatherBlue(PointSampler, float3(block1UV, fi));
-		float4 block2Z = SrcTexture.GatherBlue(PointSampler, float3(block2UV, fi));
-		float4 block3Z = SrcTexture.GatherBlue(PointSampler, float3(block3UV, fi));
+		int2 texelBase = int2(blockCoord) * 4;
 
 		float3 texels[16];
-		texels[0] = float3(block0X.w, block0Y.w, block0Z.w);
-		texels[1] = float3(block0X.z, block0Y.z, block0Z.z);
-		texels[2] = float3(block1X.w, block1Y.w, block1Z.w);
-		texels[3] = float3(block1X.z, block1Y.z, block1Z.z);
-		texels[4] = float3(block0X.x, block0Y.x, block0Z.x);
-		texels[5] = float3(block0X.y, block0Y.y, block0Z.y);
-		texels[6] = float3(block1X.x, block1Y.x, block1Z.x);
-		texels[7] = float3(block1X.y, block1Y.y, block1Z.y);
-		texels[8] = float3(block2X.w, block2Y.w, block2Z.w);
-		texels[9] = float3(block2X.z, block2Y.z, block2Z.z);
-		texels[10] = float3(block3X.w, block3Y.w, block3Z.w);
-		texels[11] = float3(block3X.z, block3Y.z, block3Z.z);
-		texels[12] = float3(block2X.x, block2Y.x, block2Z.x);
-		texels[13] = float3(block2X.y, block2Y.y, block2Z.y);
-		texels[14] = float3(block3X.x, block3Y.x, block3Z.x);
-		texels[15] = float3(block3X.y, block3Y.y, block3Z.y);
+		[unroll] for (int i = 0; i < 16; i++) {
+			int tx = i % 4;
+			int ty = i / 4;
+			texels[i] = SrcTexture.Load(int4(texelBase.x + tx, texelBase.y + ty, int(faceIndex), int(MipLevel))).rgb;
+		}
 
 		uint4 block = uint4(0, 0, 0, 0);
 		float blockMSLE = 0.0f;

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -486,17 +486,23 @@ void DynamicCubemaps::CompressToBC6H(bool a_reflections)
 {
 	auto context = globals::d3d::context;
 
-	auto& srcMipSRVs = a_reflections ? envReflectionsTextureMipSRVs : envTextureMipSRVs;
+	auto shader = GetComputeShaderBC6HEncode();
+	if (!shader) {
+		logger::error("BC6HEncodeCS failed to compile; BC6H compression disabled");
+		return;
+	}
 
-	context->CSSetShader(GetComputeShaderBC6HEncode(), nullptr, 0);
-	context->CSSetSamplers(0, 1, &bc6hPointSampler);
+	auto* srcSRV = a_reflections ? envReflectionsTextureArraySRV : envTextureArraySRV;
+
+	context->CSSetShader(shader, nullptr, 0);
+	context->CSSetShaderResources(0, 1, &srcSRV);
 
 	ID3D11Buffer* cb = bc6hEncodeCB->CB();
 	context->CSSetConstantBuffers(0, 1, &cb);
 
 	std::uint32_t mipDim = std::max(envTexture->desc.Width, envTexture->desc.Height);
 
-	for (std::uint32_t level = 0; level < MIPLEVELS; ++level) {
+	for (std::uint32_t level = 0; level < bc6hMipLevels; ++level) {
 		std::uint32_t srcWidth = std::max(1u, mipDim >> level);
 		std::uint32_t srcHeight = std::max(1u, mipDim >> level);
 		std::uint32_t blocksX = std::max(1u, srcWidth / 4);
@@ -505,11 +511,9 @@ void DynamicCubemaps::CompressToBC6H(bool a_reflections)
 		BC6HEncodeCB cbData{};
 		cbData.TextureSizeInBlocksX = blocksX;
 		cbData.TextureSizeInBlocksY = blocksY;
-		cbData.TextureSizeRcpX = 1.0f / (float)srcWidth;
-		cbData.TextureSizeRcpY = 1.0f / (float)srcHeight;
+		cbData.MipLevel = level;
 		bc6hEncodeCB->Update(cbData);
 
-		context->CSSetShaderResources(0, 1, &srcMipSRVs[level]);
 		context->CSSetUnorderedAccessViews(0, 1, &bc6hScratchUAVs[level], nullptr);
 
 		std::uint32_t dispatchX = std::max(1u, (blocksX + 7) / 8);
@@ -517,19 +521,35 @@ void DynamicCubemaps::CompressToBC6H(bool a_reflections)
 		context->Dispatch(dispatchX, dispatchY, 6);
 	}
 
+	{
+		ID3D11ShaderResourceView* nullSRV = nullptr;
+		ID3D11UnorderedAccessView* nullUAV = nullptr;
+		ID3D11Buffer* nullBuffer = nullptr;
+		context->CSSetUnorderedAccessViews(0, 1, &nullUAV, nullptr);
+		context->CSSetShaderResources(0, 1, &nullSRV);
+		context->CSSetConstantBuffers(0, 1, &nullBuffer);
+		context->CSSetShader(nullptr, nullptr, 0);
+	}
+
+	// Copy scratch → staging (same format, always valid), then upload to BC6H via
+	// UpdateSubresource so the format conversion is handled by the D3D11 runtime.
+	context->CopyResource(bc6hStagingTexture, bc6hScratchTexture->resource.get());
+
 	auto dst = a_reflections ? envReflectionsTextureBC6H : envTextureBC6H;
-	context->CopyResource(dst->resource.get(), bc6hScratchTexture->resource.get());
 
-	ID3D11ShaderResourceView* nullSRV = nullptr;
-	ID3D11UnorderedAccessView* nullUAV = nullptr;
-	ID3D11Buffer* nullBuffer = nullptr;
-	ID3D11SamplerState* nullSampler = nullptr;
+	for (std::uint32_t face = 0; face < 6; ++face) {
+		for (std::uint32_t level = 0; level < bc6hMipLevels; ++level) {
+			std::uint32_t stagingSR = D3D11CalcSubresource(level, face, bc6hMipLevels);
+			std::uint32_t dstSR = D3D11CalcSubresource(level, face, bc6hMipLevels);
 
-	context->CSSetShaderResources(0, 1, &nullSRV);
-	context->CSSetUnorderedAccessViews(0, 1, &nullUAV, nullptr);
-	context->CSSetConstantBuffers(0, 1, &nullBuffer);
-	context->CSSetSamplers(0, 1, &nullSampler);
-	context->CSSetShader(nullptr, nullptr, 0);
+			D3D11_MAPPED_SUBRESOURCE mapped{};
+			if (FAILED(context->Map(bc6hStagingTexture, stagingSR, D3D11_MAP_READ, 0, &mapped)))
+				continue;
+
+			context->UpdateSubresource(dst->resource.get(), dstSR, nullptr, mapped.pData, mapped.RowPitch, 0);
+			context->Unmap(bc6hStagingTexture, stagingSR);
+		}
+	}
 }
 
 void DynamicCubemaps::UpdateCubemap()
@@ -699,40 +719,72 @@ void DynamicCubemaps::SetupResources()
 		envReflectionsTexture->CreateSRV(srvDesc);
 		envReflectionsTexture->CreateUAV(uavDesc);
 
+		// Texture2DArray SRVs used by BC6H encoder (Load() requires array dimension, not TextureCube)
+		{
+			D3D11_SHADER_RESOURCE_VIEW_DESC arraySRVDesc = {};
+			arraySRVDesc.Format = DXGI_FORMAT_R11G11B10_FLOAT;
+			arraySRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+			arraySRVDesc.Texture2DArray.FirstArraySlice = 0;
+			arraySRVDesc.Texture2DArray.ArraySize = 6;
+			arraySRVDesc.Texture2DArray.MostDetailedMip = 0;
+			arraySRVDesc.Texture2DArray.MipLevels = MIPLEVELS;
+			DX::ThrowIfFailed(device->CreateShaderResourceView(envTexture->resource.get(), &arraySRVDesc, &envTextureArraySRV));
+			DX::ThrowIfFailed(device->CreateShaderResourceView(envReflectionsTexture->resource.get(), &arraySRVDesc, &envReflectionsTextureArraySRV));
+		}
+
 		envInferredTexture = new Texture2D(texDesc);
 		envInferredTexture->CreateSRV(srvDesc);
 		envInferredTexture->CreateUAV(uavDesc);
 
-		// BC6H scratch: R32G32B32A32_UINT at quarter-resolution, 6-face array, all mip levels
+		// BC6H scratch: R32G32B32A32_UINT at quarter-resolution, 6-face array.
+		// Mip count is determined by scratch base dimensions (W/4), not MIPLEVELS,
+		// so that CopyResource byte sizes align with the BC6H target texture.
 		{
+			std::uint32_t scratchBase = std::max(1u, texDesc.Width / 4);
+			bc6hMipLevels = 0;
+			for (std::uint32_t d = scratchBase; d > 0; d >>= 1)
+				++bc6hMipLevels;
+			// Clamp: must not exceed envTexture's mip count (source reads) or the UAV array size.
+			bc6hMipLevels = std::min<std::uint32_t>(bc6hMipLevels, MIPLEVELS);
+			bc6hMipLevels = std::min<std::uint32_t>(bc6hMipLevels, 8u);
+
 			D3D11_TEXTURE2D_DESC scratchDesc = {};
-			scratchDesc.Width = std::max(1u, texDesc.Width / 4);
+			scratchDesc.Width = scratchBase;
 			scratchDesc.Height = std::max(1u, texDesc.Height / 4);
-			scratchDesc.MipLevels = MIPLEVELS;
+			scratchDesc.MipLevels = bc6hMipLevels;
 			scratchDesc.ArraySize = 6;
 			scratchDesc.Format = DXGI_FORMAT_R32G32B32A32_UINT;
 			scratchDesc.SampleDesc.Count = 1;
 			scratchDesc.Usage = D3D11_USAGE_DEFAULT;
 			scratchDesc.BindFlags = D3D11_BIND_UNORDERED_ACCESS;
+			scratchDesc.MiscFlags = 0;
 			bc6hScratchTexture = new Texture2D(scratchDesc);
+
+			// Staging texture for CPU readback — same format/layout as scratch, CPU-readable.
+			D3D11_TEXTURE2D_DESC stagingDesc = scratchDesc;
+			stagingDesc.Usage = D3D11_USAGE_STAGING;
+			stagingDesc.BindFlags = 0;
+			stagingDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+			DX::ThrowIfFailed(device->CreateTexture2D(&stagingDesc, nullptr, &bc6hStagingTexture));
 
 			D3D11_UNORDERED_ACCESS_VIEW_DESC scratchUAVDesc = {};
 			scratchUAVDesc.Format = DXGI_FORMAT_R32G32B32A32_UINT;
 			scratchUAVDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2DARRAY;
 			scratchUAVDesc.Texture2DArray.FirstArraySlice = 0;
 			scratchUAVDesc.Texture2DArray.ArraySize = 6;
-			for (std::uint32_t level = 0; level < MIPLEVELS; ++level) {
+			for (std::uint32_t level = 0; level < bc6hMipLevels; ++level) {
 				scratchUAVDesc.Texture2DArray.MipSlice = level;
 				DX::ThrowIfFailed(device->CreateUnorderedAccessView(bc6hScratchTexture->resource.get(), &scratchUAVDesc, &bc6hScratchUAVs[level]));
 			}
 		}
 
-		// BC6H compressed cubemap textures (shader-read-only)
+		// BC6H compressed cubemap textures (shader-read-only).
+		// Must use the same mip count as scratch for CopyResource to succeed.
 		{
 			D3D11_TEXTURE2D_DESC bc6hDesc = {};
 			bc6hDesc.Width = texDesc.Width;
 			bc6hDesc.Height = texDesc.Height;
-			bc6hDesc.MipLevels = MIPLEVELS;
+			bc6hDesc.MipLevels = bc6hMipLevels;
 			bc6hDesc.ArraySize = 6;
 			bc6hDesc.Format = DXGI_FORMAT_BC6H_UF16;
 			bc6hDesc.SampleDesc.Count = 1;
@@ -744,7 +796,7 @@ void DynamicCubemaps::SetupResources()
 			bc6hSRVDesc.Format = DXGI_FORMAT_BC6H_UF16;
 			bc6hSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBE;
 			bc6hSRVDesc.TextureCube.MostDetailedMip = 0;
-			bc6hSRVDesc.TextureCube.MipLevels = MIPLEVELS;
+			bc6hSRVDesc.TextureCube.MipLevels = bc6hMipLevels;
 
 			envTextureBC6H = new Texture2D(bc6hDesc);
 			envTextureBC6H->CreateSRV(bc6hSRVDesc);
@@ -753,36 +805,11 @@ void DynamicCubemaps::SetupResources()
 			envReflectionsTextureBC6H->CreateSRV(bc6hSRVDesc);
 		}
 
-		// Per-mip Texture2DArray SRVs for R11G11B10 source textures used during BC6H encoding
-		{
-			D3D11_SHADER_RESOURCE_VIEW_DESC mipSRVDesc = {};
-			mipSRVDesc.Format = DXGI_FORMAT_R11G11B10_FLOAT;
-			mipSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
-			mipSRVDesc.Texture2DArray.FirstArraySlice = 0;
-			mipSRVDesc.Texture2DArray.ArraySize = 6;
-			mipSRVDesc.Texture2DArray.MipLevels = 1;
-			for (std::uint32_t level = 0; level < MIPLEVELS; ++level) {
-				mipSRVDesc.Texture2DArray.MostDetailedMip = level;
-				DX::ThrowIfFailed(device->CreateShaderResourceView(envTexture->resource.get(), &mipSRVDesc, &envTextureMipSRVs[level]));
-				DX::ThrowIfFailed(device->CreateShaderResourceView(envReflectionsTexture->resource.get(), &mipSRVDesc, &envReflectionsTextureMipSRVs[level]));
-			}
-		}
-
 		updateCubemapCB = new ConstantBuffer(ConstantBufferDesc<UpdateCubemapCB>());
 	}
 
 	{
 		bc6hEncodeCB = new ConstantBuffer(ConstantBufferDesc<BC6HEncodeCB>());
-
-		D3D11_SAMPLER_DESC bc6hSamplerDesc = {};
-		bc6hSamplerDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
-		bc6hSamplerDesc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
-		bc6hSamplerDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
-		bc6hSamplerDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
-		bc6hSamplerDesc.MaxAnisotropy = 1;
-		bc6hSamplerDesc.MinLOD = 0;
-		bc6hSamplerDesc.MaxLOD = D3D11_FLOAT32_MAX;
-		DX::ThrowIfFailed(device->CreateSamplerState(&bc6hSamplerDesc, &bc6hPointSampler));
 	}
 
 	{

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -243,6 +243,10 @@ void DynamicCubemaps::ClearShaderCache()
 		specularIrradianceCS->Release();
 		specularIrradianceCS = nullptr;
 	}
+	if (bc6hEncodeCS) {
+		bc6hEncodeCS->Release();
+		bc6hEncodeCS = nullptr;
+	}
 }
 
 ID3D11ComputeShader* DynamicCubemaps::GetComputeShaderUpdate()
@@ -306,6 +310,15 @@ ID3D11ComputeShader* DynamicCubemaps::GetComputeShaderSpecularIrradiance()
 		specularIrradianceCS = static_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\DynamicCubemaps\\SpecularIrradianceCS.hlsl", {}, "cs_5_0"));
 	}
 	return specularIrradianceCS;
+}
+
+ID3D11ComputeShader* DynamicCubemaps::GetComputeShaderBC6HEncode()
+{
+	if (!bc6hEncodeCS) {
+		logger::debug("Compiling BC6HEncodeCS");
+		bc6hEncodeCS = static_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\DynamicCubemaps\\BC6HEncodeCS.hlsl", {}, "cs_5_0"));
+	}
+	return bc6hEncodeCS;
 }
 
 void DynamicCubemaps::UpdateCubemapCapture(bool a_reflections)
@@ -469,6 +482,56 @@ void DynamicCubemaps::Irradiance(bool a_reflections)
 	context->CSSetUnorderedAccessViews(0, 1, &nullUAV, nullptr);
 }
 
+void DynamicCubemaps::CompressToBC6H(bool a_reflections)
+{
+	auto context = globals::d3d::context;
+
+	auto& srcMipSRVs = a_reflections ? envReflectionsTextureMipSRVs : envTextureMipSRVs;
+
+	context->CSSetShader(GetComputeShaderBC6HEncode(), nullptr, 0);
+	context->CSSetSamplers(0, 1, &bc6hPointSampler);
+
+	ID3D11Buffer* cb = bc6hEncodeCB->CB();
+	context->CSSetConstantBuffers(0, 1, &cb);
+
+	std::uint32_t mipDim = std::max(envTexture->desc.Width, envTexture->desc.Height);
+
+	for (std::uint32_t level = 0; level < MIPLEVELS; ++level) {
+		std::uint32_t srcWidth = std::max(1u, mipDim >> level);
+		std::uint32_t srcHeight = std::max(1u, mipDim >> level);
+		std::uint32_t blocksX = std::max(1u, srcWidth / 4);
+		std::uint32_t blocksY = std::max(1u, srcHeight / 4);
+
+		BC6HEncodeCB cbData{};
+		cbData.TextureSizeInBlocksX = blocksX;
+		cbData.TextureSizeInBlocksY = blocksY;
+		cbData.TextureSizeRcpX = 1.0f / (float)srcWidth;
+		cbData.TextureSizeRcpY = 1.0f / (float)srcHeight;
+		bc6hEncodeCB->Update(cbData);
+
+		context->CSSetShaderResources(0, 1, &srcMipSRVs[level]);
+		context->CSSetUnorderedAccessViews(0, 1, &bc6hScratchUAVs[level], nullptr);
+
+		std::uint32_t dispatchX = std::max(1u, (blocksX + 7) / 8);
+		std::uint32_t dispatchY = std::max(1u, (blocksY + 7) / 8);
+		context->Dispatch(dispatchX, dispatchY, 6);
+	}
+
+	auto dst = a_reflections ? envReflectionsTextureBC6H : envTextureBC6H;
+	context->CopyResource(dst->resource.get(), bc6hScratchTexture->resource.get());
+
+	ID3D11ShaderResourceView* nullSRV = nullptr;
+	ID3D11UnorderedAccessView* nullUAV = nullptr;
+	ID3D11Buffer* nullBuffer = nullptr;
+	ID3D11SamplerState* nullSampler = nullptr;
+
+	context->CSSetShaderResources(0, 1, &nullSRV);
+	context->CSSetUnorderedAccessViews(0, 1, &nullUAV, nullptr);
+	context->CSSetConstantBuffers(0, 1, &nullBuffer);
+	context->CSSetSamplers(0, 1, &nullSampler);
+	context->CSSetShader(nullptr, nullptr, 0);
+}
+
 void DynamicCubemaps::UpdateCubemap()
 {
 	ZoneScoped;
@@ -507,11 +570,16 @@ void DynamicCubemaps::UpdateCubemap()
 		break;
 
 	case NextTask::kIrradiance:
+		nextTask = NextTask::kBC6HCompress;
+		Irradiance(false);
+		break;
+
+	case NextTask::kBC6HCompress:
 		if (activeReflections)
 			nextTask = NextTask::kCapture2;
 		else
 			nextTask = NextTask::kCapture;
-		Irradiance(false);
+		CompressToBC6H(false);
 		break;
 
 	case NextTask::kCapture2:
@@ -525,8 +593,13 @@ void DynamicCubemaps::UpdateCubemap()
 		break;
 
 	case NextTask::kIrradiance2:
-		nextTask = NextTask::kCapture;
+		nextTask = NextTask::kBC6HCompress2;
 		Irradiance(true);
+		break;
+
+	case NextTask::kBC6HCompress2:
+		nextTask = NextTask::kCapture;
+		CompressToBC6H(true);
 		break;
 	}
 }
@@ -535,7 +608,10 @@ void DynamicCubemaps::PostDeferred()
 {
 	auto context = globals::d3d::context;
 
-	ID3D11ShaderResourceView* views[2] = { (activeReflections ? envReflectionsTexture : envTexture)->srv.get(), envTexture->srv.get() };
+	ID3D11ShaderResourceView* views[2] = {
+		(activeReflections ? envReflectionsTextureBC6H : envTextureBC6H)->srv.get(),
+		envTextureBC6H->srv.get()
+	};
 	context->PSSetShaderResources(30, 2, views);
 }
 
@@ -546,6 +622,7 @@ void DynamicCubemaps::SetupResources()
 	GetComputeShaderInferrence();
 	GetComputeShaderInferrenceReflections();
 	GetComputeShaderSpecularIrradiance();
+	GetComputeShaderBC6HEncode();
 
 	auto renderer = globals::game::renderer;
 	auto device = globals::d3d::device;
@@ -626,7 +703,86 @@ void DynamicCubemaps::SetupResources()
 		envInferredTexture->CreateSRV(srvDesc);
 		envInferredTexture->CreateUAV(uavDesc);
 
+		// BC6H scratch: R32G32B32A32_UINT at quarter-resolution, 6-face array, all mip levels
+		{
+			D3D11_TEXTURE2D_DESC scratchDesc = {};
+			scratchDesc.Width = std::max(1u, texDesc.Width / 4);
+			scratchDesc.Height = std::max(1u, texDesc.Height / 4);
+			scratchDesc.MipLevels = MIPLEVELS;
+			scratchDesc.ArraySize = 6;
+			scratchDesc.Format = DXGI_FORMAT_R32G32B32A32_UINT;
+			scratchDesc.SampleDesc.Count = 1;
+			scratchDesc.Usage = D3D11_USAGE_DEFAULT;
+			scratchDesc.BindFlags = D3D11_BIND_UNORDERED_ACCESS;
+			bc6hScratchTexture = new Texture2D(scratchDesc);
+
+			D3D11_UNORDERED_ACCESS_VIEW_DESC scratchUAVDesc = {};
+			scratchUAVDesc.Format = DXGI_FORMAT_R32G32B32A32_UINT;
+			scratchUAVDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2DARRAY;
+			scratchUAVDesc.Texture2DArray.FirstArraySlice = 0;
+			scratchUAVDesc.Texture2DArray.ArraySize = 6;
+			for (std::uint32_t level = 0; level < MIPLEVELS; ++level) {
+				scratchUAVDesc.Texture2DArray.MipSlice = level;
+				DX::ThrowIfFailed(device->CreateUnorderedAccessView(bc6hScratchTexture->resource.get(), &scratchUAVDesc, &bc6hScratchUAVs[level]));
+			}
+		}
+
+		// BC6H compressed cubemap textures (shader-read-only)
+		{
+			D3D11_TEXTURE2D_DESC bc6hDesc = {};
+			bc6hDesc.Width = texDesc.Width;
+			bc6hDesc.Height = texDesc.Height;
+			bc6hDesc.MipLevels = MIPLEVELS;
+			bc6hDesc.ArraySize = 6;
+			bc6hDesc.Format = DXGI_FORMAT_BC6H_UF16;
+			bc6hDesc.SampleDesc.Count = 1;
+			bc6hDesc.Usage = D3D11_USAGE_DEFAULT;
+			bc6hDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+			bc6hDesc.MiscFlags = D3D11_RESOURCE_MISC_TEXTURECUBE;
+
+			D3D11_SHADER_RESOURCE_VIEW_DESC bc6hSRVDesc = {};
+			bc6hSRVDesc.Format = DXGI_FORMAT_BC6H_UF16;
+			bc6hSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBE;
+			bc6hSRVDesc.TextureCube.MostDetailedMip = 0;
+			bc6hSRVDesc.TextureCube.MipLevels = MIPLEVELS;
+
+			envTextureBC6H = new Texture2D(bc6hDesc);
+			envTextureBC6H->CreateSRV(bc6hSRVDesc);
+
+			envReflectionsTextureBC6H = new Texture2D(bc6hDesc);
+			envReflectionsTextureBC6H->CreateSRV(bc6hSRVDesc);
+		}
+
+		// Per-mip Texture2DArray SRVs for R11G11B10 source textures used during BC6H encoding
+		{
+			D3D11_SHADER_RESOURCE_VIEW_DESC mipSRVDesc = {};
+			mipSRVDesc.Format = DXGI_FORMAT_R11G11B10_FLOAT;
+			mipSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+			mipSRVDesc.Texture2DArray.FirstArraySlice = 0;
+			mipSRVDesc.Texture2DArray.ArraySize = 6;
+			mipSRVDesc.Texture2DArray.MipLevels = 1;
+			for (std::uint32_t level = 0; level < MIPLEVELS; ++level) {
+				mipSRVDesc.Texture2DArray.MostDetailedMip = level;
+				DX::ThrowIfFailed(device->CreateShaderResourceView(envTexture->resource.get(), &mipSRVDesc, &envTextureMipSRVs[level]));
+				DX::ThrowIfFailed(device->CreateShaderResourceView(envReflectionsTexture->resource.get(), &mipSRVDesc, &envReflectionsTextureMipSRVs[level]));
+			}
+		}
+
 		updateCubemapCB = new ConstantBuffer(ConstantBufferDesc<UpdateCubemapCB>());
+	}
+
+	{
+		bc6hEncodeCB = new ConstantBuffer(ConstantBufferDesc<BC6HEncodeCB>());
+
+		D3D11_SAMPLER_DESC bc6hSamplerDesc = {};
+		bc6hSamplerDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
+		bc6hSamplerDesc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+		bc6hSamplerDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+		bc6hSamplerDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+		bc6hSamplerDesc.MaxAnisotropy = 1;
+		bc6hSamplerDesc.MinLOD = 0;
+		bc6hSamplerDesc.MaxLOD = D3D11_FLOAT32_MAX;
+		DX::ThrowIfFailed(device->CreateSamplerState(&bc6hSamplerDesc, &bc6hPointSampler));
 	}
 
 	{

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -531,25 +531,11 @@ void DynamicCubemaps::CompressToBC6H(bool a_reflections)
 		context->CSSetShader(nullptr, nullptr, 0);
 	}
 
-	// Copy scratch → staging (same format, always valid), then upload to BC6H via
-	// UpdateSubresource so the format conversion is handled by the D3D11 runtime.
-	context->CopyResource(bc6hStagingTexture, bc6hScratchTexture->resource.get());
-
+	// BC formats are bitwise-compatible with matching block-equivalent uncompressed
+	// formats for CopyResource: an R32G32B32A32_UINT (W/4 × H/4) resource maps 1:1
+	// to a BC6H_UF16 (W × H) resource because each block is 16 bytes either way.
 	auto dst = a_reflections ? envReflectionsTextureBC6H : envTextureBC6H;
-
-	for (std::uint32_t face = 0; face < 6; ++face) {
-		for (std::uint32_t level = 0; level < bc6hMipLevels; ++level) {
-			std::uint32_t stagingSR = D3D11CalcSubresource(level, face, bc6hMipLevels);
-			std::uint32_t dstSR = D3D11CalcSubresource(level, face, bc6hMipLevels);
-
-			D3D11_MAPPED_SUBRESOURCE mapped{};
-			if (FAILED(context->Map(bc6hStagingTexture, stagingSR, D3D11_MAP_READ, 0, &mapped)))
-				continue;
-
-			context->UpdateSubresource(dst->resource.get(), dstSR, nullptr, mapped.pData, mapped.RowPitch, 0);
-			context->Unmap(bc6hStagingTexture, stagingSR);
-		}
-	}
+	context->CopyResource(dst->resource.get(), bc6hScratchTexture->resource.get());
 }
 
 void DynamicCubemaps::UpdateCubemap()
@@ -737,8 +723,8 @@ void DynamicCubemaps::SetupResources()
 		envInferredTexture->CreateUAV(uavDesc);
 
 		// BC6H scratch: R32G32B32A32_UINT at quarter-resolution, 6-face array.
-		// Mip count is determined by scratch base dimensions (W/4), not MIPLEVELS,
-		// so that CopyResource byte sizes align with the BC6H target texture.
+		// Encoded directly into here via UAV, then CopyResource'd to the BC6H texture.
+		// Mip count must match the BC6H target so block-equivalent dimensions align.
 		{
 			std::uint32_t scratchBase = std::max(1u, texDesc.Width / 4);
 			bc6hMipLevels = 0;
@@ -760,13 +746,6 @@ void DynamicCubemaps::SetupResources()
 			scratchDesc.MiscFlags = 0;
 			bc6hScratchTexture = new Texture2D(scratchDesc);
 
-			// Staging texture for CPU readback — same format/layout as scratch, CPU-readable.
-			D3D11_TEXTURE2D_DESC stagingDesc = scratchDesc;
-			stagingDesc.Usage = D3D11_USAGE_STAGING;
-			stagingDesc.BindFlags = 0;
-			stagingDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-			DX::ThrowIfFailed(device->CreateTexture2D(&stagingDesc, nullptr, &bc6hStagingTexture));
-
 			D3D11_UNORDERED_ACCESS_VIEW_DESC scratchUAVDesc = {};
 			scratchUAVDesc.Format = DXGI_FORMAT_R32G32B32A32_UINT;
 			scratchUAVDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2DARRAY;
@@ -779,7 +758,6 @@ void DynamicCubemaps::SetupResources()
 		}
 
 		// BC6H compressed cubemap textures (shader-read-only).
-		// Must use the same mip count as scratch for CopyResource to succeed.
 		{
 			D3D11_TEXTURE2D_DESC bc6hDesc = {};
 			bc6hDesc.Width = texDesc.Width;

--- a/src/Features/DynamicCubemaps.h
+++ b/src/Features/DynamicCubemaps.h
@@ -103,7 +103,6 @@ public:
 	Texture2D* envTextureBC6H = nullptr;
 	Texture2D* envReflectionsTextureBC6H = nullptr;
 	Texture2D* bc6hScratchTexture = nullptr;
-	ID3D11Texture2D* bc6hStagingTexture = nullptr;
 
 	uint32_t bc6hMipLevels = 0;
 

--- a/src/Features/DynamicCubemaps.h
+++ b/src/Features/DynamicCubemaps.h
@@ -75,12 +75,36 @@ public:
 		kCapture,
 		kInferrence,
 		kIrradiance,
+		kBC6HCompress,
 		kCapture2,
 		kInferrence2,
-		kIrradiance2
+		kIrradiance2,
+		kBC6HCompress2
 	};
 
 	NextTask nextTask = NextTask::kCapture;
+
+	// BC6H compression
+	struct alignas(16) BC6HEncodeCB
+	{
+		uint TextureSizeInBlocksX;
+		uint TextureSizeInBlocksY;
+		float TextureSizeRcpX;
+		float TextureSizeRcpY;
+	};
+	STATIC_ASSERT_ALIGNAS_16(BC6HEncodeCB);
+
+	ID3D11ComputeShader* bc6hEncodeCS = nullptr;
+	ConstantBuffer* bc6hEncodeCB = nullptr;
+	ID3D11SamplerState* bc6hPointSampler = nullptr;
+
+	Texture2D* envTextureBC6H = nullptr;
+	Texture2D* envReflectionsTextureBC6H = nullptr;
+	Texture2D* bc6hScratchTexture = nullptr;
+
+	ID3D11UnorderedAccessView* bc6hScratchUAVs[8] = {};
+	ID3D11ShaderResourceView* envTextureMipSRVs[8] = {};
+	ID3D11ShaderResourceView* envReflectionsTextureMipSRVs[8] = {};
 
 	// Editor window
 
@@ -157,6 +181,10 @@ public:
 	void Inferrence(bool a_reflections);
 
 	void Irradiance(bool a_reflections);
+
+	void CompressToBC6H(bool a_reflections);
+
+	ID3D11ComputeShader* GetComputeShaderBC6HEncode();
 
 	virtual bool SupportsVR() override { return true; };
 	virtual bool IsCore() const override { return true; };

--- a/src/Features/DynamicCubemaps.h
+++ b/src/Features/DynamicCubemaps.h
@@ -89,22 +89,25 @@ public:
 	{
 		uint TextureSizeInBlocksX;
 		uint TextureSizeInBlocksY;
-		float TextureSizeRcpX;
-		float TextureSizeRcpY;
+		uint MipLevel;
+		uint pad;
 	};
 	STATIC_ASSERT_ALIGNAS_16(BC6HEncodeCB);
 
 	ID3D11ComputeShader* bc6hEncodeCS = nullptr;
 	ConstantBuffer* bc6hEncodeCB = nullptr;
-	ID3D11SamplerState* bc6hPointSampler = nullptr;
+
+	ID3D11ShaderResourceView* envTextureArraySRV = nullptr;
+	ID3D11ShaderResourceView* envReflectionsTextureArraySRV = nullptr;
 
 	Texture2D* envTextureBC6H = nullptr;
 	Texture2D* envReflectionsTextureBC6H = nullptr;
 	Texture2D* bc6hScratchTexture = nullptr;
+	ID3D11Texture2D* bc6hStagingTexture = nullptr;
+
+	uint32_t bc6hMipLevels = 0;
 
 	ID3D11UnorderedAccessView* bc6hScratchUAVs[8] = {};
-	ID3D11ShaderResourceView* envTextureMipSRVs[8] = {};
-	ID3D11ShaderResourceView* envReflectionsTextureMipSRVs[8] = {};
 
 	// Editor window
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented BC6H compression for dynamic cubemaps. Environment and reflection cubemaps are now automatically compressed during the processing pipeline. BC6H-compressed textures are used in rendering for improved performance and memory efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->