### PR TITLE
refactor: adopt common Util and HLSL helpers

### DIFF
--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
@@ -34,8 +34,6 @@
 #include "Common/VR.hlsli"
 #include "ScreenSpaceGI/common.hlsli"
 
-#define RCP_PI (0.31830988618)
-
 Texture2D<float> srcWorkingDepth : register(t0);
 Texture2D<float4> srcNormalRoughness : register(t1);
 Texture2D<float3> srcRadiance : register(t2);  // maybe half-res
@@ -228,7 +226,7 @@ void CalculateGI(
 				float2 angleRange = -sideSign * (sideSign == -1 ? float2(angleFront, angleBack) : float2(angleBack, angleFront));
 				// The math: https://www.desmos.com/calculator/je4y5ved2j
 				// Using smoothstep for cos: https://discord.com/channels/586242553746030596/586245736413528082/1102228968247144570
-				angleRange = smoothstep(0, 1, (angleRange + n) * RCP_PI + .5);
+				angleRange = smoothstep(0, 1, (angleRange + n) * Math::INV_PI + .5);
 
 				uint2 bitsRange = uint2(round(angleRange.x * 32u), round((angleRange.y - angleRange.x) * 32u));
 				uint maskedBits = s < AORadius ? ((1 << bitsRange.y) - 1) << bitsRange.x : 0;
@@ -249,7 +247,7 @@ void CalculateGI(
 
 				// The math: https://www.desmos.com/calculator/je4y5ved2j
 				// Using smoothstep for cos: https://discord.com/channels/586242553746030596/586245736413528082/1102228968247144570
-				angleRangeGI = smoothstep(0, 1, (angleRangeGI + n) * RCP_PI + .5);
+				angleRangeGI = smoothstep(0, 1, (angleRangeGI + n) * Math::INV_PI + .5);
 
 				uint2 bitsRangeGI = uint2(round(angleRangeGI.x * 32u), round((angleRangeGI.y - angleRangeGI.x) * 32u));
 				uint maskedBitsGI = s < GIRadius ? ((1 << bitsRangeGI.y) - 1) << bitsRangeGI.x : 0;

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/StereoSyncCS.hlsl
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/StereoSyncCS.hlsl
@@ -7,6 +7,8 @@
 // ambient occlusion" https://eprints.whiterose.ac.uk/id/eprint/187713/
 
 #include "Common/FrameBuffer.hlsli"
+#include "Common/Math.hlsli"
+#include "Common/Random.hlsli"
 #include "Common/SharedData.hlsli"
 #include "Common/VR.hlsli"
 
@@ -33,8 +35,8 @@ static const int kEdgeMargin = 2;               // Neighbor offset (pixels) for 
 float BlurShadow(int2 dtid, float centerDepth)
 {
 	// Per-pixel rotation from interleaved gradient noise
-	float noise = frac(52.9829189 * frac(0.06711056 * dtid.x + 0.00583715 * dtid.y));
-	float angle = noise * 6.28318530718;
+	float noise = Random::InterleavedGradientNoise(float2(dtid));
+	float angle = noise * Math::TAU;
 	float sn, cs;
 	sincos(angle, sn, cs);
 	float2x2 rot = float2x2(cs, sn, -sn, cs);

--- a/package/Shaders/Common/Math.hlsli
+++ b/package/Shaders/Common/Math.hlsli
@@ -26,6 +26,7 @@ namespace Math
 	static const float PI = 3.1415926535897932384626433832795f;  // PI
 	static const float HALF_PI = PI * 0.5f;                      // PI / 2
 	static const float TAU = PI * 2.0f;                          // PI * 2
+	static const float INV_PI = 1.0f / PI;                       // 1 / PI
 }
 
 #endif  //__MATH_DEPENDENCY_HLSL__

--- a/package/Shaders/Sky.hlsl
+++ b/package/Shaders/Sky.hlsl
@@ -1,6 +1,7 @@
 #include "Common/Color.hlsli"
 #include "Common/FrameBuffer.hlsli"
 #include "Common/Permutation.hlsli"
+#include "Common/Random.hlsli"
 #include "Common/SharedData.hlsli"
 #include "Common/VR.hlsli"
 
@@ -270,7 +271,7 @@ PS_OUTPUT main(PS_INPUT input)
 		baseColor.xyz *= discScale;
 
 		// Tiny dither to reduce visible banding on bright gradients.
-		float ign = frac(52.9829189 * frac(dot(floor(input.Position.xy), float2(0.06711056, 0.00583715))));
+		float ign = Random::InterleavedGradientNoise(floor(input.Position.xy));
 		baseColor.xyz += (ign - 0.5) * (discScale / 255.0);
 
 		yyy = 0.0;

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -1212,9 +1212,9 @@ void PerformanceOverlay::DrawABTestSection(const std::vector<DrawCallRow>& allRo
 					// Pull structured diff entries directly from ABTestingManager (in-memory snapshots)
 					this->settingsDiff = abTestingManager->GetConfigDiffEntries();
 				} else {
-					std::filesystem::path userPath = Util::PathHelpers::GetDataPath() / "SKSE/Plugins/CommunityShaders/SettingsUser.json";
-					std::filesystem::path testPath = Util::PathHelpers::GetDataPath() / "SKSE/Plugins/CommunityShaders/SettingsTest.json";
-					this->settingsDiff = Util::FileSystem::LoadJsonDiff(userPath, testPath);
+					this->settingsDiff = Util::FileSystem::LoadJsonDiff(
+						Util::PathHelpers::GetSettingsUserPath(),
+						Util::PathHelpers::GetSettingsTestPath());
 				}
 				this->settingsDiffLoaded = true;
 			}

--- a/src/Features/RenderDoc.cpp
+++ b/src/Features/RenderDoc.cpp
@@ -186,9 +186,7 @@ void RenderDoc::DrawSettings()
 				static char commentsBuffer[kCommentsBufferSize] = { 0 };
 
 				ImGui::InputTextWithHint("##CaptureComments", "Additional comments for next capture (optional)", commentsBuffer, sizeof(commentsBuffer));
-				if (ImGui::IsItemHovered()) {
-					ImGui::SetTooltip("Additional comments will be appended to automatic metadata and embedded in the .rdc file");
-				}
+				Util::AddTooltip("Additional comments will be appended to automatic metadata and embedded in the .rdc file");
 
 				if (ImGui::Button("Create Capture")) {
 					// Check available disk space before allowing capture
@@ -245,9 +243,7 @@ void RenderDoc::DrawSettings()
 				}
 
 				ImGui::TextDisabled("Capture Directory: %s", GetCapturesDirectory().c_str());
-				if (ImGui::IsItemHovered()) {
-					ImGui::SetTooltip("Right-click to copy the directory path.");
-				}
+				Util::AddTooltip("Right-click to copy the directory path.");
 
 				if (ImGui::BeginPopupContextItem()) {
 					if (ImGui::MenuItem("Copy Directory Path")) {

--- a/src/Features/VRStereoOptimizations.cpp
+++ b/src/Features/VRStereoOptimizations.cpp
@@ -6,6 +6,7 @@
 #include "State.h"
 #include "Utils/D3D.h"
 #include "Utils/Game.h"
+#include "Utils/UI.h"
 
 #include <imgui.h>
 
@@ -42,40 +43,35 @@ void VRStereoOptimizations::SaveSettings(json& o_json)
 
 void VRStereoOptimizations::LoadSettings(json& o_json)
 {
+	auto loadClampedFloat = [&](const char* key, float& dst, float lo, float hi) {
+		if (auto it = o_json.find(key); it != o_json.end() && it->is_number())
+			dst = std::clamp(it->get<float>(), lo, hi);
+	};
+	auto loadBool = [&](const char* key, bool& dst) {
+		if (auto it = o_json.find(key); it != o_json.end() && it->is_boolean())
+			dst = it->get<bool>();
+	};
+
 	if (o_json.contains("StereoMode"))
 		settings.stereoMode = o_json["StereoMode"].get<StereoMode>();
-	if (auto it = o_json.find("DisocclusionDepthThreshold"); it != o_json.end() && it->is_number())
-		settings.disocclusionDepthThreshold = std::clamp(it->get<float>(), 0.001f, 0.1f);
-	if (auto it = o_json.find("QualityJitterOffset"); it != o_json.end() && it->is_number())
-		settings.qualityJitterOffset = std::clamp(it->get<float>(), 0.0f, 1.0f);
-	if (auto it = o_json.find("FoveatedRegionRadius"); it != o_json.end() && it->is_number())
-		settings.foveatedRegionRadius = std::clamp(it->get<float>(), 0.0f, 1.0f);
-	if (auto it = o_json.find("FoveatedRegionCenterX"); it != o_json.end() && it->is_number())
-		settings.foveatedRegionCenterX = std::clamp(it->get<float>(), 0.0f, 1.0f);
-	if (auto it = o_json.find("FoveatedRegionCenterY"); it != o_json.end() && it->is_number())
-		settings.foveatedRegionCenterY = std::clamp(it->get<float>(), 0.0f, 1.0f);
-	if (auto it = o_json.find("UseEyeTracking"); it != o_json.end() && it->is_boolean())
-		settings.useEyeTracking = it->get<bool>();
-	if (auto it = o_json.find("DebugVisualization"); it != o_json.end() && it->is_boolean())
-		settings.debugVisualization = it->get<bool>();
-	if (auto it = o_json.find("DebugSkipMerge"); it != o_json.end() && it->is_boolean())
-		settings.debugSkipMerge = it->get<bool>();
-	if (auto it = o_json.find("DebugForceAllStencil"); it != o_json.end() && it->is_boolean())
-		settings.debugForceAllStencil = it->get<bool>();
-	if (auto it = o_json.find("DebugForceAllReprojectCS"); it != o_json.end() && it->is_boolean())
-		settings.debugForceAllReprojectCS = it->get<bool>();
-	if (auto it = o_json.find("DebugDepthMap"); it != o_json.end() && it->is_boolean())
-		settings.debugDepthMap = it->get<bool>();
-	if (auto it = o_json.find("DebugFullBlendDepth"); it != o_json.end() && it->is_boolean())
-		settings.debugFullBlendDepth = it->get<bool>();
-	if (auto it = o_json.find("DebugPOMDepth"); it != o_json.end() && it->is_boolean())
-		settings.debugPOMDepth = it->get<bool>();
-	if (auto it = o_json.find("FullBlendDistance"); it != o_json.end() && it->is_number())
-		settings.fullBlendDistance = std::clamp(it->get<float>(), 0.0f, 50000.0f);
-	if (auto it = o_json.find("POMDepthScale"); it != o_json.end() && it->is_number())
-		settings.pomDepthScale = std::clamp(it->get<float>(), 0.0f, 500.0f);
-	if (auto it = o_json.find("ForwardOcclusionScale"); it != o_json.end() && it->is_number())
-		settings.forwardOcclusionScale = std::clamp(it->get<float>(), 0.0f, 10.0f);
+
+	loadClampedFloat("DisocclusionDepthThreshold", settings.disocclusionDepthThreshold, 0.001f, 0.1f);
+	loadClampedFloat("QualityJitterOffset", settings.qualityJitterOffset, 0.0f, 1.0f);
+	loadClampedFloat("FoveatedRegionRadius", settings.foveatedRegionRadius, 0.0f, 1.0f);
+	loadClampedFloat("FoveatedRegionCenterX", settings.foveatedRegionCenterX, 0.0f, 1.0f);
+	loadClampedFloat("FoveatedRegionCenterY", settings.foveatedRegionCenterY, 0.0f, 1.0f);
+	loadClampedFloat("FullBlendDistance", settings.fullBlendDistance, 0.0f, 50000.0f);
+	loadClampedFloat("POMDepthScale", settings.pomDepthScale, 0.0f, 500.0f);
+	loadClampedFloat("ForwardOcclusionScale", settings.forwardOcclusionScale, 0.0f, 10.0f);
+
+	loadBool("UseEyeTracking", settings.useEyeTracking);
+	loadBool("DebugVisualization", settings.debugVisualization);
+	loadBool("DebugSkipMerge", settings.debugSkipMerge);
+	loadBool("DebugForceAllStencil", settings.debugForceAllStencil);
+	loadBool("DebugForceAllReprojectCS", settings.debugForceAllReprojectCS);
+	loadBool("DebugDepthMap", settings.debugDepthMap);
+	loadBool("DebugFullBlendDepth", settings.debugFullBlendDepth);
+	loadBool("DebugPOMDepth", settings.debugPOMDepth);
 }
 
 void VRStereoOptimizations::RestoreDefaultSettings()
@@ -260,8 +256,7 @@ void VRStereoOptimizations::DrawSettings()
 	int currentMode = static_cast<int>(settings.stereoMode);
 	if (ImGui::Combo("Enable Stereo Reprojection", &currentMode, modeNames, IM_ARRAYSIZE(modeNames)))
 		settings.stereoMode = static_cast<StereoMode>(currentMode);
-	if (ImGui::IsItemHovered())
-		ImGui::SetTooltip("Reprojects Eye 0 (left) pixels into Eye 1 (right) using depth and motion data,\nskipping redundant full shading where the views overlap.\nReduces GPU cost in VR by shading each pixel fewer times per frame.");
+	Util::AddTooltip("Reprojects Eye 0 (left) pixels into Eye 1 (right) using depth and motion data,\nskipping redundant full shading where the views overlap.\nReduces GPU cost in VR by shading each pixel fewer times per frame.");
 
 	if (globals::game::isVR && settings.stereoMode == StereoMode::Enable && !loaded) {
 		const auto& themeSettings = Menu::GetSingleton()->GetTheme();
@@ -274,18 +269,15 @@ void VRStereoOptimizations::DrawSettings()
 	ImGui::SliderFloat("Disocclusion Depth Threshold", &settings.disocclusionDepthThreshold, 0.001f, 0.1f, "%.4f");
 
 	ImGui::SliderFloat("Forward Occlusion Scale", &settings.forwardOcclusionScale, 0.0f, 1.0f, "%.2f");
-	if (ImGui::IsItemHovered())
-		ImGui::SetTooltip("Prevents Eye 0 silhouette edges from bleeding onto Eye 1 backgrounds.\nFires when Eye 0 depth is within this fraction of Eye 1 depth (e.g. 0.5 = Eye 0 less than 2x Eye 1 depth).\nLower = more aggressive. 0 = disabled.");
+	Util::AddTooltip("Prevents Eye 0 silhouette edges from bleeding onto Eye 1 backgrounds.\nFires when Eye 0 depth is within this fraction of Eye 1 depth (e.g. 0.5 = Eye 0 less than 2x Eye 1 depth).\nLower = more aggressive. 0 = disabled.");
 
 	if (globals::state->IsDeveloperMode()) {
 		if (ImGui::TreeNode("Debug")) {
 			ImGui::SliderFloat("Full Blend Distance", &settings.fullBlendDistance, 0.0f, 10000.0f, "%.0f");
-			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip("Geometry closer than this distance (game units) is fully shaded in both eyes and bilaterally blended for 2x supersampling. 0 = disabled.");
+			Util::AddTooltip("Geometry closer than this distance (game units) is fully shaded in both eyes and bilaterally blended for 2x supersampling. 0 = disabled.");
 
 			ImGui::SliderFloat("POM Depth Scale", &settings.pomDepthScale, 0.0f, 500.0f, "%.1f");
-			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip("Scale factor for POM depth correction in stereo reprojection.\n1.0 = physical scale. Increase for more visible POM stereo depth.");
+			Util::AddTooltip("Scale factor for POM depth correction in stereo reprojection.\n1.0 = physical scale. Increase for more visible POM stereo depth.");
 			ImGui::Checkbox("Skip Pixel Reprojection", &settings.debugSkipMerge);
 			ImGui::Checkbox("Full Blend Depth View", &settings.debugFullBlendDepth);
 			ImGui::Checkbox("Debug POM Depth", &settings.debugPOMDepth);

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -131,9 +131,7 @@ void HomePageRenderer::RenderWelcomeSection()
 		ImGui::PopStyleColor(3);
 		ImGui::PopStyleVar();
 
-		if (ImGui::IsItemHovered()) {
-			ImGui::SetTooltip("Join Community Shaders Discord Server");
-		}
+		Util::AddTooltip("Join Community Shaders Discord Server");
 	} else {
 		// Fallback button when Discord icon is not available
 		float buttonWidth = DISCORD_BANNER_MIN_WIDTH * scale;
@@ -141,9 +139,7 @@ void HomePageRenderer::RenderWelcomeSection()
 		if (ImGui::Button("Join Discord Server", ImVec2(buttonWidth, 0))) {
 			ShellExecuteA(NULL, "open", DISCORD_URL, NULL, NULL, SW_SHOWNORMAL);
 		}
-		if (ImGui::IsItemHovered()) {
-			ImGui::SetTooltip("Join Community Shaders Discord Server");
-		}
+		Util::AddTooltip("Join Community Shaders Discord Server");
 	}
 
 	ImGui::PopStyleVar();

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -473,8 +473,7 @@ void EditorWindow::ShowObjectsWindow()
 								pendingDeleteWidget = widget;
 								pendingDeletePopupRequested = true;
 							}
-							if (ImGui::IsItemHovered())
-								ImGui::SetTooltip("Delete JSON file");
+							Util::AddTooltip("Delete JSON file");
 						}
 					}
 				};
@@ -972,9 +971,7 @@ void EditorWindow::RenderUI()
 				ImGui::BeginDisabled();
 				ImGui::MenuItem("Edit Current Cell Lighting");
 				ImGui::EndDisabled();
-				if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-					ImGui::SetTooltip("Only available in interior cells");
-				}
+				Util::AddTooltip("Only available in interior cells", ImGuiHoveredFlags_DelayNormal | ImGuiHoveredFlags_AllowWhenDisabled);
 			}
 
 			ImGui::Separator();
