### PR TITLE
fix(fog): apply vanilla fog fade consistently to sky

### DIFF
--- a/package/Shaders/ISSAOComposite.hlsl
+++ b/package/Shaders/ISSAOComposite.hlsl
@@ -197,7 +197,7 @@ PS_OUTPUT main(PS_INPUT input)
 		fogFactor = exponentialHeightFog.w;
 	}
 	if (depth < 0.999999 || SharedData::exponentialHeightFogSettings.enabled) {
-		composedColor.xyz = (SharedData::exponentialHeightFogSettings.enabled ? 1.0 : FogNearColor.w) * lerp(composedColor.xyz, fogColor, fogFactor);
+		composedColor.xyz = FogNearColor.w * lerp(composedColor.xyz, fogColor, fogFactor);
 	}
 #		else
 	if (depth < 0.999999) {


### PR DESCRIPTION
Fixes mismatch in brightness from the sky and ground when exponential height fog is applied. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fog rendering consistency to ensure uniform visual appearance across different rendering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->