### PR TITLE
perf(VR): reduce DLSS copy operations

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -432,15 +432,23 @@ void Upscaling::DrawSettings()
 			ImGui::SliderFloat("View Resize", &debugRescale, 0.05f, 1.f);
 
 			if (ImGui::TreeNode("Upscaling Intermediates")) {
-				if (vrIntermediateColorIn[0] && vrIntermediateColorOut[0]) {
-					BUFFER_VIEWER_NODE_TITLE(vrIntermediateColorIn[0], "Left Eye In", debugRescale)
-					BUFFER_VIEWER_NODE_TITLE(vrIntermediateColorIn[1], "Right Eye In", debugRescale)
-					BUFFER_VIEWER_NODE_TITLE(vrIntermediateColorOut[0], "Left Eye Out", debugRescale)
-					BUFFER_VIEWER_NODE_TITLE(vrIntermediateColorOut[1], "Right Eye Out", debugRescale)
+				if (vrIntermediateMotionVectors[0]) {
+					bool isDLSS = GetUpscaleMethod() == UpscaleMethod::kDLSS;
+					if (vrIntermediateColorIn[0] && vrIntermediateColorOut[0]) {
+						BUFFER_VIEWER_NODE_TITLE(vrIntermediateColorIn[0], "Left Eye In", debugRescale)
+						BUFFER_VIEWER_NODE_TITLE(vrIntermediateColorIn[1], "Right Eye In", debugRescale)
+						if (!isDLSS)
+							BUFFER_VIEWER_NODE_TITLE(vrIntermediateColorOut[0], "Left Eye Out", debugRescale)
+						BUFFER_VIEWER_NODE_TITLE(vrIntermediateColorOut[1], "Right Eye Out", debugRescale)
+					}
 					BUFFER_VIEWER_NODE_TITLE(vrIntermediateMotionVectors[0], "Left Eye MVec", debugRescale)
 					BUFFER_VIEWER_NODE_TITLE(vrIntermediateMotionVectors[1], "Right Eye MVec", debugRescale)
 					BUFFER_VIEWER_NODE_TITLE(vrIntermediateReactiveMask[0], "Left Eye Reactive", debugRescale)
 					BUFFER_VIEWER_NODE_TITLE(vrIntermediateReactiveMask[1], "Right Eye Reactive", debugRescale)
+					if (vrIntermediateTransparencyMask[0]) {
+						BUFFER_VIEWER_NODE_TITLE(vrIntermediateTransparencyMask[0], "Left Eye Transparency", debugRescale)
+						BUFFER_VIEWER_NODE_TITLE(vrIntermediateTransparencyMask[1], "Right Eye Transparency", debugRescale)
+					}
 				} else {
 					ImGui::TextDisabled("VR intermediates not yet created (enter game world)");
 				}
@@ -790,12 +798,12 @@ void Upscaling::CheckResources(UpscaleMethod a_upscalemethod)
 					for (int i = 0; i < 2; i++) {
 						vrIntermediateColorIn[i].reset();
 						vrIntermediateColorOut[i].reset();
-						vrIntermediateDepth[i].reset();
 						vrIntermediateLinearDepth[i].reset();
 						vrIntermediateMotionVectors[i].reset();
 						vrIntermediateReactiveMask[i].reset();
 						vrIntermediateTransparencyMask[i].reset();
 					}
+					vrIntermediateDepth.reset();
 				}
 			}
 			if (a_upscalemethod == UpscaleMethod::kFSR)
