### PR TITLE
fix: mismatched shadercache compiler flags

### DIFF
--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1457,7 +1457,7 @@ namespace SIE
 			if (globals::state->enableAvoidFlowControl.load(std::memory_order_relaxed)) {
 				flags |= D3DCOMPILE_AVOID_FLOW_CONTROL;
 			}
-			if (cache.IsDiskCache()) {
+			if (useDiskCache) {
 				flags |= D3DCOMPILE_SKIP_VALIDATION;
 			}
 

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1448,9 +1448,18 @@ namespace SIE
 			}
 			logger::debug("Compiling {} {}:{}:{:X} to {}", pathString, magic_enum::enum_name(type), magic_enum::enum_name(shaderClass), descriptor, MergeDefinesString(defines));
 
-			// compile shaders
+			// compile shaders — match Utils/D3D.cpp CompileShader flag policy (strictness, optional toggles, validation).
 			ID3DBlob* errorBlob = nullptr;
-			const uint32_t flags = !globals::state->IsDeveloperMode() ? D3DCOMPILE_OPTIMIZATION_LEVEL3 : D3DCOMPILE_DEBUG;
+			uint32_t flags = !globals::state->IsDeveloperMode() ? (D3DCOMPILE_ENABLE_STRICTNESS | D3DCOMPILE_OPTIMIZATION_LEVEL3) : D3DCOMPILE_DEBUG;
+			if (globals::state->enablePartialPrecision.load(std::memory_order_relaxed)) {
+				flags |= D3DCOMPILE_PARTIAL_PRECISION;
+			}
+			if (globals::state->enableAvoidFlowControl.load(std::memory_order_relaxed)) {
+				flags |= D3DCOMPILE_AVOID_FLOW_CONTROL;
+			}
+			if (cache.IsDiskCache()) {
+				flags |= D3DCOMPILE_SKIP_VALIDATION;
+			}
 
 			// Track includes
 			TrackingIncludeHandler includeHandler(std::filesystem::path(path).parent_path());


### PR DESCRIPTION
fixes mismatch between live & disk caching respecting compiler flags. Developer mode remains unchanged.
Allows greater comparison to disk caching and also the end user's experience, where live compiling is slower than the disk cause it doesn't inherit the flags correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved shader compilation behavior to produce more consistent and optimized shaders across normal and developer modes. Compilation now respects runtime precision and flow-control toggles and adapts when disk caching is enabled, yielding more reliable rendering, faster builds, and smoother iteration for developers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2277)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->