### PR TITLE
ci: add choice dropdowns for workflows

### DIFF
--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -25,7 +25,11 @@ on:
             dry_run:
                 description: "If true, do not upload to Nexus; only report the planned upload"
                 required: false
+                type: choice
                 default: "true"
+                options:
+                    - "true"
+                    - "false"
             changelog:
                 description: "Optional release notes or changelog for Nexus"
                 required: false

--- a/.github/workflows/release-semantic.yaml
+++ b/.github/workflows/release-semantic.yaml
@@ -4,9 +4,13 @@ on:
     workflow_dispatch:
         inputs:
             release_type:
-                description: "Release type: rc or stable"
+                description: "Release type"
                 required: true
+                type: choice
                 default: "rc"
+                options:
+                    - rc
+                    - stable
 
 permissions:
     contents: write


### PR DESCRIPTION
## Summary

- `Release: Semantic Version` — `release_type` is now a `type: choice` dropdown (`rc` / `stable`, default `rc`) instead of a free-text box. Prevents silent fallback to RC if someone types `Stable` or `stable ` with a typo.
- `Nexus: Upload Release` — `dry_run` is now a `type: choice` dropdown (`true` / `false`, default `true`) instead of a free-text box. Makes the safe default obvious.

The `workflow_call` declaration for `dry_run` remains `type: string` (GitHub doesn't support `choice` there). The normalization step (`if [ "$INPUT_DRY_RUN" = "false" ]`) is unchanged and handles both values correctly.

## Test plan
- [ ] Confirm dropdowns render correctly in the Actions UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow configuration with improved input validation for deployment and release processes, ensuring more reliable automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->