### PR TITLE
chore(tracy): add GPU zone to ForEachLoadedFeature

### DIFF
--- a/features/Skylighting/Shaders/Features/Skylighting.ini
+++ b/features/Skylighting/Shaders/Features/Skylighting.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-2-4
+Version = 1-3-0
 
 [Nexus]
 nexusmodid = 139352

--- a/features/Terrain Blending/Shaders/Features/TerrainBlending.ini
+++ b/features/Terrain Blending/Shaders/Features/TerrainBlending.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-0-2
+Version = 1-1-0
 
 [Nexus]
 nexusmodid = 157076

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -211,9 +211,7 @@ void Deferred::ReflectionsPrepasses()
 
 	globals::game::stateUpdateFlags->set(RE::BSGraphics::ShaderFlags::DIRTY_RENDERTARGET);  // Run OMSetRenderTargets again
 
-	Feature::ForEachLoadedFeature("ReflectionsPrepass", [](Feature* feature) {
-		feature->ReflectionsPrepass();
-	});
+	Feature::ForEachLoadedFeature("ReflectionsPrepass", [](Feature* feature) { feature->ReflectionsPrepass(); }, true);
 }
 
 void Deferred::EarlyPrepasses()
@@ -236,9 +234,7 @@ void Deferred::EarlyPrepasses()
 	// Shadow maps have just been rendered — upload BSShadowDirectionalLight data to t98.
 	CopyShadowLightData();
 
-	Feature::ForEachLoadedFeature("EarlyPrepass", [](Feature* feature) {
-		feature->EarlyPrepass();
-	});
+	Feature::ForEachLoadedFeature("EarlyPrepass", [](Feature* feature) { feature->EarlyPrepass(); }, true);
 }
 
 void Deferred::PrepassPasses()
@@ -255,9 +251,7 @@ void Deferred::PrepassPasses()
 	context->OMSetRenderTargets(0, nullptr, nullptr);  // Unbind all bound render targets
 
 	globals::truePBR->PrePass();
-	Feature::ForEachLoadedFeature("Prepass", [](Feature* feature) {
-		feature->Prepass();
-	});
+	Feature::ForEachLoadedFeature("Prepass", [](Feature* feature) { feature->Prepass(); }, true);
 }
 
 void Deferred::StartDeferred()

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -5,6 +5,7 @@
 #include "FeatureVersions.h"
 #ifdef TRACY_ENABLE
 #	include <Tracy/Tracy.hpp>
+#	include <Tracy/TracyD3D11.hpp>
 #endif
 
 struct Feature
@@ -213,19 +214,28 @@ public:
 	 * @param methodName Name of the method being called (used for Tracy zone naming)
 	 * @param callback Callable that receives (Feature*) and performs the operation
 	 */
+	// Called once from State after TracyD3D11Context is created so ForEachLoadedFeature
+	// can emit GPU timer zones without pulling in State headers here.
+#ifdef TRACY_ENABLE
+	inline static TracyD3D11Ctx s_tracyCtx = nullptr;
+	static void SetTracyCtx(TracyD3D11Ctx ctx) noexcept { s_tracyCtx = ctx; }
+#endif
+
 	template <typename Func>
