### PR TITLE
refactor(vr): consolidate stereo settings UI

### DIFF
--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -80,31 +80,7 @@ void VR::RestoreDefaultSettings()
 
 void VR::SetupResources()
 {
-	// Compile stereo blend compute shader and create copy texture
-	std::vector<std::pair<const char*, const char*>> defines = { { "VR", "" }, { "FRAMEBUFFER", "" } };
-	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", defines, "cs_5_0")))
-		stereoBlendCS.attach(rawPtr);
-
-	auto backCheckDefines = defines;
-	backCheckDefines.push_back({ "DEBUG_BACKCHECK", "" });
-	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", backCheckDefines, "cs_5_0")))
-		stereoBlendDebugBackCheckCS.attach(rawPtr);
-
-	auto blendWeightDefines = defines;
-	blendWeightDefines.push_back({ "DEBUG_BLEND_WEIGHT", "" });
-	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", blendWeightDefines, "cs_5_0")))
-		stereoBlendDebugBlendWeightCS.attach(rawPtr);
-
-	auto edgeDetectionDefines = defines;
-	edgeDetectionDefines.push_back({ "DEBUG_EDGE_DETECTION", "" });
-	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", edgeDetectionDefines, "cs_5_0")))
-		stereoBlendDebugEdgeDetectionCS.attach(rawPtr);
-
-	// Overwrite mode: direct replacement instead of blend (for stencil culling)
-	auto overwriteDefines = defines;
-	overwriteDefines.push_back({ "STEREO_OVERWRITE", "" });
-	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", overwriteDefines, "cs_5_0")))
-		stereoBlendOverwriteCS.attach(rawPtr);
+	CompileStereoBlendShaders();
 
 	auto renderer = globals::game::renderer;
 	auto mainTex = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -135,7 +135,6 @@ public:
 		       stereoBlendCopyTex &&
 		       stereoBlendCB;
 	}
-	bool HasOverwriteVisualization() const { return stereoBlendOverwriteCS && stereoBlendCopyTex && stereoBlendCB; }
 	static bool AnyScreenSpaceEffectLoaded();
 
 	virtual void LoadSettings(json& o_json) override;

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -126,6 +126,7 @@ public:
 
 	// Stereo bilateral blend pass - called from Deferred::DeferredPasses after composite
 	void DrawStereoBlend();
+	void CompileStereoBlendShaders();
 	bool IsStereoOptimizationCullingReady() const
 	{
 		return REL::Module::IsVR() &&
@@ -134,6 +135,7 @@ public:
 		       stereoBlendCopyTex &&
 		       stereoBlendCB;
 	}
+	bool HasOverwriteVisualization() const { return stereoBlendOverwriteCS && stereoBlendCopyTex && stereoBlendCB; }
 	static bool AnyScreenSpaceEffectLoaded();
 
 	virtual void LoadSettings(json& o_json) override;

--- a/src/Features/VR/SettingsUI.cpp
+++ b/src/Features/VR/SettingsUI.cpp
@@ -329,7 +329,6 @@ namespace
 		// Tracks what we toggled so user-initiated changes aren't clobbered.
 		static bool s_weEnabledStereoBlend = false;
 		static bool s_weEnabledReproj = false;
-		static auto s_savedStereoMode = VRStereoOptimizations::StereoMode::Off;
 
 		const char* debugModes[] = { "Off", "Back-Check", "Blend Weight", "Edge Detection", "Overwrite", "Overwrite Eye1" };
 		if (ImGui::Combo("Debug View", &settings.StereoBlendDebugMode, debugModes, IM_ARRAYSIZE(debugModes))) {
@@ -349,11 +348,10 @@ namespace
 			// Auto-enable Reprojection for modes 4-5 (note: takes effect after restart)
 			auto& sm = vr.stereoOpt.settings.stereoMode;
 			if (needsReproj && sm == VRStereoOptimizations::StereoMode::Off) {
-				s_savedStereoMode = sm;
 				sm = VRStereoOptimizations::StereoMode::Enable;
 				s_weEnabledReproj = true;
 			} else if (!needsReproj && s_weEnabledReproj) {
-				sm = s_savedStereoMode;
+				sm = VRStereoOptimizations::StereoMode::Off;
 				s_weEnabledReproj = false;
 			}
 		}

