### PR TITLE
chore(debug): name D3D11 resources for RenderDoc

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -498,6 +498,13 @@ Follow conventional commit format for consistency:
 -   **Single Responsibility**: Each feature class should handle one graphics technique only
 -   **Function Complexity**: Keep rendering functions focused; extract complex GPU operations into separate methods
 -   **Resource Management**: Always pair graphics resource creation with proper cleanup (RAII)
+-   **D3D11 Resource Naming**: Every D3D11 resource must be named for RenderDoc debuggability. Use
+    `Util::SetResourceName(ptr, "Feature::ResourceDescription")` after raw `device->Create*` calls.
+    For wrapper types (`Texture2D`, `Buffer`, `ConstantBuffer`, etc. in `Buffer.h`), pass the name
+    to the constructor and views are named automatically. Convention: `"Feature::Name"` for the
+    resource, `"Feature::Name SRV"` / `"Feature::Name UAV"` etc. for views (handled automatically
+    by the wrappers). The canonical implementation lives in `Util::SetResourceName` (`Utils/D3D.cpp`);
+    never duplicate the GUID or re-implement the call inline.
 
 ### Common Pitfalls to Avoid
 
@@ -509,3 +516,4 @@ Follow conventional commit format for consistency:
 -   **Buffer Conflicts**: Check hlslkit buffer scanning to avoid GPU register conflicts that cause rendering issues
 -   **Graphics State Corruption**: Minimize DirectX state changes; restore state after modifications
 -   **Thread Safety**: Graphics operations must consider Skyrim's rendering thread vs game logic thread
+-   **DRY Violations in Cross-Cutting Refactors**: When adding a utility pattern across many files (e.g., resource naming, debug hooks), check whether the implementation exists in multiple places before writing a new one. For example, `Buffer.h` helper classes and raw `device->Create*` callsites both need `SetResourceName` — ensure they share a single implementation, not duplicate GUID definitions or parallel helper functions. Use a forward declaration in headers to delegate to the canonical implementation in `Utils/D3D.cpp` rather than re-implementing inline.

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -1,12 +1,32 @@
 #pragma once
 
 #include <d3d11.h>
+#include <string>
 
 #include <Windows.Foundation.h>
 #include <stdio.h>
 #include <winrt/base.h>
 #include <wrl\client.h>
 #include <wrl\wrappers\corewrappers.h>
+
+// Forward declaration — keeps Buffer.h free of Utils/D3D.h's game-type dependencies
+namespace Util
+{
+	void SetResourceName(ID3D11DeviceChild* Resource, const char* Format, ...);
+}
+
+namespace detail
+{
+	inline void SetD3DName(ID3D11DeviceChild* resource, const std::string& name, const char* suffix = nullptr)
+	{
+		if (!resource || name.empty())
+			return;
+		if (suffix)
+			Util::SetResourceName(resource, "%s%s", name.c_str(), suffix);
+		else
+			Util::SetResourceName(resource, "%s", name.c_str());
+	}
+}
 
 #define STATIC_ASSERT_ALIGNAS_16(structName) \
 	static_assert(sizeof(structName) % 16 == 0, #structName " is not a multiple of 16.");
@@ -51,11 +71,13 @@ D3D11_BUFFER_DESC ConstantBufferDesc(bool dynamic = true)
 class ConstantBuffer
 {
 public:
-	explicit ConstantBuffer(D3D11_BUFFER_DESC const& a_desc) :
+	explicit ConstantBuffer(D3D11_BUFFER_DESC const& a_desc, const char* name = nullptr) :
 		desc(a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateBuffer(&desc, nullptr, resource.put()));
+		if (name)
+			detail::SetD3DName(resource.get(), name);
 	}
 
 	ID3D11Buffer* CB() const { return resource.get(); }
@@ -103,11 +125,15 @@ D3D11_BUFFER_DESC StructuredBufferDesc(UINT a_count = 1, bool cpu_access = true)
 class StructuredBuffer
 {
 public:
-	StructuredBuffer(D3D11_BUFFER_DESC const& a_desc, UINT a_count) :
+	StructuredBuffer(D3D11_BUFFER_DESC const& a_desc, UINT a_count, const char* name = nullptr) :
 		desc(a_desc), count(a_count)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateBuffer(&desc, nullptr, resource.put()));
+		if (name) {
+			name_ = name;
+			detail::SetD3DName(resource.get(), name_);
+		}
 	}
 
 	ID3D11ShaderResourceView* SRV(size_t i = 0) const { return srvs[i].get(); }
@@ -123,6 +149,7 @@ public:
 		srv_desc.Buffer.NumElements = count;
 		winrt::com_ptr<ID3D11ShaderResourceView> srv;
 		DX::ThrowIfFailed(device->CreateShaderResourceView(resource.get(), &srv_desc, srv.put()));
+		detail::SetD3DName(srv.get(), name_, " SRV");
 		srvs.push_back(srv);
 	}
 
@@ -137,6 +164,7 @@ public:
 		uav_desc.Buffer.NumElements = count;
 		winrt::com_ptr<ID3D11UnorderedAccessView> uav;
 		DX::ThrowIfFailed(device->CreateUnorderedAccessView(resource.get(), &uav_desc, uav.put()));
+		detail::SetD3DName(uav.get(), name_, " UAV");
 		uavs.push_back(uav);
 	}
 
@@ -162,62 +190,79 @@ private:
 	winrt::com_ptr<ID3D11Buffer> resource;
 	D3D11_BUFFER_DESC desc;
 	UINT count;
+	std::string name_;
 };
 
 class Buffer
 {
 public:
-	explicit Buffer(D3D11_BUFFER_DESC const& a_desc, D3D11_SUBRESOURCE_DATA* a_init = nullptr) :
+	explicit Buffer(D3D11_BUFFER_DESC const& a_desc, D3D11_SUBRESOURCE_DATA* a_init = nullptr, const char* name = nullptr) :
 		desc(a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateBuffer(&desc, a_init, resource.put()));
+		if (name) {
+			name_ = name;
+			detail::SetD3DName(resource.get(), name_);
+		}
 	}
 
 	void CreateSRV(D3D11_SHADER_RESOURCE_VIEW_DESC const& a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateShaderResourceView(resource.get(), &a_desc, srv.put()));
+		detail::SetD3DName(srv.get(), name_, " SRV");
 	}
 
 	void CreateUAV(D3D11_UNORDERED_ACCESS_VIEW_DESC const& a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateUnorderedAccessView(resource.get(), &a_desc, uav.put()));
+		detail::SetD3DName(uav.get(), name_, " UAV");
 	}
 
 	D3D11_BUFFER_DESC desc;
 	winrt::com_ptr<ID3D11Buffer> resource;
 	winrt::com_ptr<ID3D11ShaderResourceView> srv;
 	winrt::com_ptr<ID3D11UnorderedAccessView> uav;
+
+private:
+	std::string name_;
 };
 
 class Texture1D
 {
 public:
-	explicit Texture1D(D3D11_TEXTURE1D_DESC const& a_desc) :
+	explicit Texture1D(D3D11_TEXTURE1D_DESC const& a_desc, const char* name = nullptr) :
 		desc(a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateTexture1D(&desc, nullptr, resource.put()));
+		if (name) {
+			name_ = name;
+			detail::SetD3DName(resource.get(), name_);
+		}
 	}
 
 	void CreateSRV(D3D11_SHADER_RESOURCE_VIEW_DESC const& a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateShaderResourceView(resource.get(), &a_desc, srv.put()));
+		detail::SetD3DName(srv.get(), name_, " SRV");
 	}
 
 	void CreateUAV(D3D11_UNORDERED_ACCESS_VIEW_DESC const& a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateUnorderedAccessView(resource.get(), &a_desc, uav.put()));
+		detail::SetD3DName(uav.get(), name_, " UAV");
 	}
 
 	void CreateRTV(D3D11_RENDER_TARGET_VIEW_DESC const& a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateRenderTargetView(resource.get(), &a_desc, rtv.put()));
+		detail::SetD3DName(rtv.get(), name_, " RTV");
 	}
 
 	D3D11_TEXTURE1D_DESC desc;
@@ -225,46 +270,61 @@ public:
 	winrt::com_ptr<ID3D11ShaderResourceView> srv;
 	winrt::com_ptr<ID3D11UnorderedAccessView> uav;
 	winrt::com_ptr<ID3D11RenderTargetView> rtv;
