### PR TITLE
fix: sync feature IsCore() with CORE marker file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,17 @@ foreach(FEATURE_PATH ${FEATURE_CONFIG_FILES})
             "Feature config file '${FEATURE_PATH}' is empty or contains only whitespace. Skipping version detection for this feature."
         )
     endif()
+
+    # Detect core features by checking for the CORE marker file in the
+    # feature root (features/<Folder>/CORE). FEATURE_PATH is
+    # features/<Folder>/Shaders/Features/<ShortName>.ini, so the feature
+    # root is three directories up.
+    get_filename_component(_FEATURE_DIR "${FEATURE_PATH}" DIRECTORY)
+    get_filename_component(_FEATURE_DIR "${_FEATURE_DIR}" DIRECTORY)
+    get_filename_component(_FEATURE_DIR "${_FEATURE_DIR}" DIRECTORY)
+    if(EXISTS "${_FEATURE_DIR}/CORE")
+        list(APPEND FEATURE_CORE_NAMES "\t\t\"${FEATURE}\"sv")
+    endif()
 endforeach()
 
 set_property(
@@ -234,6 +245,7 @@ set_property(
 )
 
 string(REPLACE ";" ",\n" FEATURE_VERSIONS "${FEATURE_VERSIONS}")
+string(REPLACE ";" ",\n" FEATURE_CORE_NAMES "${FEATURE_CORE_NAMES}")
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FeatureVersions.h.in

--- a/cmake/FeatureVersions.h.in
+++ b/cmake/FeatureVersions.h.in
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unordered_set>
+
 namespace FeatureVersions
 {
 	using namespace std::literals::string_view_literals;
@@ -7,5 +9,10 @@ namespace FeatureVersions
 	static const std::map<std::string_view, REL::Version> FEATURE_MINIMAL_VERSIONS
 	{
 @FEATURE_VERSIONS@
+	};
+
+	static const std::unordered_set<std::string_view> FEATURE_CORE_NAMES
+	{
+@FEATURE_CORE_NAMES@
 	};
 }

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -56,10 +56,13 @@ public:
 	/**
 	 * Whether the feature is a CORE feature
 	 * This will place it under "Core Features" in UI
-	 * Also need to create a file named "CORE" in the root of the feature folder
-	 * if it should be merged into main cs zip file
+	 * If "CORE" file is present in the root of the feature folder,
+	 * it will be merged into main cs zip file and automatically considered core
 	 */
-	virtual bool IsCore() const { return false; }
+	virtual bool IsCore() const
+	{
+		return FeatureVersions::FEATURE_CORE_NAMES.contains(const_cast<Feature*>(this)->GetShortName());
+	}
 
 	/**
 	 * Get the category for UI grouping (e.g., "Terrain", "Lighting", "Characters", etc.)


### PR DESCRIPTION
Right now, core features need two things:
- CORE file in feature folder
- override `IsCore`

The latter was forgotten for the 4 features that are now core as of 1.5. This PR makes it so `IsCore` no longer needs to be manually overridden if the CORE file is already set. If for some reason a developer wants to make `IsCore` return true without packaging it in core, then they can still override (I cannot ever foresee a developer wanting the reverse).

### Testing
Tested locally with core build + Grass Collision 3.0.2 install from Nexus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Features can now be dynamically identified as core components through an automated detection system, replacing a previous hardcoded approach and enabling proper feature categorization across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->