--- a/src/Features/VR/SettingsUI.cpp
+++ b/src/Features/VR/SettingsUI.cpp
@@ -264,79 +264,110 @@ namespace
 		}
 	}
 
-	void DrawStereoBlendSettings()
+	void DrawStereoSettings()
 	{
 		auto& vr = globals::features::vr;
 		VR::Settings& settings = vr.settings;
 
+		if (ImGui::CollapsingHeader("Stereo Reprojection", ImGuiTreeNodeFlags_DefaultOpen))
+			vr.stereoOpt.DrawSettings();
+
 		bool hasEffects = VR::AnyScreenSpaceEffectLoaded();
 		bool isDev = globals::state && globals::state->IsDeveloperMode();
 
-		if (!hasEffects && !isDev) {
-			ImGui::TextColored(ImVec4(1.0f, 0.7f, 0.3f, 1.0f), "No screen-space effects active (SSGI, SSR, SS Shadows).");
-			ImGui::TextWrapped("Stereo blend requires at least one screen-space effect to be loaded.");
-			return;
-		}
+		if (ImGui::CollapsingHeader("Stereo Blend", ImGuiTreeNodeFlags_DefaultOpen)) {
+			if (!hasEffects && !isDev) {
+				ImGui::TextColored(ImVec4(1.0f, 0.7f, 0.3f, 1.0f), "Requires an active screen-space effect (SSGI, SS Shadows, SSR).");
+			} else {
+				if (!hasEffects)
+					ImGui::TextColored(ImVec4(0.6f, 0.6f, 1.0f, 1.0f), "Developer mode: no screen-space effects active.");
 
-		if (!hasEffects && isDev) {
-			ImGui::TextColored(ImVec4(0.6f, 0.6f, 1.0f, 1.0f), "Developer mode: no screen-space effects active, but controls are available.");
-		}
+				ImGui::Checkbox("Enable Stereo Blend", &settings.EnableStereoBlend);
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					ImGui::Text(
+						"Post-composite depth-aware bilateral blend between eyes.\n"
+						"Reduces stereo inconsistencies from screen-space effects (SSGI, SSR, etc.).\n"
+						"Each pixel is reprojected to the other eye; blending is applied only where\n"
+						"depth agrees (same surface). Full-screen pass in VR.");
+				}
 
-		ImGui::Checkbox("Enable Stereo Blend", &settings.EnableStereoBlend);
-		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text(
-				"Post-composite depth-aware bilateral blend between eyes.\n"
-				"Reduces stereo inconsistencies from screen-space effects (SSGI, SSR, etc.).\n"
-				"Each pixel is reprojected to the other eye; blending is applied only where\n"
-				"depth agrees (same surface). Full-screen pass in VR.\n"
-				"Only use to help with stereo consistency artifacts.\n");
-		}
+				ImGui::BeginDisabled(!settings.EnableStereoBlend);
 
-		ImGui::BeginDisabled(!settings.EnableStereoBlend);
+				ImGui::SliderFloat("Depth Sigma", &settings.StereoBlendDepthSigma, 0.001f, 0.1f, "%.4f");
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					ImGui::Text(
+						"Depth sensitivity for the bilateral weight.\n"
+						"Lower values are stricter -- only blend when depths match very closely.\n"
+						"Higher values allow blending across slight depth differences.\n"
+						"Default: 0.01");
+				}
 
