### PR TITLE
refactor(hlsl): use Game constants

### DIFF
--- a/features/Cloud Shadows/Shaders/CloudShadows/CloudShadows.hlsli
+++ b/features/Cloud Shadows/Shaders/CloudShadows/CloudShadows.hlsli
@@ -1,9 +1,15 @@
+#include "Common/Game.hlsli"
+
 namespace CloudShadows
 {
 	TextureCube<float> CloudShadowsTexture : register(t25);
 
-	const static float CloudHeight = (2e3f / 1.428e-2) * 0.25;
-	const static float PlanetRadius = (6371e3f / 1.428e-2);
+	// 2 km cloud altitude / 6371 km planet radius converted from metres
+	// to game units. The original 1.428e-2 is GAME_UNIT_TO_M (1.428f / 100),
+	// so dividing by GAME_UNIT_TO_M is the exact same value. Game.hlsli
+	// parenthesizes the macro, so the operator precedence is preserved.
+	const static float CloudHeight = (2e3f / GAME_UNIT_TO_M) * 0.25;
+	const static float PlanetRadius = (6371e3f / GAME_UNIT_TO_M);
 	const static float RcpHPlusR = (1.0 / (CloudHeight + PlanetRadius));
 
 	float3 GetCloudShadowSampleDir(float3 rel_pos, float3 eye_to_sun)

--- a/features/Cloud Shadows/Shaders/Features/CloudShadows.ini
+++ b/features/Cloud Shadows/Shaders/Features/CloudShadows.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-3-0
+Version = 1-4-0
 
 [Nexus]
 nexusmodid = 139185

--- a/features/Inverse Square Lighting/Shaders/Features/InverseSquareLighting.ini
+++ b/features/Inverse Square Lighting/Shaders/Features/InverseSquareLighting.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-2-0
+Version = 1-3-0
 
 [Nexus]
 autoupload = false

--- a/features/Inverse Square Lighting/Shaders/InverseSquareLighting/InverseSquareLighting.hlsli
+++ b/features/Inverse Square Lighting/Shaders/InverseSquareLighting/InverseSquareLighting.hlsli
@@ -1,9 +1,9 @@
+#include "Common/Game.hlsli"
 #include "Common/SharedData.hlsli"
 
 namespace InverseSquareLighting
 {
 	static const float SCALE = 0.8f;
-	static const float METRES_TO_UNITS = 70.f;
 	static const float METRES_TO_UNITS_SQ = METRES_TO_UNITS * METRES_TO_UNITS;
 	static const float SCALED_UNITS_SQ = SCALE * METRES_TO_UNITS_SQ;
 

--- a/package/Shaders/Common/Game.hlsli
+++ b/package/Shaders/Common/Game.hlsli
@@ -4,18 +4,29 @@
 #include "Common/Math.hlsli"
 
 // Conversion constants
+//
+// All multi-token expressions are wrapped in parentheses so that callers
+// can use them inside larger expressions without operator-precedence
+// surprises (e.g. `x / GAME_UNIT_TO_M` must mean `x / (CM / 100)`,
+// not `(x / CM) / 100`).
 #define GAME_UNIT_TO_CM 1.428f
-#define GAME_UNIT_TO_M GAME_UNIT_TO_CM / 100.0f
-#define GAME_UNIT_TO_FEET GAME_UNIT_TO_CM / 30.48f
-#define GAME_UNIT_TO_INCHES GAME_UNIT_TO_CM / 2.54f
+#define GAME_UNIT_TO_M (GAME_UNIT_TO_CM / 100.0f)
+#define GAME_UNIT_TO_FEET (GAME_UNIT_TO_CM / 30.48f)
+#define GAME_UNIT_TO_INCHES (GAME_UNIT_TO_CM / 2.54f)
+
+// Reciprocal: meters to game units. Mirrors the 70.0f approximation used
+// by the Inverse Square Lighting feature so callers can switch to the
+// centralized constant without a numeric behavior change. The exact
+// reciprocal of GAME_UNIT_TO_M is 70.028011f.
+#define METRES_TO_UNITS 70.0f
 
 // Wind speed conversions
-#define WIND_RAW_TO_NORMALIZED 1.0f / 255.0f
-#define WIND_RAW_TO_PERCENT 100.0f / 255.0f
+#define WIND_RAW_TO_NORMALIZED (1.0f / 255.0f)
+#define WIND_RAW_TO_PERCENT (100.0f / 255.0f)
 
 // Direction conversions
-#define DIR_RAW_TO_DEGREES 360.0f / 256.0f
-#define DIR_RANGE_TO_DEGREES 180.0f / 256.0f
-#define RADIANS_TO_DEGREES 180.0f / Math::PI
+#define DIR_RAW_TO_DEGREES (360.0f / 256.0f)
+#define DIR_RANGE_TO_DEGREES (180.0f / 256.0f)
+#define RADIANS_TO_DEGREES (180.0f / Math::PI)
 
 #endif  // __GAME_HLSLI__


### PR DESCRIPTION
## Summary

Closes #1228

`package/Shaders/Common/Game.hlsli` already exists with the unit-conversion constants from `src/Utils/Game.h`. This wires up the remaining tasks in the issue: cross-reference, update existing shader files to use the centralized constants, and remove the duplicate definitions.

## Changes

- **`package/Shaders/Common/Game.hlsli`** — parenthesize the multi-token macros (`GAME_UNIT_TO_M`, `GAME_UNIT_TO_FEET`, `GAME_UNIT_TO_INCHES`, `WIND_*`, `DIR_*`, `RADIANS_TO_DEGREES`) so callers can use them inside larger expressions without operator-precedence surprises (`x / GAME_UNIT_TO_M` would otherwise parse as `(x / 1.428f) / 100.0f`). Also add `METRES_TO_UNITS = 70.0f` so the lighting feature can drop its local copy without changing numeric behavior.
- **`features/Inverse Square Lighting/Shaders/InverseSquareLighting/InverseSquareLighting.hlsli`** — `#include "Common/Game.hlsli"` and remove the local `static const float METRES_TO_UNITS = 70.f;`. The derived `METRES_TO_UNITS_SQ` and `SCALED_UNITS_SQ` stay in the `InverseSquareLighting` namespace and now reference the centralized constant. Numeric value unchanged (still `70.0f * 70.0f * 0.8f`).
- **`features/Cloud Shadows/Shaders/CloudShadows/CloudShadows.hlsli`** — `#include "Common/Game.hlsli"` and replace the two `1.428e-2` literals with `GAME_UNIT_TO_M`. Both expressions evaluate to the same constant: `2e3f / GAME_UNIT_TO_M` expands to `2e3f / (1.428f / 100.0f) = 140056.0`, identical to `2e3f / 1.428e-2 = 140056.0`.

## Cross-reference notes

`Game.hlsli` already mirrors the C++ `src/Utils/Game.h` `Units` namespace one-to-one (`GAME_UNIT_TO_CM`, `GAME_UNIT_TO_M`, `GAME_UNIT_TO_FEET`, `GAME_UNIT_TO_INCHES`, `WIND_RAW_TO_NORMALIZED`, `WIND_RAW_TO_PERCENT`, `DIR_RAW_TO_DEGREES`, `DIR_RANGE_TO_DEGREES`, `RADIANS_TO_DEGREES`). The new `METRES_TO_UNITS` is the only HLSL-side reciprocal not present on the C++ side — the C++ `Units` namespace exposes `GameUnitsToMeters()` as an inline helper rather than a reciprocal constant.

`#include "Common/Game.hlsli"` was already present in `Hair/Hair.hlsli`, `SubsurfaceScattering/Burley.hlsli`, and `Tests/TestHair.hlsl`. The two new includes follow the same path style.

## Verification

- Macro-expansion check via `cpp -P`:
  - `2e3f / GAME_UNIT_TO_M` → `2e3f / (1.428f / 100.0f)` → `140056.0`
  - `6371e3f / GAME_UNIT_TO_M` → `446148459.4`
  - Both match the original `1.428e-2` literals exactly.
- HLSL toolchain validation (`hlslkit-compile`, `fxc.exe`) requires Windows + Visual Studio. I do not have a Windows runner available; CI on the project's runners will exercise the full shader suite.

## Tasks

- [x] Create `package/Shaders/Common/Game.hlsli` (already done in earlier work)
- [x] Cross-reference `src/Utils/Game.h` to identify other constants that should be imported
- [x] Update existing shader files to use the centralized constants
- [x] Remove duplicate constant definitions from individual features


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of unit conversions used by cloud shadows and inverse-square lighting, reducing precision-related visual artifacts.
* **Chores**
  * Updated shader feature versions to the next release numbers.
* **Refactor**
  * Wrapped numeric expressions to ensure correct operator precedence and more robust shader calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->