### PR TITLE
fix(weather-editor): write VR precipitation settings through VR runtime

### DIFF
--- a/src/Utils/Game.h
+++ b/src/Utils/Game.h
@@ -2,6 +2,11 @@
 
 #pragma once
 
+namespace globals::game
+{
+	extern bool isVR;
+}
+
 /**
  @def GET_INSTANCE_MEMBER
  @brief Set variable in current namespace based on instance member from GetRuntimeData or GetVRRuntimeData.
@@ -27,6 +32,21 @@
  */
 #define GET_INSTANCE_MEMBER_PTR(a_value, a_source) \
 	&(!REL::Module::IsVR() ? a_source->GetRuntimeData().a_value : a_source->GetVRRuntimeData().a_value)
+
+/**
+ @def GET_SHADER_PARTICLE_SETTING
+ @brief Set variable in current namespace to a shader particle setting, using the correct flat/VR storage.
+
+ @warning Only for RE::BGSShaderParticleGeometryData. In VR, particle settings are stored in
+          data[id].value instead of directly in data[id].
+
+ @param a_value The local variable name to create.
+ @param a_source The BGSShaderParticleGeometryData instance.
+ @param a_id The BGSShaderParticleGeometryData::DataID setting.
+ @result The a_value will be set as a variable in the current namespace.
+ */
+#define GET_SHADER_PARTICLE_SETTING(a_value, a_source, a_id) \
+	auto& a_value = !globals::game::isVR ? (a_source)->GetRuntimeData().data[static_cast<uint32_t>(a_id)] : (a_source)->GetVRRuntimeData().data[static_cast<uint32_t>(a_id)].value;
 
 namespace Util
 {

--- a/src/Utils/Game.h
+++ b/src/Utils/Game.h
@@ -2,11 +2,6 @@
 
 #pragma once
 
-namespace globals::game
-{
-	extern bool isVR;
-}
-
 /**
  @def GET_INSTANCE_MEMBER
  @brief Set variable in current namespace based on instance member from GetRuntimeData or GetVRRuntimeData.
@@ -18,7 +13,7 @@ namespace globals::game
  @result The a_value will be set as a variable in the current namespace. (e.g., auto& renderTargets = state->renderTargets;)
  */
 #define GET_INSTANCE_MEMBER(a_value, a_source) \
-	auto& a_value = !globals::game::isVR ? a_source->GetRuntimeData().a_value : a_source->GetVRRuntimeData().a_value;
+	auto& a_value = !REL::Module::IsVR() ? a_source->GetRuntimeData().a_value : a_source->GetVRRuntimeData().a_value;
 
 /**
  @def GET_INSTANCE_MEMBER_PTR
@@ -31,22 +26,7 @@ namespace globals::game
  @result The a_value will be returned as a refptr. (e.g., &state->renderTargets;)
  */
 #define GET_INSTANCE_MEMBER_PTR(a_value, a_source) \
-	&(!globals::game::isVR ? a_source->GetRuntimeData().a_value : a_source->GetVRRuntimeData().a_value)
-
-/**
- @def GET_SHADER_PARTICLE_SETTING
- @brief Set variable in current namespace to a shader particle setting, using the correct flat/VR storage.
-
- @warning Only for RE::BGSShaderParticleGeometryData. In VR, particle settings are stored in
-          data[id].value instead of directly in data[id].
-
- @param a_value The local variable name to create.
- @param a_source The BGSShaderParticleGeometryData instance.
- @param a_id The BGSShaderParticleGeometryData::DataID setting.
- @result The a_value will be set as a variable in the current namespace.
- */
-#define GET_SHADER_PARTICLE_SETTING(a_value, a_source, a_id) \
-	auto& a_value = !globals::game::isVR ? (a_source)->GetRuntimeData().data[static_cast<uint32_t>(a_id)] : (a_source)->GetVRRuntimeData().data[static_cast<uint32_t>(a_id)].value;
+	&(!REL::Module::IsVR() ? a_source->GetRuntimeData().a_value : a_source->GetVRRuntimeData().a_value)
 
 namespace Util
 {

--- a/src/Utils/Game.h
+++ b/src/Utils/Game.h
@@ -18,7 +18,7 @@ namespace globals::game
  @result The a_value will be set as a variable in the current namespace. (e.g., auto& renderTargets = state->renderTargets;)
  */
 #define GET_INSTANCE_MEMBER(a_value, a_source) \
-	auto& a_value = !REL::Module::IsVR() ? a_source->GetRuntimeData().a_value : a_source->GetVRRuntimeData().a_value;
+	auto& a_value = !globals::game::isVR ? a_source->GetRuntimeData().a_value : a_source->GetVRRuntimeData().a_value;
 
 /**
  @def GET_INSTANCE_MEMBER_PTR
@@ -31,7 +31,7 @@ namespace globals::game
  @result The a_value will be returned as a refptr. (e.g., &state->renderTargets;)
  */
 #define GET_INSTANCE_MEMBER_PTR(a_value, a_source) \
-	&(!REL::Module::IsVR() ? a_source->GetRuntimeData().a_value : a_source->GetVRRuntimeData().a_value)
+	&(!globals::game::isVR ? a_source->GetRuntimeData().a_value : a_source->GetVRRuntimeData().a_value)
 
 /**
  @def GET_SHADER_PARTICLE_SETTING

--- a/src/Utils/Game.h
+++ b/src/Utils/Game.h
@@ -2,6 +2,11 @@
 
 #pragma once
 
+namespace globals::game
+{
+	extern bool isVR;
+}
+
 /**
  @def GET_INSTANCE_MEMBER
  @brief Set variable in current namespace based on instance member from GetRuntimeData or GetVRRuntimeData.
@@ -13,7 +18,7 @@
  @result The a_value will be set as a variable in the current namespace. (e.g., auto& renderTargets = state->renderTargets;)
  */
 #define GET_INSTANCE_MEMBER(a_value, a_source) \
-	auto& a_value = !REL::Module::IsVR() ? a_source->GetRuntimeData().a_value : a_source->GetVRRuntimeData().a_value;
+	auto& a_value = !globals::game::isVR ? a_source->GetRuntimeData().a_value : a_source->GetVRRuntimeData().a_value;
 
 /**
  @def GET_INSTANCE_MEMBER_PTR
@@ -26,7 +31,22 @@
  @result The a_value will be returned as a refptr. (e.g., &state->renderTargets;)
  */
 #define GET_INSTANCE_MEMBER_PTR(a_value, a_source) \
-	&(!REL::Module::IsVR() ? a_source->GetRuntimeData().a_value : a_source->GetVRRuntimeData().a_value)
+	&(!globals::game::isVR ? a_source->GetRuntimeData().a_value : a_source->GetVRRuntimeData().a_value)
+
+/**
+ @def GET_SHADER_PARTICLE_SETTING
+ @brief Set variable in current namespace to a shader particle setting, using the correct flat/VR storage.
+
+ @warning Only for RE::BGSShaderParticleGeometryData. In VR, particle settings are stored in
+          data[id].value instead of directly in data[id].
+
+ @param a_value The local variable name to create.
+ @param a_source The BGSShaderParticleGeometryData instance.
+ @param a_id The BGSShaderParticleGeometryData::DataID setting.
+ @result The a_value will be set as a variable in the current namespace.
+ */
+#define GET_SHADER_PARTICLE_SETTING(a_value, a_source, a_id) \
+	auto& a_value = !globals::game::isVR ? (a_source)->GetRuntimeData().data[static_cast<uint32_t>(a_id)] : (a_source)->GetVRRuntimeData().data[static_cast<uint32_t>(a_id)].value;
 
 namespace Util
 {

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -6,39 +6,6 @@
 #include "RE/N/NiSourceTexture.h"
 #include "Utils/Game.h"
 
-namespace
-{
-	using PrecipitationData = RE::BGSShaderParticleGeometryData;
-	using DataID = PrecipitationData::DataID;
-	using SettingValue = PrecipitationData::SETTING_VALUE;
-
-	void SetSettingValue(PrecipitationData* precipitation, DataID id, SettingValue value)
-	{
-		const auto index = static_cast<uint32_t>(id);
-		if (REL::Module::IsVR()) {
-			precipitation->GetVRRuntimeData().data[index].value = value;
-			return;
-		}
-
-		precipitation->GetRuntimeData().data[index] = value;
-	}
-
-	void SetSetting(PrecipitationData* precipitation, DataID id, float value)
-	{
-		SettingValue setting{};
-		setting.f = value;
-		SetSettingValue(precipitation, id, setting);
-	}
-
-	void SetSetting(PrecipitationData* precipitation, DataID id, uint32_t value)
-	{
-		SettingValue setting{};
-		setting.i = value;
-		SetSettingValue(precipitation, id, setting);
-	}
-
-}
-
 void PrecipitationWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
@@ -239,18 +206,32 @@ void PrecipitationWidget::ApplyChanges()
 	if (!precipitation)
 		return;
 
-	SetSetting(precipitation, DataID::kGravityVelocity, settings.gravityVelocity);
-	SetSetting(precipitation, DataID::kRotationVelocity, settings.rotationVelocity);
-	SetSetting(precipitation, DataID::kParticleSizeX, settings.particleSizeX);
-	SetSetting(precipitation, DataID::kParticleSizeY, settings.particleSizeY);
-	SetSetting(precipitation, DataID::kCenterOffsetMin, settings.centerOffsetMin);
-	SetSetting(precipitation, DataID::kCenterOffsetMax, settings.centerOffsetMax);
-	SetSetting(precipitation, DataID::kStartRotationRange, settings.startRotationRange);
-	SetSetting(precipitation, DataID::kNumSubtexturesX, settings.numSubtexturesX);
-	SetSetting(precipitation, DataID::kNumSubtexturesY, settings.numSubtexturesY);
-	SetSetting(precipitation, DataID::kParticleType, settings.particleType);
-	SetSetting(precipitation, DataID::kBoxSize, settings.boxSize);
-	SetSetting(precipitation, DataID::kParticleDensity, settings.particleDensity);
+	using DataID = RE::BGSShaderParticleGeometryData::DataID;
+
+	GET_SHADER_PARTICLE_SETTING(gravityVelocity, precipitation, DataID::kGravityVelocity)
+	gravityVelocity.f = settings.gravityVelocity;
+	GET_SHADER_PARTICLE_SETTING(rotationVelocity, precipitation, DataID::kRotationVelocity)
+	rotationVelocity.f = settings.rotationVelocity;
+	GET_SHADER_PARTICLE_SETTING(particleSizeX, precipitation, DataID::kParticleSizeX)
+	particleSizeX.f = settings.particleSizeX;
+	GET_SHADER_PARTICLE_SETTING(particleSizeY, precipitation, DataID::kParticleSizeY)
+	particleSizeY.f = settings.particleSizeY;
+	GET_SHADER_PARTICLE_SETTING(centerOffsetMin, precipitation, DataID::kCenterOffsetMin)
+	centerOffsetMin.f = settings.centerOffsetMin;
+	GET_SHADER_PARTICLE_SETTING(centerOffsetMax, precipitation, DataID::kCenterOffsetMax)
+	centerOffsetMax.f = settings.centerOffsetMax;
+	GET_SHADER_PARTICLE_SETTING(startRotationRange, precipitation, DataID::kStartRotationRange)
+	startRotationRange.f = settings.startRotationRange;
+	GET_SHADER_PARTICLE_SETTING(numSubtexturesX, precipitation, DataID::kNumSubtexturesX)
+	numSubtexturesX.i = settings.numSubtexturesX;
+	GET_SHADER_PARTICLE_SETTING(numSubtexturesY, precipitation, DataID::kNumSubtexturesY)
+	numSubtexturesY.i = settings.numSubtexturesY;
+	GET_SHADER_PARTICLE_SETTING(particleType, precipitation, DataID::kParticleType)
+	particleType.i = settings.particleType;
+	GET_SHADER_PARTICLE_SETTING(boxSize, precipitation, DataID::kBoxSize)
+	boxSize.f = settings.boxSize;
+	GET_SHADER_PARTICLE_SETTING(particleDensity, precipitation, DataID::kParticleDensity)
+	particleDensity.f = settings.particleDensity;
 	GET_INSTANCE_MEMBER(particleTexture, precipitation)
 	particleTexture.textureName = settings.particleTexture.c_str();
 	ApplyLiveParticleTexture(settings.particleTexture);

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -4,6 +4,40 @@
 #include "Globals.h"
 #include "RE/B/BSShaderManager.h"
 #include "RE/N/NiSourceTexture.h"
+#include "Utils/Game.h"
+
+namespace
+{
+	using PrecipitationData = RE::BGSShaderParticleGeometryData;
+	using DataID = PrecipitationData::DataID;
+	using SettingValue = PrecipitationData::SETTING_VALUE;
+
+	void SetSettingValue(PrecipitationData* precipitation, DataID id, SettingValue value)
+	{
+		const auto index = static_cast<uint32_t>(id);
+		if (REL::Module::IsVR()) {
+			precipitation->GetVRRuntimeData().data[index].value = value;
+			return;
+		}
+
+		precipitation->GetRuntimeData().data[index] = value;
+	}
+
+	void SetSetting(PrecipitationData* precipitation, DataID id, float value)
+	{
+		SettingValue setting{};
+		setting.f = value;
+		SetSettingValue(precipitation, id, setting);
+	}
+
+	void SetSetting(PrecipitationData* precipitation, DataID id, uint32_t value)
+	{
+		SettingValue setting{};
+		setting.i = value;
+		SetSettingValue(precipitation, id, setting);
+	}
+
+}
 
 void PrecipitationWidget::DrawWidget()
 {
@@ -166,8 +200,6 @@ void PrecipitationWidget::LoadFromGameSettings()
 	if (!precipitation)
 		return;
 
-	auto& runtime = precipitation->GetRuntimeData();
-
 	settings.gravityVelocity = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kGravityVelocity).f;
 	settings.rotationVelocity = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kRotationVelocity).f;
 	settings.particleSizeX = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kParticleSizeX).f;
@@ -180,7 +212,8 @@ void PrecipitationWidget::LoadFromGameSettings()
 	settings.particleType = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kParticleType).i;
 	settings.boxSize = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kBoxSize).f;
 	settings.particleDensity = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kParticleDensity).f;
