### PR TITLE
fix(ci): three build system fixes

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -35,6 +35,10 @@ on:
                 description: "Optional suffix to invalidate the build cache"
                 type: string
                 default: ""
+            run-vs2022:
+                description: "Include vs2022 in the build matrix; set false for release builds where only vs2026 artifacts are shipped"
+                type: boolean
+                default: true
         outputs:
             version:
                 description: "CMake project version extracted from the build"
@@ -46,7 +50,7 @@ on:
 jobs:
     cpp-build:
         name: Build plugin and addons (${{ matrix.compiler.name }})
-        if: inputs.run-cpp
+        if: inputs.run-cpp && (matrix.compiler.name != 'vs2022' || inputs.run-vs2022)
         runs-on: windows-2025
         permissions:
             contents: read

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,7 @@ jobs:
             run-shader-validation: ${{ github.event_name != 'workflow_dispatch' || inputs.validate-shaders == true }}
             run-shader-tests: ${{ github.event_name != 'workflow_dispatch' || inputs.validate-shaders == true }}
             cache-key-suffix: ${{ inputs.cache-key-suffix || '' }}
+            run-vs2022: false
 
     feature-audit:
         name: Feature Version Audit (Release)
@@ -129,7 +130,7 @@ jobs:
               uses: ncipollo/release-action@v1
               with:
                   name: "Community Shaders ${{ steps.combined_notes.outputs.release_tag }}"
-                  draft: true
+                  draft: ${{ contains(steps.combined_notes.outputs.release_tag, '-') }}
                   tag: ${{ steps.combined_notes.outputs.release_tag }}
                   artifacts: "${{ github.workspace }}/dist/*.7z"
                   bodyFile: ${{ steps.combined_notes.outputs.body_file }}

--- a/.github/workflows/upload-nexus.yaml
+++ b/.github/workflows/upload-nexus.yaml
@@ -150,13 +150,17 @@ jobs:
                   with open('nexus-upload-state.json', 'w') as f:
                       json.dump({'has_uploads': has_uploads}, f)
                   "
-                  echo "matrix<<EOF" >> $GITHUB_OUTPUT
-                  cat nexus-matrix.json >> $GITHUB_OUTPUT
-                  echo "EOF" >> $GITHUB_OUTPUT
-                  echo "upload_matrix<<EOF" >> $GITHUB_OUTPUT
-                  cat nexus-upload-matrix.json >> $GITHUB_OUTPUT
-                  echo "EOF" >> $GITHUB_OUTPUT
-                  echo "has_uploads=$(python -c \"import json; print('true' if json.load(open('nexus-upload-state.json')).get('has_uploads') else 'false')\")" >> $GITHUB_OUTPUT
+                  DELIM=$(openssl rand -hex 8)
+                  {
+                    printf 'matrix<<%s\n' "$DELIM"
+                    cat nexus-matrix.json
+                    printf '%s\n' "$DELIM"
+                    printf 'upload_matrix<<%s\n' "$DELIM"
+                    cat nexus-upload-matrix.json
+                    printf '%s\n' "$DELIM"
+                  } >> "$GITHUB_OUTPUT"
+                  HAS_UPLOADS=$(python -c 'import json; d=json.load(open("nexus-upload-state.json")); print("true" if d.get("has_uploads") else "false")')
+                  echo "has_uploads=${HAS_UPLOADS}" >> "$GITHUB_OUTPUT"
               env:
                   RELEASE_TAG: ${{ steps.resolve.outputs.tag }}
                   INPUT_NEXUS_MOD_ID: ${{ inputs.nexus_mod_id || '' }}


### PR DESCRIPTION
## Summary

- **Nexus upload crash**: The `has_uploads` output line in `upload-nexus.yaml` used nested `\"` escapes inside a double-quoted `echo "..."` string. When GitHub Actions writes the YAML `run:` block to a temp shell script, the `\"` become literal `"`, creating unbalanced quotes that bash rejects as a syntax error (exit code 2). This happened *after* `echo "matrix<<EOF"` was already written to `$GITHUB_OUTPUT`, leaving an unclosed delimiter and causing the secondary "Matching delimiter not found 'EOF'" error. Fixed by using a plain variable + single-quoted python command. Also switched to a random delimiter (`openssl rand -hex 8`) to prevent accidental content collisions.
- **v1.5.0 stayed as Draft**: `build.yaml` hardcoded `draft: true` on every release, including stable tags. Changed to `draft: ${{ contains(release_tag, '-') }}` so stable releases (e.g. `v1.5.0`) publish immediately while RC/pre-release tags (e.g. `v1.5.0-rc.4`) stay as drafts.
- **vs2022 skipped for release builds**: Added `run-vs2022` boolean input to `_build.yaml` (default `true`). `build.yaml` passes `run-vs2022: false` so the vs2022 compiler job is skipped for tag/release builds where only the vs2026 artifact is shipped. PR builds continue to run both compilers.

## Test plan

- [ ] Trigger a new tag build and verify only vs2026 runs for the C++ job
- [ ] Verify a stable tag release publishes (not draft)
- [ ] Trigger `upload-nexus.yaml` dry-run for a stable tag and verify `prepare-nexus-matrix` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration parameter to independently control Visual Studio 2022 compiler builds

* **Chores**
  * Release draft status is now automatically determined by version tag format
  * Improved workflow output processing mechanisms for enhanced reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->