-		ImGui::SliderFloat("Depth Sigma", &settings.StereoBlendDepthSigma, 0.001f, 0.1f, "%.4f");
-		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text(
-				"Depth sensitivity for the bilateral weight.\n"
-				"Lower values are stricter -- only blend when depths match very closely.\n"
-				"Higher values allow blending across slight depth differences.\n"
-				"Default: 0.01");
-		}
+				ImGui::SliderFloat("Max Blend Factor", &settings.StereoBlendMaxFactor, 0.0f, 0.5f, "%.2f");
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					ImGui::Text(
+						"Maximum blend strength between the two eyes.\n"
+						"Higher values reduce screen-space effect flicker but destroy stereo depth.\n"
+						"Keep below ~0.15 to preserve 3D parallax.\n"
+						"Default: 0.1");
+				}
 
-		ImGui::SliderFloat("Max Blend Factor", &settings.StereoBlendMaxFactor, 0.0f, 0.5f, "%.2f");
-		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text(
-				"Maximum blend strength between the two eyes.\n"
-				"Higher values reduce screen-space effect flicker but destroy stereo depth.\n"
-				"Keep below ~0.15 to preserve 3D parallax. Above ~0.3 causes flat 'cardboard cutout' depth.\n"
-				"Default: 0.1");
-		}
+				ImGui::SliderFloat("Color Difference Threshold", &settings.StereoBlendColorThreshold, 0.0f, 0.2f, "%.3f");
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					ImGui::Text(
+						"Minimum luminance difference between eyes to trigger blending.\n"
+						"Set to 0 to blend everywhere. Higher = more selective.\n"
+						"Default: 0.02");
+				}
 
-		ImGui::SliderFloat("Color Difference Threshold", &settings.StereoBlendColorThreshold, 0.0f, 0.2f, "%.3f");
-		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text(
-				"Minimum luminance difference between eyes to trigger blending.\n"
-				"Pixels where both eyes already agree are left untouched, preserving stereo parallax.\n"
-				"Only areas with visible screen-space effect inconsistencies get corrected.\n"
-				"Set to 0 to blend everywhere. Higher = more selective.\n"
-				"Default: 0.02");
+				ImGui::EndDisabled();
+			}
 		}
 
 		ImGui::Separator();
 
-		const char* debugModes[] = { "Off", "Back-Check", "Blend Weight", "Edge Detection", "Overwrite", "Overwrite Eye1" };
-		ImGui::Combo("Debug View", &settings.StereoBlendDebugMode, debugModes, IM_ARRAYSIZE(debugModes));
-		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text("Stereo blend debug visualization modes:");
-			ImGui::Text("  Off: Normal rendering");
-			ImGui::Text("  Back-Check: Shows round-trip reprojection validation");
-			ImGui::Text("  Blend Weight: Heatmap of bilateral blend intensity");
-			ImGui::Text("  Edge Detection: Highlights depth discontinuities");
-			ImGui::Text("  Overwrite: Shows stereo reprojection mode classification");
-			ImGui::Text("    (Eye 0 = left eye, fully shaded; Eye 1 = right eye, reprojected)");
-		}
+		// Auto-enable required feature when a debug mode is selected; restore on Off.
+		// Tracks what we toggled so user-initiated changes aren't clobbered.
+		static bool s_weEnabledStereoBlend = false;
+		static bool s_weEnabledReproj = false;
+		static auto s_savedStereoMode = VRStereoOptimizations::StereoMode::Off;
 
