### PR TITLE
ci: bump actions to node24 to clear deprecation warnings

### DIFF
--- a/.github/actions/setup-build-environment/action.yaml
+++ b/.github/actions/setup-build-environment/action.yaml
@@ -46,10 +46,13 @@ runs:
               Remove-Item $installerPath -ErrorAction SilentlyContinue
 
         - name: Setup MSVC environment
-          uses: ilammy/msvc-dev-cmd@v1
+          # Swapped from ilammy/msvc-dev-cmd@v1 (node20, deprecated) to
+          # TheMrMilchmann/setup-msvc-dev@v4 (node24). The new action has no
+          # `vsversion` input — the prior step installs only VS Build Tools
+          # 2026, so default detection picks it up.
+          uses: TheMrMilchmann/setup-msvc-dev@v4.0.0
           with:
               arch: x64
-              vsversion: "18.0"
 
         - name: Get MSVC version
           id: msvc_version
@@ -85,12 +88,12 @@ runs:
               Remove-Item "dummy.cpp" -ErrorAction SilentlyContinue
 
         - name: Setup vcpkg
-          uses: lukka/run-vcpkg@v11.5
+          uses: lukka/run-vcpkg@v11.6
           with:
               vcpkgJsonGlob: vcpkg.json
 
         - name: Cache CMake build output
-          uses: actions/cache@v4
+          uses: actions/cache@v5
           with:
               path: ${{ inputs.build-dir }}
               key: ${{ runner.os }}-cmake-msvc-${{ steps.msvc_version.outputs.version }}-${{ inputs.cache-key-suffix }}-${{ github.event.inputs.cache-key-suffix || 'default' }}-${{ hashFiles('.gitmodules', 'extern/**', 'CMakePresets.json', 'vcpkg.json', 'vcpkg-configuration.json') }}


### PR DESCRIPTION
## Summary

Clears the GitHub Actions node20 deprecation warnings in `.github/actions/setup-build-environment/action.yaml`. node20 actions will be force-migrated to node24 on **2026-06-02** and node20 will be removed from the runner on **2026-09-16**.

| Action | Before | After | Reason |
|---|---|---|---|
| `ilammy/msvc-dev-cmd` | `@v1` (node20) | `TheMrMilchmann/setup-msvc-dev@v4.0.0` (node24) | Original action has no node24 release; switch maintained fork |
| `lukka/run-vcpkg` | `@v11.5` (node20) | `@v11.6` (node24) | Latest in the v11 series |
| `actions/cache` | `@v4` (node20) | `@v5` (node20→node24) | Major bump |

## Notes on the MSVC swap

`TheMrMilchmann/setup-msvc-dev@v4.0.0` is API-compatible with the way we use `ilammy/msvc-dev-cmd` except for one input: it has **no `vsversion`**. We were passing `vsversion: \"18.0\"`. That's safe to drop because the preceding step (`Install Visual Studio Build Tools`) installs only VS Build Tools 2026, so the action's default detection selects it.

`arch: x64` is preserved.

## Test plan

- [ ] CI runs on this PR exercise `setup-build-environment` (cpp-build job in `_shared-build.yaml`); confirm:
  - No node20 deprecation warnings
  - MSVC `cl.exe` is on PATH (the `Get MSVC version` step depends on it)
  - vcpkg restore + cache restore succeed
  - Build succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions versions and build environment configuration to optimize CI/CD pipeline performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->