### PR TITLE
build: force AIO rebuild on HEAD change or manual delete

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,6 +494,16 @@ if(AUTO_PLUGIN_DEPLOYMENT OR AIO_ZIP_TO_DIST)
             ${CMAKE_SOURCE_DIR}/cmake/CleanupStaleEntries.cmake
     )
 
+    # If AIO was manually (or programmatically) deleted, the stamp is stale —
+    # clear it so cmake --build re-runs PREPARE_AIO to recreate the directory.
+    if(NOT EXISTS "${AIO_DIR}")
+        file(
+            REMOVE
+            "${CMAKE_CURRENT_BINARY_DIR}/prepare_aio.stamp"
+            "${CMAKE_CURRENT_BINARY_DIR}/copy_shaders.stamp"
+        )
+    endif()
+
     add_custom_target(
         PREPARE_AIO
         ALL
@@ -592,6 +602,58 @@ endif()
 
 # Automatic deployment to CommunityShaders output directory.
 if(AUTO_PLUGIN_DEPLOYMENT)
+    # Detect git HEAD changes (branch switch or new commit) and invalidate stale
+    # deploy state. BuildRelease.bat always reconfigures, so this runs on every
+    # build invocation. When HEAD changes we:
+    #   1. Touch all AIO files so robocopy /XO sees them as newer than any
+    #      previously-deployed files (including manual package installs).
+    #   2. Delete deploy stamps so CMake re-runs the robocopy commands.
+    # Files the user intentionally edited in-game remain protected by /XO on
+    # subsequent builds (same HEAD = no touch, same stamp file exists).
+    execute_process(
+        COMMAND git rev-parse --short HEAD
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        OUTPUT_VARIABLE _git_head
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(_git_head)
+        set(_git_head_stamp "${CMAKE_BINARY_DIR}/git-head.stamp")
+        set(_prev_git_head "")
+        if(EXISTS "${_git_head_stamp}")
+            file(READ "${_git_head_stamp}" _prev_git_head)
+            string(STRIP "${_prev_git_head}" _prev_git_head)
+        endif()
+        if(NOT "${_git_head}" STREQUAL "${_prev_git_head}")
+            message(
+                STATUS
+                "Git HEAD changed (${_prev_git_head} -> ${_git_head}): clearing AIO shaders and deploy stamps for full redeploy"
+            )
+            # Delete the entire AIO directory so PREPARE_AIO re-copies everything
+            # with fresh timestamps. Without this, copy_if_different skips
+            # content-identical files (shaders, textures, configs, etc.) and
+            # leaves them with old timestamps that deployed files (e.g. from a
+            # manual package install) may beat under /XO. The DLL is always
+            # rebuilt fresh by the C++ compile step so it doesn't need special
+            # handling.
+            file(REMOVE_RECURSE "${AIO_DIR}")
+            # Also clear the PREPARE_AIO / COPY_SHADERS stamps so cmake --build
+            # actually re-runs those targets.
+            file(
+                GLOB _build_stamps
+                "${CMAKE_BINARY_DIR}/*_deploy.stamp"
+                "${CMAKE_BINARY_DIR}/*_shaders_full.stamp"
+                "${CMAKE_BINARY_DIR}/*_shaders_only.stamp"
+                "${CMAKE_BINARY_DIR}/prepare_aio.stamp"
+                "${CMAKE_BINARY_DIR}/copy_shaders.stamp"
+            )
+            foreach(_stamp IN LISTS _build_stamps)
+                file(REMOVE "${_stamp}")
+            endforeach()
+        endif()
+        file(WRITE "${_git_head_stamp}" "${_git_head}")
+    endif()
+
     set(DEPLOY_TARGET_HASHES)
     if(WIN32)
         foreach(DEPLOY_TARGET $ENV{CommunityShadersOutputDir})


### PR DESCRIPTION
## Summary

- When git HEAD changes (branch switch or new commit), wipe the entire AIO staging directory and clear all deploy/prepare stamps so `cmake --build` re-copies every file with a fresh timestamp
- Adds an always-on configure-time guard: if `AIO_DIR` is missing (manual delete), clear `prepare_aio.stamp` and `copy_shaders.stamp` so `PREPARE_AIO` unconditionally reruns on the next build

## Problem

`copy_if_different` skips content-identical files, leaving them with old timestamps. A manual package install gives deployed files a newer timestamp than those stale AIO files, causing robocopy `/XO` to silently skip them — deployed shaders stay wrong even after a full rebuild.

## Test plan

- [ ] Delete AIO directory manually, run `BuildRelease.bat` — AIO should be recreated and all files deployed
- [ ] Switch branches, run `BuildRelease.bat` — AIO should be wiped and redeployed from scratch
- [ ] Normal rebuild on same branch — incremental, only changed files deployed, in-game edits protected by `/XO`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced build system cache invalidation to automatically clean up stale build artifacts and trigger fresh rebuilds when source code changes or deployment state becomes outdated, ensuring more reliable build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->