-	settings.particleTexture = runtime.particleTexture.textureName.c_str();
+	GET_INSTANCE_MEMBER(particleTexture, precipitation)
+	settings.particleTexture = particleTexture.textureName.c_str();
 }
 
 void PrecipitationWidget::SaveSettings()
@@ -206,21 +239,20 @@ void PrecipitationWidget::ApplyChanges()
 	if (!precipitation)
 		return;
 
-	auto& runtime = precipitation->GetRuntimeData();
-
-	runtime.data[static_cast<uint32_t>(RE::BGSShaderParticleGeometryData::DataID::kGravityVelocity)].f = settings.gravityVelocity;
-	runtime.data[static_cast<uint32_t>(RE::BGSShaderParticleGeometryData::DataID::kRotationVelocity)].f = settings.rotationVelocity;
-	runtime.data[static_cast<uint32_t>(RE::BGSShaderParticleGeometryData::DataID::kParticleSizeX)].f = settings.particleSizeX;
-	runtime.data[static_cast<uint32_t>(RE::BGSShaderParticleGeometryData::DataID::kParticleSizeY)].f = settings.particleSizeY;
-	runtime.data[static_cast<uint32_t>(RE::BGSShaderParticleGeometryData::DataID::kCenterOffsetMin)].f = settings.centerOffsetMin;
-	runtime.data[static_cast<uint32_t>(RE::BGSShaderParticleGeometryData::DataID::kCenterOffsetMax)].f = settings.centerOffsetMax;
-	runtime.data[static_cast<uint32_t>(RE::BGSShaderParticleGeometryData::DataID::kStartRotationRange)].f = settings.startRotationRange;
-	runtime.data[static_cast<uint32_t>(RE::BGSShaderParticleGeometryData::DataID::kNumSubtexturesX)].i = settings.numSubtexturesX;
-	runtime.data[static_cast<uint32_t>(RE::BGSShaderParticleGeometryData::DataID::kNumSubtexturesY)].i = settings.numSubtexturesY;
-	runtime.data[static_cast<uint32_t>(RE::BGSShaderParticleGeometryData::DataID::kParticleType)].i = settings.particleType;
-	runtime.data[static_cast<uint32_t>(RE::BGSShaderParticleGeometryData::DataID::kBoxSize)].f = settings.boxSize;
-	runtime.data[static_cast<uint32_t>(RE::BGSShaderParticleGeometryData::DataID::kParticleDensity)].f = settings.particleDensity;
-	runtime.particleTexture.textureName = settings.particleTexture.c_str();
+	SetSetting(precipitation, DataID::kGravityVelocity, settings.gravityVelocity);
+	SetSetting(precipitation, DataID::kRotationVelocity, settings.rotationVelocity);
+	SetSetting(precipitation, DataID::kParticleSizeX, settings.particleSizeX);
+	SetSetting(precipitation, DataID::kParticleSizeY, settings.particleSizeY);
+	SetSetting(precipitation, DataID::kCenterOffsetMin, settings.centerOffsetMin);
+	SetSetting(precipitation, DataID::kCenterOffsetMax, settings.centerOffsetMax);
+	SetSetting(precipitation, DataID::kStartRotationRange, settings.startRotationRange);
+	SetSetting(precipitation, DataID::kNumSubtexturesX, settings.numSubtexturesX);
+	SetSetting(precipitation, DataID::kNumSubtexturesY, settings.numSubtexturesY);
+	SetSetting(precipitation, DataID::kParticleType, settings.particleType);
+	SetSetting(precipitation, DataID::kBoxSize, settings.boxSize);
+	SetSetting(precipitation, DataID::kParticleDensity, settings.particleDensity);
+	GET_INSTANCE_MEMBER(particleTexture, precipitation)
+	particleTexture.textureName = settings.particleTexture.c_str();
 	ApplyLiveParticleTexture(settings.particleTexture);
 	Widget::ForceCurrentWeatherReinit();
 }

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -208,18 +208,30 @@ void PrecipitationWidget::ApplyChanges()
 
 	using DataID = RE::BGSShaderParticleGeometryData::DataID;
 