@@ -941,10 +949,11 @@ void Upscaling::CreateVRIntermediateTextures(uint32_t inWidth, uint32_t inHeight
 		vrIntermediateColorIn[i] = CreateTextureFromSource(colorSrc, inWidth, inHeight, false, true, true, ("Upscale_ColorIn_" + suffix).c_str());
 		vrIntermediateColorOut[i] = CreateTextureFromSource(colorSrc, outWidth, outHeight, false, true, false, ("Upscale_ColorOut_" + suffix).c_str());
 
-		// Depth: R24G8_TYPELESS matches the game's D24S8_TYPELESS cast group so that
-		// CopySubresourceRegion can copy from the game depth buffer without format errors.
-		// R32_TYPELESS is a different cast group and produces silent zero-copy failures.
-		{
+		// Right-eye only: Streamline.Upscale copies the right-eye depth slice here before DLSS eye 1.
+		// DLSS eye 0 reads the stereo depth directly (zero offset). R24G8_TYPELESS matches the
+		// game's D24S8_TYPELESS cast group — R32_TYPELESS is a different cast group and produces
+		// silent zero-copy failures. Only allocate once (i == 1).
+		if (i == 1) {
 			D3D11_TEXTURE2D_DESC depthDesc = {};
 			depthDesc.Width = inWidth;
 			depthDesc.Height = inHeight;
@@ -954,21 +963,20 @@ void Upscaling::CreateVRIntermediateTextures(uint32_t inWidth, uint32_t inHeight
 			depthDesc.SampleDesc.Count = 1;
 			depthDesc.Usage = D3D11_USAGE_DEFAULT;
 			depthDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
-			vrIntermediateDepth[i] = eastl::make_unique<Texture2D>(depthDesc);
+			vrIntermediateDepth = eastl::make_unique<Texture2D>(depthDesc);
 
-			Util::SetResourceName(vrIntermediateDepth[i]->resource.get(), ("Upscale_Depth_" + suffix).c_str());
+			Util::SetResourceName(vrIntermediateDepth->resource.get(), "Upscale_Depth_Right");
 
 			D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
 			srvDesc.Format = DXGI_FORMAT_R24_UNORM_X8_TYPELESS;
 			srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
 			srvDesc.Texture2D.MipLevels = 1;
-			vrIntermediateDepth[i]->CreateSRV(srvDesc);
+			vrIntermediateDepth->CreateSRV(srvDesc);
 		}
 
 		// Linear depth: R32_FLOAT so FSR's GetFfxResourceDescriptionDX11() returns a valid format.
-		// EncodeTexturesCS reads from the raw per-eye depth (via vrIntermediateDepth SRV) and
-		// writes the same non-linear value as R32_FLOAT. Kept separate from vrIntermediateDepth
-		// so DLSS can continue using the R24G8_TYPELESS copy via Streamline.
+		// EncodeTexturesCS writes the non-linear depth as R32_FLOAT for FSR. Kept separate from
+		// vrIntermediateDepth (R24G8_TYPELESS) which Streamline copies into for DLSS right eye.
 		{
 			D3D11_TEXTURE2D_DESC ldDesc = {};
 			ldDesc.Width = inWidth;
@@ -1036,7 +1044,7 @@ void Upscaling::EnsureVRIntermediateTextures()
 	}
 }
 
-void Upscaling::PreparePerEyeInputs(ID3D11Resource* colorSrc, ID3D11Resource* depthSrc)
+void Upscaling::PreparePerEyeInputs(ID3D11Resource* colorSrc)
 {
 	if (!globals::game::isVR)
 		return;
@@ -1063,14 +1071,7 @@ void Upscaling::PreparePerEyeInputs(ID3D11Resource* colorSrc, ID3D11Resource* de
 		D3D11_BOX srcBox = { offsetXIn, 0, 0, offsetXIn + eyeWidthIn, eyeHeightIn, 1 };
 
 		context->CopySubresourceRegion(vrIntermediateColorIn[i]->resource.get(), 0, 0, 0, 0, colorSrc, 0, &srcBox);
-		// Depth copy keeps vrIntermediateDepth populated for DLSS (Streamline handles R24G8_TYPELESS).
-		// FSR uses vrIntermediateLinearDepth (R32_FLOAT) written by EncodeTexturesCS instead.
-		if (GetUpscaleMethod() == UpscaleMethod::kDLSS)
-			context->CopySubresourceRegion(vrIntermediateDepth[i]->resource.get(), 0, 0, 0, 0, depthSrc, 0, &srcBox);
-		// DLSS motion vectors are written per-eye by EncodeTexturesCS with 5x5 dilation.
-		// FSR uses a raw copy here since it does not use the dilated output.
-		if (GetUpscaleMethod() != UpscaleMethod::kDLSS)
-			context->CopySubresourceRegion(vrIntermediateMotionVectors[i]->resource.get(), 0, 0, 0, 0, motionVectorRT.texture, 0, &srcBox);
+		context->CopySubresourceRegion(vrIntermediateMotionVectors[i]->resource.get(), 0, 0, 0, 0, motionVectorRT.texture, 0, &srcBox);
 
 		uint32_t depthOffset = (i == 1) ? eyeWidthIn : 0;
 		ClearHMDMask(vrIntermediateColorIn[i]->uav.get(), depthTexture.depthSRV,
@@ -1742,7 +1743,7 @@ void Upscaling::Upscale()
 
 			// u2 (MotionVectorOutput): DLSS only — 5x5 dilated MVec for ghosting reduction.
 			// u3 (DepthOutput): VR FSR only — converts R24G8_TYPELESS to R32_FLOAT so
-			//   GetFfxResourceDescriptionDX11() returns a valid format. DLSS uses vrIntermediateDepth.
+			//   GetFfxResourceDescriptionDX11() returns a valid format. DLSS depth is copied in Streamline.cpp.
 			ID3D11UnorderedAccessView* uavs[4] = {
 				globals::game::isVR ? vrIntermediateReactiveMask[i]->uav.get() : reactiveMaskTexture->uav.get(),
 				globals::game::isVR ? vrIntermediateTransparencyMask[i]->uav.get() : transparencyCompositionMaskTexture->uav.get(),

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -941,6 +941,31 @@ eastl::unique_ptr<Texture2D> Upscaling::CreateTextureFromSource(ID3D11Resource* 
 void Upscaling::CreateVRIntermediateTextures(uint32_t inWidth, uint32_t inHeight, uint32_t outWidth, uint32_t outHeight,
 	ID3D11Resource* colorSrc, ID3D11Resource* mvecSrc, ID3D11Resource* reactiveSrc, ID3D11Resource* transparencySrc)
 {
+	// Right-eye-only depth intermediate for DLSS. Streamline.Upscale copies the right-eye depth
+	// slice here before evaluating DLSS eye 1; eye 0 reads the combined stereo depth directly at
+	// zero offset. R24G8_TYPELESS matches the game's D24S8_TYPELESS cast group — R32_TYPELESS is
+	// a different cast group and produces silent zero-copy failures.
+	{
+		D3D11_TEXTURE2D_DESC depthDesc = {};
+		depthDesc.Width = inWidth;
+		depthDesc.Height = inHeight;
+		depthDesc.MipLevels = 1;
+		depthDesc.ArraySize = 1;
+		depthDesc.Format = DXGI_FORMAT_R24G8_TYPELESS;
+		depthDesc.SampleDesc.Count = 1;
+		depthDesc.Usage = D3D11_USAGE_DEFAULT;
+		depthDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+		vrIntermediateDepth = eastl::make_unique<Texture2D>(depthDesc);
+
+		Util::SetResourceName(vrIntermediateDepth->resource.get(), "Upscale_Depth_Right");
+
+		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Format = DXGI_FORMAT_R24_UNORM_X8_TYPELESS;
+		srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
+		vrIntermediateDepth->CreateSRV(srvDesc);
+	}
+
 	// All buffers are per-eye: Streamline validates all extents against the input color texture
 	// dimensions, so every tagged resource must be isolated per-eye at {0,0}.
 	for (int i = 0; i < 2; i++) {
@@ -948,31 +973,6 @@ void Upscaling::CreateVRIntermediateTextures(uint32_t inWidth, uint32_t inHeight
 
 		vrIntermediateColorIn[i] = CreateTextureFromSource(colorSrc, inWidth, inHeight, false, true, true, ("Upscale_ColorIn_" + suffix).c_str());
 		vrIntermediateColorOut[i] = CreateTextureFromSource(colorSrc, outWidth, outHeight, false, true, false, ("Upscale_ColorOut_" + suffix).c_str());
-
-		// Right-eye only: Streamline.Upscale copies the right-eye depth slice here before DLSS eye 1.
-		// DLSS eye 0 reads the stereo depth directly (zero offset). R24G8_TYPELESS matches the
-		// game's D24S8_TYPELESS cast group — R32_TYPELESS is a different cast group and produces
-		// silent zero-copy failures. Only allocate once (i == 1).
-		if (i == 1) {
-			D3D11_TEXTURE2D_DESC depthDesc = {};
-			depthDesc.Width = inWidth;
-			depthDesc.Height = inHeight;
-			depthDesc.MipLevels = 1;
-			depthDesc.ArraySize = 1;
-			depthDesc.Format = DXGI_FORMAT_R24G8_TYPELESS;
-			depthDesc.SampleDesc.Count = 1;
-			depthDesc.Usage = D3D11_USAGE_DEFAULT;
-			depthDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
-			vrIntermediateDepth = eastl::make_unique<Texture2D>(depthDesc);
-
-			Util::SetResourceName(vrIntermediateDepth->resource.get(), "Upscale_Depth_Right");
-
-			D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-			srvDesc.Format = DXGI_FORMAT_R24_UNORM_X8_TYPELESS;
-			srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-			srvDesc.Texture2D.MipLevels = 1;
-			vrIntermediateDepth->CreateSRV(srvDesc);
-		}
 
 		// Linear depth: R32_FLOAT so FSR's GetFfxResourceDescriptionDX11() returns a valid format.
 		// EncodeTexturesCS writes the non-linear depth as R32_FLOAT for FSR. Kept separate from

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -151,7 +151,7 @@ public:
 	// Owned here so both Streamline (DLSS) and FidelityFX (FSR) can use them.
 	eastl::unique_ptr<Texture2D> vrIntermediateColorIn[2];           // per-eye render resolution
 	eastl::unique_ptr<Texture2D> vrIntermediateColorOut[2];          // per-eye output resolution
-	eastl::unique_ptr<Texture2D> vrIntermediateDepth[2];             // per-eye render resolution (R24G8_TYPELESS, for DLSS)
+	eastl::unique_ptr<Texture2D> vrIntermediateDepth;                // right-eye render resolution (R24G8_TYPELESS, DLSS only)
 	eastl::unique_ptr<Texture2D> vrIntermediateLinearDepth[2];       // per-eye render resolution (R32_FLOAT, for FSR)
 	eastl::unique_ptr<Texture2D> vrIntermediateMotionVectors[2];     // per-eye render resolution
 	eastl::unique_ptr<Texture2D> vrIntermediateReactiveMask[2];      // per-eye render resolution
@@ -171,10 +171,10 @@ public:
 	/// Must be called before any per-eye EncodeTexturesCS dispatch or PreparePerEyeInputs.
 	void EnsureVRIntermediateTextures();
 
-	/// Splits the combined stereo color/depth buffers into per-eye intermediates, copies motion
-	/// vectors for non-DLSS paths, and clears the HMD hidden area.
+	/// Splits the combined stereo color buffer into per-eye intermediates, copies raw
+	/// motion vectors, and clears the HMD hidden area. FSR-only.
 	/// Reactive/transparency masks are written by EncodeTexturesCS.
-	void PreparePerEyeInputs(ID3D11Resource* colorSrc, ID3D11Resource* depthSrc);
+	void PreparePerEyeInputs(ID3D11Resource* colorSrc);
 	void FinalizePerEyeOutputs(ID3D11Resource* colorDst);
 
 	void ConfigureTAA();

--- a/src/Features/Upscaling/FidelityFX.cpp
+++ b/src/Features/Upscaling/FidelityFX.cpp
@@ -413,7 +413,7 @@ void FidelityFX::Upscale(ID3D11Resource* a_upscalingTexture, ID3D11Resource* a_r
 
 	if (globals::game::isVR) {
 		// Prepare per-eye inputs and clear mask
-		upscaling.PreparePerEyeInputs(a_upscalingTexture, depthTexture.texture);
+		upscaling.PreparePerEyeInputs(a_upscalingTexture);
 
 		uint32_t numViews = 2;
 		uint32_t eyeWidth = (uint32_t)(renderSize.x / 2);

--- a/src/Features/Upscaling/Streamline.cpp
+++ b/src/Features/Upscaling/Streamline.cpp
@@ -618,30 +618,73 @@ void Streamline::Upscale(ID3D11Resource* a_upscalingTexture, ID3D11Resource* a_r
 	ID3D11Resource* colorOut =
 		(upscaling.settings.sharpnessDLSS > 0.0f && upscaling.sharpenerTexture) ? upscaling.sharpenerTexture->resource.get() : a_upscalingTexture;
 
-	// VR: Combined-buffer mode with extent offsets causes temporal ghosting on the right eye
-	// because DLSS's internal history buffers use extent offsets as indices.
-	// Per-eye isolation with extents at {0,0} is required.
+	// VR stereo DLSS: NGX D3D11 only accepts zero-offset subrects. Non-zero offsets return
+	// FAIL_InvalidParameter because Streamline's dlssEntry.cpp never sets
+	// NVSDK_NGX_Parameter_DLSS_Enable_Output_Subrects during context creation.
+	//
+	// Both eyes copy their color slice into per-eye intermediates so ClearHMDMask can zero
+	// outside-mask regions before DLSS sees them (prevents temporal bleed into visible pixels).
+	// Eye 0 outputs directly to colorOut (zero-offset) — no intermediate output buffer needed.
+	// Eye 1 outputs to vrIntermediateColorOut[1] then copies back to kMAIN at eyeWidthOut.
+	//
+	// Eye 1 is pre-copied before eye 0 runs: at non-DLAA scales eye 0's upscaled output
+	// extends past eyeWidthIn into eye 1's input region of kMAIN.
 	if (globals::game::isVR) {
+		auto context = globals::d3d::context;
+
 		uint32_t eyeWidthOut = (uint32_t)(screenSize.x / 2);
 		uint32_t eyeHeightOut = (uint32_t)screenSize.y;
 		uint32_t eyeWidthIn = (uint32_t)(renderSize.x / 2);
 		uint32_t eyeHeightIn = (uint32_t)renderSize.y;
 
-		upscaling.PreparePerEyeInputs(a_upscalingTexture, depthTexture.texture);
+		sl::Extent perEyeIn{ 0, 0, eyeWidthIn, eyeHeightIn };
+		sl::Extent perEyeOut{ 0, 0, eyeWidthOut, eyeHeightOut };
 
-		for (uint32_t i = 0; i < 2; ++i) {
-			sl::ViewportHandle vp = (i == 1) ? viewportRight : viewport;
-			sl::Extent extentIn{ 0, 0, eyeWidthIn, eyeHeightIn };
-			sl::Extent extentOut{ 0, 0, eyeWidthOut, eyeHeightOut };
+		bool eye0Ready = upscaling.vrIntermediateColorIn[0] &&
+		                 upscaling.vrIntermediateMotionVectors[0] && upscaling.vrIntermediateReactiveMask[0] && upscaling.vrIntermediateTransparencyMask[0];
+		bool eye1Ready = upscaling.vrIntermediateColorIn[1] && upscaling.vrIntermediateColorOut[1] &&
+		                 upscaling.vrIntermediateDepth && upscaling.vrIntermediateMotionVectors[1] &&
+		                 upscaling.vrIntermediateReactiveMask[1] && upscaling.vrIntermediateTransparencyMask[1];
 
-			EvaluateDLSS(vp, i,
-				upscaling.vrIntermediateColorIn[i]->resource.get(), upscaling.vrIntermediateColorOut[i]->resource.get(),
-				upscaling.vrIntermediateDepth[i]->resource.get(), upscaling.vrIntermediateMotionVectors[i]->resource.get(),
-				upscaling.vrIntermediateReactiveMask[i]->resource.get(), upscaling.vrIntermediateTransparencyMask[i]->resource.get(),
-				extentIn, extentOut, eyeWidthOut);
+		// Pre-copy eye 1 before eye 0 runs (overlap hazard), then clear HMD mask.
+		if (eye1Ready) {
+			D3D11_BOX rightIn = { eyeWidthIn, 0, 0, eyeWidthIn * 2, eyeHeightIn, 1 };
+			context->CopySubresourceRegion(upscaling.vrIntermediateColorIn[1]->resource.get(), 0, 0, 0, 0, a_upscalingTexture, 0, &rightIn);
+			context->CopySubresourceRegion(upscaling.vrIntermediateDepth->resource.get(), 0, 0, 0, 0, depthTexture.texture, 0, &rightIn);
+			upscaling.ClearHMDMask(upscaling.vrIntermediateColorIn[1]->uav.get(), depthTexture.depthSRV,
+				eyeWidthIn, eyeHeightIn, eyeWidthIn, 0);
 		}
 
-		upscaling.FinalizePerEyeOutputs(colorOut);
+		// Eye 0: copy left-eye slice, clear HMD mask, output directly to colorOut at offset 0.
+		if (eye0Ready) {
+			D3D11_BOX leftIn = { 0, 0, 0, eyeWidthIn, eyeHeightIn, 1 };
+			context->CopySubresourceRegion(upscaling.vrIntermediateColorIn[0]->resource.get(), 0, 0, 0, 0, a_upscalingTexture, 0, &leftIn);
+			upscaling.ClearHMDMask(upscaling.vrIntermediateColorIn[0]->uav.get(), depthTexture.depthSRV,
+				eyeWidthIn, eyeHeightIn, 0, 0);
+
+			EvaluateDLSS(viewport, 0,
+				upscaling.vrIntermediateColorIn[0]->resource.get(), colorOut,
+				depthTexture.texture,
+				upscaling.vrIntermediateMotionVectors[0]->resource.get(),
+				upscaling.vrIntermediateReactiveMask[0]->resource.get(),
+				upscaling.vrIntermediateTransparencyMask[0]->resource.get(),
+				perEyeIn, perEyeOut, eyeWidthOut);
+		}
+
+		// Eye 1: evaluate into intermediate, then copy upscaled result to kMAIN right-eye position.
+		if (eye1Ready) {
+			EvaluateDLSS(viewportRight, 1,
+				upscaling.vrIntermediateColorIn[1]->resource.get(),
+				upscaling.vrIntermediateColorOut[1]->resource.get(),
+				upscaling.vrIntermediateDepth->resource.get(),
+				upscaling.vrIntermediateMotionVectors[1]->resource.get(),
+				upscaling.vrIntermediateReactiveMask[1]->resource.get(),
+				upscaling.vrIntermediateTransparencyMask[1]->resource.get(),
+				perEyeIn, perEyeOut, eyeWidthOut);
+
+			D3D11_BOX rightOut = { 0, 0, 0, eyeWidthOut, eyeHeightOut, 1 };
+			context->CopySubresourceRegion(colorOut, 0, eyeWidthOut, 0, 0, upscaling.vrIntermediateColorOut[1]->resource.get(), 0, &rightOut);
+		}
 	} else {
 		// Non-VR: Simple full-texture upscale.
 		sl::Extent extentIn{ 0, 0, (uint)renderSize.x, (uint)renderSize.y };

--- a/src/Features/Upscaling/Streamline.cpp
+++ b/src/Features/Upscaling/Streamline.cpp
@@ -640,6 +640,9 @@ void Streamline::Upscale(ID3D11Resource* a_upscalingTexture, ID3D11Resource* a_r
 		sl::Extent perEyeIn{ 0, 0, eyeWidthIn, eyeHeightIn };
 		sl::Extent perEyeOut{ 0, 0, eyeWidthOut, eyeHeightOut };
 
+		// Both flags track the same creation pool (EnsureVRIntermediateTextures creates all
+		// intermediates atomically), so in practice eye0Ready == eye1Ready. The separate checks
+		// are kept for null-safety and to document which resources each eye path actually uses.
 		bool eye0Ready = upscaling.vrIntermediateColorIn[0] &&
 		                 upscaling.vrIntermediateMotionVectors[0] && upscaling.vrIntermediateReactiveMask[0] && upscaling.vrIntermediateTransparencyMask[0];
 		bool eye1Ready = upscaling.vrIntermediateColorIn[1] && upscaling.vrIntermediateColorOut[1] &&


### PR DESCRIPTION
NGX D3D11 requires zero-offset subrects — non-zero offsets return FAIL_InvalidParameter because Streamline's dlssEntry.cpp never sets NVSDK_NGX_Parameter_DLSS_Enable_Output_Subrects during context creation. Per-eye intermediates with zero-offset extents are therefore required.

Optimized copy strategy vs prior approach (10 ops → 8 ops):
- Eye 1 pre-copied before eye 0 runs: at non-DLAA scales eye 0's upscaled output extends past eyeWidthIn into eye 1's input region
- Eye 0 outputs directly to colorOut, eliminating its copy-back
- Only right-eye depth copy needed; eye 0 reads kMAIN depth directly
- ClearHMDMask dispatched per-eye on the intermediates before DLSS

DLSS depth and color copies are now handled entirely in Streamline::Upscale. PreparePerEyeInputs is FSR-only; its DLSS motion-vector guard and depthSrc parameter are removed. vrIntermediateDepth de-arrayed to a single field.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VR depth is now managed as a single right-eye resource, improving stability and resource handling.
  * Debug UI corrected to show Left/Right Eye Out only for non-DLSS upscalers.

* **New Features**
  * Conditional “Left/Right Eye Transparency” visualization added when transparency masks are present.

* **Refactor**
  * Streamlined VR upscaling flow and per-eye preparation to comply with stereo DLSS requirements and simplify intermediate handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->