+
+private:
+	std::string name_;
 };
 
 class Texture2D
 {
 public:
-	explicit Texture2D(D3D11_TEXTURE2D_DESC const& a_desc) :
+	explicit Texture2D(D3D11_TEXTURE2D_DESC const& a_desc, const char* name = nullptr) :
 		desc(a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateTexture2D(&desc, nullptr, resource.put()));
+		if (name) {
+			name_ = name;
+			detail::SetD3DName(resource.get(), name_);
+		}
 	}
 
-	explicit Texture2D(ID3D11Texture2D* a_resource)
+	explicit Texture2D(ID3D11Texture2D* a_resource, const char* name = nullptr)
 	{
 		a_resource->GetDesc(&desc);
 		resource.attach(a_resource);
+		if (name) {
+			name_ = name;
+			detail::SetD3DName(resource.get(), name_);
+		}
 	}
 
 	void CreateSRV(D3D11_SHADER_RESOURCE_VIEW_DESC const& a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateShaderResourceView(resource.get(), &a_desc, srv.put()));
+		detail::SetD3DName(srv.get(), name_, " SRV");
 	}
 
 	void CreateUAV(D3D11_UNORDERED_ACCESS_VIEW_DESC const& a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateUnorderedAccessView(resource.get(), &a_desc, uav.put()));
+		detail::SetD3DName(uav.get(), name_, " UAV");
 	}
 
 	void CreateRTV(D3D11_RENDER_TARGET_VIEW_DESC const& a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateRenderTargetView(resource.get(), &a_desc, rtv.put()));
+		detail::SetD3DName(rtv.get(), name_, " RTV");
 	}
 
 	void CreateDSV(D3D11_DEPTH_STENCIL_VIEW_DESC const& a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateDepthStencilView(resource.get(), &a_desc, dsv.put()));
+		detail::SetD3DName(dsv.get(), name_, " DSV");
 	}
 
 	D3D11_TEXTURE2D_DESC desc;
@@ -273,34 +333,44 @@ public:
 	winrt::com_ptr<ID3D11UnorderedAccessView> uav;
 	winrt::com_ptr<ID3D11RenderTargetView> rtv;
 	winrt::com_ptr<ID3D11DepthStencilView> dsv;
+
+private:
+	std::string name_;
 };
 
 class Texture3D
 {
 public:
-	explicit Texture3D(D3D11_TEXTURE3D_DESC const& a_desc) :
+	explicit Texture3D(D3D11_TEXTURE3D_DESC const& a_desc, const char* name = nullptr) :
 		desc(a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateTexture3D(&desc, nullptr, resource.put()));
+		if (name) {
+			name_ = name;
+			detail::SetD3DName(resource.get(), name_);
+		}
 	}
 
 	void CreateSRV(D3D11_SHADER_RESOURCE_VIEW_DESC const& a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateShaderResourceView(resource.get(), &a_desc, srv.put()));
+		detail::SetD3DName(srv.get(), name_, " SRV");
 	}
 
 	void CreateUAV(D3D11_UNORDERED_ACCESS_VIEW_DESC const& a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateUnorderedAccessView(resource.get(), &a_desc, uav.put()));
+		detail::SetD3DName(uav.get(), name_, " UAV");
 	}
 
 	void CreateRTV(D3D11_RENDER_TARGET_VIEW_DESC const& a_desc)
 	{
 		auto device = globals::d3d::device;
 		DX::ThrowIfFailed(device->CreateRenderTargetView(resource.get(), &a_desc, rtv.put()));
+		detail::SetD3DName(rtv.get(), name_, " RTV");
 	}
 
 	D3D11_TEXTURE3D_DESC desc;
@@ -308,4 +378,7 @@ public:
 	winrt::com_ptr<ID3D11ShaderResourceView> srv;
 	winrt::com_ptr<ID3D11UnorderedAccessView> uav;
 	winrt::com_ptr<ID3D11RenderTargetView> rtv;
+
+private:
+	std::string name_;
 };

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -5,6 +5,7 @@
 #include "ShaderCache.h"
 #include "State.h"
 #include "TruePBR.h"
+#include "Utils/D3D.h"
 
 #include "Features/DynamicCubemaps.h"
 #include "Features/IBL.h"
@@ -126,9 +127,11 @@ void Deferred::SetupResources()
 		samplerDesc.MinLOD = 0;
 		samplerDesc.MaxLOD = D3D11_FLOAT32_MAX;
 		DX::ThrowIfFailed(device->CreateSamplerState(&samplerDesc, &linearSampler));
+		Util::SetResourceName(linearSampler, "Deferred::LinearSampler");
 
 		samplerDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
 		DX::ThrowIfFailed(device->CreateSamplerState(&samplerDesc, &pointSampler));
+		Util::SetResourceName(pointSampler, "Deferred::PointSampler");
 	}
 
 	{
@@ -139,6 +142,7 @@ void Deferred::SetupResources()
 		blendDesc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
 		blendDesc.RenderTarget[1].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_BLUE;
 		DX::ThrowIfFailed(device->CreateBlendState(&blendDesc, compositeBlendState.put()));
+		Util::SetResourceName(compositeBlendState.get(), "Deferred::CompositeBlendState");
 
 		D3D11_DEPTH_STENCIL_DESC dsDesc{};
 		dsDesc.DepthEnable = TRUE;
@@ -146,6 +150,7 @@ void Deferred::SetupResources()
 		dsDesc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ZERO;
 		dsDesc.StencilEnable = FALSE;
 		DX::ThrowIfFailed(device->CreateDepthStencilState(&dsDesc, compositeDepthStencilState.put()));
+		Util::SetResourceName(compositeDepthStencilState.get(), "Deferred::CompositeDepthStencilState");
 
 		D3D11_DEPTH_STENCIL_DESC stencilDsDesc{};
 		stencilDsDesc.DepthEnable = TRUE;
@@ -160,12 +165,14 @@ void Deferred::SetupResources()
 		stencilDsDesc.FrontFace.StencilPassOp = D3D11_STENCIL_OP_KEEP;
 		stencilDsDesc.BackFace = stencilDsDesc.FrontFace;
 		DX::ThrowIfFailed(device->CreateDepthStencilState(&stencilDsDesc, compositeStencilDSState.put()));
+		Util::SetResourceName(compositeStencilDSState.get(), "Deferred::CompositeStencilDSState");
 
 		D3D11_RASTERIZER_DESC rsDesc{};
 		rsDesc.FillMode = D3D11_FILL_SOLID;
 		rsDesc.CullMode = D3D11_CULL_NONE;
 		rsDesc.DepthClipEnable = FALSE;
 		DX::ThrowIfFailed(device->CreateRasterizerState(&rsDesc, compositeRasterizerState.put()));
+		Util::SetResourceName(compositeRasterizerState.get(), "Deferred::CompositeRasterizerState");
 	}
 
 	// Directional shadow structured buffer (t98): CPU-written each frame, read-only on GPU.
@@ -186,7 +193,7 @@ void Deferred::SetupResources()
 		srvDesc.Buffer.NumElements = 1;
 
 		delete directionalShadowLights;
-		directionalShadowLights = new Buffer(sbDesc);
+		directionalShadowLights = new Buffer(sbDesc, nullptr, "Deferred::DirectionalShadowLights");
 		directionalShadowLights->CreateSRV(srvDesc);
 	}
 }

--- a/src/Features/CloudShadows.cpp
+++ b/src/Features/CloudShadows.cpp
@@ -1,6 +1,7 @@
 #include "CloudShadows.h"
 
 #include "State.h"
+#include "Utils/D3D.h"
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	CloudShadows::Settings,
@@ -153,22 +154,24 @@ void CloudShadows::SetupResources()
 
 		texDesc.Format = srvDesc.Format = DXGI_FORMAT_R8_UNORM;
 
-		texCubemapCloudOcc = new Texture2D(texDesc);
+		texCubemapCloudOcc = new Texture2D(texDesc, "CloudShadows::CubemapCloudOcc");
 		texCubemapCloudOcc->CreateSRV(srvDesc);
 
 		for (int i = 0; i < 6; ++i) {
 			reflections.cubeSideRTV[i]->GetDesc(&rtvDesc);
 			rtvDesc.Format = texDesc.Format;
 			DX::ThrowIfFailed(device->CreateRenderTargetView(texCubemapCloudOcc->resource.get(), &rtvDesc, cubemapCloudOccRTVs + i));
+			Util::SetResourceName(cubemapCloudOccRTVs[i], "CloudShadows::CubemapCloudOcc RTV[%d]", i);
 		}
 
