### PR TITLE
ci(nexus): fix core-body.json empty file crash

### DIFF
--- a/.github/workflows/upload-nexus.yaml
+++ b/.github/workflows/upload-nexus.yaml
@@ -146,14 +146,19 @@ jobs:
                   python tools/feature_version_audit.py "${ARGS[@]}"
 
                   # Inject GitHub release body as the core changelog.
-                  # The jq filter returns the body as a JSON string (newlines preserved),
-                  # which Python reads via json.load so special characters are handled safely.
+                  # Fetch releases list as raw JSON and let Python search it — avoids
+                  # jq version quirks where array[0] on an empty array produces no output
+                  # instead of null, leaving the file empty and breaking json.load.
                   gh api "repos/$GITHUB_REPOSITORY/releases" \
-                    --jq "[.[] | select(.tag_name == \"$RELEASE_TAG\") | .body][0] // \"\"" \
-                    2>/dev/null > core-body.json || echo '""' > core-body.json
+                    2>/dev/null > releases.json || echo '[]' > releases.json
                   python -c "
-                  import json
-                  body = json.load(open('core-body.json')) or ''
+                  import json, os
+                  with open('releases.json') as f:
+                      releases = json.load(f)
+                  if not isinstance(releases, list):
+                      releases = []
+                  tag = os.environ.get('RELEASE_TAG', '')
+                  body = next((r.get('body') or '' for r in releases if r.get('tag_name') == tag), '')
                   with open('nexus-matrix-raw.json') as f:
                       data = json.load(f)
                   for row in data:


### PR DESCRIPTION
## Summary

The Nexus upload workflow failed on run [25238008146](https://github.com/community-shaders/skyrim-community-shaders/actions/runs/25238008146) after v1.5.0 was published. Root cause: `gh api --jq` with `[...][0]` array indexing on jq 1.6 (ubuntu-latest) produces **zero bytes** of stdout when the matching result is found but the expression short-circuits — leaving `core-body.json` at 0 bytes. Since `gh api` still exits 0, the `|| echo '""'` fallback never fires, and `json.load` raises `JSONDecodeError: Expecting value`.

Confirmed the data was present (v1.5.0 body is 51K chars, published 2h before the run) — this was a jq processing quirk, not a missing release.

**Fix**: drop jq entirely and fetch the releases list as raw JSON, then let Python search for the matching tag. Handles all edge cases (empty list, null body, non-list error response) with no jq dependency.

## Test plan

- [ ] Re-run the Nexus upload workflow for v1.5.0 and confirm `prepare-nexus-matrix` succeeds
- [ ] Confirm the core changelog is populated with the GitHub release body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of the release upload process by enhancing error handling when retrieving release metadata, with more robust fallback behavior during data retrieval failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->