### PR TITLE
chore(vr): add Tracy zones for SSS dispatches

### DIFF
--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -188,32 +188,37 @@ void ScreenSpaceShadows::DrawShadows()
 		auto dispatchList = Bend::BuildDispatchList(const_cast<float*>(lightProj), viewportSize, minRenderBounds, maxRenderBounds);
 
 		for (int i = 0; i < dispatchList.DispatchCount; i++) {
-			TracyD3D11Zone(globals::state->tracyCtx, "SSS - Ray March");
-
 			auto dispatchData = dispatchList.Dispatch[i];
 
-			RaymarchCB data{};
-			data.LightCoordinate[0] = dispatchList.LightCoordinate_Shader[0];
-			data.LightCoordinate[1] = dispatchList.LightCoordinate_Shader[1];
-			data.LightCoordinate[2] = dispatchList.LightCoordinate_Shader[2];
-			data.LightCoordinate[3] = dispatchList.LightCoordinate_Shader[3];
+			{
+				TracyD3D11Zone(globals::state->tracyCtx, "SSS - DispatchEye CB");
 
-			data.WaveOffset[0] = dispatchData.WaveOffset_Shader[0];
-			data.WaveOffset[1] = dispatchData.WaveOffset_Shader[1];
+				RaymarchCB data{};
+				data.LightCoordinate[0] = dispatchList.LightCoordinate_Shader[0];
+				data.LightCoordinate[1] = dispatchList.LightCoordinate_Shader[1];
+				data.LightCoordinate[2] = dispatchList.LightCoordinate_Shader[2];
+				data.LightCoordinate[3] = dispatchList.LightCoordinate_Shader[3];
 
-			data.FarDepthValue = 1.0f;
-			data.NearDepthValue = 0.0f;
+				data.WaveOffset[0] = dispatchData.WaveOffset_Shader[0];
+				data.WaveOffset[1] = dispatchData.WaveOffset_Shader[1];
 
-			data.DynamicRes = dynamicRes;
+				data.FarDepthValue = 1.0f;
+				data.NearDepthValue = 0.0f;
 
-			data.InvDepthTextureSize[0] = invTexSizeX;
-			data.InvDepthTextureSize[1] = invTexSizeY;
+				data.DynamicRes = dynamicRes;
 
-			data.settings = bendSettings;
+				data.InvDepthTextureSize[0] = invTexSizeX;
+				data.InvDepthTextureSize[1] = invTexSizeY;
 
-			raymarchCB->Update(data);
+				data.settings = bendSettings;
 
-			context->Dispatch(dispatchData.WaveCount[0], dispatchData.WaveCount[1], dispatchData.WaveCount[2]);
+				raymarchCB->Update(data);
+			}
+
+			{
+				TracyD3D11Zone(globals::state->tracyCtx, "SSS - DispatchEye Sweep");
+				context->Dispatch(dispatchData.WaveCount[0], dispatchData.WaveCount[1], dispatchData.WaveCount[2]);
+			}
 		}
 
 		if (globals::state->frameAnnotations) {
@@ -227,11 +232,17 @@ void ScreenSpaceShadows::DrawShadows()
 	if (!globals::game::isVR) {
 		DispatchEye(nullptr, GetComputeRaymarch(), lightProjectionF.data(), InvTexSizeX, InvTexSizeY);
 	} else {
-		DispatchEye("Left Eye", GetComputeRaymarch(), lightProjectionF.data(), InvTexSizeX, InvTexSizeY);
+		{
+			TracyD3D11Zone(globals::state->tracyCtx, "SSS - Left Eye");
+			DispatchEye("Left Eye", GetComputeRaymarch(), lightProjectionF.data(), InvTexSizeX, InvTexSizeY);
+		}
 
 		// Calculate light projection for right eye
 		auto lightProjectionRightF = CalculateLightProjection(1);
-		DispatchEye("Right Eye", GetComputeRaymarchRight(), lightProjectionRightF.data(), InvTexSizeX, InvTexSizeY);
+		{
+			TracyD3D11Zone(globals::state->tracyCtx, "SSS - Right Eye");
+			DispatchEye("Right Eye", GetComputeRaymarchRight(), lightProjectionRightF.data(), InvTexSizeX, InvTexSizeY);
+		}
 	}
 
 	ID3D11ShaderResourceView* views[1]{ nullptr };

--- a/src/Features/VR/StereoBlend.cpp
+++ b/src/Features/VR/StereoBlend.cpp
@@ -150,7 +150,13 @@ void VR::DrawStereoBlend()
 	}
 
 	context->CSSetShader(activeCS, nullptr, 0);
-	context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
+	if (isOverwriteMode) {
+		TracyD3D11Zone(globals::state->tracyCtx, "StereoBlend - Overwrite");
+		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
+	} else {
+		TracyD3D11Zone(globals::state->tracyCtx, "StereoBlend - Bilateral");
+		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
+	}
 
 	// Cleanup
 	ID3D11ShaderResourceView* nullSRVs[4] = {};