-		texCubemapCloudOccCopy = new Texture2D(texDesc);
+		texCubemapCloudOccCopy = new Texture2D(texDesc, "CloudShadows::CubemapCloudOccCopy");
 		texCubemapCloudOccCopy->CreateSRV(srvDesc);
 
 		for (int i = 0; i < 6; ++i) {
 			reflections.cubeSideRTV[i]->GetDesc(&rtvDesc);
 			rtvDesc.Format = texDesc.Format;
 			DX::ThrowIfFailed(device->CreateRenderTargetView(texCubemapCloudOccCopy->resource.get(), &rtvDesc, cubemapCloudOccCopyRTVs + i));
+			Util::SetResourceName(cubemapCloudOccCopyRTVs[i], "CloudShadows::CubemapCloudOccCopy RTV[%d]", i);
 		}
 	}
 	{
@@ -186,6 +189,7 @@ void CloudShadows::SetupResources()
 		blendDesc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
 
 		DX::ThrowIfFailed(device->CreateBlendState(&blendDesc, &cloudShadowBlendState));
+		Util::SetResourceName(cloudShadowBlendState, "CloudShadows::BlendState");
 	}
 }
 

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -5,6 +5,7 @@
 
 #include "ShaderCache.h"
 #include "State.h"
+#include "Utils/D3D.h"
 
 constexpr auto MIPLEVELS = 8;
 
@@ -643,6 +644,7 @@ void DynamicCubemaps::SetupResources()
 		samplerDesc.MinLOD = 0;
 		samplerDesc.MaxLOD = D3D11_FLOAT32_MAX;
 		DX::ThrowIfFailed(device->CreateSamplerState(&samplerDesc, &computeSampler));
+		Util::SetResourceName(computeSampler, "DynamicCubemaps::ComputeSampler");
 	}
 
 	auto& cubemap = renderer->GetRendererData().cubemapRenderTargets[RE::RENDER_TARGETS_CUBEMAP::kREFLECTIONS];
@@ -715,10 +717,12 @@ void DynamicCubemaps::SetupResources()
 			arraySRVDesc.Texture2DArray.MostDetailedMip = 0;
 			arraySRVDesc.Texture2DArray.MipLevels = MIPLEVELS;
 			DX::ThrowIfFailed(device->CreateShaderResourceView(envTexture->resource.get(), &arraySRVDesc, &envTextureArraySRV));
+			Util::SetResourceName(envTextureArraySRV, "DynamicCubemaps::EnvTexture ArraySRV");
 			DX::ThrowIfFailed(device->CreateShaderResourceView(envReflectionsTexture->resource.get(), &arraySRVDesc, &envReflectionsTextureArraySRV));
+			Util::SetResourceName(envReflectionsTextureArraySRV, "DynamicCubemaps::EnvReflections ArraySRV");
 		}
 
-		envInferredTexture = new Texture2D(texDesc);
+		envInferredTexture = new Texture2D(texDesc, "DynamicCubemaps::EnvInferred");
 		envInferredTexture->CreateSRV(srvDesc);
 		envInferredTexture->CreateUAV(uavDesc);
 
@@ -744,7 +748,7 @@ void DynamicCubemaps::SetupResources()
 			scratchDesc.Usage = D3D11_USAGE_DEFAULT;
 			scratchDesc.BindFlags = D3D11_BIND_UNORDERED_ACCESS;
 			scratchDesc.MiscFlags = 0;
-			bc6hScratchTexture = new Texture2D(scratchDesc);
+			bc6hScratchTexture = new Texture2D(scratchDesc, "DynamicCubemaps::BC6HScratch");
 
 			D3D11_UNORDERED_ACCESS_VIEW_DESC scratchUAVDesc = {};
 			scratchUAVDesc.Format = DXGI_FORMAT_R32G32B32A32_UINT;
@@ -754,6 +758,7 @@ void DynamicCubemaps::SetupResources()
 			for (std::uint32_t level = 0; level < bc6hMipLevels; ++level) {
 				scratchUAVDesc.Texture2DArray.MipSlice = level;
 				DX::ThrowIfFailed(device->CreateUnorderedAccessView(bc6hScratchTexture->resource.get(), &scratchUAVDesc, &bc6hScratchUAVs[level]));
+				Util::SetResourceName(bc6hScratchUAVs[level], "DynamicCubemaps::BC6HScratch UAV mip%u", level);
 			}
 		}
 
@@ -776,22 +781,22 @@ void DynamicCubemaps::SetupResources()
 			bc6hSRVDesc.TextureCube.MostDetailedMip = 0;
 			bc6hSRVDesc.TextureCube.MipLevels = bc6hMipLevels;
 
-			envTextureBC6H = new Texture2D(bc6hDesc);
+			envTextureBC6H = new Texture2D(bc6hDesc, "DynamicCubemaps::EnvTextureBC6H");
 			envTextureBC6H->CreateSRV(bc6hSRVDesc);
 
-			envReflectionsTextureBC6H = new Texture2D(bc6hDesc);
+			envReflectionsTextureBC6H = new Texture2D(bc6hDesc, "DynamicCubemaps::EnvReflectionsBC6H");
 			envReflectionsTextureBC6H->CreateSRV(bc6hSRVDesc);
 		}
 
-		updateCubemapCB = new ConstantBuffer(ConstantBufferDesc<UpdateCubemapCB>());
+		updateCubemapCB = new ConstantBuffer(ConstantBufferDesc<UpdateCubemapCB>(), "DynamicCubemaps::UpdateCubemapCB");
 	}
 
 	{
-		bc6hEncodeCB = new ConstantBuffer(ConstantBufferDesc<BC6HEncodeCB>());
+		bc6hEncodeCB = new ConstantBuffer(ConstantBufferDesc<BC6HEncodeCB>(), "DynamicCubemaps::BC6HEncodeCB");
 	}
 
 	{
-		spmapCB = new ConstantBuffer(ConstantBufferDesc<SpecularMapFilterSettingsCB>());
+		spmapCB = new ConstantBuffer(ConstantBufferDesc<SpecularMapFilterSettingsCB>(), "DynamicCubemaps::SpmapCB");
 	}
 
 	{
@@ -805,11 +810,13 @@ void DynamicCubemaps::SetupResources()
 		for (std::uint32_t level = 1; level < MIPLEVELS; ++level) {
 			uavDesc.Texture2DArray.MipSlice = level;
 			DX::ThrowIfFailed(device->CreateUnorderedAccessView(envTexture->resource.get(), &uavDesc, &uavArray[level - 1]));
+			Util::SetResourceName(uavArray[level - 1], "DynamicCubemaps::EnvTexture UAV mip%u", level);
 		}
 
 		for (std::uint32_t level = 1; level < MIPLEVELS; ++level) {
 			uavDesc.Texture2DArray.MipSlice = level;
 			DX::ThrowIfFailed(device->CreateUnorderedAccessView(envReflectionsTexture->resource.get(), &uavDesc, &uavReflectionsArray[level - 1]));
+			Util::SetResourceName(uavReflectionsArray[level - 1], "DynamicCubemaps::EnvReflections UAV mip%u", level);
 		}
 	}
 

--- a/src/Features/GrassCollision.cpp
+++ b/src/Features/GrassCollision.cpp
@@ -2,6 +2,7 @@
 
 #include "State.h"
 #include "Utils/ActorUtils.h"
+#include "Utils/D3D.h"
 
 static const uint MAX_BOUNDING_BOXES = 64;
 static const uint MAX_COLLISIONS_PER_BOUNDING_BOX = 64;
@@ -275,7 +276,7 @@ void GrassCollision::SetupResources()
 		sbDesc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
 		sbDesc.StructureByteStride = sizeof(BoundingBoxPacked);
 		sbDesc.ByteWidth = sizeof(BoundingBoxPacked) * MAX_BOUNDING_BOXES;
-		collisionBoundingBoxes = eastl::make_unique<Buffer>(sbDesc);
+		collisionBoundingBoxes = eastl::make_unique<Buffer>(sbDesc, nullptr, "GrassCollision::BoundingBoxes");
 
 		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc;
 		srvDesc.Format = DXGI_FORMAT_UNKNOWN;
