### PR TITLE
fix(truepbr): remove aggressive MATO clearing

### DIFF
--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -1337,12 +1337,8 @@ struct TESBoundObject_Clone3D
 			auto* stat = static_cast<RE::TESObjectSTAT*>(ref->data.objectReference);
 			RE::BGSMaterialObject* currentMato = stat->data.materialObj;
 
-			// Resolve PBR MATO data for the three-way condition as a single pointer:
-			//   non-null  -> apply MATO to geometries
-			//   null      -> clear any previously applied MATO from geometries
-			// This covers all negative cases (currentMato == nullptr, singlePass ==
-			// false, or no matching PBR entry) with one branch so the clear path is
-			// never silently skipped.
+			// Resolve PBR MATO data: non-null applies MATO to geometries with
+			// fork-before-write protection; null means no PBR config and is a no-op.
 			auto* pbrData = (currentMato != nullptr && currentMato->directionalData.singlePass) ? truePBR->GetPBRMaterialObjectData(currentMato) : nullptr;
 
 			if (pbrData != nullptr) {
@@ -1389,23 +1385,6 @@ struct TESBoundObject_Clone3D
 						}
 					}
 
-					return RE::BSVisit::BSVisitControl::kContinue;
-				});
-			} else {
-				RE::BSVisit::TraverseScenegraphGeometries(result, [](RE::BSGeometry* geometry) {
-					if (auto* shaderProperty = static_cast<RE::BSShaderProperty*>(geometry->GetGeometryRuntimeData().shaderProperty.get())) {
-						if (shaderProperty->GetMaterialType() == RE::BSShaderMaterial::Type::kLighting &&
-							shaderProperty->flags.any(RE::BSShaderProperty::EShaderPropertyFlag::kVertexLighting)) {
-							if (auto* material = static_cast<BSLightingShaderMaterialPBR*>(shaderProperty->material)) {
-								auto& ext = BSLightingShaderMaterialPBR::All[material];
-								if (ext.materialObjectData != nullptr) {
-									material->ClearMaterialObjectData();
-									ext.materialObjectData = nullptr;
-									ext.lastOwnerRefFormID = 0;
-								}
-							}
-						}
-					}
 					return RE::BSVisit::BSVisitControl::kContinue;
 				});
 			}


### PR DESCRIPTION
Previous PR#2046 included a broken commit (4d07fa09) that resulted in the original fix commit (e32cfb52) not functioning as expected. This change removes the problematic branch and restores the fix to functional state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved physically-based rendering material handling during object cloning to prevent unintended data corruption and enhance performance by eliminating unnecessary clearing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->