-	precipitation->GetSettingRef(DataID::kGravityVelocity).f = settings.gravityVelocity;
-	precipitation->GetSettingRef(DataID::kRotationVelocity).f = settings.rotationVelocity;
-	precipitation->GetSettingRef(DataID::kParticleSizeX).f = settings.particleSizeX;
-	precipitation->GetSettingRef(DataID::kParticleSizeY).f = settings.particleSizeY;
-	precipitation->GetSettingRef(DataID::kCenterOffsetMin).f = settings.centerOffsetMin;
-	precipitation->GetSettingRef(DataID::kCenterOffsetMax).f = settings.centerOffsetMax;
-	precipitation->GetSettingRef(DataID::kStartRotationRange).f = settings.startRotationRange;
-	precipitation->GetSettingRef(DataID::kNumSubtexturesX).i = settings.numSubtexturesX;
-	precipitation->GetSettingRef(DataID::kNumSubtexturesY).i = settings.numSubtexturesY;
-	precipitation->GetSettingRef(DataID::kParticleType).i = settings.particleType;
-	precipitation->GetSettingRef(DataID::kBoxSize).f = settings.boxSize;
-	precipitation->GetSettingRef(DataID::kParticleDensity).f = settings.particleDensity;
+	GET_SHADER_PARTICLE_SETTING(gravityVelocity, precipitation, DataID::kGravityVelocity)
+	gravityVelocity.f = settings.gravityVelocity;
+	GET_SHADER_PARTICLE_SETTING(rotationVelocity, precipitation, DataID::kRotationVelocity)
+	rotationVelocity.f = settings.rotationVelocity;
+	GET_SHADER_PARTICLE_SETTING(particleSizeX, precipitation, DataID::kParticleSizeX)
+	particleSizeX.f = settings.particleSizeX;
+	GET_SHADER_PARTICLE_SETTING(particleSizeY, precipitation, DataID::kParticleSizeY)
+	particleSizeY.f = settings.particleSizeY;
+	GET_SHADER_PARTICLE_SETTING(centerOffsetMin, precipitation, DataID::kCenterOffsetMin)
+	centerOffsetMin.f = settings.centerOffsetMin;
+	GET_SHADER_PARTICLE_SETTING(centerOffsetMax, precipitation, DataID::kCenterOffsetMax)
+	centerOffsetMax.f = settings.centerOffsetMax;
+	GET_SHADER_PARTICLE_SETTING(startRotationRange, precipitation, DataID::kStartRotationRange)
+	startRotationRange.f = settings.startRotationRange;
+	GET_SHADER_PARTICLE_SETTING(numSubtexturesX, precipitation, DataID::kNumSubtexturesX)
+	numSubtexturesX.i = settings.numSubtexturesX;
+	GET_SHADER_PARTICLE_SETTING(numSubtexturesY, precipitation, DataID::kNumSubtexturesY)
+	numSubtexturesY.i = settings.numSubtexturesY;
+	GET_SHADER_PARTICLE_SETTING(particleType, precipitation, DataID::kParticleType)
+	particleType.i = settings.particleType;
+	GET_SHADER_PARTICLE_SETTING(boxSize, precipitation, DataID::kBoxSize)
+	boxSize.f = settings.boxSize;
+	GET_SHADER_PARTICLE_SETTING(particleDensity, precipitation, DataID::kParticleDensity)
+	particleDensity.f = settings.particleDensity;
 	GET_INSTANCE_MEMBER(particleTexture, precipitation)
 	particleTexture.textureName = settings.particleTexture.c_str();
 	ApplyLiveParticleTexture(settings.particleTexture);

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -208,30 +208,18 @@ void PrecipitationWidget::ApplyChanges()
 
 	using DataID = RE::BGSShaderParticleGeometryData::DataID;
 
