### PR TITLE
ci: use RELEASE_PAT for semantic-release

### DIFF
--- a/.github/workflows/release-semantic.yaml
+++ b/.github/workflows/release-semantic.yaml
@@ -23,13 +23,7 @@ jobs:
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-                  # PAT required for two reasons:
-                  # 1. Allows semantic-release to push the version commit and tag
-                  #    to the protected dev branch (GITHUB_TOKEN cannot bypass
-                  #    branch protection).
-                  # 2. A PAT-sourced tag push triggers downstream workflows
-                  #    (release-build.yaml); GITHUB_TOKEN pushes do not.
-                  token: ${{ secrets.RELEASE_PAT }}
+                  persist-credentials: false
 
             - name: Configure git identity
               run: |
@@ -52,5 +46,10 @@ jobs:
                       @semantic-release/github
                   tag_format: "v${version}"
               env:
+                  # RELEASE_PAT required for two reasons:
+                  # 1. Allows pushing the version commit and tag to the protected
+                  #    dev branch (GITHUB_TOKEN cannot bypass branch protection).
+                  # 2. A PAT-sourced tag push triggers downstream workflows
+                  #    (release-build.yaml); GITHUB_TOKEN pushes do not.
                   GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
                   RELEASE_TYPE: ${{ github.event.inputs.release_type }}

--- a/.github/workflows/release-semantic.yaml
+++ b/.github/workflows/release-semantic.yaml
@@ -23,6 +23,13 @@ jobs:
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
+                  # PAT required for two reasons:
+                  # 1. Allows semantic-release to push the version commit and tag
+                  #    to the protected dev branch (GITHUB_TOKEN cannot bypass
+                  #    branch protection).
+                  # 2. A PAT-sourced tag push triggers downstream workflows
+                  #    (release-build.yaml); GITHUB_TOKEN pushes do not.
+                  token: ${{ secrets.RELEASE_PAT }}
 
             - name: Configure git identity
               run: |
@@ -45,5 +52,5 @@ jobs:
                       @semantic-release/github
                   tag_format: "v${version}"
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
                   RELEASE_TYPE: ${{ github.event.inputs.release_type }}


### PR DESCRIPTION
## Summary

Replaces `GITHUB_TOKEN` with `RELEASE_PAT` in the semantic-release workflow. This unblocks re-enabling branch protection on `dev` and fixes the build not auto-triggering after a release.

## Why GITHUB_TOKEN doesn't work with branch protection

GitHub has two hard rules for `GITHUB_TOKEN`:

1. **Cannot bypass branch protection.** The `chore(release):` commit and the version tag are pushed directly to `dev` by semantic-release. With a PR requirement on `dev`, this push is rejected — `GITHUB_TOKEN` has no way to bypass pull request requirements even for admin-level callers.

2. **Cannot trigger downstream workflows.** When `GITHUB_TOKEN` pushes a tag, GitHub explicitly suppresses the resulting `push: tags` event to prevent workflow loops. This is why `Release: Build Artifacts` never auto-triggers after `Release: Semantic Version` runs.

A PAT from an account in the branch protection bypass list is subject to neither restriction.

## Required setup before merging

### 1. Create a fine-grained PAT

Go to **GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens → Generate new token**.

| Field | Value |
|-------|-------|
| Token name | `community-shaders-release` (or similar) |
| Expiration | 1 year (set a calendar reminder to rotate) |
| Resource owner | `community-shaders` |
| Repository access | Only `skyrim-community-shaders` |

**Repository permissions required:**

| Permission | Level | Reason |
|------------|-------|--------|
| Contents | Read and write | Push the `chore(release):` commit to `dev`, push version tags, create GitHub releases |
| Workflows | Read and write | Needed if semantic-release ever touches workflow files via `@semantic-release/git`; safe to include |
| Metadata | Read | Automatically included, cannot be removed |

> **Note:** `Contents: Read and write` covers commits, branches, tags, and releases on this repo. No other scopes are needed.

### 2. Add the PAT as a repository secret

Go to **community-shaders/skyrim-community-shaders → Settings → Secrets and variables → Actions → New repository secret**.

| Field | Value |
|-------|-------|
| Name | `RELEASE_PAT` |
| Value | *(paste the token)* |

### 3. Add the PAT owner to the branch protection bypass list

Go to **community-shaders/skyrim-community-shaders → Settings → Branches → dev → Edit**.

Enable:
- ✅ Require a pull request before merging
- ✅ Require approvals (set to your preferred count)

Under **"Allow specified actors to bypass required pull requests"**, add the GitHub account that owns the PAT.

### 4. Re-enable branch protection on `dev`

Once the secret is set and the bypass actor is added, merge this PR and re-enable the rule.

## What changes after this lands

- `Release: Semantic Version` can push directly to protected `dev`
- The version tag push automatically fires `Release: Build Artifacts` — no more manual trigger needed after the release workflow runs
- All other workflows continue to use `GITHUB_TOKEN` (no other changes needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to improve automation reliability. This ensures version commits and tags are created correctly during releases and helps downstream workflows trigger as intended for protected branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->