### PR TITLE
ci: fix nexus upload pipeline and release auto-trigger

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -50,7 +50,7 @@ on:
 jobs:
     cpp-build:
         name: Build plugin and addons (${{ matrix.compiler.name }})
-        if: inputs.run-cpp
+        if: inputs.run-cpp && (matrix.compiler.name != 'vs2022' || inputs.run-vs2022)
         runs-on: windows-2025
         permissions:
             contents: read

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -50,7 +50,7 @@ on:
 jobs:
     cpp-build:
         name: Build plugin and addons (${{ matrix.compiler.name }})
-        if: inputs.run-cpp && (matrix.compiler.name != 'vs2022' || inputs.run-vs2022)
+        if: inputs.run-cpp
         runs-on: windows-2025
         permissions:
             contents: read

--- a/.github/workflows/nexus-upload-on-release.yaml
+++ b/.github/workflows/nexus-upload-on-release.yaml
@@ -1,24 +1,18 @@
 name: Nexus Upload (Post Release)
 
 on:
-    workflow_run:
-        workflows: ["Build Community Shaders and addons"]
-        types: [completed]
-        branches:
-            - "v[0-9]*.[0-9]*.[0-9]*"
+    release:
+        types: [published]
 
 jobs:
     nexus-upload:
         name: Nexus Upload (dry run)
-        # workflow_run always runs in the base repo context, so secrets are available
-        # regardless of whether the triggering PR/push came from a fork.
-        # head_branch for a tag-triggered workflow_run is the tag name (e.g. v1.2.3).
+        # Fires when a draft release is published. Only stable tags (no '-') are uploaded.
         if: >
-            github.event.workflow_run.conclusion == 'success' &&
-            !contains(github.event.workflow_run.head_branch, '-')
+            !contains(github.event.release.tag_name, '-')
         uses: ./.github/workflows/upload-nexus.yaml
         with:
-            tag: ${{ github.event.workflow_run.head_branch }}
+            tag: ${{ github.event.release.tag_name }}
             artifact_pattern: "CommunityShaders-*.7z"
             dry_run: "true"
         secrets:

--- a/.github/workflows/upload-nexus.yaml
+++ b/.github/workflows/upload-nexus.yaml
@@ -120,6 +120,7 @@ jobs:
               run: |
                   ARGS=( --export-nexus-matrix --matrix-output nexus-matrix-raw.json )
                   PREVIOUS_TAG=$(git tag --merged "$RELEASE_TAG" --list 'v*.*.*' --sort=-v:refname 2>/dev/null \
+                    | grep -v -- '-' \
                     | awk -v current="$RELEASE_TAG" '$0 != current { print; exit }')
                   if [ -n "$PREVIOUS_TAG" ]; then
                     ARGS+=( --base "$PREVIOUS_TAG" )

--- a/.github/workflows/upload-nexus.yaml
+++ b/.github/workflows/upload-nexus.yaml
@@ -98,11 +98,18 @@ jobs:
                     echo "ERROR: '$TAG' is a pre-release tag. Only stable releases are uploaded to Nexus." >&2
                     exit 1
                   fi
+                  DRAFT=$(gh api "repos/$GITHUB_REPOSITORY/releases" \
+                    --jq ".[] | select(.tag_name == \"$TAG\") | .draft" 2>/dev/null | head -1)
+                  if [ "$DRAFT" != "false" ]; then
+                    echo "ERROR: Release '$TAG' is not published. Publish the GitHub release before uploading to Nexus." >&2
+                    exit 1
+                  fi
                   VERSION="${TAG#v}"
                   echo "tag=$TAG" >> $GITHUB_OUTPUT
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
               env:
                   INPUT_TAG: ${{ inputs.tag || '' }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Compute dry-run mode
               id: dryrun


### PR DESCRIPTION
## Summary

- **Nexus upload bash quoting**: Fixed multiline GITHUB_OUTPUT with random delimiter; was crashing with exit code 2 on every run
- **Skip vs2022 for releases**: Use matrix exclude so tag/release builds only run vs2026; vs2022 excluded via `strategy.matrix.exclude` (matrix context not valid in job-level `if`)
- **Nexus stable-tag baseline**: `PREVIOUS_TAG` was resolving to `v1.5.0-rc.5` instead of `v1.4.11` due to version sort ordering; fixed with `grep -v -- '-'` to skip pre-release tags
- **Nexus auto-trigger on publish**: Replaced `workflow_run` trigger (fired while release still a draft, causing `gh release download` 404) with `release: [published]`; added explicit draft-release guard in resolve step for manual dispatch

## Test plan

- [ ] Trigger `Upload Nexus Release` manually with a published stable tag — should pass resolve step
- [ ] Trigger `Upload Nexus Release` manually with a draft tag — should fail fast at resolve with clear error
- [ ] Publish a draft release — `Nexus Upload (Post Release)` should fire automatically
- [ ] Publish a pre-release (RC) — auto-trigger should be skipped by `if` condition
- [ ] Tag-triggered build: verify only vs2026 matrix runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to trigger on GitHub release events and added validation to ensure only published releases are processed for artifact upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->