-	GET_SHADER_PARTICLE_SETTING(gravityVelocity, precipitation, DataID::kGravityVelocity)
-	gravityVelocity.f = settings.gravityVelocity;
-	GET_SHADER_PARTICLE_SETTING(rotationVelocity, precipitation, DataID::kRotationVelocity)
-	rotationVelocity.f = settings.rotationVelocity;
-	GET_SHADER_PARTICLE_SETTING(particleSizeX, precipitation, DataID::kParticleSizeX)
-	particleSizeX.f = settings.particleSizeX;
-	GET_SHADER_PARTICLE_SETTING(particleSizeY, precipitation, DataID::kParticleSizeY)
-	particleSizeY.f = settings.particleSizeY;
-	GET_SHADER_PARTICLE_SETTING(centerOffsetMin, precipitation, DataID::kCenterOffsetMin)
-	centerOffsetMin.f = settings.centerOffsetMin;
-	GET_SHADER_PARTICLE_SETTING(centerOffsetMax, precipitation, DataID::kCenterOffsetMax)
-	centerOffsetMax.f = settings.centerOffsetMax;
-	GET_SHADER_PARTICLE_SETTING(startRotationRange, precipitation, DataID::kStartRotationRange)
-	startRotationRange.f = settings.startRotationRange;
-	GET_SHADER_PARTICLE_SETTING(numSubtexturesX, precipitation, DataID::kNumSubtexturesX)
-	numSubtexturesX.i = settings.numSubtexturesX;
-	GET_SHADER_PARTICLE_SETTING(numSubtexturesY, precipitation, DataID::kNumSubtexturesY)
-	numSubtexturesY.i = settings.numSubtexturesY;
-	GET_SHADER_PARTICLE_SETTING(particleType, precipitation, DataID::kParticleType)
-	particleType.i = settings.particleType;
-	GET_SHADER_PARTICLE_SETTING(boxSize, precipitation, DataID::kBoxSize)
-	boxSize.f = settings.boxSize;
-	GET_SHADER_PARTICLE_SETTING(particleDensity, precipitation, DataID::kParticleDensity)
-	particleDensity.f = settings.particleDensity;
+	precipitation->GetSettingRef(DataID::kGravityVelocity).f = settings.gravityVelocity;
+	precipitation->GetSettingRef(DataID::kRotationVelocity).f = settings.rotationVelocity;
+	precipitation->GetSettingRef(DataID::kParticleSizeX).f = settings.particleSizeX;
+	precipitation->GetSettingRef(DataID::kParticleSizeY).f = settings.particleSizeY;
+	precipitation->GetSettingRef(DataID::kCenterOffsetMin).f = settings.centerOffsetMin;
+	precipitation->GetSettingRef(DataID::kCenterOffsetMax).f = settings.centerOffsetMax;
+	precipitation->GetSettingRef(DataID::kStartRotationRange).f = settings.startRotationRange;
+	precipitation->GetSettingRef(DataID::kNumSubtexturesX).i = settings.numSubtexturesX;
+	precipitation->GetSettingRef(DataID::kNumSubtexturesY).i = settings.numSubtexturesY;
+	precipitation->GetSettingRef(DataID::kParticleType).i = settings.particleType;
+	precipitation->GetSettingRef(DataID::kBoxSize).f = settings.boxSize;
+	precipitation->GetSettingRef(DataID::kParticleDensity).f = settings.particleDensity;
 	GET_INSTANCE_MEMBER(particleTexture, precipitation)
 	particleTexture.textureName = settings.particleTexture.c_str();
 	ApplyLiveParticleTexture(settings.particleTexture);


