### PR TITLE
fix(deferred): restore UAV bind on vanilla normals targets

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -586,6 +586,31 @@ namespace Hooks
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
+	// kNORMAL_TAAMASK_SSRMASK and its swap need UAV bind because DeferredCompositeCS
+	// writes vanilla-encoded normals through UAV1 (`normals.UAV` in Deferred::DeferredPasses),
+	// which feeds the post-pass vanilla SSAO chain (ISSAORawAO -> ISSAOComposite). Without
+	// these hooks the UAV is null, the CS write is silently dropped, and vanilla SSAO reads
+	// uninitialized data and produces hard wedge-shaped shadow artifacts.
+	struct CreateRenderTarget_Normals
+	{
+		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
+		{
+			globals::state->ModifyRenderTarget(a_target, a_properties);
+			func(This, a_target, a_properties);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	struct CreateRenderTarget_NormalsSwap
+	{
+		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
+		{
+			globals::state->ModifyRenderTarget(a_target, a_properties);
+			func(This, a_target, a_properties);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
 	struct CreateRenderTarget_MotionVectors
 	{
 		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
@@ -952,6 +977,8 @@ namespace Hooks
 
 		logger::info("Hooking BSShaderRenderTargets::Create::CreateRenderTarget(s)");
 		stl::write_thunk_call<CreateRenderTarget_Main>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0x3F0, 0x3F3, 0x548));
+		stl::write_thunk_call<CreateRenderTarget_Normals>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0x458, 0x45B, 0x5B0));
+		stl::write_thunk_call<CreateRenderTarget_NormalsSwap>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0x46B, 0x46E, 0x5C3));
 		stl::write_thunk_call<CreateRenderTarget_MotionVectors>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0x4F0, 0x4EF, 0x64E));
 
 		stl::write_thunk_call<CreateRenderTarget_RefractionNormals>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0x503, 0x502, 0x661));


### PR DESCRIPTION
## Summary

- Restores the `CreateRenderTarget_Normals` and `CreateRenderTarget_NormalsSwap` hooks removed in #2178.
- Vanilla SSAO renders correctly again for users without Screen Space GI installed.
- Closes #2267 

## Root cause

`DeferredCompositeCS.hlsl:333` writes vanilla-encoded normals through UAV1 (`normals.UAV` in `Deferred::DeferredPasses`) so the post-pass vanilla SSAO chain (`ISSAORawAO` -> `ISSAOComposite`) sees current-frame normals. Those hook structs added `D3D11_BIND_UNORDERED_ACCESS` to `kNORMAL_TAAMASK_SSRMASK` and its swap, which is what makes that UAV non-null.

#2178 removed them because the PS-variant deferred composite from #2150 didn't need that UAV. #2150 was later reverted (`1e3b6faa7`), restoring the CS path, but the hook removal stayed. Result: UAV1 is null, the CS write is silently dropped, vanilla SSAO samples uninitialized data, and produces hard wedge-shaped shadow artifacts.

The bug only surfaced for users without SSGI installed. The Screen Space GI feature force-disables vanilla SSAO every frame at [`src/Features/ScreenSpaceGI.cpp:710-712`](src/Features/ScreenSpaceGI.cpp#L710-L712) regardless of its own enabled state, so any rig with SSGI installed never saw the broken output.

## Why just restore the hooks instead of `git revert fcc5921dd`

The other two hunks of #2178 (`DeferredCompositePS.hlsl` signature fixes and a `Deferred.cpp` `SetupRenderTarget(normalRoughnessRT, ...)` removal) were tied to #2150's PS path. Both went away with the #2150 revert -- `DeferredCompositePS.hlsl` no longer exists and `normalRoughnessRT` isn't a thing in HEAD. The hook removal in `src/Hooks.cpp` is the only surviving piece, so a targeted re-add is functionally identical to a revert and reads more clearly in the log.

## Diagnosis evidence

RenderDoc capture of an affected frame (event IDs from the bug capture):

- `DeferredCompositeCS` dispatch at EID 47449: `UAVs = [Main(63), NULL, MotionVectors(92)]` — UAV1 is `ResourceId(0)`.
- Vanilla `kNORMAL_TAAMASK_SSRMASK` (resource 82) usage timeline: `Clear@41356, PS_Resource@47484, PS_Resource@47821, PS_Resource@47910` — never written, only sampled.
- `ISSAORawAO` at EID 47821 reads resource 82 as t1 and produces wedge-banded AO into the SAO chain, ending up in `SAOTex` (resource 154) consumed by `ISSAOComposite` at EID 47910.

## Test plan

- [x] Build `ALL` preset, deploy to a Skyrim install that does **not** have Screen Space GI installed.
- [x] Confirm vanilla SSAO no longer produces hard wedge-shaped shadow artifacts (the regression reported by users).
- [x] Capture a RenderDoc frame and verify `DeferredCompositeCS` dispatch now shows a non-null UAV1 bound to `kNORMAL_TAAMASK_SSRMASK`, and that the target is written each frame (not just cleared).
- [x] Confirm Screen Space GI installs (with `EnableVanillaSSAO=false`) still look identical -- SSGI's runtime patch zeroes the vanilla SSAO enable byte before this UAV is ever sampled, so it should be unaffected.
- [x] Confirm Screen Space GI installs with `EnableVanillaSSAO=true` now produce a correct vanilla SSAO contribution rather than the previous artifact.
- [x] VR sanity check (changes affect VR address tables identically -- third arg `0x5B0` / `0x5C3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal graphics rendering infrastructure with improved render target processing and handling for better rendering efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->