@@ -293,7 +294,7 @@ void GrassCollision::SetupResources()
 		sbDesc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
 		sbDesc.StructureByteStride = sizeof(float4);
 		sbDesc.ByteWidth = sizeof(float4) * MAX_COLLISIONS;
-		collisionInstances = eastl::make_unique<Buffer>(sbDesc);
+		collisionInstances = eastl::make_unique<Buffer>(sbDesc, nullptr, "GrassCollision::Instances");
 
 		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc;
 		srvDesc.Format = DXGI_FORMAT_UNKNOWN;

--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -674,7 +674,7 @@ void HDRDisplay::SetupResources()
 	srvDesc.Format = texDesc.Format;
 	uavDesc.Format = texDesc.Format;
 
-	hdrTexture = new Texture2D(texDesc);
+	hdrTexture = new Texture2D(texDesc, "HDR::HdrTexture");
 	hdrTexture->CreateSRV(srvDesc);
 	hdrTexture->CreateUAV(uavDesc);
 
@@ -691,7 +691,7 @@ void HDRDisplay::SetupResources()
 	srvDesc.Format = texDesc.Format;
 	uavDesc.Format = texDesc.Format;
 
-	outputTexture = new Texture2D(texDesc);
+	outputTexture = new Texture2D(texDesc, "HDR::OutputTexture");
 	outputTexture->CreateSRV(srvDesc);
 	outputTexture->CreateUAV(uavDesc);
 
@@ -708,7 +708,7 @@ void HDRDisplay::SetupResources()
 	D3D11_UNORDERED_ACCESS_VIEW_DESC uiUavDesc = uavDesc;
 	uiUavDesc.Format = uiTexDesc.Format;
 
-	uiTexture = new Texture2D(uiTexDesc);
+	uiTexture = new Texture2D(uiTexDesc, "HDR::UiTexture");
 	uiTexture->CreateSRV(uiSrvDesc);
 	uiTexture->CreateUAV(uiUavDesc);
 
@@ -719,7 +719,7 @@ void HDRDisplay::SetupResources()
 	rtvDesc.Texture2D.MipSlice = 0;
 	uiTexture->CreateRTV(rtvDesc);
 
-	hdrDataCB = new ConstantBuffer(ConstantBufferDesc<HDRDataCB>());
+	hdrDataCB = new ConstantBuffer(ConstantBufferDesc<HDRDataCB>(), "HDR::DataCB");
 
 	UpdateHDRData();
 

--- a/src/Features/HairSpecular.cpp
+++ b/src/Features/HairSpecular.cpp
@@ -1,5 +1,6 @@
 #include "HairSpecular.h"
 
+#include "Utils/D3D.h"
 #include <DirectXTex.h>
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
@@ -113,7 +114,7 @@ void HairSpecular::SetupResources()
 			return;
 		}
 
-		texTangentShift = eastl::make_unique<Texture2D>(reinterpret_cast<ID3D11Texture2D*>(pResource));
+		texTangentShift = eastl::make_unique<Texture2D>(reinterpret_cast<ID3D11Texture2D*>(pResource), "HairSpecular::TangentShift");
 
 		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {
 			.Format = texTangentShift->desc.Format,

--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -326,7 +326,7 @@ void IBL::SetupResources()
 			return;
 		}
 
-		staticDiffuseIBLTexture = eastl::make_unique<Texture2D>(reinterpret_cast<ID3D11Texture2D*>(pResource));
+		staticDiffuseIBLTexture = eastl::make_unique<Texture2D>(reinterpret_cast<ID3D11Texture2D*>(pResource), "IBL::StaticDiffuse");
 
 		staticDiffuseIBLTexture->desc.MiscFlags |= D3D11_RESOURCE_MISC_TEXTURECUBE;
 
@@ -362,7 +362,7 @@ void IBL::SetupResources()
 			return;
 		}
 
-		staticSpecularIBLTexture = eastl::make_unique<Texture2D>(reinterpret_cast<ID3D11Texture2D*>(pResource));
+		staticSpecularIBLTexture = eastl::make_unique<Texture2D>(reinterpret_cast<ID3D11Texture2D*>(pResource), "IBL::StaticSpecular");
 
 		staticSpecularIBLTexture->desc.MiscFlags |= D3D11_RESOURCE_MISC_TEXTURECUBE;
 

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -114,7 +114,7 @@ void LightLimitFix::SetupResources()
 
 		sbDesc.StructureByteStride = sizeof(ClusterAABB);
 		sbDesc.ByteWidth = sizeof(ClusterAABB) * numElements;
-		clusters = eastl::make_unique<Buffer>(sbDesc);
+		clusters = eastl::make_unique<Buffer>(sbDesc, nullptr, "LLF::Clusters");
 		srvDesc.Buffer.NumElements = numElements;
 		clusters->CreateSRV(srvDesc);
 		uavDesc.Buffer.NumElements = numElements;
@@ -123,7 +123,7 @@ void LightLimitFix::SetupResources()
 		numElements = 1;
 		sbDesc.StructureByteStride = sizeof(uint32_t);
 		sbDesc.ByteWidth = sizeof(uint32_t) * numElements;
-		lightIndexCounter = eastl::make_unique<Buffer>(sbDesc);
+		lightIndexCounter = eastl::make_unique<Buffer>(sbDesc, nullptr, "LLF::LightIndexCounter");
 		srvDesc.Buffer.NumElements = numElements;
 		lightIndexCounter->CreateSRV(srvDesc);
 		uavDesc.Buffer.NumElements = numElements;
@@ -132,7 +132,7 @@ void LightLimitFix::SetupResources()
 		numElements = clusterCount * CLUSTER_MAX_LIGHTS;
 		sbDesc.StructureByteStride = sizeof(uint32_t);
 		sbDesc.ByteWidth = sizeof(uint32_t) * numElements;
-		lightIndexList = eastl::make_unique<Buffer>(sbDesc);
+		lightIndexList = eastl::make_unique<Buffer>(sbDesc, nullptr, "LLF::LightIndexList");
 		srvDesc.Buffer.NumElements = numElements;
 		lightIndexList->CreateSRV(srvDesc);
 		uavDesc.Buffer.NumElements = numElements;
@@ -141,7 +141,7 @@ void LightLimitFix::SetupResources()
 		numElements = clusterCount;
 		sbDesc.StructureByteStride = sizeof(LightGrid);
 		sbDesc.ByteWidth = sizeof(LightGrid) * numElements;
-		lightGrid = eastl::make_unique<Buffer>(sbDesc);
+		lightGrid = eastl::make_unique<Buffer>(sbDesc, nullptr, "LLF::LightGrid");
 		srvDesc.Buffer.NumElements = numElements;
 		lightGrid->CreateSRV(srvDesc);
 		uavDesc.Buffer.NumElements = numElements;
@@ -156,7 +156,7 @@ void LightLimitFix::SetupResources()
 		sbDesc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
 		sbDesc.StructureByteStride = sizeof(LightData);
 		sbDesc.ByteWidth = sizeof(LightData) * MAX_LIGHTS;
-		lights = eastl::make_unique<Buffer>(sbDesc);
+		lights = eastl::make_unique<Buffer>(sbDesc, nullptr, "LLF::Lights");
 
 		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc;
 		srvDesc.Format = DXGI_FORMAT_UNKNOWN;

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -364,7 +364,7 @@ void ScreenSpaceGI::SetupResources()
 
 	logger::debug("Creating buffers...");
 	{
-		ssgiCB = eastl::make_unique<ConstantBuffer>(ConstantBufferDesc<SSGICB>());
+		ssgiCB = eastl::make_unique<ConstantBuffer>(ConstantBufferDesc<SSGICB>(), "SSGI::CB");
 	}
 
 	logger::debug("Creating textures...");
@@ -401,7 +401,7 @@ void ScreenSpaceGI::SetupResources()
 		texDesc.MipLevels = srvDesc.Texture2D.MipLevels = 5;
 
 		{
-			texRadiance = eastl::make_unique<Texture2D>(texDesc);
+			texRadiance = eastl::make_unique<Texture2D>(texDesc, "SSGI::Radiance");
 			texRadiance->CreateSRV(srvDesc);
 			// No default UAV needed: prefilterRadiance binds per-mip UAVs via uavRadiance[].
 
@@ -413,6 +413,7 @@ void ScreenSpaceGI::SetupResources()
 					.Texture2D = { .MipSlice = i }
 				};
 				DX::ThrowIfFailed(device->CreateUnorderedAccessView(texRadiance->resource.get(), &mipUavDesc, uavRadiance[i].put()));
