### PR TITLE
fix(vr): rebuild DLSS feature on LoadingMenu close

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -598,6 +598,32 @@ void Upscaling::DataLoaded()
 	// The game defaults this to a non-zero value
 	static auto fDRClampOffset = RE::GetINISetting("fDRClampOffset:Display");
 	fDRClampOffset->data.f = 0.0f;
+
+	// VR + DLSS workaround: rebuild the DLSS feature on cell/worldspace transitions to
+	// clear a persistent post-load GPU-time regression (see pendingDLSSReset comment).
+	if (globals::game::isVR)
+		MenuOpenCloseEventHandler::Register();
+}
+
+RE::BSEventNotifyControl Upscaling::MenuOpenCloseEventHandler::ProcessEvent(
+	const RE::MenuOpenCloseEvent* a_event, RE::BSTEventSource<RE::MenuOpenCloseEvent>*)
+{
+	if (a_event && a_event->menuName == RE::LoadingMenu::MENU_NAME && !a_event->opening)
+		globals::features::upscaling.pendingDLSSReset.store(true, std::memory_order_relaxed);
+	return RE::BSEventNotifyControl::kContinue;
+}
+
+bool Upscaling::MenuOpenCloseEventHandler::Register()
+{
+	static MenuOpenCloseEventHandler singleton;
+	auto ui = globals::game::ui;
+	if (!ui) {
+		logger::error("[Upscaling] UI event source not found; DLSS reset-on-load disabled");
+		return false;
+	}
+	ui->GetEventSource<RE::MenuOpenCloseEvent>()->AddEventSink(&singleton);
+	logger::info("[Upscaling] Registered MenuOpenCloseEventHandler for DLSS reset-on-load");
+	return true;
 }
 
 void Upscaling::Load()
@@ -1781,6 +1807,14 @@ void Upscaling::Upscale()
 		TracyD3D11Zone(globals::state->tracyCtx, "Upscaling Dispatch");
 
 		if (upscaleMethod == UpscaleMethod::kDLSS) {
+			// VR-only workaround: a worldspace/cell transition causes ~2-3ms persistent GPU-time
+			// regression in the DLSS feature that only clears on a manual mode/preset toggle.
+			// Mirror that toggle by tearing down the DLSS feature on LoadingMenu close — the next
+			// SetDLSSOptions/slEvaluateFeature call below recreates it with current per-eye extents.
+			if (globals::game::isVR && pendingDLSSReset.exchange(false, std::memory_order_relaxed)) {
+				logger::debug("[Upscaling] LoadingMenu close detected — rebuilding DLSS feature");
+				streamline.DestroyDLSSResources();
+			}
 			streamline.Upscale(main.texture, reactiveMaskTexture->resource.get(), transparencyCompositionMaskTexture->resource.get(), motionVectorCopyTexture->resource.get());
 		} else if (upscaleMethod == UpscaleMethod::kFSR) {
 			fidelityFX.Upscale(main.texture, reactiveMaskTexture->resource.get(), transparencyCompositionMaskTexture->resource.get(), motionVector.texture, settings.sharpnessFSR);

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -206,6 +206,13 @@ public:
 	bool previousUpscalingWasActive = false;
 	bool depthUpscaleUseWideKernel = false;
 
+	/// Set by MenuOpenCloseEventHandler when LoadingMenu closes (cell/worldspace transitions,
+	/// initial load). Consumed at the start of Upscale() to force a one-frame DLSS feature
+	/// rebuild — works around a VR-only persistent ~2-3ms GPU regression after worldspace
+	/// loads that otherwise only clears when the user manually toggles DLSS/preset. VR+DLSS
+	/// only; flat has no repro and per-eye extent asymmetry doesn't apply.
+	std::atomic<bool> pendingDLSSReset{ false };
+
 	void CopySharedD3D12Resources();
 	void PostDisplay();
 	void PerformUpscaling();
@@ -286,5 +293,12 @@ private:
 	{
 		static void thunk();
 		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	class MenuOpenCloseEventHandler : public RE::BSTEventSink<RE::MenuOpenCloseEvent>
+	{
+	public:
+		virtual RE::BSEventNotifyControl ProcessEvent(const RE::MenuOpenCloseEvent* a_event, RE::BSTEventSource<RE::MenuOpenCloseEvent>*) override;
+		static bool Register();
 	};
 };


### PR DESCRIPTION
A persistent ~2-3ms GPU-time regression appears in VR after worldspace or cell loads when DLSS is enabled, only clearing when the user manually toggles the upscaling mode or DLSS preset. That toggle path runs DestroyDLSSResources, so mirror it automatically by registering a MenuOpenCloseEventHandler that flags pendingDLSSReset on LoadingMenu close and consumes it at the top of the DLSS branch in Upscale(). slEvaluateFeature recreates the feature on the next frame with the current per-eye extents.

VR-only: flat has no repro and no per-eye extent asymmetry that the recreate would address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DLSS upscaling stability in VR by fixing issues that occurred during menu transitions. The feature now properly handles menu state changes to ensure consistent visual quality and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->