@@ -982,16 +979,12 @@ void EditorWindow::RenderUI()
 			if (ImGui::Checkbox("Auto-Apply Changes", &settings.autoApplyChanges)) {
 				Save();
 			}
-			if (ImGui::IsItemHovered()) {
-				ImGui::SetTooltip("Automatically apply weather changes to the game as you edit");
-			}
+			Util::AddTooltip("Automatically apply weather changes to the game as you edit");
 
 			if (ImGui::Checkbox("Enable Inherit From Parent", &settings.enableInheritFromParent)) {
 				Save();
 			}
-			if (ImGui::IsItemHovered()) {
-				ImGui::SetTooltip("Show inherit from parent options in weather widgets");
-			}
+			Util::AddTooltip("Show inherit from parent options in weather widgets");
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Window")) {
@@ -1004,8 +997,7 @@ void EditorWindow::RenderUI()
 			}
 			if (hdrActive) {
 				ImGui::EndDisabled();
-				if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
-					ImGui::SetTooltip("Viewport is unavailable when HDR Display is enabled");
+				Util::AddTooltip("Viewport is unavailable when HDR Display is enabled", ImGuiHoveredFlags_DelayNormal | ImGuiHoveredFlags_AllowWhenDisabled);
 			}
 			if (ImGui::Checkbox("Palette", &PaletteWindow::GetSingleton()->open)) {
 			}
