### PR TITLE
ci(nexus): show per-feature version in prepare-artifacts report

### DIFF
--- a/.github/workflows/upload-nexus.yaml
+++ b/.github/workflows/upload-nexus.yaml
@@ -266,7 +266,7 @@ jobs:
                     echo "  Nexus mod ID: ${{ matrix.nexus_mod_id }}"
                     echo "  Artifact name: nexus-upload-${{ matrix.name }}"
                     echo "  Release tag: ${{ needs.prepare-nexus-matrix.outputs.tag }}"
-                    echo "  Version: ${{ needs.prepare-nexus-matrix.outputs.version }}"
+                    echo "  Version: ${{ matrix.mod_version || needs.prepare-nexus-matrix.outputs.version }}"
                     echo "  Mod filename: ${{ matrix.mod_filename }}"
                     echo "  Auto upload: ${{ matrix.auto_upload }}"
                     if [ "$DRY_RUN" = "true" ]; then


### PR DESCRIPTION
## Summary

- The `Report planned Nexus upload` step in `prepare-artifacts` was always showing the global release version (`needs.prepare-nexus-matrix.outputs.version`) for every feature, even when a feature has a `mod_version` override in the upload matrix
- One-line fix: use `matrix.mod_version || needs.prepare-nexus-matrix.outputs.version` so the log accurately reflects what will actually be uploaded to Nexus

## Test plan

- [ ] Trigger dry-run upload and verify log shows correct per-feature version (e.g. addon features pinned to an older version show their pinned version, not the release version)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow version reporting to prioritize matrix-specific versions when available, ensuring accurate version display in deployment logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->