### PR TITLE
build(clangd): add config for IDE include resolution

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -8,4 +8,4 @@ CompileFlags:
     - -Iextern/CommonLibSSE-NG/include
     - -Ibuild/ALL/vcpkg_installed/x64-windows-static-md/include
     - -Ipackage/Shaders
-  Compiler: cl
+  Compiler: clang-cl

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,11 @@
+CompileFlags:
+  Add:
+    - -std=c++23
+    - -DENABLE_SKYRIM_AE
+    - -DENABLE_SKYRIM_SE
+    - -DENABLE_SKYRIM_VR
+    - -Isrc
+    - -Iextern/CommonLibSSE-NG/include
+    - -Ibuild/ALL/vcpkg_installed/x64-windows-static-md/include
+    - -Ipackage/Shaders
+  Compiler: cl


### PR DESCRIPTION
## Summary

- Adds `.clangd` config to the repo root so clangd-based IDEs (VS Code, CLion, etc.) resolve includes without spurious warnings
- Covers the default `ALL` preset build dir (`build/ALL/vcpkg_installed/...`), which also covers `ALL-WITH-AUTO-DEPLOYMENT` since it shares the same `binaryDir`
- Sets the three Skyrim edition defines (`ENABLE_SKYRIM_AE/SE/VR`) so edition-gated code is properly analyzed

## Test plan

- [ ] Open a source file in VS Code with clangd — verify no spurious "file not found" include warnings
- [ ] Confirm Tracy-gated code (`#ifdef TRACY_ENABLE`) is correctly inactive in default analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added development environment configuration to establish compiler settings and improve code analysis capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->