@@ -1089,8 +1081,7 @@ void EditorWindow::RenderUI()
 				ImGui::PopStyleColor();
 			}
 			ImGui::PopStyleVar(2);
-			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip(canUndo ? "Undo (Ctrl+Z) - %d states" : "Undo (Ctrl+Z) - No changes to undo", (int)undoStack.size());
+			Util::AddTooltip(canUndo ? std::format("Undo (Ctrl+Z) - {} states", (int)undoStack.size()).c_str() : "Undo (Ctrl+Z) - No changes to undo");
 		}
 
 		// Right-aligned items — use SetCursorScreenPos to bypass menu bar GroupOffset
@@ -1229,23 +1220,20 @@ void EditorWindow::RenderUI()
 			bool isActive = previewMode == PreviewMode::FreeCamera || previewMode == PreviewMode::FreeCameraLocked;
 			if (DrawToggleIconButton("##FreeCamera", menu->uiIcons.freeCamera.texture, isActive, freeCameraX))
 				EnterPreviewMode(PreviewMode::FreeCamera);
-			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip(isActive ? "Exit Free Camera" : "Free Camera (scroll to adjust speed)");
+			Util::AddTooltip(isActive ? "Exit Free Camera" : "Free Camera (scroll to adjust speed)");
 		}
 		if (hasPlayMode) {
 			bool isActive = previewMode == PreviewMode::PlayMode;
 			if (DrawToggleIconButton("##PlayMode", menu->uiIcons.playMode.texture, isActive, playModeX))
 				EnterPreviewMode(PreviewMode::PlayMode);
-			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip(isActive ? "Exit Play Mode" : "Play Mode - Walk around normally");
+			Util::AddTooltip(isActive ? "Exit Play Mode" : "Play Mode - Walk around normally");
 		}
 
 		if (hasPauseButton) {
 			bool isPaused = IsTimePaused();
 			if (DrawToggleIconButton("##GlobalPauseTime", menu->uiIcons.pauseTime.texture, isPaused, pauseButtonX))
 				TogglePause();
-			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip(isPaused ? "Resume Time" : "Pause Time");
+			Util::AddTooltip(isPaused ? "Resume Time" : "Pause Time");
 		}
 
 		// Period text and time slider