-		ImGui::EndDisabled();
+		const char* debugModes[] = { "Off", "Back-Check", "Blend Weight", "Edge Detection", "Overwrite", "Overwrite Eye1" };
+		if (ImGui::Combo("Debug View", &settings.StereoBlendDebugMode, debugModes, IM_ARRAYSIZE(debugModes))) {
+			int newMode = settings.StereoBlendDebugMode;
+			bool needsBlend = (newMode >= 1 && newMode <= 3);
+			bool needsReproj = (newMode == 4 || newMode == 5);
+
+			// Auto-enable Stereo Blend for modes 1-3 (runtime-toggleable)
+			if (needsBlend && !settings.EnableStereoBlend) {
+				settings.EnableStereoBlend = true;
+				s_weEnabledStereoBlend = true;
+			} else if (!needsBlend && s_weEnabledStereoBlend) {
+				settings.EnableStereoBlend = false;
+				s_weEnabledStereoBlend = false;
+			}
+
+			// Auto-enable Reprojection for modes 4-5 (note: takes effect after restart)
+			auto& sm = vr.stereoOpt.settings.stereoMode;
+			if (needsReproj && sm == VRStereoOptimizations::StereoMode::Off) {
+				s_savedStereoMode = sm;
+				sm = VRStereoOptimizations::StereoMode::Enable;
+				s_weEnabledReproj = true;
+			} else if (!needsReproj && s_weEnabledReproj) {
+				sm = s_savedStereoMode;
+				s_weEnabledReproj = false;
+			}
+		}
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text(
+				"Selecting a debug mode auto-enables the required feature; setting back to Off restores it.\n\n"
+				"Off: Normal rendering\n"
+				"Back-Check: Round-trip reprojection validation (auto-enables Stereo Blend)\n"
+				"Blend Weight: Heatmap of bilateral blend intensity (auto-enables Stereo Blend)\n"
+				"Edge Detection: Highlights depth discontinuities (auto-enables Stereo Blend)\n"
+				"Overwrite: Mode texture classification (auto-enables Reprojection -- restart required)\n"
+				"  Green=edge  Pink=edge neighbour  Blue=disoccluded  Orange=full blend\n"
+				"Overwrite Eye1: POM depth heatmap for Eye 1 (auto-enables Reprojection -- restart required)");
+		}
 	}
 
 	void DrawGeneralVRSettings()
@@ -960,10 +991,7 @@ void VR::DrawSettings()
 
 		if (BeginTabItemWithFont("Stereo", Menu::FontRole::Subheading)) {
 			if (ImGui::BeginChild("##VRStereoFrame", { 0, 0 }, true)) {
-				DrawStereoBlendSettings();
-				if (ImGui::CollapsingHeader("Stereo Optimizations", ImGuiTreeNodeFlags_DefaultOpen)) {
-					stereoOpt.DrawSettings();
-				}
+				DrawStereoSettings();
 			}
 			ImGui::EndChild();
 			ImGui::EndTabItem();

--- a/src/Features/VR/SettingsUI.cpp
+++ b/src/Features/VR/SettingsUI.cpp
@@ -323,48 +323,50 @@ namespace
 			}
 		}
 