+				Util::SetResourceName(uavRadiance[i].get(), "SSGI::Radiance UAV mip%u", i);
 			}
 
 			// Staging texture for mip 0 radiance. radianceDisocc writes it directly,
@@ -436,7 +437,7 @@ void ScreenSpaceGI::SetupResources()
 				.Texture2D = { .MipSlice = 0 }
 			};
 
-			texRadianceTemp = eastl::make_unique<Texture2D>(tempTexDesc);
+			texRadianceTemp = eastl::make_unique<Texture2D>(tempTexDesc, "SSGI::RadianceTemp");
 			texRadianceTemp->CreateSRV(tempSrvDesc);
 			texRadianceTemp->CreateUAV(tempUavDesc);
 		}
@@ -446,21 +447,23 @@ void ScreenSpaceGI::SetupResources()
 		texDesc.Format = srvDesc.Format = uavDesc.Format = DXGI_FORMAT_R16_FLOAT;
 
 		{
-			texWorkingDepth = eastl::make_unique<Texture2D>(texDesc);
+			texWorkingDepth = eastl::make_unique<Texture2D>(texDesc, "SSGI::WorkingDepth");
 			texWorkingDepth->CreateSRV(srvDesc);
 			for (int i = 0; i < 5; ++i) {
 				uavDesc.Texture2D.MipSlice = i;
 				DX::ThrowIfFailed(device->CreateUnorderedAccessView(texWorkingDepth->resource.get(), &uavDesc, uavWorkingDepth[i].put()));
+				Util::SetResourceName(uavWorkingDepth[i].get(), "SSGI::WorkingDepth UAV mip%d", i);
 			}
 		}
 
 		srvDesc.Format = uavDesc.Format = texDesc.Format = DXGI_FORMAT_R8G8_UNORM;
 		{
-			texNormal = eastl::make_unique<Texture2D>(texDesc);
+			texNormal = eastl::make_unique<Texture2D>(texDesc, "SSGI::Normal");
 			texNormal->CreateSRV(srvDesc);
 			for (uint i = 0; i < 5; ++i) {
 				uavDesc.Texture2D.MipSlice = i;
 				DX::ThrowIfFailed(device->CreateUnorderedAccessView(texNormal->resource.get(), &uavDesc, uavNormal[i].put()));
+				Util::SetResourceName(uavNormal[i].get(), "SSGI::Normal UAV mip%u", i);
 			}
 		}
 
@@ -468,55 +471,55 @@ void ScreenSpaceGI::SetupResources()
 		texDesc.MipLevels = srvDesc.Texture2D.MipLevels = 1;
 		srvDesc.Format = uavDesc.Format = texDesc.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
 		{
-			texIlY[0] = eastl::make_unique<Texture2D>(texDesc);
+			texIlY[0] = eastl::make_unique<Texture2D>(texDesc, "SSGI::IlY[0]");
 			texIlY[0]->CreateSRV(srvDesc);
 			texIlY[0]->CreateUAV(uavDesc);
 
-			texIlY[1] = eastl::make_unique<Texture2D>(texDesc);
+			texIlY[1] = eastl::make_unique<Texture2D>(texDesc, "SSGI::IlY[1]");
 			texIlY[1]->CreateSRV(srvDesc);
 			texIlY[1]->CreateUAV(uavDesc);
 
-			texGiSpecular[0] = eastl::make_unique<Texture2D>(texDesc);
+			texGiSpecular[0] = eastl::make_unique<Texture2D>(texDesc, "SSGI::GiSpecular[0]");
 			texGiSpecular[0]->CreateSRV(srvDesc);
 			texGiSpecular[0]->CreateUAV(uavDesc);
 
-			texGiSpecular[1] = eastl::make_unique<Texture2D>(texDesc);
+			texGiSpecular[1] = eastl::make_unique<Texture2D>(texDesc, "SSGI::GiSpecular[1]");
 			texGiSpecular[1]->CreateSRV(srvDesc);
 			texGiSpecular[1]->CreateUAV(uavDesc);
 		}
 		srvDesc.Format = uavDesc.Format = texDesc.Format = DXGI_FORMAT_R16G16_FLOAT;
 		{
-			texIlCoCg[0] = eastl::make_unique<Texture2D>(texDesc);
+			texIlCoCg[0] = eastl::make_unique<Texture2D>(texDesc, "SSGI::IlCoCg[0]");
 			texIlCoCg[0]->CreateSRV(srvDesc);
 			texIlCoCg[0]->CreateUAV(uavDesc);
 
-			texIlCoCg[1] = eastl::make_unique<Texture2D>(texDesc);
+			texIlCoCg[1] = eastl::make_unique<Texture2D>(texDesc, "SSGI::IlCoCg[1]");
 			texIlCoCg[1]->CreateSRV(srvDesc);
 			texIlCoCg[1]->CreateUAV(uavDesc);
 		}
 
 		srvDesc.Format = uavDesc.Format = texDesc.Format = DXGI_FORMAT_R8_UNORM;
 		{
-			texAo[0] = eastl::make_unique<Texture2D>(texDesc);
+			texAo[0] = eastl::make_unique<Texture2D>(texDesc, "SSGI::AO[0]");
 			texAo[0]->CreateSRV(srvDesc);
 			texAo[0]->CreateUAV(uavDesc);
 
-			texAo[1] = eastl::make_unique<Texture2D>(texDesc);
+			texAo[1] = eastl::make_unique<Texture2D>(texDesc, "SSGI::AO[1]");
 			texAo[1]->CreateSRV(srvDesc);
 			texAo[1]->CreateUAV(uavDesc);
 
-			texAccumFrames[0] = eastl::make_unique<Texture2D>(texDesc);
+			texAccumFrames[0] = eastl::make_unique<Texture2D>(texDesc, "SSGI::AccumFrames[0]");
 			texAccumFrames[0]->CreateSRV(srvDesc);
 			texAccumFrames[0]->CreateUAV(uavDesc);
 
-			texAccumFrames[1] = eastl::make_unique<Texture2D>(texDesc);
+			texAccumFrames[1] = eastl::make_unique<Texture2D>(texDesc, "SSGI::AccumFrames[1]");
 			texAccumFrames[1]->CreateSRV(srvDesc);
 			texAccumFrames[1]->CreateUAV(uavDesc);
 		}
 
 		srvDesc.Format = uavDesc.Format = texDesc.Format = DXGI_FORMAT_R11G11B10_FLOAT;
 		{
-			texPrevGeo = eastl::make_unique<Texture2D>(texDesc);
+			texPrevGeo = eastl::make_unique<Texture2D>(texDesc, "SSGI::PrevGeo");
 			texPrevGeo->CreateSRV(srvDesc);
 			texPrevGeo->CreateUAV(uavDesc);
 		}
@@ -544,7 +547,7 @@ void ScreenSpaceGI::SetupResources()
 			return;
 		}
 
-		texNoise = eastl::make_unique<Texture2D>(reinterpret_cast<ID3D11Texture2D*>(pResource));
+		texNoise = eastl::make_unique<Texture2D>(reinterpret_cast<ID3D11Texture2D*>(pResource), "SSGI::Noise");
 
 		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {
 			.Format = texNoise->desc.Format,
@@ -568,9 +571,11 @@ void ScreenSpaceGI::SetupResources()
 			.MaxLOD = D3D11_FLOAT32_MAX
 		};
 		DX::ThrowIfFailed(device->CreateSamplerState(&samplerDesc, linearClampSampler.put()));
+		Util::SetResourceName(linearClampSampler.get(), "SSGI::LinearClampSampler");
 
 		samplerDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
 		DX::ThrowIfFailed(device->CreateSamplerState(&samplerDesc, pointClampSampler.put()));
+		Util::SetResourceName(pointClampSampler.get(), "SSGI::PointClampSampler");
 	}
 
 	CompileComputeShaders();

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -1,6 +1,7 @@
 #include "ScreenSpaceShadows.h"
 
 #include "State.h"
+#include "Utils/D3D.h"
 
 #pragma warning(push)
 #pragma warning(disable: 4838 4244)