@@ -1266,9 +1254,7 @@ void EditorWindow::RenderUI()
 				open = false;
 			}
 		}
-		if (ImGui::IsItemHovered()) {
-			ImGui::SetTooltip("Close Weather Editor (Esc)");
-		}
+		Util::AddTooltip("Close Weather Editor (Esc)");
 
 		ImGui::PopClipRect();  // End bottom-border clip rect
 

--- a/src/WeatherEditor/PaletteWindow.cpp
+++ b/src/WeatherEditor/PaletteWindow.cpp
@@ -86,9 +86,7 @@ void PaletteWindow::DrawColorsTab()
 				ImGui::EndPopup();
 			}
 
-			if (ImGui::IsItemHovered()) {
-				ImGui::SetTooltip("RGB: %.3f, %.3f, %.3f\nClick to copy\nRight-click to clear", color.x, color.y, color.z);
-			}
+			Util::AddTooltip(std::format("RGB: {:.3f}, {:.3f}, {:.3f}\nClick to copy\nRight-click to clear", color.x, color.y, color.z).c_str());
 		} else {
 			// Show empty favorite slot with star
 			ImVec4 emptyColor(0.2f, 0.2f, 0.2f, 1.0f);
@@ -105,9 +103,7 @@ void PaletteWindow::DrawColorsTab()
 
 			DrawIconStar(center, starSize, starColor, false);
 
-			if (ImGui::IsItemHovered()) {
-				ImGui::SetTooltip("Drag a colour here to add to favourites");
-			}
+			Util::AddTooltip("Drag a colour here to add to favourites");
 		}
 
 		// Drag-and-drop target
