### PR TITLE
ci(nexus): fix GITHUB_OUTPUT delimiter and auto-generate changelogs

### DIFF
--- a/.github/workflows/upload-nexus.yaml
+++ b/.github/workflows/upload-nexus.yaml
@@ -162,10 +162,10 @@ jobs:
                   {
                     printf 'matrix<<%s\n' "$DELIM"
                     cat nexus-matrix.json
-                    printf '%s\n' "$DELIM"
+                    printf '\n%s\n' "$DELIM"
                     printf 'upload_matrix<<%s\n' "$DELIM"
                     cat nexus-upload-matrix.json
-                    printf '%s\n' "$DELIM"
+                    printf '\n%s\n' "$DELIM"
                   } >> "$GITHUB_OUTPUT"
                   HAS_UPLOADS=$(python -c 'import json; d=json.load(open("nexus-upload-state.json")); print("true" if d.get("has_uploads") else "false")')
                   echo "has_uploads=${HAS_UPLOADS}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/upload-nexus.yaml
+++ b/.github/workflows/upload-nexus.yaml
@@ -144,6 +144,26 @@ jobs:
                     ARGS+=( --core-artifact-pattern "$INPUT_ARTIFACT_PATTERN" )
                   fi
                   python tools/feature_version_audit.py "${ARGS[@]}"
+
+                  # Inject GitHub release body as the core changelog.
+                  # The jq filter returns the body as a JSON string (newlines preserved),
+                  # which Python reads via json.load so special characters are handled safely.
+                  gh api "repos/$GITHUB_REPOSITORY/releases" \
+                    --jq "[.[] | select(.tag_name == \"$RELEASE_TAG\") | .body][0] // \"\"" \
+                    2>/dev/null > core-body.json || echo '""' > core-body.json
+                  python -c "
+                  import json
+                  body = json.load(open('core-body.json')) or ''
+                  with open('nexus-matrix-raw.json') as f:
+                      data = json.load(f)
+                  for row in data:
+                      if row.get('name') == 'core':
+                          row['changelog'] = body
+                          break
+                  with open('nexus-matrix-raw.json', 'w') as f:
+                      json.dump(data, f)
+                  "
+
                   python -c "
                   import json
                   with open('nexus-matrix-raw.json') as f:
