### PR TITLE
feat(menu): add simple mode quality preset system

### DIFF
--- a/features/Screen Space GI/Shaders/Features/ScreenSpaceGI.ini
+++ b/features/Screen Space GI/Shaders/Features/ScreenSpaceGI.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 4-1-0
+Version = 4-2-0
 
 [Nexus]
 nexusmodid = 130375

--- a/features/Wetness Effects/Shaders/Features/WetnessEffects.ini
+++ b/features/Wetness Effects/Shaders/Features/WetnessEffects.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 3-1-0
+Version = 3-2-0
 
 [Nexus]
 nexusmodid = 112739

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -348,12 +348,9 @@ void Feature::DrawSimpleSettings()
 	                             *runtimeEnabled :
 	                             !globals::state->IsFeatureDisabled(shortName);
 
-	if (!runtimeAvailable && !simpleModeBootCaptured) {
-		simpleModeBootInitial = globals::state->IsFeatureDisabled(shortName);
-		simpleModeBootCaptured = true;
-	}
-	const bool restartPending = !runtimeAvailable &&
-	                            globals::state->IsFeatureDisabled(shortName) != simpleModeBootInitial;
+	// Loaded features were enabled at boot by definition; a restart is needed only
+	// if the user has since toggled the boot setting to disabled.
+	const bool restartPending = !runtimeAvailable && globals::state->IsFeatureDisabled(shortName);
 
 	const auto& palette = globals::menu->GetTheme().StatusPalette;
 	if (restartPending)

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -397,34 +397,23 @@ void Feature::DrawSimpleSettings()
 		overlay.assign(presets[lastAppliedQualityIdx].label.data(), presets[lastAppliedQualityIdx].label.size());
 	}
 