@@ -152,10 +148,9 @@ void PaletteWindow::DrawColorsTab()
 				ImGui::EndDragDropSource();
 			}
 
-			if (ImGui::IsItemHovered()) {
-				ImGui::SetTooltip("RGB: %.3f, %.3f, %.3f\nUsed %d times\nClick to copy",
-					entry->color.x, entry->color.y, entry->color.z, entry->useCount);
-			}
+			Util::AddTooltip(std::format("RGB: {:.3f}, {:.3f}, {:.3f}\nUsed {} times\nClick to copy",
+				entry->color.x, entry->color.y, entry->color.z, entry->useCount)
+					.c_str());
 		}
 	}
 	ImGui::Spacing();
@@ -208,10 +203,9 @@ void PaletteWindow::DrawColorsTab()
 				ImGui::EndPopup();
 			}
 
-			if (ImGui::IsItemHovered()) {
-				ImGui::SetTooltip("RGB: %.3f, %.3f, %.3f\nUsed %d times\nClick to copy\nRight-click to remove",
-					entry->color.x, entry->color.y, entry->color.z, entry->useCount);
-			}
+			Util::AddTooltip(std::format("RGB: {:.3f}, {:.3f}, {:.3f}\nUsed {} times\nClick to copy\nRight-click to remove",
+				entry->color.x, entry->color.y, entry->color.z, entry->useCount)
+					.c_str());
 
 			colorIndex++;
 		}