--- a/src/Features/VRStereoOptimizations.cpp
+++ b/src/Features/VRStereoOptimizations.cpp
@@ -359,18 +359,28 @@ void VRStereoOptimizations::DispatchStencil()
 	// Input: t0 = depth, b1 = params CB
 	// Output: u0 = per-pixel mode texture
 	{
-		ID3D11ShaderResourceView* srvs[1]{ depthSRV };
-		ID3D11UnorderedAccessView* uavs[1]{ texPerPixelMode->uav.get() };
+		TracyD3D11Zone(globals::state->tracyCtx, "StereoOpt - Mode Classify");
 
-		context->CSSetConstantBuffers(1, 1, &cbPtr);
-		context->CSSetShaderResources(0, 1, srvs);
-		context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
-		auto* activeStencilCS = (settings.debugDepthMap && stencilDebugDepthMapCS) ? stencilDebugDepthMapCS.get() : stencilCS.get();
-		context->CSSetShader(activeStencilCS, nullptr, 0);
+		{
+			TracyD3D11Zone(globals::state->tracyCtx, "StereoOpt - Mode Classify Bind");
 
-		uint32_t fullWidth = texPerPixelMode->desc.Width;
-		uint32_t fullHeight = texPerPixelMode->desc.Height;
-		context->Dispatch((fullWidth + 7) / 8, (fullHeight + 7) / 8, 1);
+			ID3D11ShaderResourceView* srvs[1]{ depthSRV };
+			ID3D11UnorderedAccessView* uavs[1]{ texPerPixelMode->uav.get() };
+
+			context->CSSetConstantBuffers(1, 1, &cbPtr);
+			context->CSSetShaderResources(0, 1, srvs);
+			context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
+			auto* activeStencilCS = (settings.debugDepthMap && stencilDebugDepthMapCS) ? stencilDebugDepthMapCS.get() : stencilCS.get();
+			context->CSSetShader(activeStencilCS, nullptr, 0);
+		}
+
+		{
+			TracyD3D11Zone(globals::state->tracyCtx, "StereoOpt - Mode Classify Dispatch");
+
+			uint32_t fullWidth = texPerPixelMode->desc.Width;
+			uint32_t fullHeight = texPerPixelMode->desc.Height;
+			context->Dispatch((fullWidth + 7) / 8, (fullHeight + 7) / 8, 1);
+		}
 
 		// Cleanup CS bindings
 		ID3D11ShaderResourceView* nullSRV = nullptr;
@@ -383,7 +393,10 @@ void VRStereoOptimizations::DispatchStencil()
 	}
 
 	// Transfer classification to hardware stencil buffer
-	ExecuteStencilWritePass();
+	{
+		TracyD3D11Zone(globals::state->tracyCtx, "StereoOpt - Stencil Write");
+		ExecuteStencilWritePass();
+	}
 
 	stencilActive = true;
 	stencilSwapCount = 0;


### PR DESCRIPTION
## Summary

Adds Tracy GPU and CPU profiling zones around VR stereo passes and per-eye Screen Space Shadows dispatches. No logic changes — instrumentation only.

## Why

Recent VR perf investigation surfaced significant per-frame cost in the `VRStereoOptimizations` and `StereoBlend` passes that was previously invisible in Tracy captures. Without these zones, future VR perf work — both validating optimizations and identifying further targets — cannot be measured. The instrumentation gap was the single biggest blocker on data-driven VR perf decisions.

## What

Eight zone categories across three files:

- **`src/Features/VR/StereoBlend.cpp`** — `StereoBlend - Overwrite` / `StereoBlend - Bilateral` (conditional on `isOverwriteMode`).
- **`src/Features/VRStereoOptimizations.cpp`** — `StereoOpt - Stencil Write`, `StereoOpt - Mode Classify` (parent), with `Mode Classify Bind` and `Mode Classify Dispatch` sub-zones.
- **`src/Features/ScreenSpaceShadows.cpp`** — `SSS - Left Eye` / `SSS - Right Eye` outer zones at the `DispatchEye` call sites in `DrawShadows()`. The pre-existing `SSS - Ray March` zone inside the Bend dispatch loop was renamed and split into `SSS - DispatchEye CB` (CB upload per sweep) and `SSS - DispatchEye Sweep` (the dispatch itself), giving per-sweep granularity. Net effect: the loop is more profilable, not less.

## Risk

Zero. Tracy macros (`TracyD3D11Zone`, `ZoneScoped`) compile to nothing when `TRACY_SUPPORT=OFF` (the default).

## Validation

- Built successfully with `./BuildRelease.bat ALL` (default preset, `TRACY_SUPPORT=OFF`). No warnings introduced; the only build warning is an unrelated `extern/FidelityFX-SDK` CMake deprecation.
- Captures with `ALL-TRACY` will surface the new zones for validation. Sample data (from a test build of these zones on a downstream branch) showed `StereoOpt - Mode Classify` at ~306 µs/frame and `StereoBlend - Overwrite` at ~303 µs/frame — costs that were entirely invisible before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal performance profiling instrumentation across screen-space shadows, stereo blending, and VR stereo optimization systems for improved performance monitoring and analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->