### PR TITLE
ci: fix ERELEASEBRANCHES and allow RC version bump to dev

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,11 @@ jobs:
               with:
                   fetch-depth: 0
 
+            - name: Configure git identity
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
             - name: Apply feature version bumps
               run: |
                   python tools/feature_version_audit.py \

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,12 +1,11 @@
-const releaseType = process.env.RELEASE_TYPE || 'rc';
+const isRC = (process.env.RELEASE_TYPE || 'rc') === 'rc';
 
 module.exports = {
-  branches: [
-    {
-      name: 'dev',
-      ...(releaseType === 'rc' ? { prerelease: 'rc' } : {}),
-    },
-  ],
+  // RC: needs 'main' as non-prerelease anchor (semantic-release v25 requires >= 1).
+  // Stable: 'dev' is the release branch directly.
+  branches: isRC
+    ? ['main', { name: 'dev', prerelease: 'rc' }]
+    : ['dev'],
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
@@ -17,7 +16,8 @@ module.exports = {
           {
             files: ['CMakeLists.txt'],
             from: 'VERSION [0-9]+\\.[0-9]+\\.[0-9]+',
-            to: 'VERSION ${nextRelease.version}',
+            // Strip prerelease suffix so CMake gets '1.5.0' not '1.5.0-rc.1'
+            to: "VERSION ${nextRelease.version.split('-')[0]}",
             results: [
               {
                 file: 'CMakeLists.txt',

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -16,17 +16,9 @@ module.exports = {
           {
             files: ['CMakeLists.txt'],
             from: 'VERSION [0-9]+\\.[0-9]+\\.[0-9]+',
-            // Strip prerelease suffix so CMake gets '1.5.0' not '1.5.0-rc.1'
+            // Strip prerelease suffix so CMake gets '1.5.0' not '1.5.0-rc.1'.
+            // No results assertion: stable after RC is a no-op (version already set).
             to: "VERSION ${nextRelease.version.split('-')[0]}",
-            results: [
-              {
-                file: 'CMakeLists.txt',
-                hasChanged: true,
-                numReplacements: 1,
-                numMatches: 1,
-              },
-            ],
-            countMatches: true,
           },
         ],
       },


### PR DESCRIPTION
- Add 'main' as non-prerelease anchor for RC mode (semantic-release v25 requires >= 1 non-prerelease branch; prerelease-only config throws ERELEASEBRANCHES with empty [])
- Stable mode uses 'dev' directly as release branch
- Strip prerelease suffix in CMakeLists replacement so CMake gets '1.5.0' not '1.5.0-rc.1' (CMake VERSION rejects prerelease syntax)
- Add git identity config step so @semantic-release/git can commit version bump back to dev for both RC and stable releases

Prereq: 'main' branch must exist on remote (create from v1.4.11 tag).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made release automation deterministic by configuring a consistent commit author for automated version updates.
  * Improved release/version handling so prerelease and stable flows produce correct version strings and branch selection for releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->