@@ -235,9 +229,7 @@ void PaletteWindow::DrawValuesTab()
 				ImGui::SetClipboardText(std::to_string(entry->value).c_str());
 			}
 
-			if (ImGui::IsItemHovered()) {
-				ImGui::SetTooltip("Used %d times\nClick to copy", entry->useCount);
-			}
+			Util::AddTooltip(std::format("Used {} times\nClick to copy", entry->useCount).c_str());
 		}
 	}
 	ImGui::Spacing();
@@ -277,9 +269,7 @@ void PaletteWindow::DrawValuesTab()
 				ImGui::EndPopup();
 			}
 
-			if (ImGui::IsItemHovered()) {
-				ImGui::SetTooltip("Used %d times\nClick to copy\nRight-click to remove", entry->useCount);
-			}
+			Util::AddTooltip(std::format("Used {} times\nClick to copy\nRight-click to remove", entry->useCount).c_str());
 		}
 	}
 }

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -141,9 +141,7 @@ void WeatherWidget::DrawWidget()
 				if (Util::ButtonWithFlash("Inherit All")) {
 					InheritAllFromParent();
 				}
-				if (ImGui::IsItemHovered()) {
-					ImGui::SetTooltip("Copy all parameter values from parent weather");
-				}
+				Util::AddTooltip("Copy all parameter values from parent weather");
 
 				if (!parent->IsOpen()) {
 					ImGui::SameLine();
@@ -247,9 +245,7 @@ void WeatherWidget::DrawWidget()
 								pendingReinit = true;
 							}
 						}
-						if (ImGui::IsItemHovered()) {
-							ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-						}
+						Util::AddTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
 						ImGui::SameLine();
 					}
 
@@ -268,9 +264,7 @@ void WeatherWidget::DrawWidget()
 								}
 							}
 						}
-						if (ImGui::IsItemHovered()) {
-							ImGui::SetTooltip("Open this ImageSpace for editing");
-						}
+						Util::AddTooltip("Open this ImageSpace for editing");
 					}
 
 					ImGui::PopID();
@@ -295,9 +289,7 @@ void WeatherWidget::DrawWidget()
 								pendingReinit = true;
 							}
 						}
-						if (ImGui::IsItemHovered()) {
-							ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-						}
+						Util::AddTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
 						ImGui::SameLine();
 					}
 
@@ -316,9 +308,7 @@ void WeatherWidget::DrawWidget()
 								}
 							}
 						}
