### PR TITLE
fix: compiler remaining tasks

### DIFF
--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -2971,7 +2971,10 @@ namespace SIE
 		const uint64_t total = compilationSet.totalTasks.load(std::memory_order_relaxed);
 		const uint64_t done = compilationSet.completedTasks.load(std::memory_order_relaxed) +
 		                     compilationSet.failedTasks.load(std::memory_order_relaxed);
-		const uint64_t remaining = (total > done) ? (total - done) : 0;
+		// This task has already finished running, but Complete(task) has not yet updated the counters.
+		// Include the current task in the local progress snapshot so the logged remaining count is accurate.
+		const uint64_t doneIncludingCurrent = (done < total) ? (done + 1) : total;
+		const uint64_t remaining = (total > doneIncludingCurrent) ? (total - doneIncludingCurrent) : 0;
 
 		// Proxy for permutation complexity: descriptor low 32 bits from GetId(); popcount = active defines.
 		// Shader file size provides a secondary signal for source complexity.

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -2966,7 +2966,12 @@ namespace SIE
 
 		QueryPerformanceCounter(&end);
 		const double elapsedMs = static_cast<double>(end.QuadPart - start.QuadPart) * 1000.0 / freq.QuadPart;
-		const uint64_t remaining = compilationSet.totalTasks - compilationSet.completedTasks.load(std::memory_order_relaxed) - compilationSet.failedTasks.load(std::memory_order_relaxed);
+		// Use saturating math: without a lock, Clear() can zero totalTasks while completedTasks
+		// still reads high briefly, which would otherwise underflow uint64_t (logs as ~2^64-1).
+		const uint64_t total = compilationSet.totalTasks.load(std::memory_order_relaxed);
+		const uint64_t done = compilationSet.completedTasks.load(std::memory_order_relaxed) +
+		                     compilationSet.failedTasks.load(std::memory_order_relaxed);
+		const uint64_t remaining = (total > done) ? (total - done) : 0;
 
 		// Proxy for permutation complexity: descriptor low 32 bits from GetId(); popcount = active defines.
 		// Shader file size provides a secondary signal for source complexity.


### PR DESCRIPTION
[15:54:03.843] [28964] [I] [ShaderTiming] Very slow 12317ms | queue_wait=0ms | remaining=18446744073709551615 | defines=5 | src=111008B | prio=3350 | Lighting:Pixel:GLINT TRUE_PBR DEFERRED WETNESS_EFFECTS WATER_EFFECTS VOLUMETRIC_SHADOWS UNIFIED_WATER TERRAIN_VARIATION TERRAIN_SHADOWS SSS SCREEN_SPACE_SHADOWS LOD_BLENDING ISL LIGHT_LIMIT_FIX CS_HAIR EXTENDED_TRANSLUCENCY EXTENDED_MATERIALS EXP_HEIGHT_FOG CLOUD_SHADOWS TERRAIN_BLENDING SKYLIGHTING IBL DYNAMIC_CUBEMAPS LANDSCAPE MULTI_TEXTURE ANISO_LIGHTING VC 


Previously it shows something like that ^ with nonsense for "remaining"
Now correctly shows the below, accurately counting down the remaining shaders to compile:
[16:52:52.354] [28832] [I] [ShaderTiming] Very slow 11714ms | queue_wait=115ms | remaining=5 | defines=4 | src=109690B | prio=2320 | Lighting:Pixel:GLINT TRUE_PBR DEFERRED WETNESS_EFFECTS WATER_EFFECTS VOLUMETRIC_SHADOWS UNIFIED_WATER TERRAIN_SHADOWS SSS SCREEN_SPACE_SHADOWS LOD_BLENDING ISL LIGHT_LIMIT_FIX CS_HAIR EXTENDED_TRANSLUCENCY EXTENDED_MATERIALS EXP_HEIGHT_FOG CLOUD_SHADOWS TERRAIN_BLENDING SKYLIGHTING IBL DYNAMIC_CUBEMAPS ANISO_LIGHTING VC 
[16:52:52.638] [8144 ] [I] [ShaderTiming] Very slow 12022ms | queue_wait=52ms | remaining=4 | defines=5 | src=109690B | prio=2350 | Lighting:Pixel:GLINT TRUE_PBR DEFERRED WETNESS_EFFECTS WATER_EFFECTS VOLUMETRIC_SHADOWS UNIFIED_WATER TERRAIN_SHADOWS SSS SCREEN_SPACE_SHADOWS LOD_BLENDING ISL LIGHT_LIMIT_FIX CS_HAIR EXTENDED_TRANSLUCENCY EXTENDED_MATERIALS EXP_HEIGHT_FOG CLOUD_SHADOWS TERRAIN_BLENDING SKYLIGHTING IBL DYNAMIC_CUBEMAPS ANISO_LIGHTING DO_ALPHA_TEST VC 
[16:53:07.486] [24744] [I] [ShaderTiming] Very slow 26880ms | queue_wait=49ms | remaining=3 | defines=6 | src=109690B | prio=3080 | Lighting:Pixel:TRUE_PBR DEFERRED WETNESS_EFFECTS WATER_EFFECTS VOLUMETRIC_SHADOWS UNIFIED_WATER TERRAIN_VARIATION TERRAIN_SHADOWS SSS SCREEN_SPACE_SHADOWS LOD_BLENDING ISL LIGHT_LIMIT_FIX CS_HAIR EXTENDED_TRANSLUCENCY EXTENDED_MATERIALS EXP_HEIGHT_FOG CLOUD_SHADOWS TERRAIN_BLENDING SKYLIGHTING IBL DYNAMIC_CUBEMAPS LOD_LAND_BLEND LANDSCAPE MULTI_TEXTURE VC 
[16:53:13.901] [10880] [I] [ShaderTiming] Very slow 33314ms | queue_wait=30ms | remaining=2 | defines=5 | src=109690B | prio=3350 | Lighting:Pixel:GLINT TRUE_PBR DEFERRED WETNESS_EFFECTS WATER_EFFECTS VOLUMETRIC_SHADOWS UNIFIED_WATER TERRAIN_VARIATION TERRAIN_SHADOWS SSS SCREEN_SPACE_SHADOWS LOD_BLENDING ISL LIGHT_LIMIT_FIX CS_HAIR EXTENDED_TRANSLUCENCY EXTENDED_MATERIALS EXP_HEIGHT_FOG CLOUD_SHADOWS TERRAIN_BLENDING SKYLIGHTING IBL DYNAMIC_CUBEMAPS LANDSCAPE MULTI_TEXTURE ANISO_LIGHTING VC 
[16:53:14.455] [8924 ] [I] [ShaderTiming] Very slow 33895ms | queue_wait=2ms | remaining=1 | defines=7 | src=109690B | prio=3410 | Lighting:Pixel:GLINT TRUE_PBR DEFERRED WETNESS_EFFECTS WATER_EFFECTS VOLUMETRIC_SHADOWS UNIFIED_WATER TERRAIN_VARIATION TERRAIN_SHADOWS SSS SCREEN_SPACE_SHADOWS LOD_BLENDING ISL LIGHT_LIMIT_FIX CS_HAIR EXTENDED_TRANSLUCENCY EXTENDED_MATERIALS EXP_HEIGHT_FOG CLOUD_SHADOWS TERRAIN_BLENDING SKYLIGHTING IBL DYNAMIC_CUBEMAPS LOD_LAND_BLEND LANDSCAPE MULTI_TEXTURE ANISO_LIGHTING VC 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shader compilation timing logs so concurrent updates no longer produce invalid or negative "remaining" values, yielding consistent and reliable debug output during parallel shader builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->