### PR DESCRIPTION
- Issue: 
Fixes giant snow flakes/ice crystals appearing in VR when Weather Editor is active in VR.

- Reason: 
BGSShaderParticleGeometryData uses different particle setting layouts in flat and VR. In flat, each entry is 4 bytes while in VR each entry is 8 bytes. The editor reads these values with GetSettingValue(), which already handles both layouts correctly. But PrecipitationWidget.cpp wrote changes back through GetRuntimeData().data[...], which is the flat 4-byte path. In VR this can corrupt precipitation values like particle size or density.

- Fix:
Precipitation settings now write through VR-aware helper. In VR it writes GetVRRuntimeData().data[i].value; in flat it keeps using GetRuntimeData().data[i]. Particle texture access is also VR-aware now.  

Pics (winterhold in front of frozen heath) - weather as indicated in pics

RC3:

<img width="1975" height="1921" alt="rc3" src="https://github.com/user-attachments/assets/83c90b5c-2c8d-4eeb-b730-0ce0eab0b7c0" />


this PR:
<img width="1902" height="1897" alt="pr" src="https://github.com/user-attachments/assets/954c00cb-df41-47d6-8b96-b8e58a233674" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Refactored precipitation widget to use setting accessors for data access and configuration updates.
  * Replaced VR detection mechanism with a shared boolean flag system for centralized VR state management.
  * Updated shader particle geometry data access patterns.
  * Modified particle texture handling and live updates in precipitation settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->