### PR TITLE
fix(water effects): fix water caustics X4000 warnings

### DIFF
--- a/features/Water Effects/Shaders/Features/WaterEffects.ini
+++ b/features/Water Effects/Shaders/Features/WaterEffects.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-1-1
+Version = 1-1-2
 
 [Nexus]
 autoupload = false

--- a/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
+++ b/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
@@ -27,9 +27,9 @@ namespace WaterEffects
 			float2 causticsUV2 = PanCausticsUV(causticsUV, 1.0 * 0.2, -0.5);
 
 			float causticsHigh = 1.0;
-
-			if (causticsFade > 0.0)
+			if (causticsFade > 0.0) {
 				causticsHigh = min(SampleCaustics(causticsUV1), SampleCaustics(causticsUV2)) * 4.0;
+			}
 
 			causticsUV *= 0.5;
 
@@ -37,12 +37,11 @@ namespace WaterEffects
 			causticsUV2 = PanCausticsUV(causticsUV, 1.0 * 0.1, -0.5);
 
 			float causticsLow = 1.0;
-
-			if (causticsFade < 1.0)
+			if (causticsFade < 1.0) {
 				causticsLow = min(SampleCaustics(causticsUV1), SampleCaustics(causticsUV2)) * 4.0;
+			}
 
-			float caustics = lerp(causticsLow, causticsHigh, causticsFade);
-
+			const float caustics = lerp(causticsLow, causticsHigh, causticsFade);
 			return lerp(1.0, caustics, shoreFactorCaustics);
 		}
 

--- a/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
+++ b/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
@@ -26,20 +26,20 @@ namespace WaterEffects
 			float2 causticsUV1 = PanCausticsUV(causticsUV, 0.5 * 0.2, 1.0);
 			float2 causticsUV2 = PanCausticsUV(causticsUV, 1.0 * 0.2, -0.5);
 
-			float causticsHigh = 1.0;
-			if (causticsFade > 0.0) {
-				causticsHigh = min(SampleCaustics(causticsUV1), SampleCaustics(causticsUV2)) * 4.0;
-			}
+			const float causticsHigh =
+				(causticsFade > 0.0)
+					? (min(SampleCaustics(causticsUV1), SampleCaustics(causticsUV2)) * 4.0)
+					: 1.0;
 
 			causticsUV *= 0.5;
 
 			causticsUV1 = PanCausticsUV(causticsUV, 0.5 * 0.1, 1.0);
 			causticsUV2 = PanCausticsUV(causticsUV, 1.0 * 0.1, -0.5);
 
-			float causticsLow = 1.0;
-			if (causticsFade < 1.0) {
-				causticsLow = min(SampleCaustics(causticsUV1), SampleCaustics(causticsUV2)) * 4.0;
-			}
+			const float causticsLow =
+				(causticsFade < 1.0)
+					? (min(SampleCaustics(causticsUV1), SampleCaustics(causticsUV2)) * 4.0)
+					: 1.0;
 
 			const float caustics = lerp(causticsLow, causticsHigh, causticsFade);
 			return lerp(1.0, caustics, shoreFactorCaustics);


### PR DESCRIPTION
should address some warning X4000 (“use of potentially uninitialized variable”) warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal cleanup of the water caustics shader for improved maintainability; no visual changes to caustics rendering.
* **Chores**
  * Water effects configuration version bumped (minor patch update).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->