-						if (ImGui::IsItemHovered()) {
-							ImGui::SetTooltip("Open this Volumetric Lighting for editing");
-						}
+						Util::AddTooltip("Open this Volumetric Lighting for editing");
 					}
 
 					ImGui::PopID();
@@ -338,9 +328,7 @@ void WeatherWidget::DrawWidget()
 							pendingReinit = true;
 						}
 					}
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-					}
+					Util::AddTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
 					ImGui::SameLine();
 				}
 
@@ -359,9 +347,7 @@ void WeatherWidget::DrawWidget()
 							}
 						}
 					}
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("Open this Precipitation for editing");
-					}
+					Util::AddTooltip("Open this Precipitation for editing");
 				}
 
 				ImGui::Spacing();
@@ -379,9 +365,7 @@ void WeatherWidget::DrawWidget()
 							pendingReinit = true;
 						}
 					}
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-					}
+					Util::AddTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
 					ImGui::SameLine();
 				}
 
@@ -400,9 +384,7 @@ void WeatherWidget::DrawWidget()
 							}
 						}
 					}
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("Open this Visual Effect for editing");
-					}
+					Util::AddTooltip("Open this Visual Effect for editing");
 				}
 
 				ImGui::Spacing();
@@ -1386,9 +1368,7 @@ void WeatherWidget::DrawProperties(std::string category, std::map<std::string, i
 					changed = true;
 				}
 			}
-			if (ImGui::IsItemHovered()) {
-				ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-			}
+			Util::AddTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
 			ImGui::SameLine();
 		}
 

--- a/src/WeatherEditor/WeatherUtils.cpp
+++ b/src/WeatherEditor/WeatherUtils.cpp
@@ -559,8 +559,7 @@ namespace TOD
 				s_todSliderTracker.OnValueChanged(valueName, values[i], currentTime);
 			}
 
-			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip("%.0f%%", factors[i] * 100.0f);
+			Util::AddTooltip(std::format("{:.0f}%", factors[i] * 100.0f).c_str());
 			ImGui::PopItemWidth();
 
 			if (!isActive)
@@ -695,8 +694,7 @@ namespace TOD
 
 			wasPopupOpen[id] = isPopupOpen;
 
-			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip("%s - %.0f%%", GetPeriodName(i), factors[i] * 100.0f);
+			Util::AddTooltip(std::format("{} - {:.0f}%", GetPeriodName(i), factors[i] * 100.0f).c_str());
 
 			ImGui::EndChild();
 		}
@@ -744,8 +742,7 @@ namespace TOD
 						changed = true;
 					}
 				}
-				if (ImGui::IsItemHovered())
-					ImGui::SetTooltip("Inherit from parent");
+				Util::AddTooltip("Inherit from parent");
 				ImGui::PopStyleVar();
 				ImGui::SameLine(0, 2 * scale);
 			}
@@ -782,8 +779,7 @@ namespace TOD
 
 			ImGui::EndDisabled();
 
-			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip("%.0f%%", factors[i] * 100.0f);
+			Util::AddTooltip(std::format("{:.0f}%", factors[i] * 100.0f).c_str());
 			ImGui::PopItemWidth();
 
 			if (!isActive || (inheritFlags && inheritFlags[i]))
@@ -845,9 +841,7 @@ namespace TOD
 			ImGui::PopStyleVar();
 			ImGui::PopStyleColor(2);
 
-			if (ImGui::IsItemHovered()) {
-				ImGui::SetTooltip("Inherit from parent weather");
-			}
+			Util::AddTooltip("Inherit from parent weather");
 		}
 
 		if (!anyActive)
@@ -1041,9 +1035,7 @@ namespace TOD
 			ImGui::PopStyleVar();
 			ImGui::PopStyleColor(2);
 
-			if (ImGui::IsItemHovered()) {
-				ImGui::SetTooltip("Inherit from parent weather");
-			}
+			Util::AddTooltip("Inherit from parent weather");
 		}
 
 		ImGui::TableSetColumnIndex(1);
@@ -1101,8 +1093,7 @@ namespace TOD
 			if (ImGui::SliderInt(id.c_str(), &values[i], -127, 127))
 				changed = true;
 
-			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip("%.0f%%", factors[i] * 100.0f);
+			Util::AddTooltip(std::format("{:.0f}%", factors[i] * 100.0f).c_str());
 
 			ImGui::PopItemWidth();
 

--- a/src/WeatherEditor/Widget.cpp
+++ b/src/WeatherEditor/Widget.cpp
@@ -324,8 +324,7 @@ void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSav
 		}
 		if (isLocked)
 			ImGui::PopStyleColor(2);
