### PR TITLE
refactor(volumetric-lighting): use constant for threshold

### DIFF
--- a/package/Shaders/ISApplyVolumetricLighting.hlsl
+++ b/package/Shaders/ISApplyVolumetricLighting.hlsl
@@ -34,6 +34,7 @@ cbuffer PerGeometry : register(b2)
 PS_OUTPUT main(PS_INPUT input)
 {
 	PS_OUTPUT psout;
+	static const float kVLThresholdBias = 1.0 / 128.0;
 
 	float2 screenPosition = FrameBuffer::GetDynamicResolutionAdjustedScreenPosition(input.TexCoord);
 	float depth = DepthTex.Sample(DepthSampler, screenPosition).x;
@@ -49,7 +50,7 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float noiseGrad = 0.03125 * NoiseGradSamplerTex.Sample(NoiseGradSamplerSampler, 0.125 * input.Position.xy).x;
 
-	float adjustedVl = max(0, noiseGrad + vl - 0.0078125);
+	float adjustedVl = max(0, noiseGrad + vl - kVLThresholdBias);
 
 	if (0.001 < g_IntensityX_TemporalY.y) {
 		float2 motionVector = MotionVectorsTex.Sample(MotionVectorsSampler, screenPosition).xy;

--- a/package/Shaders/ISApplyVolumetricLighting.hlsl
+++ b/package/Shaders/ISApplyVolumetricLighting.hlsl
@@ -50,7 +50,7 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float noiseGrad = 0.03125 * NoiseGradSamplerTex.Sample(NoiseGradSamplerSampler, 0.125 * input.Position.xy).x;
 
-	float adjustedVl = max(0, noiseGrad + vl - kVLThresholdBias);
+	float adjustedVl = max(0.0, noiseGrad + vl - kVLThresholdBias);
 
 	if (0.001 < g_IntensityX_TemporalY.y) {
 		float2 motionVector = MotionVectorsTex.Sample(MotionVectorsSampler, screenPosition).xy;


### PR DESCRIPTION
small fix i saw when doing hdr sun

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tuned volumetric lighting computation for more consistent rendering results and improved stability of light thresholds, reducing subtle artifacts in volumetric effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->