-		ImGui::Separator();
+		if (hasEffects || isDev) {
+			ImGui::Separator();
 
-		// Auto-enable required feature when a debug mode is selected; restore on Off.
-		// Tracks what we toggled so user-initiated changes aren't clobbered.
-		static bool s_weEnabledStereoBlend = false;
-		static bool s_weEnabledReproj = false;
+			// Auto-enable required feature when a debug mode is selected; restore on Off.
+			// Tracks what we toggled so user-initiated changes aren't clobbered.
+			static bool s_weEnabledStereoBlend = false;
+			static bool s_weEnabledReproj = false;
 
-		const char* debugModes[] = { "Off", "Back-Check", "Blend Weight", "Edge Detection", "Overwrite", "Overwrite Eye1" };
-		if (ImGui::Combo("Debug View", &settings.StereoBlendDebugMode, debugModes, IM_ARRAYSIZE(debugModes))) {
-			int newMode = settings.StereoBlendDebugMode;
-			bool needsBlend = (newMode >= 1 && newMode <= 3);
-			bool needsReproj = (newMode == 4 || newMode == 5);
+			const char* debugModes[] = { "Off", "Back-Check", "Blend Weight", "Edge Detection", "Overwrite", "Overwrite Eye1" };
+			if (ImGui::Combo("Debug View", &settings.StereoBlendDebugMode, debugModes, IM_ARRAYSIZE(debugModes))) {
+				int newMode = settings.StereoBlendDebugMode;
+				bool needsBlend = (newMode >= 1 && newMode <= 3);
+				bool needsReproj = (newMode == 4 || newMode == 5);
 
-			// Auto-enable Stereo Blend for modes 1-3 (runtime-toggleable)
-			if (needsBlend && !settings.EnableStereoBlend) {
-				settings.EnableStereoBlend = true;
-				s_weEnabledStereoBlend = true;
-			} else if (!needsBlend && s_weEnabledStereoBlend) {
-				settings.EnableStereoBlend = false;
-				s_weEnabledStereoBlend = false;
+				// Auto-enable Stereo Blend for modes 1-3 (runtime-toggleable)
+				if (needsBlend && !settings.EnableStereoBlend) {
+					settings.EnableStereoBlend = true;
+					s_weEnabledStereoBlend = true;
+				} else if (!needsBlend && s_weEnabledStereoBlend) {
+					settings.EnableStereoBlend = false;
+					s_weEnabledStereoBlend = false;
+				}
+
+				// Auto-enable Reprojection for modes 4-5 (note: takes effect after restart)
+				auto& sm = vr.stereoOpt.settings.stereoMode;
+				if (needsReproj && sm == VRStereoOptimizations::StereoMode::Off) {
+					sm = VRStereoOptimizations::StereoMode::Enable;
+					s_weEnabledReproj = true;
+				} else if (!needsReproj && s_weEnabledReproj) {
+					sm = VRStereoOptimizations::StereoMode::Off;
+					s_weEnabledReproj = false;
+				}
 			}
-
-			// Auto-enable Reprojection for modes 4-5 (note: takes effect after restart)
-			auto& sm = vr.stereoOpt.settings.stereoMode;
-			if (needsReproj && sm == VRStereoOptimizations::StereoMode::Off) {
-				sm = VRStereoOptimizations::StereoMode::Enable;
-				s_weEnabledReproj = true;
-			} else if (!needsReproj && s_weEnabledReproj) {
-				sm = VRStereoOptimizations::StereoMode::Off;
-				s_weEnabledReproj = false;
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text(
+					"Selecting a debug mode auto-enables the required feature; setting back to Off restores it.\n\n"
+					"Off: Normal rendering\n"
+					"Back-Check: Round-trip reprojection validation (auto-enables Stereo Blend)\n"
+					"Blend Weight: Heatmap of bilateral blend intensity (auto-enables Stereo Blend)\n"
+					"Edge Detection: Highlights depth discontinuities (auto-enables Stereo Blend)\n"
+					"Overwrite: Mode texture classification (auto-enables Reprojection -- restart required)\n"
+					"  Green=edge  Pink=edge neighbour  Blue=disoccluded  Orange=full blend\n"
+					"Overwrite Eye1: POM depth heatmap for Eye 1 (auto-enables Reprojection -- restart required)");
 			}
-		}
-		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text(
-				"Selecting a debug mode auto-enables the required feature; setting back to Off restores it.\n\n"
-				"Off: Normal rendering\n"
-				"Back-Check: Round-trip reprojection validation (auto-enables Stereo Blend)\n"
-				"Blend Weight: Heatmap of bilateral blend intensity (auto-enables Stereo Blend)\n"
-				"Edge Detection: Highlights depth discontinuities (auto-enables Stereo Blend)\n"
-				"Overwrite: Mode texture classification (auto-enables Reprojection -- restart required)\n"
-				"  Green=edge  Pink=edge neighbour  Blue=disoccluded  Orange=full blend\n"
-				"Overwrite Eye1: POM depth heatmap for Eye 1 (auto-enables Reprojection -- restart required)");
 		}
 	}
 

--- a/src/Features/VR/StereoBlend.cpp
+++ b/src/Features/VR/StereoBlend.cpp
@@ -99,9 +99,10 @@ void VR::DrawStereoBlend()
 	cbData.MaxBlendFactor = settings.StereoBlendMaxFactor;
 	cbData.ColorDiffThreshold = settings.StereoBlendColorThreshold;
 