-		if (ImGui::IsItemHovered())
-			ImGui::SetTooltip(isLocked ? "Unlock Weather" : "Force This Weather");
+		Util::AddTooltip(isLocked ? "Unlock Weather" : "Force This Weather");
 	};
 
 	auto drawUnsavedIndicator = [&]() {
@@ -333,8 +332,7 @@ void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSav
 			return;
 		ImGui::SameLine();
 		ImGui::TextColored(menu->GetTheme().StatusPalette.Warning, "(UNSAVED CHANGES)");
-		if (ImGui::IsItemHovered())
-			ImGui::SetTooltip("Unsaved changes - click save to keep");
+		Util::AddTooltip("Unsaved changes - click save to keep");
 	};
 
 	if (useIcons) {
@@ -357,8 +355,7 @@ void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSav
 			ImGui::SameLine();
 			if (ImGui::ImageButton((std::string(searchId) + suffix).c_str(), texture, buttonSize))
 				callback();
-			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip("%s", tooltip);
+			Util::AddTooltip(tooltip);
 		};
 
 		// Apply button
@@ -369,8 +366,7 @@ void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSav
 				ImGui::SameLine();
 				if (ImGui::Button("Apply"))
 					ApplyChanges();
-				if (ImGui::IsItemHovered())
-					ImGui::SetTooltip("Apply changes to the game");
+				Util::AddTooltip("Apply changes to the game");
 			}
 		}
 
@@ -387,8 +383,7 @@ void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSav
 					if (ImGui::ImageButton((std::string(searchId) + "_Delete").c_str(), menu->uiIcons.deleteSettings.texture, buttonSize))
 						ImGui::OpenPopup("DeleteConfirmation");
 				}
-				if (ImGui::IsItemHovered())
-					ImGui::SetTooltip("Delete saved file");
+				Util::AddTooltip("Delete saved file");
 			}
 		}
 
@@ -422,8 +417,7 @@ void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSav
 				if (ImGui::Button(label, size))
 					callback();
 			}
-			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip("%s", tooltip);
+			Util::AddTooltip(tooltip);
 		};
 
 		auto textButton = [&](const char* label, const char* tooltip, auto callback) {
@@ -433,8 +427,7 @@ void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSav
 			size.y = buttonHeight;
 			if (Util::ButtonWithFlash(label, size))
 				callback();
-			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip("%s", tooltip);
+			Util::AddTooltip(tooltip);
 		};
 
 		// Apply button
@@ -459,8 +452,7 @@ void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSav
 	if (showApply && RequiresManualApply() && editorWindow->settings.autoApplyChanges && menu) {
 		ImGui::SameLine();
 		ImGui::TextColored(menu->GetTheme().StatusPalette.Warning, "(Changes require manual apply)");
-		if (ImGui::IsItemHovered())
-			ImGui::SetTooltip("This form type is only re-read by the engine on weather reinit.\nAuto-apply is disabled - use the Apply button.");
+		Util::AddTooltip("This form type is only re-read by the engine on weather reinit.\nAuto-apply is disabled - use the Apply button.");
 	}
 
 	ImGui::Separator();


### PR DESCRIPTION
Maintenance-only refactor; no functionality changes. Unifies duplicated logic onto existing helpers in src/Utils/ and package/Shaders/Common/.

HLSL:
- Add Math::INV_PI; replace local RCP_PI macro in gi.cs.hlsl.
- Replace inline TAU literal in StereoSyncCS with Math::TAU.
- Replace local InterleavedGradientNoise reimplementations in Sky.hlsl and StereoSyncCS with Random::InterleavedGradientNoise.

C++:
- VRStereoOptimizations: collapse 17-line JSON LoadSettings boilerplate to two file-local lambdas; preserves clamp ranges and key names exactly.
- PerformanceOverlay: use Util::PathHelpers::GetSettingsUserPath / GetSettingsTestPath instead of hand-built paths.
- VRStereoOptimizations, RenderDoc, HomePageRenderer, and all 5 WeatherEditor files: migrate raw IsItemHovered/SetTooltip pattern to Util::AddTooltip (43 sites total). Migrated tooltips gain the project-standard DelayNormal hover and viewport-aware positioning, matching the rest of the UI. Two AllowWhenDisabled sites preserve that flag combined with DelayNormal. Sites with dynamic string content that need hover-guarded perf are left as-is.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized tooltip behavior across weather editor and UI elements for improved consistency.
  * Simplified shader noise generation and mathematical operations for better code maintainability.

* **Bug Fixes**
  * Corrected file path resolution for settings fallback loading in the performance overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->