### PR TITLE
build(dynamic cubemaps): fix X4000 warning

### DIFF
--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -147,7 +147,10 @@ namespace DynamicCubemaps
 #		endif
 
 #		if defined(SKYLIGHTING)
-		const float skylightingSpecular = SharedData::InInterior ? 0.0 : Skylighting::EvaluateSpecular(skylighting, SphericalHarmonics::FauxSpecularLobe(N, V, roughness));
+		float skylightingSpecular = 0.0;
+		if (!SharedData::InInterior) {
+			skylightingSpecular = Skylighting::EvaluateSpecular(skylighting, SphericalHarmonics::FauxSpecularLobe(N, V, roughness));
+		}
 #		endif
 
 #		if defined(IBL)

--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -49,13 +49,7 @@ namespace DynamicCubemaps
 #		endif
 
 #		if defined(SKYLIGHTING)
-		float skylightingSpecular = 1.0;
-		if (!SharedData::InInterior) {
-			sh2 specularLobe = SphericalHarmonics::FauxSpecularLobe(N, V, roughness);
-			skylightingSpecular = Skylighting::EvaluateSpecular(skylighting, specularLobe);
-		} else {
-			skylightingSpecular = 0.0;
-		}
+		const float skylightingSpecular = SharedData::InInterior ? 0.0 : Skylighting::EvaluateSpecular(skylighting, SphericalHarmonics::FauxSpecularLobe(N, V, roughness));
 #		endif
 
 #		if defined(IBL)
@@ -153,13 +147,7 @@ namespace DynamicCubemaps
 #		endif
 
 #		if defined(SKYLIGHTING)
-		float skylightingSpecular = 1.0;
-		if (!SharedData::InInterior) {
-			sh2 specularLobe = SphericalHarmonics::FauxSpecularLobe(N, V, roughness);
-			skylightingSpecular = Skylighting::EvaluateSpecular(skylighting, specularLobe);
-		} else {
-			skylightingSpecular = 0.0;
-		}
+		const float skylightingSpecular = SharedData::InInterior ? 0.0 : Skylighting::EvaluateSpecular(skylighting, SphericalHarmonics::FauxSpecularLobe(N, V, roughness));
 #		endif
 
 #		if defined(IBL)
@@ -198,20 +186,20 @@ namespace DynamicCubemaps
 				specularIrradiance = (specularIrradiance / max(specularIrradianceLuminance, 0.001)) * directionalAmbientColorSpecular;
 				finalIrradiance = Color::IrradianceToLinear(specularIrradiance);
 			} else {
-				float3 specularIrradiance = 1.0;
+				float3 specularIrradianceReflections = 0.0;
+				if (skylightingSpecular > 0.0) {
+					specularIrradianceReflections = EnvReflectionsTexture.SampleLevel(SampColorSampler, R, level);
+					float lum = Color::RGBToLuminance(EnvReflectionsTexture.SampleLevel(SampColorSampler, R, 15));
+					specularIrradianceReflections = (specularIrradianceReflections / max(lum, 0.001)) * directionalAmbientColorSpecular;
+					specularIrradianceReflections = Color::IrradianceToLinear(specularIrradianceReflections);
+				}
+				float3 specularIrradiance = 0.0;
 				if (skylightingSpecular < 1.0) {
 					specularIrradiance = EnvTexture.SampleLevel(SampColorSampler, R, level);
 					float lum = Color::RGBToLuminance(EnvTexture.SampleLevel(SampColorSampler, R, 15));
 					float dalcScaled = Color::IrradianceToGamma(Color::IrradianceToLinear(directionalAmbientColorSpecular) * skylightingSpecular);
 					specularIrradiance = (specularIrradiance / max(lum, 0.001)) * dalcScaled;
 					specularIrradiance = Color::IrradianceToLinear(specularIrradiance);
-				}
-				float3 specularIrradianceReflections = 1.0;
-				if (skylightingSpecular > 0.0) {
-					specularIrradianceReflections = EnvReflectionsTexture.SampleLevel(SampColorSampler, R, level);
-					float lum = Color::RGBToLuminance(EnvReflectionsTexture.SampleLevel(SampColorSampler, R, 15));
-					specularIrradianceReflections = (specularIrradianceReflections / max(lum, 0.001)) * directionalAmbientColorSpecular;
-					specularIrradianceReflections = Color::IrradianceToLinear(specularIrradianceReflections);
 				}
 				finalIrradiance = lerp(specularIrradiance, specularIrradianceReflections, skylightingSpecular);
 			}

--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -49,7 +49,10 @@ namespace DynamicCubemaps
 #		endif
 
 #		if defined(SKYLIGHTING)
-		const float skylightingSpecular = SharedData::InInterior ? 0.0 : Skylighting::EvaluateSpecular(skylighting, SphericalHarmonics::FauxSpecularLobe(N, V, roughness));
+		float skylightingSpecular = 0.0;
+		if (!SharedData::InInterior) {
+			skylightingSpecular = Skylighting::EvaluateSpecular(skylighting, SphericalHarmonics::FauxSpecularLobe(N, V, roughness));
+		}
 #		endif
 
 #		if defined(IBL)

--- a/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
+++ b/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 2-3-0
+Version = 2-3-1
 
 [Nexus]
 autoupload = false


### PR DESCRIPTION
didn't see anything out of the blue but review is definitely needed.
should address warning X4000 (“use of potentially uninitialized variable”) in dynamic cubemaps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined dynamic cubemap skylighting specular handling to ensure specular irradiance and reflection terms are computed only where appropriate, improving blending and reducing lighting artifacts—results in more consistent lighting between interior and exterior scenes.
* **Chores**
  * Dynamic Cubemaps version updated (2.3.0 → 2.3.1).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->