-	static inline void ForEachLoadedFeature(std::string_view methodName, Func&& callback)
+	static inline void ForEachLoadedFeature(std::string_view methodName, Func&& callback, bool emitGpuZone = false)
 	{
 		for (auto* feature : GetFeatureList()) {
 			if (feature->loaded) {
 #ifdef TRACY_ENABLE
 				{
-					// ZoneTransientN allocates the source location dynamically so the
-					// runtime string becomes the zone's actual name in Tracy, not just
-					// a per-instance annotation on a static "ForEachLoadedFeature" zone.
 					const auto zoneName = std::format("{}::{}", feature->GetShortName(), methodName);
 					ZoneTransientN(___tracy_feature_zone, zoneName.c_str(), true);
-					callback(feature);
+					if (emitGpuZone) {
+						TracyD3D11ZoneTransientS(s_tracyCtx, ___tracy_d3d11_feature_zone, zoneName.c_str(), 0, s_tracyCtx != nullptr);
+						callback(feature);
+					} else {
+						callback(feature);
+					}
 				}
 #else
 				callback(feature);

--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -199,14 +199,10 @@ void IBL::ReflectionsPrepass()
 
 void IBL::Prepass()
 {
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "IBL");
-
 	if (settings.DisableInInteriors && Util::IsInterior())
 		return;
 
 	auto context = globals::d3d::context;
-	auto state = globals::state;
 
 	auto& dynamicCubemaps = globals::features::dynamicCubemaps;
 
@@ -218,7 +214,6 @@ void IBL::Prepass()
 		context->PSSetShaderResources(76, 2, views);
 	}
 
-	state->BeginPerfEvent("IBL");
 	std::array<ID3D11ShaderResourceView*, 1> srvs = { (dynamicCubemaps.loaded && envTexture) ? envTexture->srv.get() : nullptr };
 	std::array<ID3D11UnorderedAccessView*, 1> uavs = { envIBLTexture->uav.get() };
 	std::array<ID3D11SamplerState*, 1> samplers = { Deferred::GetSingleton()->linearSampler };
@@ -261,7 +256,6 @@ void IBL::Prepass()
 		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
 		context->CSSetShader(nullptr, nullptr, 0);
 	}
-	state->EndPerfEvent();
 
 	// Set PS shader resource
 	{

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -124,7 +124,7 @@ ID3D11ComputeShader* ScreenSpaceShadows::GetComputeRaymarchRight()
 
 void ScreenSpaceShadows::DrawShadows()
 {
-	ZoneScoped;
+	ZoneScopedS(8);
 	auto state = globals::state;
 	TracyD3D11Zone(state->tracyCtx, "Screen Space Shadows");
 

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -474,6 +474,7 @@ void Skylighting::SetViewFrustumVR::thunk(RE::NiCamera* a_camera, RE::NiFrustum*
 
 void Skylighting::RenderOcclusion()
 {
+	ZoneScopedS(8);
 	auto shaderCache = globals::shaderCache;
 	auto state = globals::state;
 	auto renderer = globals::game::renderer;
@@ -574,8 +575,11 @@ void Skylighting::RenderOcclusion()
 				PrecipitationShaderDirection = { PrecipitationShaderDirectionF.x, PrecipitationShaderDirectionF.y, PrecipitationShaderDirectionF.z };
 
 				static REL::Relocation<void(RE::Precipitation*, RE::NiPointer<RE::NiCamera>)> _computeProjection{ REL::RelocationID(25643, 26185) };
-				_computeProjection(precip, precip->occlusionData.camera);
-				precip->SetupMask();
+				{
+					ZoneScopedN("Skylighting - Setup Projection");
+					_computeProjection(precip, precip->occlusionData.camera);
+					precip->SetupMask();
+				}
 
 				BSParticleShaderRainEmitter* rain = new BSParticleShaderRainEmitter;
 				{
@@ -596,7 +600,10 @@ void Skylighting::RenderOcclusion()
 
 				precipitation = precipitationCopy;
 
-				_computeProjection(precip, precip->occlusionData.camera);
+				{
+					ZoneScopedN("Skylighting - Restore Projection");
+					_computeProjection(precip, precip->occlusionData.camera);
+				}
 
 				state->EndPerfEvent();
 			}

--- a/src/Features/TerrainBlending.cpp
+++ b/src/Features/TerrainBlending.cpp
@@ -831,7 +831,7 @@ void TerrainBlending::ClearShaderCache()
 
 void TerrainBlending::Hooks::Main_RenderDepth::thunk(bool a1, bool a2)
 {
-	ZoneScoped;
+	ZoneScopedS(8);
 
 	auto& singleton = globals::features::terrainBlending;
 	auto shaderCache = globals::shaderCache;
@@ -859,7 +859,10 @@ void TerrainBlending::Hooks::Main_RenderDepth::thunk(bool a1, bool a2)
 		singleton.renderDepth = true;
 		singleton.ResetDepth();
 
-		func(a1, a2);
+		{
+			ZoneScopedN("Terrain Depth - Game Render");
+			func(a1, a2);
+		}
 
 		singleton.renderDepth = false;
 
@@ -873,7 +876,10 @@ void TerrainBlending::Hooks::Main_RenderDepth::thunk(bool a1, bool a2)
 		mainDepth.depthSRV = singleton.depthSRVBackup;
 		zPrepassCopy.depthSRV = singleton.prepassSRVBackup;
 
-		func(a1, a2);
+		{
+			ZoneScopedN("Terrain Depth - Game Render");
+			func(a1, a2);
+		}
 	}
 }
 

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -691,6 +691,7 @@ void State::SetupResources()
 	featureLevel = globals::d3d::device->GetFeatureLevel();
 
 	tracyCtx = TracyD3D11Context(globals::d3d::device, globals::d3d::context);
+	Feature::SetTracyCtx(tracyCtx);
 }
 
 void State::ModifyShaderLookup(const RE::BSShader& a_shader, uint& a_vertexDescriptor, uint& a_pixelDescriptor, bool a_forceDeferred)

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -691,7 +691,9 @@ void State::SetupResources()
 	featureLevel = globals::d3d::device->GetFeatureLevel();
 
 	tracyCtx = TracyD3D11Context(globals::d3d::device, globals::d3d::context);
+#ifdef TRACY_ENABLE
 	Feature::SetTracyCtx(tracyCtx);
+#endif
 }
 
 void State::ModifyShaderLookup(const RE::BSShader& a_shader, uint& a_vertexDescriptor, uint& a_pixelDescriptor, bool a_forceDeferred)


### PR DESCRIPTION
Introduce TracyD3D11 GPU zones in ForEachLoadedFeature via optional emitGpuZone param, wired through a static TracyD3D11Ctx set from State after device init. Remove manual BeginPerfEvent/TracyD3D11Zone calls from IBL now covered by the centralized path. Refine CPU zones in ScreenSpaceShadows, Skylighting, and TerrainBlending with callstack depth and named sub-zones for finer profiling granularity.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved GPU profiling integration for several rendering passes to capture finer-grained timing.
  * Adjusted profiling scopes for skylighting, terrain depth, screen-space shadows, and prepass iterations.
  * Removed redundant profiling in the image-based lighting pass to reduce telemetry noise.
* **Documentation/Metadata**
  * Bumped Skylighting and Terrain Blending shader feature metadata versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->