### PR TITLE
ci: fix nexus upload and skip vs2022 for releases

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -35,6 +35,10 @@ on:
                 description: "Optional suffix to invalidate the build cache"
                 type: string
                 default: ""
+            run-vs2022:
+                description: "Include vs2022 in the build matrix; set false for release builds where only vs2026 artifacts are shipped"
+                type: boolean
+                default: true
         outputs:
             version:
                 description: "CMake project version extracted from the build"
@@ -46,7 +50,7 @@ on:
 jobs:
     cpp-build:
         name: Build plugin and addons (${{ matrix.compiler.name }})
-        if: inputs.run-cpp
+        if: inputs.run-cpp && (matrix.compiler.name != 'vs2022' || inputs.run-vs2022)
         runs-on: windows-2025
         permissions:
             contents: read

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -73,7 +73,7 @@ jobs:
             fail-fast: false
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   ref: ${{ inputs.ref }}
                   repository: ${{ inputs.repository }}
@@ -129,7 +129,7 @@ jobs:
 
             - name: Upload dist artifacts
               if: success() && matrix.compiler.name == 'vs2026'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: dist-artifacts
                   path: dist/
@@ -151,7 +151,7 @@ jobs:
             fail-fast: false
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   ref: ${{ inputs.ref }}
                   repository: ${{ inputs.repository }}
@@ -212,7 +212,7 @@ jobs:
 
             - name: Upload shader validation logs
               if: failure() && steps.check-hlsl.outputs.skip != 'true'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: shader-validation-logs-${{ matrix.config.name }}
                   path: |
@@ -229,7 +229,7 @@ jobs:
             contents: read
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   ref: ${{ inputs.ref }}
                   repository: ${{ inputs.repository }}
@@ -266,7 +266,7 @@ jobs:
 
             - name: Upload test results on failure
               if: failure() && steps.check-hlsl.outputs.skip != 'true'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: shader-test-results
                   path: |

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -50,7 +50,7 @@ on:
 jobs:
     cpp-build:
         name: Build plugin and addons (${{ matrix.compiler.name }})
-        if: inputs.run-cpp && (matrix.compiler.name != 'vs2022' || inputs.run-vs2022)
+        if: inputs.run-cpp
         runs-on: windows-2025
         permissions:
             contents: read
@@ -67,6 +67,9 @@ jobs:
                       vs-version: "2022"
                       cmake-preset: ALL-VS2022
                       build-dir: build/ALL-VS2022
+                exclude:
+                    - compiler:
+                          name: ${{ !inputs.run-vs2022 && 'vs2022' || '' }}
             fail-fast: false
         steps:
             - name: Checkout code

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
             run-shader-validation: ${{ github.event_name != 'workflow_dispatch' || inputs.validate-shaders == true }}
             run-shader-tests: ${{ github.event_name != 'workflow_dispatch' || inputs.validate-shaders == true }}
             cache-key-suffix: ${{ inputs.cache-key-suffix || '' }}
-            run-vs2022: false
+            run-vs2022: ${{ github.event_name == 'workflow_dispatch' && github.ref_type != 'tag' }}
 
     feature-audit:
         name: Feature Version Audit (Release)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,7 @@ jobs:
             run-shader-validation: ${{ github.event_name != 'workflow_dispatch' || inputs.validate-shaders == true }}
             run-shader-tests: ${{ github.event_name != 'workflow_dispatch' || inputs.validate-shaders == true }}
             cache-key-suffix: ${{ inputs.cache-key-suffix || '' }}
+            run-vs2022: false
 
     feature-audit:
         name: Feature Version Audit (Release)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
         continue-on-error: true
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   submodules: recursive
@@ -65,7 +65,7 @@ jobs:
                   cat feature-version-audit-latest.md
 
             - name: Upload feature audit markdown
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: feature-version-audit
                   path: feature-version-audit-latest.md
@@ -95,14 +95,14 @@ jobs:
                   fi
 
             - name: Download dist artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v7
               with:
                   name: dist-artifacts
                   path: dist/
 
             - name: Download feature audit artifact
               continue-on-error: true
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v7
               with:
                   name: feature-version-audit
                   path: .