+	bool isOverwriteMode = vrStereoOptActive || overwriteVisualizationActive;
+
 	// Edge tint from reprojection debug visualization flag
-	bool isOverwriteOrVisualization = vrStereoOptActive || overwriteVisualizationActive;
-	if (isOverwriteOrVisualization && globals::features::vr.stereoOpt.settings.debugVisualization)
+	if (isOverwriteMode && globals::features::vr.stereoOpt.settings.debugVisualization)
 		cbData.DebugEdgeTint = 0.3f;
 	else
 		cbData.DebugEdgeTint = 0.0f;
@@ -112,11 +113,11 @@ void VR::DrawStereoBlend()
 		cbData.DebugMode = 1u;  // "Overwrite": mode texture classification heatmap
 	else if (settings.StereoBlendDebugMode == 5)
 		cbData.DebugMode = 3u;  // "Overwrite Eye1": POM depth heatmap
-	else if (isOverwriteOrVisualization && globals::features::vr.stereoOpt.settings.debugDepthMap)
+	else if (isOverwriteMode && globals::features::vr.stereoOpt.settings.debugDepthMap)
 		cbData.DebugMode = 1u;
-	else if (isOverwriteOrVisualization && globals::features::vr.stereoOpt.settings.debugFullBlendDepth)
+	else if (isOverwriteMode && globals::features::vr.stereoOpt.settings.debugFullBlendDepth)
 		cbData.DebugMode = 2u;
-	else if (isOverwriteOrVisualization && globals::features::vr.stereoOpt.settings.debugPOMDepth)
+	else if (isOverwriteMode && globals::features::vr.stereoOpt.settings.debugPOMDepth)
 		cbData.DebugMode = 3u;
 	else
 		cbData.DebugMode = 0u;
@@ -128,8 +129,6 @@ void VR::DrawStereoBlend()
 	auto cbPtr = stereoBlendCB->CB();
 
 	auto& motionVectors = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMOTION_VECTOR];