@@ -345,10 +346,10 @@ bool ScreenSpaceShadows::HasShaderDefine(RE::BSShader::Type)
 
 void ScreenSpaceShadows::SetupResources()
 {
-	raymarchCB = new ConstantBuffer(ConstantBufferDesc<RaymarchCB>());
+	raymarchCB = new ConstantBuffer(ConstantBufferDesc<RaymarchCB>(), "SSS::RaymarchCB");
 
 	if (globals::game::isVR) {
-		stereoSyncCB = new ConstantBuffer(ConstantBufferDesc<StereoSyncCB>());
+		stereoSyncCB = new ConstantBuffer(ConstantBufferDesc<StereoSyncCB>(), "SSS::StereoSyncCB");
 	}
 
 	{
@@ -367,6 +368,7 @@ void ScreenSpaceShadows::SetupResources()
 		samplerDesc.BorderColor[2] = 1.0f;
 		samplerDesc.BorderColor[3] = 1.0f;
 		DX::ThrowIfFailed(device->CreateSamplerState(&samplerDesc, &pointBorderSampler));
+		Util::SetResourceName(pointBorderSampler, "SSS::PointBorderSampler");
 	}
 
 	{
@@ -389,12 +391,12 @@ void ScreenSpaceShadows::SetupResources()
 			.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D,
 			.Texture2D = { .MipSlice = 0 }
 		};
-		screenSpaceShadowsTexture = new Texture2D(texDesc);
+		screenSpaceShadowsTexture = new Texture2D(texDesc, "SSS::ShadowTexture");
 		screenSpaceShadowsTexture->CreateSRV(srvDesc);
 		screenSpaceShadowsTexture->CreateUAV(uavDesc);
 
 		if (globals::game::isVR) {
-			stereoSyncCopyTex = new Texture2D(texDesc);
+			stereoSyncCopyTex = new Texture2D(texDesc, "SSS::StereoSyncCopy");
 			stereoSyncCopyTex->CreateSRV(srvDesc);
 		}
 	}

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -2,6 +2,7 @@
 
 #include "ShaderCache.h"
 #include "State.h"
+#include "Utils/D3D.h"
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	Skylighting::Settings,
@@ -67,7 +68,7 @@ void Skylighting::SetupResources()
 		precipitationOcclusion.depthSRV->GetDesc(&srvDesc);
 		precipitationOcclusion.views[0]->GetDesc(&dsvDesc);
 
-		texOcclusion = new Texture2D(texDesc);
+		texOcclusion = new Texture2D(texDesc, "Skylighting::Occlusion");
 		texOcclusion->CreateSRV(srvDesc);
 		texOcclusion->CreateDSV(dsvDesc);
 	}
@@ -100,13 +101,13 @@ void Skylighting::SetupResources()
 				.WSize = texDesc.Depth }
 		};
 
-		texProbeArray = new Texture3D(texDesc);
+		texProbeArray = new Texture3D(texDesc, "Skylighting::ProbeArray");
 		texProbeArray->CreateSRV(srvDesc);
 		texProbeArray->CreateUAV(uavDesc);
 
 		texDesc.Format = srvDesc.Format = uavDesc.Format = DXGI_FORMAT_R8_UINT;
 
-		texAccumFramesArray = new Texture3D(texDesc);
+		texAccumFramesArray = new Texture3D(texDesc, "Skylighting::AccumFramesArray");
 		texAccumFramesArray->CreateSRV(srvDesc);
 		texAccumFramesArray->CreateUAV(uavDesc);
 	}
@@ -121,6 +122,7 @@ void Skylighting::SetupResources()
 		samplerDesc.MinLOD = 0;
 		samplerDesc.MaxLOD = D3D11_FLOAT32_MAX;
 		DX::ThrowIfFailed(device->CreateSamplerState(&samplerDesc, comparisonSampler.put()));
+		Util::SetResourceName(comparisonSampler.get(), "Skylighting::ComparisonSampler");
 	}
 
 	CompileComputeShaders();

--- a/src/Features/TerrainBlending.cpp
+++ b/src/Features/TerrainBlending.cpp
@@ -655,14 +655,17 @@ void TerrainBlending::SetupResources()
 		D3D11_TEXTURE2D_DESC texDesc;
 		mainDepth.texture->GetDesc(&texDesc);
 		DX::ThrowIfFailed(device->CreateTexture2D(&texDesc, NULL, &terrainDepth.texture));
+		Util::SetResourceName(terrainDepth.texture, "TerrainBlending::TerrainDepth");
 
 		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc;
 		mainDepth.depthSRV->GetDesc(&srvDesc);
 		DX::ThrowIfFailed(device->CreateShaderResourceView(terrainDepth.texture, &srvDesc, &terrainDepth.depthSRV));
+		Util::SetResourceName(terrainDepth.depthSRV, "TerrainBlending::TerrainDepth SRV");
 
 		D3D11_DEPTH_STENCIL_VIEW_DESC dsvDesc;
 		mainDepth.views[0]->GetDesc(&dsvDesc);
 		DX::ThrowIfFailed(device->CreateDepthStencilView(terrainDepth.texture, &dsvDesc, &terrainDepth.views[0]));
+		Util::SetResourceName(terrainDepth.views[0], "TerrainBlending::TerrainDepth DSV");
 	}
 
 	{
@@ -673,7 +676,7 @@ void TerrainBlending::SetupResources()
 		texDesc.Format = DXGI_FORMAT_R32_FLOAT;
 		texDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
 
-		blendedDepthTexture = new Texture2D(texDesc);
+		blendedDepthTexture = new Texture2D(texDesc, "TerrainBlending::BlendedDepth");
 
 		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
 		main.SRV->GetDesc(&srvDesc);
@@ -689,7 +692,7 @@ void TerrainBlending::SetupResources()
 		srvDesc.Format = texDesc.Format;
 		uavDesc.Format = texDesc.Format;
 
-		blendedDepthTexture16 = new Texture2D(texDesc);
+		blendedDepthTexture16 = new Texture2D(texDesc, "TerrainBlending::BlendedDepth16");
 		blendedDepthTexture16->CreateSRV(srvDesc);
 		blendedDepthTexture16->CreateUAV(uavDesc);
 
@@ -699,7 +702,7 @@ void TerrainBlending::SetupResources()
 		srvDesc.Format = texDesc.Format;
 		uavDesc.Format = texDesc.Format;
 
-		mainDepthCopy = new Texture2D(texDesc);
+		mainDepthCopy = new Texture2D(texDesc, "TerrainBlending::MainDepthCopy");
 		mainDepthCopy->CreateSRV(srvDesc);
 		mainDepthCopy->CreateUAV(uavDesc);
 
@@ -717,6 +720,7 @@ void TerrainBlending::SetupResources()
 		depthStencilDesc.DepthFunc = D3D11_COMPARISON_LESS_EQUAL;
 		depthStencilDesc.StencilEnable = false;
 		DX::ThrowIfFailed(device->CreateDepthStencilState(&depthStencilDesc, &terrainDepthStencilState));
+		Util::SetResourceName(terrainDepthStencilState, "TerrainBlending::DepthStencilState");
 	}
 }
 

--- a/src/Features/TerrainShadows.cpp
+++ b/src/Features/TerrainShadows.cpp
@@ -153,7 +153,7 @@ void TerrainShadows::SetupResources()
 
 	logger::debug("Creating constant buffers...");
 	{
-		shadowUpdateCB = std::make_unique<ConstantBuffer>(ConstantBufferDesc<ShadowUpdateCB>());
+		shadowUpdateCB = std::make_unique<ConstantBuffer>(ConstantBufferDesc<ShadowUpdateCB>(), "TerrainShadows::UpdateCB");
 	}
 
 	CompileComputeShaders();
@@ -241,7 +241,7 @@ void TerrainShadows::LoadHeightmap()
 		}
 
 		texHeightMap.release();
-		texHeightMap = std::make_unique<Texture2D>(reinterpret_cast<ID3D11Texture2D*>(pResource));
+		texHeightMap = std::make_unique<Texture2D>(reinterpret_cast<ID3D11Texture2D*>(pResource), "TerrainShadows::HeightMap");
 
 		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {
 			.Format = texHeightMap->desc.Format,
@@ -299,7 +299,7 @@ void TerrainShadows::Precompute()
 			.Texture2D = { .MipSlice = 0 }
 		};
 
-		texShadowHeight = std::make_unique<Texture2D>(texDesc);
+		texShadowHeight = std::make_unique<Texture2D>(texDesc, "TerrainShadows::ShadowHeight");
 		texShadowHeight->CreateSRV(srvDesc);
 		texShadowHeight->CreateUAV(uavDesc);
 	}

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -6,6 +6,7 @@
 #include "VR/OpenVRDetection.h"
 
 #include "State.h"