--- a/.github/workflows/cleanup-pre-releases.yaml
+++ b/.github/workflows/cleanup-pre-releases.yaml
@@ -22,7 +22,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   ref: ${{ github.event.repository.default_branch }}
 

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -44,7 +44,7 @@ jobs:
             hlsl-should-build: ${{ steps.changed-files.outputs.hlsl_any_changed == 'true' || steps.changed-files.outputs.cmake_any_changed == 'true' || steps.changed-files.outputs.ci_any_changed == 'true' || steps.changed-files.outcome == 'failure' }}
             shader-tests-should-build: ${{ steps.changed-files.outputs.shader_tests_any_changed == 'true' || steps.changed-files.outputs.hlsl_any_changed == 'true' || steps.changed-files.outputs.cmake_any_changed == 'true' || steps.changed-files.outputs.ci_any_changed == 'true' || steps.changed-files.outcome == 'failure' }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
 
@@ -129,7 +129,7 @@ jobs:
             pull-requests: write
         steps:
             - name: Download dist artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v7
               with:
                   name: dist-artifacts
                   path: dist/
@@ -213,7 +213,7 @@ jobs:
             contents: read
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   submodules: recursive
@@ -240,7 +240,7 @@ jobs:
 
             - name: Upload feature audit markdown (PR)
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: pr-feature-audit
                   path: pr-feature-audit.md
@@ -255,7 +255,7 @@ jobs:
         steps:
             - name: Download feature audit markdown (PR)
               continue-on-error: true
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v7
               with:
                   name: pr-feature-audit
                   path: .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,7 @@ jobs:
                   extra_plugins: |
                       @google/semantic-release-replace-plugin
                       @semantic-release/git
+                      @semantic-release/github
                   tag_format: "v${version}"
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/todo.yaml
+++ b/.github/workflows/todo.yaml
@@ -14,7 +14,7 @@ jobs:
     build:
         runs-on: "ubuntu-latest"
         steps:
-            - uses: "actions/checkout@v3"
+            - uses: "actions/checkout@v6"
             - name: "TODO to Issue"
               uses: "alstr/todo-to-issue-action@master"
               env:

--- a/.github/workflows/update-buffers-wiki.yaml
+++ b/.github/workflows/update-buffers-wiki.yaml
@@ -20,7 +20,7 @@ jobs:
         runs-on: windows-2022
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   submodules: recursive
 

--- a/.github/workflows/upload-nexus.yaml
+++ b/.github/workflows/upload-nexus.yaml
@@ -150,13 +150,17 @@ jobs:
                   with open('nexus-upload-state.json', 'w') as f:
                       json.dump({'has_uploads': has_uploads}, f)
                   "
-                  echo "matrix<<EOF" >> $GITHUB_OUTPUT
-                  cat nexus-matrix.json >> $GITHUB_OUTPUT
-                  echo "EOF" >> $GITHUB_OUTPUT
-                  echo "upload_matrix<<EOF" >> $GITHUB_OUTPUT
-                  cat nexus-upload-matrix.json >> $GITHUB_OUTPUT
-                  echo "EOF" >> $GITHUB_OUTPUT
-                  echo "has_uploads=$(python -c \"import json; print('true' if json.load(open('nexus-upload-state.json')).get('has_uploads') else 'false')\")" >> $GITHUB_OUTPUT
+                  DELIM=$(openssl rand -hex 8)
+                  {
+                    printf 'matrix<<%s\n' "$DELIM"
+                    cat nexus-matrix.json
+                    printf '%s\n' "$DELIM"
+                    printf 'upload_matrix<<%s\n' "$DELIM"
+                    cat nexus-upload-matrix.json
+                    printf '%s\n' "$DELIM"
+                  } >> "$GITHUB_OUTPUT"
+                  HAS_UPLOADS=$(python -c 'import json; d=json.load(open("nexus-upload-state.json")); print("true" if d.get("has_uploads") else "false")')
+                  echo "has_uploads=${HAS_UPLOADS}" >> "$GITHUB_OUTPUT"
               env:
                   RELEASE_TAG: ${{ steps.resolve.outputs.tag }}
                   INPUT_NEXUS_MOD_ID: ${{ inputs.nexus_mod_id || '' }}

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -30,5 +30,15 @@ module.exports = {
         message: 'chore(release): ${nextRelease.version} [skip ci]',
       },
     ],
+    [
+      '@semantic-release/github',
+      {
+        draft: true,
+        assets: [],
+        successComment: false,
+        failComment: false,
+        releasedLabels: false,
+      },
+    ],
   ],
 };

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -33,7 +33,7 @@ module.exports = {
     [
       '@semantic-release/github',
       {
-        draft: true,
+        draftRelease: true,
         assets: [],
         successComment: false,
         failComment: false,


### PR DESCRIPTION
## Summary

- **Nexus upload crash** (`upload-nexus.yaml`): The `has_uploads` output line used nested `\"` escapes inside `echo "...$(python -c \"...\")"`. When GitHub Actions writes the YAML `run:` block to a temp shell script the `\"` become literal `"`, creating unbalanced quotes that bash rejects (exit code 2) after `matrix<<EOF` is already open in `$GITHUB_OUTPUT`, causing the secondary "Matching delimiter not found 'EOF'" error. Fixed with a variable + single-quoted python command, and switched to a random delimiter.
- **Skip vs2022 for release builds** (`_build.yaml`, `build.yaml`): Added `run-vs2022` boolean input (default `true`) to `_build.yaml`. `build.yaml` passes `false` to skip the vs2022 job for tag/release builds where only the vs2026 artifact is shipped. PR builds still run both.
- **Missing changelog** (`.releaserc.js`, `release.yaml`): `.releaserc.js` had `@semantic-release/release-notes-generator` but no `@semantic-release/github`, so the generated changelog was discarded. Added `@semantic-release/github` with `draft: true` and no assets. The build workflow's `gh release view --json body` step then reads the changelog and appends the feature audit on top.

## Test plan
- [ ] Run release workflow for an RC and verify the draft release body contains a changelog
- [ ] Trigger a tag build and verify only vs2026 runs for the C++ job
- [ ] Trigger `upload-nexus.yaml` dry-run and verify `prepare-nexus-matrix` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an option to skip VS2022 builds so CI can selectively omit that configuration.
  * Build workflow now forwards the new option for dispatch runs.
  * Upgraded several CI action versions (checkout, upload/download-artifact) across workflows.
  * Made CI artifact/output composition and upload-detection more robust.
  * Enabled semantic-release publishing to GitHub (draft releases, no assets, comments disabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->