@@ -174,6 +194,7 @@ jobs:
                   INPUT_NEXUS_MOD_ID: ${{ inputs.nexus_mod_id || '' }}
                   INPUT_MOD_FILENAME: ${{ inputs.mod_filename || '' }}
                   INPUT_ARTIFACT_PATTERN: ${{ inputs.artifact_pattern || '' }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     prepare-artifacts:
         needs: prepare-nexus-matrix
@@ -256,7 +277,7 @@ jobs:
             tag_name: ${{ needs.prepare-nexus-matrix.outputs.tag }}
             mod_version: ${{ matrix.mod_version || needs.prepare-nexus-matrix.outputs.version }}
             mod_filename: ${{ matrix.mod_filename }}
-            changelog: ${{ inputs.changelog || '' }}
+            changelog: ${{ matrix.changelog || inputs.changelog || '' }}
         secrets:
             UNEX_NEXUSMODS_SESSION_COOKIE: ${{ secrets.UNEX_NEXUSMODS_SESSION_COOKIE }}
             UNEX_APIKEY: ${{ secrets.UNEX_APIKEY }}

--- a/tools/feature_version_audit.py
+++ b/tools/feature_version_audit.py
@@ -317,6 +317,44 @@ def get_commit_author(commit_hash):
     except Exception:
         return None
 
+def get_feature_changelog(feature_dir, feature_info, base_ref):
+    """Return bullet-point changelog of user-facing commits since base_ref.
+
+    Includes feat, fix, perf, and breaking-change commits only.
+    Deduplicates by subject line and preserves commit order (newest first).
+    """
+    if not base_ref:
+        return ""
+    paths = [str(feature_dir).replace("\\", "/")]
+    if feature_info:
+        name = feature_info.get('name', '')
+        for suffix in ('.h', '.cpp'):
+            p = DEFAULT_FEATURE_HEADERS_DIR / (name + suffix)
+            if p.exists():
+                paths.append(str(p).replace("\\", "/"))
+        src_dir = DEFAULT_FEATURE_HEADERS_DIR / name
+        if src_dir.exists() and src_dir.is_dir():
+            paths.append(str(src_dir).replace("\\", "/"))
+    try:
+        raw = subprocess.check_output(
+            ["git", "log", f"{base_ref}..{HEAD_REF}", "--pretty=%s", "--"] + paths,
+            cwd=str(PROJECT_ROOT),
+            stderr=subprocess.DEVNULL,
+        ).decode("utf-8", errors="replace")
+    except Exception:
+        return ""
+    seen = set()
+    lines = []
+    for msg in raw.splitlines():
+        msg = msg.strip()
+        if not msg or msg in seen:
+            continue
+        seen.add(msg)
+        if (RE_COMMIT_FEAT.match(msg) or RE_COMMIT_FIX.match(msg) or
+                RE_COMMIT_PERF.match(msg) or RE_COMMIT_BREAKING.search(msg)):
+            lines.append(f"- {msg}")
+    return "\n".join(lines)
+
 def apply_version_bump(ini_path, proposed_ver_str):
     try:
         with open(ini_path, "r", encoding="utf-8") as f:
@@ -875,7 +913,7 @@ def format_metadata_summary(feature_metadata):
     return lines, metadata_issues
 
 
-def build_nexus_upload_matrix(feature_metadata, core_mod_id, core_filename, core_artifact_pattern):
+def build_nexus_upload_matrix(feature_metadata, core_mod_id, core_filename, core_artifact_pattern, base_ref=None):
     rows = [
         {
             'name': 'core',
@@ -883,6 +921,7 @@ def build_nexus_upload_matrix(feature_metadata, core_mod_id, core_filename, core
             'artifact_name': 'nexus-upload-core',
             'nexus_mod_id': core_mod_id,
             'mod_filename': core_filename,
+            'changelog': '',  # filled by workflow from GitHub release body
         }
     ]
     def sanitize_name(name):
@@ -923,6 +962,11 @@ def build_nexus_upload_matrix(feature_metadata, core_mod_id, core_filename, core
         }
         if mod_version:
             row['mod_version'] = mod_version
+        if base_ref:
+            feature_dir = FEATURES_DIR / name
+            changelog = get_feature_changelog(feature_dir, info, base_ref)
+            if changelog:
+                row['changelog'] = changelog
 
         rows.append(row)
     return rows
@@ -1129,6 +1173,7 @@ def main():
             args.core_mod_id,
             args.core_filename,
             args.core_artifact_pattern,
+            base_ref=base_ref,
         )
         output_path = args.matrix_output
         with open(output_path, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary

- **Fix**: `json.dump()` produces no trailing newline, causing the GITHUB_OUTPUT multiline delimiter to land on the same line as the last JSON character instead of its own line. GitHub Actions requires the delimiter at column 0. Fixed by using `printf '\n%s\n'` for both closing delimiters.
- **Feature**: Auto-generate per-feature and core changelogs for Nexus uploads:
  - `feature_version_audit.py` now adds a `changelog` field to each feature row in the upload matrix, built from `feat`/`fix`/`perf`/breaking commits touching that feature's files since the previous stable tag
  - Core row's changelog is the GitHub release body (fetched via `gh api` list endpoint, JSON-encoded for safe multiline handling) injected into the matrix before the split step
  - `upload-to-nexus` job uses `matrix.changelog || inputs.changelog || ''` so manual `workflow_dispatch` with an explicit changelog still works as override

## Test plan

- [ ] Delimiter fix: run the Nexus upload workflow on a published stable release and confirm `prepare-nexus-matrix` succeeds (matrix output parses correctly)
- [ ] Core changelog: confirm the Nexus upload for the core mod includes the GitHub release notes
- [ ] Feature changelogs: confirm feature uploads (e.g. ScreenSpaceGI, Skylighting) include relevant commit bullet points
- [ ] Manual dispatch with `changelog` input: confirm the explicit value is used when `matrix.changelog` is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated changelog generation now included in release uploads, extracting commit-derived information for both core and feature components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->