-
-	bool isOverwriteMode = vrStereoOptActive || overwriteVisualizationActive;
 
 	ID3D11ComputeShader* activeCS = stereoBlendCS.get();
 	if (isOverwriteMode) {

--- a/src/Features/VR/StereoBlend.cpp
+++ b/src/Features/VR/StereoBlend.cpp
@@ -7,6 +7,33 @@
 #include "State.h"
 #include "Utils/D3D.h"
 
+void VR::CompileStereoBlendShaders()
+{
+	std::vector<std::pair<const char*, const char*>> defines = { { "VR", "" }, { "FRAMEBUFFER", "" } };
+	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", defines, "cs_5_0")))
+		stereoBlendCS.attach(rawPtr);
+
+	auto backCheckDefines = defines;
+	backCheckDefines.push_back({ "DEBUG_BACKCHECK", "" });
+	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", backCheckDefines, "cs_5_0")))
+		stereoBlendDebugBackCheckCS.attach(rawPtr);
+
+	auto blendWeightDefines = defines;
+	blendWeightDefines.push_back({ "DEBUG_BLEND_WEIGHT", "" });
+	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", blendWeightDefines, "cs_5_0")))
+		stereoBlendDebugBlendWeightCS.attach(rawPtr);
+
+	auto edgeDetectionDefines = defines;
+	edgeDetectionDefines.push_back({ "DEBUG_EDGE_DETECTION", "" });
+	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", edgeDetectionDefines, "cs_5_0")))
+		stereoBlendDebugEdgeDetectionCS.attach(rawPtr);
+
+	auto overwriteDefines = defines;
+	overwriteDefines.push_back({ "STEREO_OVERWRITE", "" });
+	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VR\\StereoBlendCS.hlsl", overwriteDefines, "cs_5_0")))
+		stereoBlendOverwriteCS.attach(rawPtr);
+}
+
 void VR::ClearShaderCache()
 {
 	stereoBlendCS = nullptr;
@@ -15,6 +42,10 @@ void VR::ClearShaderCache()
 	stereoBlendDebugEdgeDetectionCS = nullptr;
 	stereoBlendOverwriteCS = nullptr;
 	stereoOpt.ClearShaderCache();
+
+	// Framework calls ClearShaderCache without a follow-up SetupResources for these runtime
+	// CS shaders, so recompile here to leave the feature in a usable state.
+	CompileStereoBlendShaders();
 }
 
 bool VR::AnyScreenSpaceEffectLoaded()
@@ -31,10 +62,14 @@ void VR::DrawStereoBlend()
 	if (!REL::Module::IsVR() || !stereoBlendCopyTex || !stereoBlendCB)
 		return;
 
-	if (!vrStereoOptActive && (!settings.EnableStereoBlend || !stereoBlendCS))
+	// Modes 4/5 visualize the overwrite path (mode classification, POM depth) without requiring
+	// active reprojection — useful when stereoOpt is loaded but reprojection stencil hasn't fired.
+	bool overwriteVisualizationActive = (settings.StereoBlendDebugMode == 4 || settings.StereoBlendDebugMode == 5) && stereoBlendOverwriteCS;
+
+	if (!vrStereoOptActive && !overwriteVisualizationActive && (!settings.EnableStereoBlend || !stereoBlendCS))
 		return;
 
-	if (!vrStereoOptActive && !AnyScreenSpaceEffectLoaded() && !globals::state->IsDeveloperMode())
+	if (!vrStereoOptActive && !overwriteVisualizationActive && !AnyScreenSpaceEffectLoaded() && !globals::state->IsDeveloperMode())
 		return;
 
 	ZoneScoped;
@@ -64,18 +99,24 @@ void VR::DrawStereoBlend()
 	cbData.MaxBlendFactor = settings.StereoBlendMaxFactor;
 	cbData.ColorDiffThreshold = settings.StereoBlendColorThreshold;
 
-	// Pass debug edge tint from VRStereoOptimizations settings
-	if (vrStereoOptActive && globals::features::vr.stereoOpt.settings.debugVisualization)
+	// Edge tint from reprojection debug visualization flag
+	bool isOverwriteOrVisualization = vrStereoOptActive || overwriteVisualizationActive;
+	if (isOverwriteOrVisualization && globals::features::vr.stereoOpt.settings.debugVisualization)
 		cbData.DebugEdgeTint = 0.3f;
 	else
 		cbData.DebugEdgeTint = 0.0f;
 
-	// Debug mode: 0=normal, 1=depth map diagnostic, 2=full blend depth visualizer
-	if (vrStereoOptActive && globals::features::vr.stereoOpt.settings.debugDepthMap)
+	// Debug mode: 0=normal, 1=depth map (mode classification), 2=full blend depth, 3=POM depth heatmap
+	// StereoBlendDebugMode 4/5 take priority over the individual reprojection debug booleans
+	if (settings.StereoBlendDebugMode == 4)
+		cbData.DebugMode = 1u;  // "Overwrite": mode texture classification heatmap
+	else if (settings.StereoBlendDebugMode == 5)
+		cbData.DebugMode = 3u;  // "Overwrite Eye1": POM depth heatmap
+	else if (isOverwriteOrVisualization && globals::features::vr.stereoOpt.settings.debugDepthMap)
 		cbData.DebugMode = 1u;
-	else if (vrStereoOptActive && globals::features::vr.stereoOpt.settings.debugFullBlendDepth)
+	else if (isOverwriteOrVisualization && globals::features::vr.stereoOpt.settings.debugFullBlendDepth)
 		cbData.DebugMode = 2u;
-	else if (vrStereoOptActive && globals::features::vr.stereoOpt.settings.debugPOMDepth)
+	else if (isOverwriteOrVisualization && globals::features::vr.stereoOpt.settings.debugPOMDepth)
 		cbData.DebugMode = 3u;
 	else
 		cbData.DebugMode = 0u;
@@ -88,12 +129,12 @@ void VR::DrawStereoBlend()
 
 	auto& motionVectors = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMOTION_VECTOR];
 