+#include "Utils/D3D.h"
 #include "Utils/VRUtils.h"
 
 #include <d3d11.h>
@@ -111,14 +112,14 @@ void VR::SetupResources()
 	mainTex.texture->GetDesc(&mainDesc);
 	mainDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
 	mainDesc.MiscFlags = 0;
-	stereoBlendCopyTex = eastl::make_unique<Texture2D>(mainDesc);
+	stereoBlendCopyTex = eastl::make_unique<Texture2D>(mainDesc, "VR::StereoBlendCopyTex");
 	D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {
 		.Format = mainDesc.Format,
 		.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D,
 		.Texture2D = { .MostDetailedMip = 0, .MipLevels = 1 }
 	};
 	stereoBlendCopyTex->CreateSRV(srvDesc);
-	stereoBlendCB = eastl::make_unique<ConstantBuffer>(ConstantBufferDesc<StereoBlendCB>());
+	stereoBlendCB = eastl::make_unique<ConstantBuffer>(ConstantBufferDesc<StereoBlendCB>(), "VR::StereoBlendCB");
 
 	if (globals::game::isVR && stereoOpt.settings.stereoMode != VRStereoOptimizations::StereoMode::Off) {
 		stereoOpt.SetupResources();

--- a/src/Features/VR/InSceneOverlay.cpp
+++ b/src/Features/VR/InSceneOverlay.cpp
@@ -222,6 +222,7 @@ void VR::InitInSceneResources()
 		logger::error("VR: Failed to create sampler state");
 		return;
 	}
+	Util::SetResourceName(temp.sampler.get(), "VR::InSceneOverlaySampler");
 
 	inSceneResources = std::move(temp);
 	inSceneResources.initialized = true;

--- a/src/Features/VR/StereoBlend.cpp
+++ b/src/Features/VR/StereoBlend.cpp
@@ -143,6 +143,7 @@ void VR::DrawStereoBlend()
 			sampDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
 			sampDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
 			globals::d3d::device->CreateSamplerState(&sampDesc, stereoBlendLinearSampler.put());
+			Util::SetResourceName(stereoBlendLinearSampler.get(), "VR::StereoBlendLinearSampler");
 		}
 		ID3D11SamplerState* samplers[] = { stereoBlendLinearSampler.get() };
 		context->CSSetSamplers(0, 1, samplers);

--- a/src/Features/VRStereoOptimizations.cpp
+++ b/src/Features/VRStereoOptimizations.cpp
@@ -96,7 +96,7 @@ void VRStereoOptimizations::SetupResources()
 	auto renderer = globals::game::renderer;
 
 	// Constant buffers
-	paramsCB = eastl::make_unique<ConstantBuffer>(ConstantBufferDesc<VRStereoOptParams>());
+	paramsCB = eastl::make_unique<ConstantBuffer>(ConstantBufferDesc<VRStereoOptParams>(), "VRStereoOpt::ParamsCB");
 
 	// Get main RT dimensions for per-eye calculations
 	auto& main = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];
@@ -118,7 +118,7 @@ void VRStereoOptimizations::SetupResources()
 		modeDesc.CPUAccessFlags = 0;
 		modeDesc.MiscFlags = 0;
 
-		texPerPixelMode = eastl::make_unique<Texture2D>(modeDesc);
+		texPerPixelMode = eastl::make_unique<Texture2D>(modeDesc, "VRStereoOpt::PerPixelMode");
 		texPerPixelMode->CreateSRV(D3D11_SHADER_RESOURCE_VIEW_DESC{
 			.Format = DXGI_FORMAT_R8_UINT,
 			.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D,
@@ -146,7 +146,7 @@ void VRStereoOptimizations::SetupResources()
 		pomDesc.CPUAccessFlags = 0;
 		pomDesc.MiscFlags = 0;
 
-		texPomOffset = eastl::make_unique<Texture2D>(pomDesc);
+		texPomOffset = eastl::make_unique<Texture2D>(pomDesc, "VRStereoOpt::PomOffset");
 		texPomOffset->CreateSRV(D3D11_SHADER_RESOURCE_VIEW_DESC{
 			.Format = DXGI_FORMAT_R16_FLOAT,
 			.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D,
@@ -174,6 +174,7 @@ void VRStereoOptimizations::SetupResources()
 		dssDesc.BackFace = dssDesc.FrontFace;
 
 		DX::ThrowIfFailed(device->CreateDepthStencilState(&dssDesc, stencilWriteDSS.put()));
+		Util::SetResourceName(stencilWriteDSS.get(), "VRStereoOpt::StencilWriteDSS");
 	}
 
 	// Rasterizer state for stencil write: no culling, no depth clip

--- a/src/Features/VolumetricShadows.cpp
+++ b/src/Features/VolumetricShadows.cpp
@@ -1,6 +1,7 @@
 #include "VolumetricShadows.h"
 
 #include "State.h"
+#include "Utils/D3D.h"
 
 void VolumetricShadows::SetupResources()
 {
@@ -17,6 +18,7 @@ void VolumetricShadows::SetupResources()
 		samplerDesc.MinLOD = 0;
 		samplerDesc.MaxLOD = D3D11_FLOAT32_MAX;
 		DX::ThrowIfFailed(device->CreateSamplerState(&samplerDesc, &linearSampler));
+		Util::SetResourceName(linearSampler, "VolumetricShadows::LinearSampler");
 	}
 
 	// Compile compute shaders
@@ -102,6 +104,7 @@ void VolumetricShadows::CopyShadowLightData()
 
 				auto device = globals::d3d::device;
 				DX::ThrowIfFailed(device->CreateTexture2D(&copyDesc, nullptr, &shadowCopyTexture));
+				Util::SetResourceName(shadowCopyTexture, "VolumetricShadows::ShadowCopy");
 
 				D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc{};
 				srvDesc.Format = copyDesc.Format;
@@ -109,42 +112,52 @@ void VolumetricShadows::CopyShadowLightData()
 				srvDesc.Texture2D.MostDetailedMip = 0;
 				srvDesc.Texture2D.MipLevels = 2;
 				DX::ThrowIfFailed(device->CreateShaderResourceView(shadowCopyTexture, &srvDesc, &shadowCopySRV));
+				Util::SetResourceName(shadowCopySRV, "VolumetricShadows::ShadowCopy SRV");
 
 				// Create mip-specific SRVs for blur passes
 				srvDesc.Texture2D.MostDetailedMip = 0;
 				srvDesc.Texture2D.MipLevels = 1;
 				DX::ThrowIfFailed(device->CreateShaderResourceView(shadowCopyTexture, &srvDesc, &shadowCopyMip0SRV));
+				Util::SetResourceName(shadowCopyMip0SRV, "VolumetricShadows::ShadowCopy SRV mip0");
 
 				srvDesc.Texture2D.MostDetailedMip = 1;
 				srvDesc.Texture2D.MipLevels = 1;
 				DX::ThrowIfFailed(device->CreateShaderResourceView(shadowCopyTexture, &srvDesc, &shadowCopyMip1SRV));
+				Util::SetResourceName(shadowCopyMip1SRV, "VolumetricShadows::ShadowCopy SRV mip1");
 
 				D3D11_UNORDERED_ACCESS_VIEW_DESC uavDesc{};
 				uavDesc.Format = copyDesc.Format;
 				uavDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D;
 				uavDesc.Texture2D.MipSlice = 0;
 				DX::ThrowIfFailed(device->CreateUnorderedAccessView(shadowCopyTexture, &uavDesc, &shadowCopyMip0UAV));
+				Util::SetResourceName(shadowCopyMip0UAV, "VolumetricShadows::ShadowCopy UAV mip0");
 
 				uavDesc.Texture2D.MipSlice = 1;
 				DX::ThrowIfFailed(device->CreateUnorderedAccessView(shadowCopyTexture, &uavDesc, &shadowCopyMip1UAV));
+				Util::SetResourceName(shadowCopyMip1UAV, "VolumetricShadows::ShadowCopy UAV mip1");
 
 				// Create temporary texture for blur intermediate result
 				DX::ThrowIfFailed(device->CreateTexture2D(&copyDesc, nullptr, &shadowBlurTempTexture));
+				Util::SetResourceName(shadowBlurTempTexture, "VolumetricShadows::ShadowBlurTemp");
 
 				// Create mip-specific SRVs for blur temp texture
 				srvDesc.Texture2D.MostDetailedMip = 0;
 				srvDesc.Texture2D.MipLevels = 1;
 				DX::ThrowIfFailed(device->CreateShaderResourceView(shadowBlurTempTexture, &srvDesc, &shadowBlurTempMip0SRV));
+				Util::SetResourceName(shadowBlurTempMip0SRV, "VolumetricShadows::ShadowBlurTemp SRV mip0");
 
 				srvDesc.Texture2D.MostDetailedMip = 1;
 				srvDesc.Texture2D.MipLevels = 1;
 				DX::ThrowIfFailed(device->CreateShaderResourceView(shadowBlurTempTexture, &srvDesc, &shadowBlurTempMip1SRV));
+				Util::SetResourceName(shadowBlurTempMip1SRV, "VolumetricShadows::ShadowBlurTemp SRV mip1");
 
 				uavDesc.Texture2D.MipSlice = 0;
 				DX::ThrowIfFailed(device->CreateUnorderedAccessView(shadowBlurTempTexture, &uavDesc, &shadowBlurTempMip0UAV));
+				Util::SetResourceName(shadowBlurTempMip0UAV, "VolumetricShadows::ShadowBlurTemp UAV mip0");
 
 				uavDesc.Texture2D.MipSlice = 1;
 				DX::ThrowIfFailed(device->CreateUnorderedAccessView(shadowBlurTempTexture, &uavDesc, &shadowBlurTempMip1UAV));
+				Util::SetResourceName(shadowBlurTempMip1UAV, "VolumetricShadows::ShadowBlurTemp UAV mip1");
 			}
 
 			// Get input dimensions for dispatch sizing

--- a/src/Menu/BackgroundBlur.cpp
+++ b/src/Menu/BackgroundBlur.cpp
@@ -134,14 +134,17 @@ namespace BackgroundBlur
 				logger::error("Failed to create {} texture", name);
 				return false;
 			}
+			Util::SetResourceName(tex.get(), "BackgroundBlur::%s", name);
 			if (FAILED(device->CreateRenderTargetView(tex.get(), nullptr, rtv.put()))) {
 				logger::error("Failed to create {} RTV", name);
 				return false;
 			}
+			Util::SetResourceName(rtv.get(), "BackgroundBlur::%s RTV", name);
 			if (FAILED(device->CreateShaderResourceView(tex.get(), nullptr, srv.put()))) {
 				logger::error("Failed to create {} SRV", name);
 				return false;
 			}
+			Util::SetResourceName(srv.get(), "BackgroundBlur::%s SRV", name);
 			return true;
 		}
 
