### PR TITLE
chore(hdr): add nexus metadata

### DIFF
--- a/features/HDR Display/Shaders/Features/HDRDisplay.ini
+++ b/features/HDR Display/Shaders/Features/HDRDisplay.ini
@@ -2,4 +2,6 @@
 Version = 1-0-1
 
 [Nexus]
-autoupload = false
+nexusmodid = 179371
+nexusfilename = HDR
+autoupload = true

--- a/src/Features/HDRDisplay.h
+++ b/src/Features/HDRDisplay.h
@@ -9,8 +9,13 @@
 
 struct HDRDisplay : public Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "179371";
+
+public:
 	virtual inline std::string GetName() override { return "HDR Display"; }
 	virtual inline std::string GetShortName() override { return "HDRDisplay"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetCategory() const override { return "Display"; }
 	virtual inline bool SupportsVR() override { return false; }
 	virtual inline bool IsCore() const override { return false; }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HDR Display now exposes a direct Nexus Mod link for easy access to the mod page.

* **Chores**
  * Integrated HDR Display with the Nexus Mod platform.
  * Enabled automatic upload to streamline updates and improve accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->