### PR TITLE
fix(lighting): gate EMAT+PARALLAX on tbnTr

### DIFF
--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -75,7 +75,7 @@ namespace SIE
 
 	namespace SShaderCache
 	{
-		static bool GetShaderDefines(const RE::BSShader&, uint32_t, std::span<D3D_SHADER_MACRO>);
+		static void GetShaderDefines(const RE::BSShader&, uint32_t, D3D_SHADER_MACRO*);
 		static std::string GetShaderString(ShaderClass, const RE::BSShader&, uint32_t, bool = false);
 		/**
 		 * @brief Resolve image-space shader descriptor when applicable.
@@ -130,18 +130,12 @@ namespace SIE
 			return 0x3F & (descriptor >> 24);
 		}
 
-		static bool GetLightingShaderDefines(uint32_t descriptor, std::span<D3D_SHADER_MACRO> defines)
+		static void GetLightingShaderDefines(uint32_t descriptor, std::span<D3D_SHADER_MACRO> defines)
 		{
 			static REL::Relocation<void(uint32_t, D3D_SHADER_MACRO*)> VanillaGetLightingShaderDefines(RELOCATION_ID(101631, 108698));
 			VanillaGetLightingShaderDefines(descriptor, defines.data());
 
 			size_t lastIndex = std::ranges::find_if(defines, [](const D3D_SHADER_MACRO& macro) { return macro.Name == nullptr; }) - defines.begin();
-
-			if (lastIndex == 0) {
-				// The vanilla function produced no defines for this descriptor.
-				// This indicates an invalid or unknown descriptor that should not be compiled.
-				return false;
-			}
 
 			if (descriptor & static_cast<uint32_t>(ShaderCache::LightingShaderFlags::Deferred)) {
 				defines[lastIndex++] = { "DEFERRED", nullptr };
@@ -160,7 +154,6 @@ namespace SIE
 			}
 
 			defines[lastIndex] = { nullptr, nullptr };
-			return true;
 		}
 
 		static void GetBloodSplaterShaderDefines(uint32_t descriptor, std::span<D3D_SHADER_MACRO> defines)
@@ -677,7 +670,7 @@ namespace SIE
 			return;
 		}
 
-		static bool GetShaderDefines(const RE::BSShader& shader, uint32_t descriptor, std::span<D3D_SHADER_MACRO> defines)
+		static void GetShaderDefines(const RE::BSShader& shader, uint32_t descriptor, std::span<D3D_SHADER_MACRO> defines)
 		{
 			switch (shader.shaderType.get()) {
 			case RE::BSShader::Type::Grass:
@@ -696,7 +689,8 @@ namespace SIE
 				GetImagespaceShaderDefines(shader, defines);
 				break;
 			case RE::BSShader::Type::Lighting:
-				return GetLightingShaderDefines(descriptor, defines);
+				GetLightingShaderDefines(descriptor, defines);
+				break;
 			case RE::BSShader::Type::DistantTree:
 				GetDistantTreeShaderDefines(descriptor, defines);
 				break;
@@ -710,7 +704,6 @@ namespace SIE
 				GetUtilityShaderDefines(descriptor, defines);
 				break;
 			}
-			return true;
 		}
 
 		static std::array<std::array<std::unordered_map<std::string, int32_t>,
@@ -1441,12 +1434,7 @@ namespace SIE
 					defines[lastIndex++] = { shaderDefines->at(i).first.c_str(), shaderDefines->at(i).second.c_str() };
 			}
 			defines[lastIndex] = { nullptr, nullptr };  // do final entry
-			if (!GetShaderDefines(shader, descriptor, std::span{ defines }.subspan(lastIndex))) {
-				logger::warn("Skipping {} shader {}::{:X}: empty defines from invalid descriptor",
-					magic_enum::enum_name(shaderClass), magic_enum::enum_name(type), descriptor);
-				cache.AddCompletedShader(shaderClass, shader, descriptor, nullptr);
-				return nullptr;
-			}
+			GetShaderDefines(shader, descriptor, std::span{ defines }.subspan(lastIndex));
 
 			const std::wstring path = GetShaderPath(
 				shader.shaderType == RE::BSShader::Type::ImageSpace ?


### PR DESCRIPTION
Restrict the EMAT && PARALLAX block in Lighting.hlsl to the same condition that gates tbnTr's declaration: (defined(SKINNED) || !defined(MODELSPACENORMALS)).

Without this, descriptors like Lighting::3000005 (Parallax + VC + ModelSpaceNormals, no Skinned) failed with `undeclared identifier 'tbnTr'`. For MODELSPACENORMALS+!SKINNED meshes the vertex shader doesn't produce valid TBN data anyway, so skipping the parallax path is correct.

Partial revert of #2239 / fc352db93: keeps the HLSL fix but drops the ShaderCache.cpp `lastIndex == 0` guard, which was rejecting legitimate Lighting:Vertex:0 (technique=None, no flags) shaders that vanilla GetLightingShaderDefines correctly emits zero defines for and that compile fine on feature defines alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shader compilation to no longer skip compilation for certain descriptor configurations.

* **Refactor**
  * Streamlined internal shader-define generation logic for more consistent compilation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->