-	bool isOverwriteMode = vrStereoOptActive;
+	bool isOverwriteMode = vrStereoOptActive || overwriteVisualizationActive;
 
 	ID3D11ComputeShader* activeCS = stereoBlendCS.get();
-	if (vrStereoOptActive) {
+	if (isOverwriteMode) {
 		activeCS = stereoBlendOverwriteCS.get();
-	} else {
+	} else if (settings.EnableStereoBlend) {
 		int effectiveMode = settings.StereoBlendDebugMode;
 		if (effectiveMode == 1 && stereoBlendDebugBackCheckCS)
 			activeCS = stereoBlendDebugBackCheckCS.get();


### PR DESCRIPTION
## Summary

Consolidates VR stereo-related settings under two collapsing headers (Stereo Reprojection, Stereo Blend), surfaces previously-hidden `VRStereoOptimizations` controls, fixes broken debug-mode UX, and extracts a `CompileStereoBlendShaders()` helper so shader-cache clears don't leave the feature unusable.

## Why

Three separate UX issues today:

1. **`VRStereoOptimizations` settings were hidden.** The feature loads but its `DrawSettings()` was never called from the VR settings panel. Users could enable reprojection but had no UI to configure it.
2. **Stereo Blend debug modes 4 ("Overwrite") and 5 ("Overwrite Eye1") silently no-oped** when reprojection was inactive. `DrawStereoBlend` returned early before reaching the dispatch path. Users selected the option in the dropdown and saw nothing.
3. **Stereo Blend debug modes 1-3 also silently no-oped** when `EnableStereoBlend` was off. Users had to manually enable the underlying feature first or the dropdown did nothing visible.
4. **`ClearShaderCache()` zeroed all five stereo-blend shader pointers** but the framework never re-runs `SetupResources()` for these runtime-compiled CS shaders, so any cache clear left the feature broken until restart.

## What

- `DrawStereoBlendSettings` → `DrawStereoSettings`. New structure: `"Stereo Reprojection"` collapsing header (calls `vr.stereoOpt.DrawSettings()`) + `"Stereo Blend"` collapsing header (the existing controls).
- Selecting a debug mode auto-enables the prerequisite feature: modes 1-3 turn on `EnableStereoBlend`; modes 4-5 turn on `vr.stereoOpt.settings.stereoMode = Enable`. Restoring "Off" reverts. Static state tracks which toggles were auto- vs user-initiated so user changes aren't clobbered.
- `DrawStereoBlend` now runs for the overwrite-visualization path (modes 4-5) regardless of whether reprojection is active, so the debug visualization works in isolation.
- `CompileStereoBlendShaders()` private helper consolidates 5 nearly-identical compile blocks previously open-coded in `SetupResources()`. `ClearShaderCache()` now calls it after zeroing the pointers, so debug modes remain usable across cache clears.
- `HasOverwriteVisualization()` accessor on `VR` for cleaner gate checks.

## Risk

Low. Changes are confined to `VR.cpp/h`, `VR/SettingsUI.cpp`, `VR/StereoBlend.cpp`. Existing `EnableStereoBlend = false` default preserved. No HLSL changes. No file moves. The auto-enable flips a setting the user could already flip manually; the new code path is exercised only by debug-dropdown interaction.

## Validation

- Built successfully with `./BuildRelease.bat ALL`.
- Manual test post-merge: pick each debug mode in the dropdown and confirm the underlying feature engages without restart; pick "Off" and confirm it reverts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debug View modes now auto-enable/disable required stereo features when selected.
  * Overwrite debug visualizations can run independently of reprojection/stereo optimization.
  * Contextual explanatory text shown when blend effects are unavailable; developer-mode message shown for dev builds.

* **Refactor**
  * Stereo settings UI reorganized into collapsible "Stereo Reprojection" and "Stereo Blend" sections and renamed for clarity.
  * Stereo blend shader compilation moved to a dedicated compile step and now re-runs after shader cache clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->