### PR TITLE
fix(HDR): increase max slider peaknits to 10k

### DIFF
--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -512,7 +512,7 @@ void HDRDisplay::DrawSettings()
 			ImGui::Text("203 nits is the ITU BT.2408 reference. Increase for a brighter image.");
 		}
 
-		ImGui::SliderInt("Peak Brightness (nits)", reinterpret_cast<int*>(&currentPeakNits), 400, 2000);
+		ImGui::SliderInt("Peak Brightness (nits)", reinterpret_cast<int*>(&currentPeakNits), 400, 10000);
 		{
 			std::lock_guard<std::mutex> lock(settingsMutex);
 			if (currentPeakNits <= settings.hdrPaperWhite) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced HDR display configuration: the peak brightness adjustment slider range has been expanded to provide users with more control. The maximum brightness value can now be set up to 10000 nits, increased from the previous 2000 nit limit. This enables more precise calibration of HDR displays to meet specific brightness requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->