### PR TITLE
feat: specific shader compiler flags per feature

### DIFF
--- a/src/Feature.h
+++ b/src/Feature.h
@@ -46,6 +46,13 @@ protected:
 
 public:
 	virtual bool HasShaderDefine(RE::BSShader::Type) { return false; }
+
+	/**
+	 * Optional refinement for shader permutation defines by BSShader descriptor.
+	 * Used when building macro lists (e.g. Lighting). If true (along with loaded &&
+	 * HasShaderDefine(shaderType)), this feature's shader define is appended for this permutation.
+	 */
+	virtual bool RefineShaderDefineForDescriptor(RE::BSShader::Type /*shaderType*/, uint32_t /*descriptor*/) { return true; }
 	/**
 	 * Whether the feature supports VR.
 	 *

--- a/src/Features/TerrainVariation.cpp
+++ b/src/Features/TerrainVariation.cpp
@@ -3,6 +3,7 @@
 #include "../Globals.h"
 #include "../State.h"
 #include "../Util.h"
+#include "ShaderCache.h"
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	TerrainVariation::Settings,
@@ -55,6 +56,22 @@ void TerrainVariation::PostPostLoad()
 {
 	logger::info("TerrainVariation: Feature initialized");
 	UpdateShaderSettings();
+}
+
+bool TerrainVariation::RefineShaderDefineForDescriptor(RE::BSShader::Type shaderType, uint32_t descriptor)
+{
+	if (shaderType != RE::BSShader::Type::Lighting) {
+		return true;
+	}
+	const auto technique = static_cast<SIE::ShaderCache::LightingShaderTechniques>(0x3F & (descriptor >> 24));
+	switch (technique) {
+	case SIE::ShaderCache::LightingShaderTechniques::MTLand:
+	case SIE::ShaderCache::LightingShaderTechniques::MTLandLODBlend:
+	case SIE::ShaderCache::LightingShaderTechniques::LODLand:
+		return true;
+	default:
+		return false;
+	}
 }
 
 void TerrainVariation::LoadSettings(json& o_json)

--- a/src/Features/TerrainVariation.h
+++ b/src/Features/TerrainVariation.h
@@ -14,7 +14,6 @@ public:
 	{
 		return loaded && shaderType == RE::BSShader::Type::Lighting;
 	}
-	}
 	virtual bool RefineShaderDefineForDescriptor(RE::BSShader::Type shaderType, uint32_t descriptor) override;
 	virtual bool IsCore() const override { return false; };
 	virtual bool SupportsVR() override { return true; }

--- a/src/Features/TerrainVariation.h
+++ b/src/Features/TerrainVariation.h
@@ -12,8 +12,8 @@ public:
 	virtual inline std::string_view GetShaderDefineName() override { return "TERRAIN_VARIATION"; }
 	virtual inline bool HasShaderDefine(RE::BSShader::Type shaderType) override
 	{
-		return (shaderType == RE::BSShader::Type::Lighting);
 		return loaded && shaderType == RE::BSShader::Type::Lighting;
+	}
 	}
 	virtual bool RefineShaderDefineForDescriptor(RE::BSShader::Type shaderType, uint32_t descriptor) override;
 	virtual bool IsCore() const override { return false; };

--- a/src/Features/TerrainVariation.h
+++ b/src/Features/TerrainVariation.h
@@ -13,7 +13,9 @@ public:
 	virtual inline bool HasShaderDefine(RE::BSShader::Type shaderType) override
 	{
 		return (shaderType == RE::BSShader::Type::Lighting);
+		return loaded && shaderType == RE::BSShader::Type::Lighting;
 	}
+	virtual bool RefineShaderDefineForDescriptor(RE::BSShader::Type shaderType, uint32_t descriptor) override;
 	virtual bool IsCore() const override { return false; };
 	virtual bool SupportsVR() override { return true; }
 	virtual std::string_view GetCategory() const override { return FeatureCategories::kLandscapeAndTextures; }

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -148,7 +148,8 @@ namespace SIE
 			}
 
 			for (auto* feature : Feature::GetFeatureList()) {
-				if (feature->loaded && feature->HasShaderDefine(RE::BSShader::Type::Lighting)) {
+				if (feature->loaded && feature->HasShaderDefine(RE::BSShader::Type::Lighting) &&
+					feature->RefineShaderDefineForDescriptor(RE::BSShader::Type::Lighting, descriptor)) {
 					defines[lastIndex++] = { feature->GetShaderDefineName().data(), nullptr };
 				}
 			}


### PR DESCRIPTION
optionally lets features define specific flags for the compiler to prevent them being parsed for dozens of unrelated shaders. Useful for tv (is applied here) and may be useful for features like hair, or other self-contained shaders that do not interract with much beyond Lighting.hlsl.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shader refinement hook allowing features to opt into specific shader permutations.

* **Bug Fixes**
  * Terrain variation shader define now only applies when the feature is fully loaded and for targeted lighting techniques, reducing unnecessary shader permutations and improving rendering efficiency.

* **Chores**
  * Shader list generation now respects per-feature refinement decisions for lighting shaders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->