### PR TITLE
fix(VR): skip kSAO_CAMERAZ RTV in depth pass

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1931,8 +1931,11 @@ void Upscaling::UpscaleDepth()
 		ID3D11ShaderResourceView* srvs[] = { refractionNormals.SRVCopy, depthCopy.depthSRV, depthCopy.stencilSRV };
 		context->PSSetShaderResources(0, ARRAYSIZE(srvs), srvs);
 
-		ID3D11RenderTargetView* rtvs[] = { refractionNormals.RTV, saoCameraZ.RTV };
-		context->OMSetRenderTargets(ARRAYSIZE(rtvs), rtvs, depth.views[0]);
+		// kSAO_CAMERAZ is at quarter-stereo resolution in VR; the full-stereo viewport would
+		// corrupt only the top-left quarter. The engine's ISSAOCameraZ pass populates it correctly.
+		ID3D11RenderTargetView* rtvs[] = { refractionNormals.RTV,
+			globals::game::isVR ? nullptr : saoCameraZ.RTV };
+		context->OMSetRenderTargets(2, rtvs, depth.views[0]);
 
 		context->PSSetShader(depthUpscalePS, nullptr, 0);
 		context->Draw(3, 0);


### PR DESCRIPTION
## Summary

- kSAO_CAMERAZ is allocated at per-eye (half-stereo) resolution in VR (e.g. 4299×4565) but the fullscreen depth upscale draw uses a full-stereo viewport (8598×4565)
- This causes the pixel shader to write garbage into the left-eye region of kSAO_CAMERAZ
- The engine's own ISSAOCameraZ pass correctly populates kSAO_CAMERAZ, so we only need to stop corrupting it
- Fix: pass `nullptr` for RTV slot 1 in VR, matching the engine's own pass behavior

## Test plan

- [ ] Build ALL preset
- [ ] Test in VR — no kSAO_CAMERAZ rendering artifacts in left-eye

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue causing corruption of VR stereo output during the upscaling process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->