@@ -196,10 +199,12 @@ namespace BackgroundBlur
 		cbDesc.ByteWidth = sizeof(BlurConstants);
 		if (!checkCreate(device->CreateBuffer(&cbDesc, nullptr, constantBuffer.put()), "blur constant buffer"))
 			return false;
+		Util::SetResourceName(constantBuffer.get(), "BackgroundBlur::BlurCB");
 
 		cbDesc.ByteWidth = sizeof(WindowConstants);
 		if (!checkCreate(device->CreateBuffer(&cbDesc, nullptr, windowConstantBuffer.put()), "window constant buffer"))
 			return false;
+		Util::SetResourceName(windowConstantBuffer.get(), "BackgroundBlur::WindowCB");
 
 		// Create sampler state
 		D3D11_SAMPLER_DESC samplerDesc = {};
@@ -212,6 +217,7 @@ namespace BackgroundBlur
 		samplerDesc.MaxLOD = D3D11_FLOAT32_MAX;
 		if (!checkCreate(device->CreateSamplerState(&samplerDesc, samplerState.put()), "blur sampler state"))
 			return false;
+		Util::SetResourceName(samplerState.get(), "BackgroundBlur::Sampler");
 
 		// Create blend states
 		D3D11_BLEND_DESC blendDesc = {};
@@ -225,12 +231,14 @@ namespace BackgroundBlur
 		blendDesc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
 		if (!checkCreate(device->CreateBlendState(&blendDesc, blendState.put()), "blur blend state"))
 			return false;
+		Util::SetResourceName(blendState.get(), "BackgroundBlur::BlendState");
 
 		// Composite: pre-multiplied alpha (SrcBlend=ONE, DestBlendAlpha=INV_SRC_ALPHA)
 		blendDesc.RenderTarget[0].SrcBlend = D3D11_BLEND_ONE;
 		blendDesc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
 		if (!checkCreate(device->CreateBlendState(&blendDesc, compositeBlendState.put()), "composite blend state"))
 			return false;
+		Util::SetResourceName(compositeBlendState.get(), "BackgroundBlur::CompositeBlendState");
 
 		// Create scissor-enabled rasterizer state
 		D3D11_RASTERIZER_DESC rsDesc = {};
@@ -241,6 +249,7 @@ namespace BackgroundBlur
 		rsDesc.ScissorEnable = TRUE;
 		if (!checkCreate(device->CreateRasterizerState(&rsDesc, scissorRasterizerState.put()), "scissor rasterizer state"))
 			return false;
+		Util::SetResourceName(scissorRasterizerState.get(), "BackgroundBlur::ScissorRasterizerState");
 
 		initialized = true;
 		return true;

--- a/src/Menu/IconLoader.cpp
+++ b/src/Menu/IconLoader.cpp
@@ -4,6 +4,7 @@
 
 #include "Globals.h"
 #include "Menu.h"
+#include "Utils/D3D.h"
 #include "Utils/FileSystem.h"
 
 #include <d3d11.h>
@@ -53,6 +54,7 @@ namespace Util::IconLoader
 			stbi_image_free(image_data);
 			return false;
 		}
+		Util::SetResourceName(pTexture, "IconLoader::%s", filename);
 
 		ID3D11DeviceContext* context = nullptr;
 		device->GetImmediateContext(&context);
@@ -74,6 +76,7 @@ namespace Util::IconLoader
 				context->Release();
 			return false;
 		}
+		Util::SetResourceName(*out_srv, "IconLoader::%s SRV", filename);
 
 		if (context) {
 			context->GenerateMips(*out_srv);

--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -1,6 +1,7 @@
 #include "UI.h"
 
 #include "../WeatherEditor/EditorWindow.h"
+#include "D3D.h"
 #include "FileSystem.h"
 #include "Menu.h"
 #include "Menu/Fonts.h"
@@ -1784,6 +1785,8 @@ namespace Util
 		};
 
 		HRESULT hr = device->CreateShaderResourceView(pTexture, &srvDesc, out_srv);
+		if (SUCCEEDED(hr) && *out_srv)
+			Util::SetResourceName(*out_srv, "UI::DDS:%s", filename);
 		pTexture->Release();
 
 		if (FAILED(hr) || !*out_srv) {


### PR DESCRIPTION
All D3D11 resources created by Community Shaders now carry a descriptive debug name via SetPrivateData(WKPDID_D3DDebugObjectName), so they appear as e.g. "SSGI::Radiance SRV" in RenderDoc instead of generic indices like "Texture #47".

Changes:
- Buffer.h: add optional `name` parameter to all wrapper class constructors (ConstantBuffer, StructuredBuffer, Buffer, Texture1D, Texture2D, Texture3D); view creation methods (CreateSRV/UAV/RTV/DSV) automatically append " SRV" / " UAV" etc. to the base name. detail::SetD3DName delegates to Util::SetResourceName via a forward declaration, keeping the GUID definition in one place (D3D.cpp).
- Util::SetResourceName used directly for raw device->Create* objects (samplers, blend states, depth-stencil states, rasterizer states, raw RTVs/SRVs not owned by a wrapper) across: Deferred, CloudShadows, DynamicCubemaps, VolumetricShadows, ScreenSpaceGI, ScreenSpaceShadows, Skylighting, TerrainBlending, TerrainShadows, LightLimitFix, GrassCollision, HairSpecular, HDRDisplay, IBL, VR, VRStereoOpt, VR::StereoBlend, VR::InSceneOverlay, BackgroundBlur, IconLoader, Utils::UI.
- .claude/CLAUDE.md: add DRY pitfall note for cross-cutting refactors.

No behaviour change; naming calls are init-time only with zero per-frame overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced resource naming conventions throughout the graphics framework.
  * Updated buffer and texture constructors to support optional resource labeling parameters.
  * Added systematic naming infrastructure for dynamically created graphics resources across multiple feature modules.
  * Established centralized utility patterns for resource identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->