### PR TITLE
ci: support hotfix branches in semantic-release

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,11 +1,22 @@
 const isRC = (process.env.RELEASE_TYPE || 'rc') === 'rc';
 
 module.exports = {
-  // RC: needs 'main' as non-prerelease anchor (semantic-release v25 requires >= 1).
-  // Stable: 'dev' is the release branch directly.
+  // RC:     'main' is the non-prerelease anchor required by semantic-release v25.
+  //         'dev' produces rc pre-releases.
+  // Stable: 'dev' is the primary release branch.
+  //         'hotfix/N.N.x' maintenance branches allow patch releases from a
+  //         tagged stable baseline without carrying unreleased dev work.
+  //         Branch naming: hotfix/1.5.x (the x.y maintenance line, not a specific patch).
   branches: isRC
     ? ['main', { name: 'dev', prerelease: 'rc' }]
-    : ['dev'],
+    : [
+        'dev',
+        {
+          name: 'hotfix/+([0-9])?(.{+([0-9]),x}).x',
+          range: '${name.split("/")[1]}',
+          channel: '${name.split("/")[1]}',
+        },
+      ],
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',


### PR DESCRIPTION
## Summary

Adds a maintenance branch pattern to `.releaserc.js` so patch releases can be cut from a tagged stable baseline without carrying unreleased `dev` work.

Without this change, triggering `release.yaml` from any branch other than `dev` causes semantic-release to abort with *"not triggered in the context of a release branch"*.

---

## Hotfix Release Process

### When to use

Use a hotfix release when `dev` has moved forward with new unreleased features and a critical fix needs to ship against the last stable tag.

If `dev` has no unreleased features yet, you can release directly from `dev` as normal.

### Branch naming

Hotfix branches represent a **maintenance line**, not a single patch:

```
hotfix/1.5.x   ← correct (the 1.5 line)
hotfix/1.5.1   ← wrong (semantic-release won't match this)
```

### Step-by-step

**1. Land the fix on `dev` first (normal PR flow)**

```bash
# fix merged to dev via PR as usual
```

**2. Create a hotfix branch from the stable tag**

```bash
git fetch community-shaders
git checkout -b hotfix/1.5.x v1.5.0
```

**3. Cherry-pick the fix from `dev`**

```bash
git cherry-pick <commit-sha>   # the fix commit from dev
git push origin hotfix/1.5.x
```

**4. Trigger the release**

Go to **Actions → Semantic Release → Run workflow**, select branch `hotfix/1.5.x`, set `release_type: stable`.

The workflow will:
- Auto-bump any feature INI versions that changed on this branch
- Run semantic-release, which sees `v1.5.0` as the baseline and produces `v1.5.1`
- Update `CMakeLists.txt` version and commit it
- Create a draft GitHub release tagged `v1.5.1`
- Trigger the build and Nexus upload pipeline automatically

**5. Publish the release**

Review the draft release on GitHub, then publish it. The Nexus upload will trigger automatically on publish.

**6. Clean up**

The `hotfix/1.5.x` branch can be deleted after the release is published. All fixes should already be on `dev` from step 1.

---

## What changes in `.releaserc.js`

The `branches` config for stable releases now includes:

```js
{
  name: 'hotfix/+([0-9])?(.{+([0-9]),x}).x',
  range: '${name.split("/")[1]}',
  channel: '${name.split("/")[1]}',
}
```

- `name` — glob pattern matching `hotfix/1.5.x`, `hotfix/2.0.x`, etc.
- `range` — tells semantic-release to only consider `1.5.x` versions on this branch
- `channel` — publishes to the `1.5.x` release channel (prevents it from being treated as the latest stable)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation configuration to support maintenance branch releases. The system now enables hotfix branches to trigger automated patch releases while preserving existing release candidate branch behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->