-	if (n == 0) {
-		// No quality presets — render as a simple on/off checkbox.
-		bool isOn = currentlyOn;
-		if (ImGui::Checkbox(label.c_str(), &isOn) && currentlyOn != isOn) {
+	int v = currentValue;
+	if (ImGui::SliderInt(label.c_str(), &v, 0, sliderMax, overlay.c_str(), ImGuiSliderFlags_AlwaysClamp)) {
+		const bool wantOn = v >= 1;
+		if (currentlyOn != wantOn) {
 			if (runtimeAvailable)
-				*runtimeEnabled = isOn;
+				*runtimeEnabled = wantOn;
 			else
 				ToggleAtBootSetting();
 		}
-	} else {
-		int v = currentValue;
-		if (ImGui::SliderInt(label.c_str(), &v, 0, sliderMax, overlay.c_str(), ImGuiSliderFlags_AlwaysClamp)) {
-			const bool wantOn = v >= 1;
-			if (currentlyOn != wantOn) {
-				if (runtimeAvailable)
-					*runtimeEnabled = wantOn;
-				else
-					ToggleAtBootSetting();
-			}
-			if (wantOn && v <= n) {
-				const int idx = v - 1;
-				ApplyPreset(this, presets[idx]);
-				lastAppliedQualityIdx = idx;
-			} else if (!wantOn) {
-				lastAppliedQualityIdx = -1;
-			}
-			// v == n+1 (Custom slot): leave lastAppliedQualityIdx as-is.
+		if (wantOn && n > 0 && v <= n) {
+			const int idx = v - 1;
+			ApplyPreset(this, presets[idx]);
+			lastAppliedQualityIdx = idx;
+		} else if (!wantOn) {
+			lastAppliedQualityIdx = -1;
 		}
+		// v == n+1 (Custom slot): leave lastAppliedQualityIdx as-is.
 	}
 
 	if (auto _tt = Util::HoverTooltipWrapper()) {

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -334,6 +334,106 @@ bool Feature::ReapplyOverrideSettings()
 	return false;
 }
 
+void Feature::DrawSimpleSettings()
+{
+	bool* runtimeEnabled = GetEnabledFlag();
+	auto presets = GetQualityPresets();
+	const std::string shortName = GetShortName();
+
+	// On/off uses the runtime flag when available, otherwise the boot-toggle (every
+	// feature supports it). Boot path requires a restart; only mark it as such once
+	// the user actually flips it from the value captured at first render.
+	const bool runtimeAvailable = runtimeEnabled != nullptr;
+	const bool currentlyOn = runtimeAvailable ?
+	                             *runtimeEnabled :
+	                             !globals::state->IsFeatureDisabled(shortName);
+
+	if (!runtimeAvailable && !simpleModeBootCaptured) {
+		simpleModeBootInitial = globals::state->IsFeatureDisabled(shortName);
+		simpleModeBootCaptured = true;
+	}
+	const bool restartPending = !runtimeAvailable &&
+	                            globals::state->IsFeatureDisabled(shortName) != simpleModeBootInitial;
+
+	const auto& palette = globals::menu->GetTheme().StatusPalette;
+	if (restartPending)
+		ImGui::PushStyleColor(ImGuiCol_Text, palette.RestartNeeded);
+
+	// Slider label includes the version (e.g. "Screen Space GI v2.1.0").
+	std::string label = GetName();
+	if (!version.empty()) {
+		label += " v";
+		label += version;
+	}
+
+	const int n = static_cast<int>(presets.size());
+	const int sliderMax = std::max(1, n);
+	int currentValue;
+	std::string overlay;
+	if (!currentlyOn) {
+		currentValue = 0;
+		overlay = "Off";
+	} else if (n == 0) {
+		currentValue = 1;
+		overlay = "On";
+	} else if (lastAppliedQualityIdx >= 0 && lastAppliedQualityIdx < n) {
+		currentValue = lastAppliedQualityIdx + 1;
+		overlay.assign(presets[lastAppliedQualityIdx].label.data(), presets[lastAppliedQualityIdx].label.size());
+	} else {
+		currentValue = 1;
+		overlay = "Custom";
+	}
+
+	int v = currentValue;
+	if (ImGui::SliderInt(label.c_str(), &v, 0, sliderMax, overlay.c_str(), ImGuiSliderFlags_AlwaysClamp)) {
+		const bool wantOn = v >= 1;
+		if (currentlyOn != wantOn) {
+			if (runtimeAvailable)
+				*runtimeEnabled = wantOn;
+			else
+				ToggleAtBootSetting();
+		}
+		if (wantOn && n > 0) {
+			const int idx = v - 1;
+			if (idx >= 0 && idx < n) {
+				ApplyPreset(this, presets[idx]);
+				lastAppliedQualityIdx = idx;
+			}
+		} else if (!wantOn) {
+			lastAppliedQualityIdx = -1;
+		}
+	}
+
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		auto [description, keyFeatures] = GetFeatureSummary();
+		if (!description.empty())
+			ImGui::TextWrapped("%s", description.c_str());
+		if (!keyFeatures.empty()) {
+			if (!description.empty())
+				ImGui::Spacing();
+			ImGui::TextUnformatted("Key features:");
+			for (const auto& k : keyFeatures)
+				ImGui::BulletText("%s", k.c_str());
+		}
+		if (currentValue >= 1 && n > 0) {
+			const auto& desc = presets[currentValue - 1].description;
+			if (!desc.empty()) {
+				ImGui::Separator();
+				ImGui::TextWrapped("%s: %.*s", overlay.c_str(),
+					static_cast<int>(desc.size()), desc.data());
+			}
+		}
+		if (!runtimeAvailable) {
+			ImGui::Separator();
+			ImGui::TextColored(palette.RestartNeeded,
+				"Toggling Off/On for this feature requires a game restart.");
+		}
+	}
+
+	if (restartPending)
+		ImGui::PopStyleColor();
+}
+
 void Feature::DrawUnloadedUI()
 {
 	// Prioritize detailed failure message if available

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -367,7 +367,20 @@ void Feature::DrawSimpleSettings()
 	}
 
 	const int n = static_cast<int>(presets.size());
-	const int sliderMax = std::max(1, n);
+
+	// Resolve "Custom" on first render by asking the feature to match its settings
+	// against its presets; saves the user from a "Custom" label when settings still
+	// match a preset (e.g. after JSON load).
+	if (currentlyOn && n > 0 && lastAppliedQualityIdx < 0)
+		lastAppliedQualityIdx = DetectCurrentQuality();
+
+	// When in Custom state with presets available, give the slider an extra stop at
+	// n+1 so dragging back to position 1 still fires SliderInt's change event and
+	// applies the first preset. Without this, Custom and "preset 0" would share
+	// position 1 and clicking 1 would be a no-op.
+	const bool inCustom = currentlyOn && n > 0 && (lastAppliedQualityIdx < 0 || lastAppliedQualityIdx >= n);
+	const int sliderMax = inCustom ? n + 1 : std::max(1, n);
+
 	int currentValue;
 	std::string overlay;
 	if (!currentlyOn) {
@@ -376,12 +389,12 @@ void Feature::DrawSimpleSettings()
 	} else if (n == 0) {
 		currentValue = 1;
 		overlay = "On";
-	} else if (lastAppliedQualityIdx >= 0 && lastAppliedQualityIdx < n) {
+	} else if (inCustom) {
+		currentValue = n + 1;
+		overlay = "Custom";
+	} else {
 		currentValue = lastAppliedQualityIdx + 1;
 		overlay.assign(presets[lastAppliedQualityIdx].label.data(), presets[lastAppliedQualityIdx].label.size());
-	} else {
-		currentValue = 1;
-		overlay = "Custom";
 	}
 
 	int v = currentValue;
@@ -393,15 +406,14 @@ void Feature::DrawSimpleSettings()
 			else
 				ToggleAtBootSetting();
 		}
-		if (wantOn && n > 0) {
+		if (wantOn && n > 0 && v <= n) {
 			const int idx = v - 1;
-			if (idx >= 0 && idx < n) {
-				ApplyPreset(this, presets[idx]);
-				lastAppliedQualityIdx = idx;
-			}
+			ApplyPreset(this, presets[idx]);
+			lastAppliedQualityIdx = idx;
 		} else if (!wantOn) {
 			lastAppliedQualityIdx = -1;
 		}
+		// v == n+1 (Custom slot): leave lastAppliedQualityIdx as-is.
 	}
 
 	if (auto _tt = Util::HoverTooltipWrapper()) {

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -397,23 +397,34 @@ void Feature::DrawSimpleSettings()
 		overlay.assign(presets[lastAppliedQualityIdx].label.data(), presets[lastAppliedQualityIdx].label.size());
 	}
 
-	int v = currentValue;
-	if (ImGui::SliderInt(label.c_str(), &v, 0, sliderMax, overlay.c_str(), ImGuiSliderFlags_AlwaysClamp)) {
-		const bool wantOn = v >= 1;
-		if (currentlyOn != wantOn) {
+	if (n == 0) {
+		// No quality presets — render as a simple on/off checkbox.
+		bool isOn = currentlyOn;
+		if (ImGui::Checkbox(label.c_str(), &isOn) && currentlyOn != isOn) {
 			if (runtimeAvailable)
-				*runtimeEnabled = wantOn;
+				*runtimeEnabled = isOn;
 			else
 				ToggleAtBootSetting();
 		}
-		if (wantOn && n > 0 && v <= n) {
-			const int idx = v - 1;
-			ApplyPreset(this, presets[idx]);
-			lastAppliedQualityIdx = idx;
-		} else if (!wantOn) {
-			lastAppliedQualityIdx = -1;
+	} else {
+		int v = currentValue;
+		if (ImGui::SliderInt(label.c_str(), &v, 0, sliderMax, overlay.c_str(), ImGuiSliderFlags_AlwaysClamp)) {
+			const bool wantOn = v >= 1;
+			if (currentlyOn != wantOn) {
+				if (runtimeAvailable)
+					*runtimeEnabled = wantOn;
+				else
+					ToggleAtBootSetting();
+			}
+			if (wantOn && v <= n) {
+				const int idx = v - 1;
+				ApplyPreset(this, presets[idx]);
+				lastAppliedQualityIdx = idx;
+			} else if (!wantOn) {
+				lastAppliedQualityIdx = -1;
+			}
+			// v == n+1 (Custom slot): leave lastAppliedQualityIdx as-is.
 		}
-		// v == n+1 (Custom slot): leave lastAppliedQualityIdx as-is.
 	}
 
 	if (auto _tt = Util::HoverTooltipWrapper()) {
@@ -427,7 +438,7 @@ void Feature::DrawSimpleSettings()
 			for (const auto& k : keyFeatures)
 				ImGui::BulletText("%s", k.c_str());
 		}
-		if (currentValue >= 1 && n > 0) {
+		if (currentValue >= 1 && currentValue <= n) {
 			const auto& desc = presets[currentValue - 1].description;
 			if (!desc.empty()) {
 				ImGui::Separator();

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -3,6 +3,7 @@
 #include "FeatureCategories.h"
 #include "FeatureConstraints.h"
 #include "FeatureVersions.h"
+#include <span>  // GetQualityPresets() return type
 #ifdef TRACY_ENABLE
 #	include <Tracy/Tracy.hpp>
 #	include <Tracy/TracyD3D11.hpp>
@@ -165,6 +166,15 @@ public:
 	 * Return nullptr if the feature has no enable toggle (in which case Off is hidden).
 	 */
 	virtual bool* GetEnabledFlag() { return nullptr; }
+
+	/**
+	 * Returns the index into GetQualityPresets() that matches the feature's current
+	 * settings, or -1 when the settings don't match any preset (Custom). Used by the
+	 * Simple menu to position the slider correctly on first render after a JSON load.
+	 * Default returns -1; features that can compare their settings to their tiers
+	 * should override.
+	 */
+	virtual int DetectCurrentQuality() const { return -1; }
 
 	/**
 	 * Render the Simple-mode settings UI: Off button + quality preset row.

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -79,13 +79,7 @@ struct Feature
 	// Nexus Mods base URL for Skyrim Special Edition
 	static constexpr std::string_view NEXUS_BASE_URL = "https://www.nexusmods.com/skyrimspecialedition/mods/";
 	bool loaded = false;
-	// The two simple-mode bools fit in the natural padding between `loaded` and
-	// `lastAppliedQualityIdx`; the int then fills the remaining padding before the
-	// 8-byte-aligned std::string. Reordering this group triggers C4324 in alignas(16)
-	// derived classes.
-	bool simpleModeBootCaptured = false;
-	bool simpleModeBootInitial = false;  // snapshot of IsFeatureDisabled at first render
-	int lastAppliedQualityIdx = -1;      // -1 = unknown/Custom
+	int lastAppliedQualityIdx = -1;  // -1 = unknown/Custom
 	std::string version;
 	std::string failedLoadedMessage;
 

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -10,6 +10,60 @@
 
 struct Feature
 {
+	// Generic named-preset entry. The enum type E is feature-specific; the surrounding
+	// shape is shared so SSGI's QualityPreset and WetnessEffects::ClimatePreset use
+	// the same dispatch.
+	template <typename E>
+	struct Preset
+	{
+		E id;
+		std::string_view label;
+		std::string_view description;
+		// apply receives the preset id so one shared thunk can dispatch all entries
+		// of an enum. nullptr apply is a no-op (e.g. a "Custom" sentinel).
+		void (*apply)(Feature*, E) = nullptr;
+		// Optional VR variant; falls back to apply when null.
+		void (*vrApply)(Feature*, E) = nullptr;
+	};
+
+	// Quality tiers for the simple menu. Authors declare a sparse subset; missing
+	// tiers don't appear in the UI.
+	enum class QualityLevel : uint8_t
+	{
+		Low,
+		Medium,
+		High,
+		Ultra
+	};
+	using QualityPreset = Preset<QualityLevel>;
+
+	// Apply a preset, picking vrApply on VR when available.
+	template <typename E>
+	static void ApplyPreset(Feature* feature, const Preset<E>& preset)
+	{
+		if (preset.vrApply && REL::Module::IsVR())
+			preset.vrApply(feature, preset.id);
+		else if (preset.apply)
+			preset.apply(feature, preset.id);
+	}
+
+	// Apply a quality tier without going through ImGui (controller menu, scripts).
+	// Returns false if the feature does not expose that tier.
+	bool ApplyQualityPreset(QualityLevel level)
+	{
+		auto presets = GetQualityPresets();
+		for (size_t i = 0; i < presets.size(); ++i) {
+			if (presets[i].id == level) {
+				ApplyPreset(this, presets[i]);
+				if (auto* en = GetEnabledFlag())
+					*en = true;
+				lastAppliedQualityIdx = static_cast<int>(i);
+				return true;
+			}
+		}
+		return false;
+	}
+
 	// For global settings search
 	struct SettingSearchEntry
 	{
@@ -24,6 +78,13 @@ struct Feature
 	// Nexus Mods base URL for Skyrim Special Edition
 	static constexpr std::string_view NEXUS_BASE_URL = "https://www.nexusmods.com/skyrimspecialedition/mods/";
 	bool loaded = false;
+	// The two simple-mode bools fit in the natural padding between `loaded` and
+	// `lastAppliedQualityIdx`; the int then fills the remaining padding before the
+	// 8-byte-aligned std::string. Reordering this group triggers C4324 in alignas(16)
+	// derived classes.
+	bool simpleModeBootCaptured = false;
+	bool simpleModeBootInitial = false;  // snapshot of IsFeatureDisabled at first render
+	int lastAppliedQualityIdx = -1;      // -1 = unknown/Custom
 	std::string version;
 	std::string failedLoadedMessage;
 
@@ -90,6 +151,26 @@ public:
 	virtual void Reset() {}
 	virtual void DrawSettings() {}
 	virtual void DrawUnloadedUI();
+
+	/**
+	 * Quality preset list for the global Simple menu.
+	 * Default: empty — feature renders just an Enable toggle (or nothing if no enable flag).
+	 * Override and return a span over a `static constexpr std::array<QualityPreset, N>` to
+	 * expose Off/Low/Medium/High etc. Missing tiers are skipped gracefully.
+	 */
+	virtual std::span<const QualityPreset> GetQualityPresets() const { return {}; }
+
+	/**
+	 * Pointer to the feature's `Enabled` bool, used by the Simple menu's Off button.
+	 * Return nullptr if the feature has no enable toggle (in which case Off is hidden).
+	 */
+	virtual bool* GetEnabledFlag() { return nullptr; }
+
+	/**
+	 * Render the Simple-mode settings UI: Off button + quality preset row.
+	 * Implemented in Feature.cpp; features generally do not need to override.
+	 */
+	void DrawSimpleSettings();
 
 	virtual void ReflectionsPrepass() {};
 	virtual void Prepass() {}

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -63,17 +63,24 @@ namespace
 		ssgi->recompileFlag = true;
 	}
 
-	// VR variants force AO-only (EnableGI=false) for performance; vrApply is null where
-	// the SE/AE tuning is acceptable on VR and ApplyPreset falls back to apply.
+	// Shared tier table — both the apply lambdas and DetectCurrentQuality read from here
+	// so a single edit keeps application and detection in sync.
+	// VR High intentionally mirrors flat (vrApply=nullptr -> ApplyPreset falls back to apply).
+	static constexpr std::array<std::pair<QualityTier, QualityTier>, 3> kTierValues = { {
+		{ { 10, 12, 2, true }, { 1, 6, 2, false } },  // Low  (flat / VR)
+		{ { 4, 8, 1, true }, { 3, 8, 1, false } },    // Medium
+		{ { 4, 8, 0, true }, { 4, 8, 0, true } },     // High (no VR variant — uses flat)
+	} };
+
 	static constexpr std::array<Feature::QualityPreset, 3> kQualityPresets = { {
 		{ Feature::QualityLevel::Low, "Low", "Quarter resolution, blurred. AO + basic GI.",
-			[](Feature* f, Feature::QualityLevel) { ApplyTier(f, { 10, 12, 2, true }); },
-			[](Feature* f, Feature::QualityLevel) { ApplyTier(f, { 1, 6, 2, false }); } },
+			[](Feature* f, Feature::QualityLevel) { ApplyTier(f, kTierValues[0].first); },
+			[](Feature* f, Feature::QualityLevel) { ApplyTier(f, kTierValues[0].second); } },
 		{ Feature::QualityLevel::Medium, "Medium", "Half resolution, balanced quality and performance.",
-			[](Feature* f, Feature::QualityLevel) { ApplyTier(f, { 4, 8, 1, true }); },
-			[](Feature* f, Feature::QualityLevel) { ApplyTier(f, { 3, 8, 1, false }); } },
+			[](Feature* f, Feature::QualityLevel) { ApplyTier(f, kTierValues[1].first); },
+			[](Feature* f, Feature::QualityLevel) { ApplyTier(f, kTierValues[1].second); } },
 		{ Feature::QualityLevel::High, "High", "Full resolution, clean output with full GI.",
-			[](Feature* f, Feature::QualityLevel) { ApplyTier(f, { 4, 8, 0, true }); },
+			[](Feature* f, Feature::QualityLevel) { ApplyTier(f, kTierValues[2].first); },
 			nullptr },
 	} };
 }
@@ -85,16 +92,9 @@ std::span<const Feature::QualityPreset> ScreenSpaceGI::GetQualityPresets() const
 
 int ScreenSpaceGI::DetectCurrentQuality() const
 {
-	// SSGI tiers vary by platform — VR uses AO-only variants. Each tier matches when
-	// its critical knobs (slices, steps, resolution mode, GI on/off) all match.
 	const bool isVR = REL::Module::IsVR();
-	static constexpr std::array<std::pair<QualityTier, QualityTier>, 3> tiers = { {
-		{ { 10, 12, 2, true }, { 1, 6, 2, false } },  // Low (flat / VR)
-		{ { 4, 8, 1, true }, { 3, 8, 1, false } },    // Medium
-		{ { 4, 8, 0, true }, { 4, 8, 0, true } },     // High (no VR variant — uses flat)
-	} };
-	for (size_t i = 0; i < tiers.size(); ++i) {
-		const auto& q = isVR ? tiers[i].second : tiers[i].first;
+	for (size_t i = 0; i < kTierValues.size(); ++i) {
+		const auto& q = isVR ? kTierValues[i].second : kTierValues[i].first;
 		if (settings.NumSlices == q.numSlices &&
 			settings.NumSteps == q.numSteps &&
 			settings.ResolutionMode == q.resolutionMode &&

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -40,6 +40,49 @@ void ScreenSpaceGI::RestoreDefaultSettings()
 	recompileFlag = true;
 }
 
+namespace
+{
+	// Per-tier values applied by ApplyTier.
+	struct QualityTier
+	{
+		uint numSlices;
+		uint numSteps;
+		int resolutionMode;
+		bool enableGI;
+	};
+
+	void ApplyTier(Feature* f, const QualityTier& q)
+	{
+		auto* ssgi = static_cast<ScreenSpaceGI*>(f);
+		ssgi->settings.Enabled = true;
+		ssgi->settings.NumSlices = q.numSlices;
+		ssgi->settings.NumSteps = q.numSteps;
+		ssgi->settings.ResolutionMode = q.resolutionMode;
+		ssgi->settings.EnableBlur = true;
+		ssgi->settings.EnableGI = q.enableGI;
+		ssgi->recompileFlag = true;
+	}
+
+	// VR variants force AO-only (EnableGI=false) for performance; vrApply is null where
+	// the SE/AE tuning is acceptable on VR and ApplyPreset falls back to apply.
+	static constexpr std::array<Feature::QualityPreset, 3> kQualityPresets = { {
+		{ Feature::QualityLevel::Low, "Low", "Quarter resolution, blurred. AO + basic GI.",
+			[](Feature* f, Feature::QualityLevel) { ApplyTier(f, { 10, 12, 2, true }); },
+			[](Feature* f, Feature::QualityLevel) { ApplyTier(f, { 1, 6, 2, false }); } },
+		{ Feature::QualityLevel::Medium, "Medium", "Half resolution, balanced quality and performance.",
+			[](Feature* f, Feature::QualityLevel) { ApplyTier(f, { 4, 8, 1, true }); },
+			[](Feature* f, Feature::QualityLevel) { ApplyTier(f, { 3, 8, 1, false }); } },
+		{ Feature::QualityLevel::High, "High", "Full resolution, clean output with full GI.",
+			[](Feature* f, Feature::QualityLevel) { ApplyTier(f, { 4, 8, 0, true }); },
+			nullptr },
+	} };
+}
+
+std::span<const Feature::QualityPreset> ScreenSpaceGI::GetQualityPresets() const
+{
+	return kQualityPresets;
+}
+
 void ScreenSpaceGI::DrawSettings()
 {
 	static bool showAdvanced;

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -83,6 +83,28 @@ std::span<const Feature::QualityPreset> ScreenSpaceGI::GetQualityPresets() const
 	return kQualityPresets;
 }
 
+int ScreenSpaceGI::DetectCurrentQuality() const
+{
+	// SSGI tiers vary by platform — VR uses AO-only variants. Each tier matches when
+	// its critical knobs (slices, steps, resolution mode, GI on/off) all match.
+	const bool isVR = REL::Module::IsVR();
+	static constexpr std::array<std::pair<QualityTier, QualityTier>, 3> tiers = { {
+		{ { 10, 12, 2, true }, { 1, 6, 2, false } },  // Low (flat / VR)
+		{ { 4, 8, 1, true }, { 3, 8, 1, false } },    // Medium
+		{ { 4, 8, 0, true }, { 4, 8, 0, true } },     // High (no VR variant — uses flat)
+	} };
+	for (size_t i = 0; i < tiers.size(); ++i) {
+		const auto& q = isVR ? tiers[i].second : tiers[i].first;
+		if (settings.NumSlices == q.numSlices &&
+			settings.NumSteps == q.numSteps &&
+			settings.ResolutionMode == q.resolutionMode &&
+			settings.EnableGI == q.enableGI &&
+			settings.EnableBlur)
+			return static_cast<int>(i);
+	}
+	return -1;
+}
+
 void ScreenSpaceGI::DrawSettings()
 {
 	static bool showAdvanced;

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -173,36 +173,21 @@ void ScreenSpaceGI::DrawSettings()
 
 			ImGui::TableNextColumn();
 			if (ImGui::Button("Low", { -1, 0 })) {
-				settings.NumSlices = 10;
-				settings.NumSteps = 12;
-				settings.ResolutionMode = 2;
-				settings.EnableBlur = true;
-				settings.EnableGI = true;
-				recompileFlag = true;
+				ApplyTier(this, kTierValues[0].first);
 			}
 			if (auto _tt = Util::HoverTooltipWrapper())
 				ImGui::Text("Quarter res and blurry.");
 
 			ImGui::TableNextColumn();
 			if (ImGui::Button("Standard", { -1, 0 })) {
-				settings.NumSlices = 4;
-				settings.NumSteps = 8;
-				settings.ResolutionMode = 1;
-				settings.EnableBlur = true;
-				settings.EnableGI = true;
-				recompileFlag = true;
+				ApplyTier(this, kTierValues[1].first);
 			}
 			if (auto _tt = Util::HoverTooltipWrapper())
 				ImGui::Text("Half res and somewhat stable.");
 
 			ImGui::TableNextColumn();
 			if (ImGui::Button("Extreme", { -1, 0 })) {
-				settings.NumSlices = 4;
-				settings.NumSteps = 8;
-				settings.ResolutionMode = 0;
-				settings.EnableBlur = true;
-				settings.EnableGI = true;
-				recompileFlag = true;
+				ApplyTier(this, kTierValues[2].first);
 			}
 			if (auto _tt = Util::HoverTooltipWrapper())
 				ImGui::Text("Full res and clean.");

--- a/src/Features/ScreenSpaceGI.h
+++ b/src/Features/ScreenSpaceGI.h
@@ -42,6 +42,7 @@ public:
 
 	virtual std::span<const QualityPreset> GetQualityPresets() const override;
 	virtual bool* GetEnabledFlag() override { return &settings.Enabled; }
+	virtual int DetectCurrentQuality() const override;
 
 	virtual void LoadSettings(json& o_json) override;
 	virtual void SaveSettings(json& o_json) override;

--- a/src/Features/ScreenSpaceGI.h
+++ b/src/Features/ScreenSpaceGI.h
@@ -40,6 +40,9 @@ public:
 	virtual void RestoreDefaultSettings() override;
 	virtual void DrawSettings() override;
 
+	virtual std::span<const QualityPreset> GetQualityPresets() const override;
+	virtual bool* GetEnabledFlag() override { return &settings.Enabled; }
+
 	virtual void LoadSettings(json& o_json) override;
 	virtual void SaveSettings(json& o_json) override;
 

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -45,10 +45,17 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 // Climate preset data - defines regional weather characteristics
 // Precipitation rates calculated from actual shader mechanics: grid size, interval, and raindrop chance
 
+// Shared dispatch for all CLIMATE_PRESET_INFO entries.
+static void ClimateApplyThunk(Feature* f, WetnessEffects::ClimatePreset id)
+{
+	static_cast<WetnessEffects*>(f)->ApplyClimatePreset(id);
+}
+
+// Embeds Feature::Preset<E> for shared label/description/apply, alongside
+// Wetness-specific rich metadata used by the climate analysis UI.
 struct ClimatePresetInfo
 {
-	const char* name;
-	const char* shortDescription;
+	Feature::Preset<WetnessEffects::ClimatePreset> preset;
 	const char* const* detailedDescription;
 	const char* const* effectDescription;
 	WetnessEffects::ClimateSettings settings;
@@ -137,48 +144,33 @@ static constexpr const char* MONSOON_EFFECTS[] = {
 	nullptr
 };
 
-static constexpr std::array<ClimatePresetInfo, 6> CLIMATE_PRESET_INFO = {
-	{ { "Custom",
-		  "User-defined custom settings",
-		  nullptr,
-		  nullptr,
-		  { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f } },
-		// Legacy (Original Skyrim)
-		{
-			"Legacy",
-			"Original rain effect values (very light)",
-			LEGACY_DETAILED,
-			LEGACY_EFFECTS,
-			{ 1.0f, 1.0f, 1.0f, 0.3f, 4.0f, 0.5f } },
-		// Nordic Standard
-		{
-			"Nordic (Default)",
-			"Balanced Nordic climate (moderate rain)",
-			NORDIC_DETAILED,
-			NORDIC_EFFECTS,
-			{ 1.0f, 1.0f, 1.0f, 1.0f, 3.0f, 1.0f } },
-		// Arctic Tundra
-		{
-			"Arctic Tundra",
-			"Cold, dry Arctic climate (light rain)",
-			ARCTIC_DETAILED,
-			ARCTIC_EFFECTS,
-			{ 0.5f, 0.3f, 0.5f, 0.3f, 3.5f, 0.4f } },
-		// Temperate Coastal
-		{
-			"Temperate Coastal",
-			"Maritime climate (heavy rain)",
-			COASTAL_DETAILED,
-			COASTAL_EFFECTS,
-			{ 1.5f, 1.7f, 1.7f, 0.8f, 2.5f, 0.25f } },
-		// Monsoon/Extreme
-		{
-			"Monsoon/Extreme",
-			"Extreme monsoon climate (extreme rain)",
-			MONSOON_DETAILED,
-			MONSOON_EFFECTS,
-			{ 2.0f, 2.5f, 2.0f, 1.0f, 2.0f, 0.2f } } }
-};
+static constexpr std::array<ClimatePresetInfo, 6> CLIMATE_PRESET_INFO = { {
+	// Custom is a sentinel — apply=nullptr means "no-op" (user has customized values)
+	{ { WetnessEffects::ClimatePreset::Custom, "Custom", "User-defined custom settings", nullptr, nullptr },
+		nullptr,
+		nullptr,
+		{ 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f } },
+	{ { WetnessEffects::ClimatePreset::Legacy, "Legacy", "Original rain effect values (very light)", &ClimateApplyThunk, nullptr },
+		LEGACY_DETAILED,
+		LEGACY_EFFECTS,
+		{ 1.0f, 1.0f, 1.0f, 0.3f, 4.0f, 0.5f } },
+	{ { WetnessEffects::ClimatePreset::NordicStandard, "Nordic (Default)", "Balanced Nordic climate (moderate rain)", &ClimateApplyThunk, nullptr },
+		NORDIC_DETAILED,
+		NORDIC_EFFECTS,
+		{ 1.0f, 1.0f, 1.0f, 1.0f, 3.0f, 1.0f } },
+	{ { WetnessEffects::ClimatePreset::ArcticTundra, "Arctic Tundra", "Cold, dry Arctic climate (light rain)", &ClimateApplyThunk, nullptr },
+		ARCTIC_DETAILED,
+		ARCTIC_EFFECTS,
+		{ 0.5f, 0.3f, 0.5f, 0.3f, 3.5f, 0.4f } },
+	{ { WetnessEffects::ClimatePreset::TemperateCoastal, "Temperate Coastal", "Maritime climate (heavy rain)", &ClimateApplyThunk, nullptr },
+		COASTAL_DETAILED,
+		COASTAL_EFFECTS,
+		{ 1.5f, 1.7f, 1.7f, 0.8f, 2.5f, 0.25f } },
+	{ { WetnessEffects::ClimatePreset::MonsoonExtreme, "Monsoon/Extreme", "Extreme monsoon climate (extreme rain)", &ClimateApplyThunk, nullptr },
+		MONSOON_DETAILED,
+		MONSOON_EFFECTS,
+		{ 2.0f, 2.5f, 2.0f, 1.0f, 2.0f, 0.2f } },
+} };
 
 // Extract just the settings for the actual climate preset array
 static const std::array<WetnessEffects::ClimateSettings, 6> CLIMATE_PRESETS = { {
@@ -257,10 +249,10 @@ void WetnessEffects::DrawSettings()
 	ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.2f, 0.3f, 0.4f, 0.6f));    // Subtle blue background
 	ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.25f, 0.35f, 0.45f, 0.8f));  // Slightly darker for button
 
-	// Extract names for combo box
+	// Extract names for combo box. Labels come from string literals so .data() is null-terminated.
 	const char* presetNames[CLIMATE_PRESET_INFO.size()];
 	for (size_t i = 0; i < CLIMATE_PRESET_INFO.size(); ++i) {
-		presetNames[i] = CLIMATE_PRESET_INFO[i].name;
+		presetNames[i] = CLIMATE_PRESET_INFO[i].preset.label.data();
 	}
 	// Map preset enum to combo index (Custom=0, Legacy=1, Nordic=2, Arctic=3, Coastal=4, Monsoon=5)
 	int currentComboIndex = static_cast<int>(climatePreset);
@@ -272,10 +264,8 @@ void WetnessEffects::DrawSettings()
 		// Update the preset selection
 		climatePreset = newPreset;
 
-		// Apply preset settings (but not for Custom, which just means user-modified)
-		if (newPreset != ClimatePreset::Custom) {
-			ApplyClimatePreset(newPreset);
-		}
+		// Route through shared dispatch — Custom's apply is null and becomes a no-op.
+		Feature::ApplyPreset(this, CLIMATE_PRESET_INFO[static_cast<size_t>(newPreset)].preset);
 	}
 
 	ImGui::PopStyleColor(2);  // Pop both style colors
@@ -290,7 +280,7 @@ void WetnessEffects::DrawSettings()
 			} else {
 				// Build combined description lines for actual presets
 				std::vector<const char*> tooltipLines;
-				tooltipLines.push_back(info.shortDescription);
+				tooltipLines.push_back(info.preset.description.data());
 				// Add detailed description
 				for (const char* const* line = info.detailedDescription; *line != nullptr; ++line) {
 					tooltipLines.push_back(*line);
@@ -875,9 +865,9 @@ void WetnessEffects::DrawWeatherAnalysis() const
 			// const auto& climate = GetClimateSettings(climatePreset); // Unused, remove to fix warning treated as error
 			const auto& presetInfo = CLIMATE_PRESET_INFO[static_cast<size_t>(climatePreset)];
 
-			ImGui::Text("Active Preset: %s", presetInfo.name);
+			ImGui::Text("Active Preset: %s", presetInfo.preset.label.data());
 			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text("%s", presetInfo.shortDescription);
+				ImGui::Text("%s", presetInfo.preset.description.data());
 			}
 
 			ImGui::Text("Precipitation Rate Calculation");

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -166,6 +166,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	FirstTimeSetupCompleted,
 	SkipClearCacheConfirmation,
 	AutoHideFeatureList,
+	SimpleMode,
 	SkipConstraintWarning,
 	RequireShiftToDock,
 	UseResolutionFont,

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -409,6 +409,7 @@ public:
 		bool FirstTimeSetupCompleted = false;                                               // Track if first-time setup has been completed
 		bool SkipClearCacheConfirmation = false;                                            // Skip confirmation dialog when clearing shader cache
 		bool AutoHideFeatureList = false;                                                   // Auto-hide left feature list panel, show on hover
+		bool SimpleMode = false;                                                            // Render features' simplified Off/quality-preset UI instead of full advanced settings
 		bool SkipConstraintWarning = false;                                                 // Skip popup when a setting change creates new constraints
 		bool RequireShiftToDock = true;                                                     // Require holding Shift to dock windows
 		bool UseResolutionFont = true;                                                      // When true, runtime font size scales with screen resolution; when persisted to theme files, FontSize is zeroed for backward compatibility

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -219,6 +219,76 @@ namespace
 	bool g_dontShowAgainCheckbox = false;
 }
 
+// Single scrollable page of all in-menu features. Loaded features with simple-mode
+// controls render their slider/toggle inline; remaining features appear as labeled
+// rows so users can see what's installed.
+static void RenderSimpleModePage()
+{
+	bool& simpleMode = globals::menu->GetSettings().SimpleMode;
+	ImGui::Checkbox("Simple Mode", &simpleMode);
+	if (auto _tt = Util::HoverTooltipWrapper())
+		ImGui::TextUnformatted("Turn off to return to the full advanced settings menu.");
+	ImGui::Separator();
+	ImGui::Spacing();
+
+	std::vector<Feature*> sorted;
+	for (auto* f : Feature::GetFeatureList()) {
+		if (f->IsInMenu())
+			sorted.push_back(f);
+	}
+	std::ranges::sort(sorted, [](Feature* a, Feature* b) { return a->GetName() < b->GetName(); });
+
+	// Every loaded feature gets an inline control via DrawSimpleSettings (boot-toggle
+	// fallback when no runtime enable flag); only features that failed to load drop
+	// into the issues list.
+	std::vector<Feature*> issues;
+	for (auto* feat : sorted) {
+		if (feat->loaded) {
+			ImGui::PushID(feat);
+			feat->DrawSimpleSettings();
+			ImGui::PopID();
+		} else {
+			issues.push_back(feat);
+		}
+	}
+
+	if (issues.empty())
+		return;
+
+	ImGui::Spacing();
+	ImGui::SeparatorText("Installation Issues");
+
+	const auto& palette = globals::menu->GetTheme().StatusPalette;
+	for (auto* feat : issues) {
+		ImGui::PushID(feat);
+		std::string row = feat->GetName();
+		if (!feat->version.empty())
+			row += " v" + feat->version;
+		ImGui::TextColored(palette.Error, "%s", row.c_str());
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::TextColored(palette.Error, "%s",
+				feat->failedLoadedMessage.empty() ?
+					"This feature failed to load." :
+					feat->failedLoadedMessage.c_str());
+			auto [description, keyFeatures] = feat->GetFeatureSummary();
+			if (!description.empty()) {
+				ImGui::Separator();
+				ImGui::TextWrapped("%s", description.c_str());
+			}
+			if (!keyFeatures.empty()) {
+				if (description.empty())
+					ImGui::Separator();
+				else
+					ImGui::Spacing();
+				ImGui::TextUnformatted("Key features:");
+				for (const auto& k : keyFeatures)
+					ImGui::BulletText("%s", k.c_str());
+			}
+		}
+		ImGui::PopID();
+	}
+}
+
 void FeatureListRenderer::RenderFeatureList(
 	float footerHeight,
 	size_t& selectedMenu,
@@ -228,6 +298,14 @@ void FeatureListRenderer::RenderFeatureList(
 	const std::function<void()>& drawGeneralSettings,
 	const std::function<void()>& drawAdvancedSettings)
 {
+	// Simple mode: hide tabs/category list entirely and render a single page.
+	if (globals::menu->GetSettings().SimpleMode) {
+		ImGui::BeginChild("SimpleModePage", ImVec2(0, -footerHeight));
+		RenderSimpleModePage();
+		ImGui::EndChild();
+		return;
+	}
+
 	ImGui::BeginChild("Menus Table", ImVec2(0, -footerHeight));
 
 	auto menuList = BuildMenuList(featureSearch, categoryExpansionStates, drawGeneralSettings, drawAdvancedSettings);
@@ -750,7 +828,10 @@ void FeatureListRenderer::DrawMenuVisitor::RenderFeatureSettings(Feature* feat, 
 				ImGui::BeginDisabled();
 
 			ImVec2 cursorPosBefore = ImGui::GetCursorPos();
-			feat->DrawSettings();
+			if (globals::menu->GetSettings().SimpleMode)
+				feat->DrawSimpleSettings();
+			else
+				feat->DrawSettings();
 			ImVec2 cursorPosAfter = ImGui::GetCursorPos();
 
 			if (sceneControlled)

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -239,15 +239,17 @@ static void RenderSimpleModePage()
 	std::ranges::sort(sorted, [](Feature* a, Feature* b) { return a->GetName() < b->GetName(); });
 
 	// Every loaded feature gets an inline control via DrawSimpleSettings (boot-toggle
-	// fallback when no runtime enable flag); only features that failed to load drop
-	// into the issues list.
+	// fallback when no runtime enable flag). Unloaded features go to the issues list,
+	// except obsolete ones with their INI removed — those are silently dropped to
+	// match the advanced menu's filtering, surfaced again in developer mode.
+	const bool devMode = globals::state->IsDeveloperMode();
 	std::vector<Feature*> issues;
 	for (auto* feat : sorted) {
 		if (feat->loaded) {
 			ImGui::PushID(feat);
 			feat->DrawSimpleSettings();
 			ImGui::PopID();
-		} else {
+		} else if (devMode || !FeatureIssues::IsObsoleteFeature(feat->GetShortName())) {
 			issues.push_back(feat);
 		}
 	}

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -238,14 +238,14 @@ static void RenderSimpleModePage()
 	}
 	std::ranges::sort(sorted, [](Feature* a, Feature* b) { return a->GetName() < b->GetName(); });
 
-	// Every loaded feature gets an inline control via DrawSimpleSettings (boot-toggle
-	// fallback when no runtime enable flag). Unloaded features go to the issues list,
-	// except obsolete ones with their INI removed — those are silently dropped to
-	// match the advanced menu's filtering, surfaced again in developer mode.
+	// Loaded features and features intentionally disabled at boot both get a slider
+	// (the latter shows as Off). Only genuinely failed/missing features go to issues,
+	// except obsolete ones — those are silently dropped unless developer mode is on.
 	const bool devMode = globals::state->IsDeveloperMode();
 	std::vector<Feature*> issues;
 	for (auto* feat : sorted) {
-		if (feat->loaded) {
+		const bool bootDisabled = globals::state->IsFeatureDisabled(feat->GetShortName());
+		if (feat->loaded || bootDisabled) {
 			ImGui::PushID(feat);
 			feat->DrawSimpleSettings();
 			ImGui::PopID();

--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -444,6 +444,13 @@ void SettingsTabRenderer::RenderBehaviorTab()
 			ImGui::Text("Automatically hides the left feature list panel. Move cursor to the left edge to show it.");
 		}
 
+		ImGui::Checkbox("Simple Mode", &globals::menu->GetSettings().SimpleMode);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text(
+				"Show a simplified Off / quality-preset UI for each feature instead of the full advanced settings.\n"
+				"Features without quality presets fall back to a single Enable toggle.");
+		}
+
 		if (ImGui::Checkbox("Require Shift to Dock", &globals::menu->GetSettings().RequireShiftToDock)) {
 			ImGui::GetIO().ConfigDockingWithShift = globals::menu->GetSettings().RequireShiftToDock;
 		}


### PR DESCRIPTION
Adds a shared Preset<E> template on Feature plus a global QualityLevel enum for the simple menu. SSGI declares Low/Medium/High tiers (with VR variants) via the new system. WetnessEffects refactored so its existing ClimatePreset combo routes through the same Feature::ApplyPreset dispatch via one shared thunk.

Simple mode hides the feature list and renders a single scrollable page. Each loaded feature renders inline as a slider (Off / preset names / Custom) when it has quality presets, or as a checkbox otherwise. The on/off uses the runtime GetEnabledFlag() when overridden, otherwise falls back to ToggleAtBootSetting() — features on the boot path get their label tinted with StatusPalette.RestartNeeded and a "(restart required)" hint. Features that failed to load appear under "Installation Issues" colored with StatusPalette.Error and the failure message in the tooltip.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
<img width="1265" height="1433" alt="image" src="https://github.com/user-attachments/assets/5aa7af66-91f3-4da0-b298-1dd0ac28e4af" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simple Mode: single-page simplified feature UI with a Behavior setting to enable it.
  * Per-feature simple controls: On/Off plus selectable quality presets and a “Custom” option.
  * Installation Issues section lists unloaded features with error details.

* **Improvements**
  * Preset-aware tooltips show feature summaries, preset descriptions, and restart notices for boot-only changes.
  * Presets detect/apply current quality and support VR-aware variants; Simple Mode setting is persisted.
  * Updated feature versions for Screen Space GI and Wetness Effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->