### PR TITLE
feat(height fog): separate inscattering color settings

### DIFF
--- a/features/Exponential Height Fog/Shaders/ExponentialHeightFog/ExponentialHeightFog.hlsli
+++ b/features/Exponential Height Fog/Shaders/ExponentialHeightFog/ExponentialHeightFog.hlsli
@@ -99,17 +99,16 @@ namespace ExponentialHeightFog
 		float3 lightDir = SharedData::DirLightDirection.xyz;
 		float lightDirZ = lightDir.z;
 
-		float exponentialHeightLineIntegral = 0.0f;
+		float sunlightFogAttenuation = 0.0f;
 
 		// Integral = Density * (1 - exp2(-slope * inf)) / slope
 		if (lightDirZ > 0.001f) {
 			float slope = max(fogHeightFalloff * lightDirZ, 1e-8f);
-			exponentialHeightLineIntegral = localDensity / slope;
-		} else {
-			return 0.0f;
+			float exponentialHeightLineIntegral = localDensity / slope;
+			sunlightFogAttenuation = saturate(exp2(-exponentialHeightLineIntegral));
 		}
 
-		return saturate(exp2(-exponentialHeightLineIntegral));
+		return lerp(1.0f, sunlightFogAttenuation, SharedData::exponentialHeightFogSettings.sunlightAttenuationAmount);
 	}
 }
 #endif

--- a/features/Exponential Height Fog/Shaders/ExponentialHeightFog/ExponentialHeightFog.hlsli
+++ b/features/Exponential Height Fog/Shaders/ExponentialHeightFog/ExponentialHeightFog.hlsli
@@ -14,6 +14,20 @@ namespace ExponentialHeightFog
 		return SharedData::exponentialHeightFogSettings.respectVanillaFogFade != 0 ? vanillaFogFade : 1.0f;
 	}
 
+	bool ShouldDisableVanillaFog()
+	{
+		return SharedData::exponentialHeightFogSettings.enabled && SharedData::exponentialHeightFogSettings.disableVanillaFog != 0;
+	}
+
+	// Henyey-Greenstein phase function for physically-based inscattering.
+	// g: asymmetry parameter [-1, 1]. Positive = forward scattering, 0 = isotropic.
+	float HenyeyGreenstein(float cosTheta, float g)
+	{
+		float g2 = g * g;
+		float denom = 1.0f + g2 - 2.0f * g * cosTheta;
+		return (1.0f - g2) / (4.0f * Math::PI * pow(max(denom, 1e-5f), 1.5f));
+	}
+
 	float4 GetExponentialHeightFog(float3 positionWS, float3 cameraWS, float3 fogColor)
 	{
 		float fogHeightFalloff = SharedData::exponentialHeightFogSettings.fogHeightFalloff * 0.001f;
@@ -57,9 +71,11 @@ namespace ExponentialHeightFog
 
 		float3 directionalInscattering = 0;
 
-		// Calculate directional light inscattering
+		// Calculate directional light inscattering using Henyey-Greenstein phase function
 		if (SharedData::exponentialHeightFogSettings.directionalInscatteringMultiplier > 0) {
-			float3 directionalLightInscattering = SharedData::DirLightColor.xyz * pow(saturate(dot(normalize(positionWS), SharedData::DirLightDirection.xyz)), SharedData::exponentialHeightFogSettings.directionalInscatteringExponent) / (2 * Math::TAU);
+			float cosTheta = dot(normalize(positionWS), SharedData::DirLightDirection.xyz);
+			float phase = HenyeyGreenstein(cosTheta, SharedData::exponentialHeightFogSettings.directionalInscatteringAnisotropy);
+			float3 directionalLightInscattering = SharedData::DirLightColor.xyz * phase;
 			float dirExponentialHeightLineIntegral = exponentialHeightLineIntegralCalc * max(rayLength - SharedData::exponentialHeightFogSettings.startDistance, 0);
 			float dirExpFogFactor = saturate(exp2(-dirExponentialHeightLineIntegral));
 			directionalInscattering = directionalLightInscattering * (1 - dirExpFogFactor) * SharedData::exponentialHeightFogSettings.directionalInscatteringMultiplier;

--- a/features/Exponential Height Fog/Shaders/ExponentialHeightFog/ExponentialHeightFog.hlsli
+++ b/features/Exponential Height Fog/Shaders/ExponentialHeightFog/ExponentialHeightFog.hlsli
@@ -61,13 +61,17 @@ namespace ExponentialHeightFog
 
 		float expFogFactor = saturate(exp2(-exponentialHeightLineIntegral));
 
+		float3 fogInscatteringColor = fogColor * SharedData::exponentialHeightFogSettings.originalFogColorAmount;
+		fogInscatteringColor += SharedData::exponentialHeightFogSettings.fogInscatteringColor.rgb * SharedData::exponentialHeightFogSettings.fogInscatteringColor.a;
+
 #if defined(DYNAMIC_CUBEMAPS)
 		if (SharedData::exponentialHeightFogSettings.useDynamicCubemaps > 0) {
-			float3 tintColor = lerp(fogColor, SharedData::exponentialHeightFogSettings.inscatteringTint.xyz, SharedData::exponentialHeightFogSettings.inscatteringTint.w);
 			float3 cubemapColor = DynamicCubemaps::EnvReflectionsTexture.SampleLevel(SampColorSampler, normalize(lerp(positionWS, float3(0, 0, 1), saturate((SharedData::exponentialHeightFogSettings.cubemapMipLevel + 1) / 8))), SharedData::exponentialHeightFogSettings.cubemapMipLevel).xyz;
-			fogColor = tintColor * cubemapColor * (1.0f - expFogFactor);
+			fogInscatteringColor += cubemapColor * SharedData::exponentialHeightFogSettings.inscatteringTint.rgb * SharedData::exponentialHeightFogSettings.inscatteringTint.a;
 		}
 #endif
+
+		fogColor = fogInscatteringColor * (1.0f - expFogFactor);
 
 		float3 directionalInscattering = 0;
 

--- a/features/Exponential Height Fog/Shaders/Features/ExponentialHeightFog.ini
+++ b/features/Exponential Height Fog/Shaders/Features/ExponentialHeightFog.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-1-0
+Version = 1-2-0
 
 [Nexus]
 autoupload = false

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -260,9 +260,9 @@ namespace SharedData
 		float directionalInscatteringAnisotropy;
 		float4 inscatteringTint;
 		float cubemapMipLevel;
+		float sunlightAttenuationAmount;
 		uint respectVanillaFogFade;
 		uint disableVanillaFog;
-		float pad;
 	};
 
 	cbuffer FeatureData : register(b6)

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -257,11 +257,12 @@ namespace SharedData
 		float fogHeightFalloff;
 		float fogDensity;
 		float directionalInscatteringMultiplier;
-		float directionalInscatteringExponent;
+		float directionalInscatteringAnisotropy;
 		float4 inscatteringTint;
 		float cubemapMipLevel;
 		uint respectVanillaFogFade;
-		float2 pad;
+		uint disableVanillaFog;
+		float pad;
 	};
 
 	cbuffer FeatureData : register(b6)

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -263,6 +263,9 @@ namespace SharedData
 		float sunlightAttenuationAmount;
 		uint respectVanillaFogFade;
 		uint disableVanillaFog;
+		float4 fogInscatteringColor;
+		float originalFogColorAmount;
+		float3 pad;
 	};
 
 	cbuffer FeatureData : register(b6)

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -854,8 +854,12 @@ PS_OUTPUT main(PS_INPUT input)
 	}
 #		endif
 #		if defined(EXP_HEIGHT_FOG)
+	float vanillaFogFactor = fogFactor;
+	float3 vanillaFogColor = fogColor;
+	float expFogFactor = 0;
 	if (SharedData::exponentialHeightFogSettings.enabled) {
 		float4 exponentialHeightFog = ExponentialHeightFog::GetExponentialHeightFog(input.WorldPosition.xyz, FrameBuffer::CameraPosAdjust[eyeIndex].xyz, fogColor);
+		expFogFactor = exponentialHeightFog.w;
 #			if defined(ADDBLEND) || defined(MULTBLEND) || defined(MULTBLEND_DECAL)
 		fogColor = exponentialHeightFog.xyz;
 		fogFactor = exponentialHeightFog.w;
@@ -863,14 +867,30 @@ PS_OUTPUT main(PS_INPUT input)
 		fogColor = lightColor;
 		alpha *= 1 - exponentialHeightFog.w;
 #			endif
+		if (ExponentialHeightFog::ShouldDisableVanillaFog()) {
+			vanillaFogFactor = 0;
+		}
 	}
 #		endif
 #		if defined(ADDBLEND)
+#			if defined(EXP_HEIGHT_FOG)
+	float3 blendedColor = lightColor * (1 - vanillaFogFactor) * (1 - expFogFactor);
+#			else
 	float3 blendedColor = lightColor * (1 - fogFactor);
+#			endif
 #		elif defined(MULTBLEND) || defined(MULTBLEND_DECAL)
+#			if defined(EXP_HEIGHT_FOG)
+	float3 blendedColor = lerp(lightColor, 1.0.xxx, saturate(1.5 * vanillaFogFactor).xxx);
+	blendedColor = lerp(blendedColor, 1.0.xxx, saturate(1.5 * expFogFactor).xxx);
+#			else
 	float3 blendedColor = lerp(lightColor, 1.0.xxx, saturate(1.5 * fogFactor).xxx);
+#			endif
 #		else
+#			if defined(EXP_HEIGHT_FOG)
+	float3 blendedColor = lerp(lightColor, vanillaFogColor, vanillaFogFactor.xxx);
+#			else
 	float3 blendedColor = lerp(lightColor, fogColor, fogFactor.xxx);
+#			endif
 #		endif
 #	else
 	float3 blendedColor = lightColor.xyz;

--- a/package/Shaders/ISSAOComposite.hlsl
+++ b/package/Shaders/ISSAOComposite.hlsl
@@ -194,15 +194,23 @@ PS_OUTPUT main(PS_INPUT input)
 	float4 positionWS = float4(2 * float2(monoUV.x, -monoUV.y + 1) - 1, depth, 1);
 	positionWS = mul(FrameBuffer::CameraViewProjInverse[eyeIndex], positionWS);
 	positionWS.xyz = positionWS.xyz / positionWS.w;
+	float4 exponentialHeightFog = (float4)0;
 	if (exponentialHeightFogEnabled) {
-		float4 exponentialHeightFog = ExponentialHeightFog::GetExponentialHeightFog(positionWS.xyz, FrameBuffer::CameraPosAdjust[eyeIndex].xyz, fogColor);
-		fogColor = exponentialHeightFog.xyz;
-		fogFactor = exponentialHeightFog.w;
+		exponentialHeightFog = ExponentialHeightFog::GetExponentialHeightFog(positionWS.xyz, FrameBuffer::CameraPosAdjust[eyeIndex].xyz, fogColor);
 	}
 	if (isGeometryDepth || exponentialHeightFogEnabled) {
 		float fogFade = exponentialHeightFogEnabled ? ExponentialHeightFog::GetVanillaFogFade(FogNearColor.w) : FogNearColor.w;
 		float3 fogSource = exponentialHeightFogEnabled && !isGeometryDepth ? composedColor.xyz : fogFade * composedColor.xyz;
-		composedColor.xyz = lerp(fogSource, fogFade * fogColor, fogFactor);
+		if (exponentialHeightFogEnabled && !ExponentialHeightFog::ShouldDisableVanillaFog()) {
+			// Apply vanilla fog first, then exp fog on top
+			composedColor.xyz = lerp(fogSource, fogFade * fogColor, Color::FogAlpha(fogFactor));
+			composedColor.xyz = lerp(composedColor.xyz, fogFade * exponentialHeightFog.xyz, exponentialHeightFog.w);
+		} else if (exponentialHeightFogEnabled) {
+			// Disable vanilla fog, only apply exp height fog
+			composedColor.xyz = lerp(fogSource, fogFade * exponentialHeightFog.xyz, exponentialHeightFog.w);
+		} else {
+			composedColor.xyz = lerp(fogSource, fogFade * fogColor, Color::FogAlpha(fogFactor));
+		}
 	}
 #		else
 	if (isGeometryDepth) {

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -3087,14 +3087,28 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	}
 #		endif
 #		if defined(EXP_HEIGHT_FOG)
+	float3 vanillaFogColor = fogColor;
+	float vanillaFogFactor = fogFactor;
 	if (SharedData::exponentialHeightFogSettings.enabled) {
 		float4 exponentialHeightFog = ExponentialHeightFog::GetExponentialHeightFog(input.WorldPosition.xyz, FrameBuffer::CameraPosAdjust[eyeIndex].xyz, fogColor);
 		fogColor = exponentialHeightFog.xyz;
 		fogFactor = exponentialHeightFog.w;
 	}
 #		endif
-	if (FrameBuffer::FrameParams.y && FrameBuffer::FrameParams.z)
+	if (FrameBuffer::FrameParams.y && FrameBuffer::FrameParams.z) {
+#		if defined(EXP_HEIGHT_FOG)
+		if (SharedData::exponentialHeightFogSettings.enabled) {
+			if (!ExponentialHeightFog::ShouldDisableVanillaFog()) {
+				color.xyz = lerp(color.xyz, vanillaFogColor, vanillaFogFactor);
+			}
+			color.xyz = lerp(color.xyz, fogColor, fogFactor);
+		} else {
+			color.xyz = lerp(color.xyz, fogColor, fogFactor);
+		}
+#		else
 		color.xyz = lerp(color.xyz, fogColor, fogFactor);
+#		endif
+	}
 #	endif
 
 #	if defined(TESTCUBEMAP) && defined(ENVMAP) && defined(DYNAMIC_CUBEMAPS)

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -1279,13 +1279,26 @@ PS_OUTPUT main(PS_INPUT input)
 #						if defined(EXP_HEIGHT_FOG)
 	if (SharedData::exponentialHeightFogSettings.enabled) {
 		float4 exponentialHeightFog = ExponentialHeightFog::GetExponentialHeightFog(input.WPosition.xyz, FrameBuffer::CameraPosAdjust[eyeIndex].xyz, fogColor);
-		fogColor = exponentialHeightFog.xyz;
-		fogDistanceFactor = exponentialHeightFog.w;
+		if (ExponentialHeightFog::ShouldDisableVanillaFog()) {
+			fogColor = exponentialHeightFog.xyz;
+			fogColor *= GetWaterFogFade(eyeIndex);
+			finalColorPreFog = lerp(finalColorPreFog, fogColor, exponentialHeightFog.w);
+		} else {
+			fogColor *= GetWaterFogFade(eyeIndex);
+			finalColorPreFog = lerp(finalColorPreFog, fogColor, fogDistanceFactor);
+			float3 expFogColor = exponentialHeightFog.xyz * GetWaterFogFade(eyeIndex);
+			finalColorPreFog = lerp(finalColorPreFog, expFogColor, exponentialHeightFog.w);
+		}
+	} else {
+		fogColor *= GetWaterFogFade(eyeIndex);
+		finalColorPreFog = lerp(finalColorPreFog, fogColor, fogDistanceFactor);
 	}
-#						endif
+#						else
 	fogColor *= GetWaterFogFade(eyeIndex);
+	finalColorPreFog = lerp(finalColorPreFog, fogColor, fogDistanceFactor);
+#						endif
 
-	float3 finalColor = lerp(finalColorPreFog, fogColor, fogDistanceFactor);
+	float3 finalColor = finalColorPreFog;
 
 #						if defined(WETNESS_EFFECTS) && defined(DEBUG_WETNESS_EFFECTS)
 	// DEBUG MODE: Override water color with debug visualization
@@ -1317,13 +1330,25 @@ PS_OUTPUT main(PS_INPUT input)
 #						if defined(EXP_HEIGHT_FOG)
 	if (SharedData::exponentialHeightFogSettings.enabled) {
 		float4 exponentialHeightFog = ExponentialHeightFog::GetExponentialHeightFog(input.WPosition.xyz, FrameBuffer::CameraPosAdjust[eyeIndex].xyz, preFogColor);
-		preFogColor = exponentialHeightFog.xyz;
-		fogDistanceFactor = exponentialHeightFog.w;
+		if (ExponentialHeightFog::ShouldDisableVanillaFog()) {
+			preFogColor = exponentialHeightFog.xyz;
+			preFogColor *= GetWaterFogFade(eyeIndex);
+			finalColorPreFog = lerp(finalColorPreFog, preFogColor, exponentialHeightFog.w);
+		} else {
+			preFogColor *= GetWaterFogFade(eyeIndex);
+			finalColorPreFog = lerp(finalColorPreFog, preFogColor, fogDistanceFactor);
+			float3 expFogColor = exponentialHeightFog.xyz * GetWaterFogFade(eyeIndex);
+			finalColorPreFog = lerp(finalColorPreFog, expFogColor, exponentialHeightFog.w);
+		}
+	} else {
+		preFogColor *= GetWaterFogFade(eyeIndex);
+		finalColorPreFog = lerp(finalColorPreFog, preFogColor, fogDistanceFactor);
 	}
-#						endif
+#						else
 	preFogColor *= GetWaterFogFade(eyeIndex);
 
 	finalColorPreFog = lerp(finalColorPreFog, preFogColor, fogDistanceFactor);
+#						endif
 
 	float3 refractionColor = diffuseOutput.refractionColor;
 

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -1355,7 +1355,7 @@ PS_OUTPUT main(PS_INPUT input)
 	float fogFactor = min(FogParam.w, pow(saturate(-diffuseOutput.depth * FogParam.y - FogParam.x), FogParam.z));
 	float3 fogColor = Color::Fog(lerp(FogNearColor.xyz, FogFarColor.xyz, fogFactor));
 #						if defined(EXP_HEIGHT_FOG)
-	if (SharedData::exponentialHeightFogSettings.enabled) {
+	if (SharedData::exponentialHeightFogSettings.enabled && ExponentialHeightFog::ShouldDisableVanillaFog()) {
 		fogFactor = 0;
 	}
 #						endif

--- a/src/Features/ExponentialHeightFog.cpp
+++ b/src/Features/ExponentialHeightFog.cpp
@@ -11,10 +11,11 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	fogHeightFalloff,
 	fogDensity,
 	directionalInscatteringMultiplier,
-	directionalInscatteringExponent,
+	directionalInscatteringAnisotropy,
 	inscatteringTint,
 	cubemapMipLevel,
-	respectVanillaFogFade)
+	respectVanillaFogFade,
+	disableVanillaFog)
 
 void ExponentialHeightFog::RestoreDefaultSettings()
 {
@@ -39,7 +40,17 @@ void ExponentialHeightFog::DrawSettings()
 	Util::WeatherUI::SliderFloat("Fog Height Falloff", this, "fogHeightFalloff", &settings.fogHeightFalloff, 0.001f, 2.0f, "%.3f");
 	Util::WeatherUI::SliderFloat("Fog Density", this, "fogDensity", &settings.fogDensity, 0.0f, 1.0f, "%.3f");
 	Util::WeatherUI::SliderFloat("Directional Light Inscattering Multiplier", this, "directionalInscatteringMultiplier", &settings.directionalInscatteringMultiplier, 0.0f, 10.0f, "%.2f");
-	Util::WeatherUI::SliderFloat("Directional Light Inscattering Exponent", this, "directionalInscatteringExponent", &settings.directionalInscatteringExponent, 1.0f, 128.0f, "%.2f");
+	Util::WeatherUI::SliderFloat("Directional Light Inscattering Anisotropy", this, "directionalInscatteringAnisotropy", &settings.directionalInscatteringAnisotropy, -0.99f, 0.99f, "%.3f");
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text(
+			"Controls the asymmetry of inscattering via the Henyey-Greenstein phase function.\n"
+			"Positive values produce forward scattering (glow around sun).\n"
+			"Zero is isotropic. Negative values produce back scattering.");
+	}
+	ImGui::Checkbox("Disable Vanilla Fog", (bool*)&settings.disableVanillaFog);
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text("Disables the vanilla fog entirely. Only exponential height fog will be applied.");
+	}
 	Util::WeatherUI::Checkbox("Apply Vanilla Fade", this, "respectVanillaFogFade", (bool*)&settings.respectVanillaFogFade);
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text("Applies vanilla fade brightness to exponential height fog.");
@@ -93,12 +104,12 @@ void ExponentialHeightFog::RegisterWeatherVariables()
 		0.0f, 10.0f));
 
 	registry->RegisterVariable(std::make_shared<WeatherVariables::FloatVariable>(
-		"Directional Inscattering Exponent",
-		"directionalInscatteringExponent",
-		"Controls the size of the directional inscattering cone",
-		&settings.directionalInscatteringExponent,
-		4.0f,
-		1.0f, 128.0f));
+		"Directional Inscattering Anisotropy",
+		"directionalInscatteringAnisotropy",
+		"Henyey-Greenstein asymmetry parameter. Positive = forward scattering, 0 = isotropic, negative = back scattering.",
+		&settings.directionalInscatteringAnisotropy,
+		0.7f,
+		-0.99f, 0.99f));
 
 	registry->RegisterVariable(std::make_shared<WeatherVariables::Float4Variable>(
 		"Inscattering Cubemap Tint",
@@ -112,6 +123,16 @@ void ExponentialHeightFog::RegisterWeatherVariables()
 		"Apply Vanilla Fade",
 		"Apply vanilla fade brightness to exponential height fog",
 		(bool*)&settings.respectVanillaFogFade,
+		false,
+		[](const bool& from, const bool& to, float factor) {
+			return factor > 0.5f ? to : from;
+		}));
+
+	registry->RegisterVariable(std::make_shared<WeatherVariables::WeatherVariable<bool>>(
+		"disableVanillaFog",
+		"Disable Vanilla Fog",
+		"Disables vanilla fog entirely, only exponential height fog is applied",
+		(bool*)&settings.disableVanillaFog,
 		false,
 		[](const bool& from, const bool& to, float factor) {
 			return factor > 0.5f ? to : from;

--- a/src/Features/ExponentialHeightFog.cpp
+++ b/src/Features/ExponentialHeightFog.cpp
@@ -14,6 +14,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	directionalInscatteringAnisotropy,
 	inscatteringTint,
 	cubemapMipLevel,
+	sunlightAttenuationAmount,
 	respectVanillaFogFade,
 	disableVanillaFog)
 
@@ -40,6 +41,7 @@ void ExponentialHeightFog::DrawSettings()
 	Util::WeatherUI::SliderFloat("Fog Height Falloff", this, "fogHeightFalloff", &settings.fogHeightFalloff, 0.001f, 2.0f, "%.3f");
 	Util::WeatherUI::SliderFloat("Fog Density", this, "fogDensity", &settings.fogDensity, 0.0f, 1.0f, "%.3f");
 	Util::WeatherUI::SliderFloat("Directional Light Inscattering Multiplier", this, "directionalInscatteringMultiplier", &settings.directionalInscatteringMultiplier, 0.0f, 10.0f, "%.2f");
+	Util::WeatherUI::SliderFloat("Sunlight Attenuation Amount", this, "sunlightAttenuationAmount", &settings.sunlightAttenuationAmount, 0.0f, 1.0f, "%.2f");
 	Util::WeatherUI::SliderFloat("Directional Light Inscattering Anisotropy", this, "directionalInscatteringAnisotropy", &settings.directionalInscatteringAnisotropy, -0.99f, 0.99f, "%.3f");
 	if (auto _tt = Util::HoverTooltipWrapper()) {
 		ImGui::Text(
@@ -102,6 +104,14 @@ void ExponentialHeightFog::RegisterWeatherVariables()
 		&settings.directionalInscatteringMultiplier,
 		1.0f,
 		0.0f, 10.0f));
+
+	registry->RegisterVariable(std::make_shared<WeatherVariables::FloatVariable>(
+		"Sunlight Attenuation Amount",
+		"sunlightAttenuationAmount",
+		"Amount of fog attenuation applied to direct sunlight",
+		&settings.sunlightAttenuationAmount,
+		1.0f,
+		0.0f, 1.0f));
 
 	registry->RegisterVariable(std::make_shared<WeatherVariables::FloatVariable>(
 		"Directional Inscattering Anisotropy",

--- a/src/Features/ExponentialHeightFog.cpp
+++ b/src/Features/ExponentialHeightFog.cpp
@@ -16,7 +16,9 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	cubemapMipLevel,
 	sunlightAttenuationAmount,
 	respectVanillaFogFade,
-	disableVanillaFog)
+	disableVanillaFog,
+	fogInscatteringColor,
+	originalFogColorAmount)
 
 void ExponentialHeightFog::RestoreDefaultSettings()
 {
@@ -39,6 +41,8 @@ void ExponentialHeightFog::DrawSettings()
 	Util::WeatherUI::SliderFloat("Start Distance", this, "startDistance", &settings.startDistance, 0.0f, 100000.0f, "%.1f");
 	Util::WeatherUI::SliderFloat("Fog Height", this, "fogHeight", &settings.fogHeight, -22000.0f, 22000.0f, "%.1f");
 	Util::WeatherUI::SliderFloat("Fog Height Falloff", this, "fogHeightFalloff", &settings.fogHeightFalloff, 0.001f, 2.0f, "%.3f");
+	Util::WeatherUI::ColorEdit4("Fog Inscattering Color", this, "fogInscatteringColor", (float*)&settings.fogInscatteringColor);
+	Util::WeatherUI::SliderFloat("Original Fog Color Amount", this, "originalFogColorAmount", &settings.originalFogColorAmount, 0.0f, 1.0f, "%.2f");
 	Util::WeatherUI::SliderFloat("Fog Density", this, "fogDensity", &settings.fogDensity, 0.0f, 1.0f, "%.3f");
 	Util::WeatherUI::SliderFloat("Directional Light Inscattering Multiplier", this, "directionalInscatteringMultiplier", &settings.directionalInscatteringMultiplier, 0.0f, 10.0f, "%.2f");
 	Util::WeatherUI::SliderFloat("Sunlight Attenuation Amount", this, "sunlightAttenuationAmount", &settings.sunlightAttenuationAmount, 0.0f, 1.0f, "%.2f");
@@ -88,6 +92,21 @@ void ExponentialHeightFog::RegisterWeatherVariables()
 		&settings.fogHeightFalloff,
 		0.2f,
 		0.001f, 2.0f));
+
+	registry->RegisterVariable(std::make_shared<WeatherVariables::Float4Variable>(
+		"Fog Inscattering Color",
+		"fogInscatteringColor",
+		"Color added to the fog inscattering contribution",
+		&settings.fogInscatteringColor,
+		float4{ 0.0f, 0.0f, 0.0f, 1.0f }));
+
+	registry->RegisterVariable(std::make_shared<WeatherVariables::FloatVariable>(
+		"Original Fog Color Amount",
+		"originalFogColorAmount",
+		"Amount of the original fog color added to fog inscattering",
+		&settings.originalFogColorAmount,
+		1.0f,
+		0.0f, 1.0f));
 
 	registry->RegisterVariable(std::make_shared<WeatherVariables::FloatVariable>(
 		"Fog Density",

--- a/src/Features/ExponentialHeightFog.h
+++ b/src/Features/ExponentialHeightFog.h
@@ -40,11 +40,12 @@ struct ExponentialHeightFog : Feature
 		float fogHeightFalloff = 0.2f;
 		float fogDensity = 0.02f;
 		float directionalInscatteringMultiplier = 1.0f;
-		float directionalInscatteringExponent = 4.0f;
+		float directionalInscatteringAnisotropy = 0.7f;
 		float4 inscatteringTint = { 1.0f, 1.0f, 1.0f, 1.0f };
 		float cubemapMipLevel = 3.0f;
 		uint respectVanillaFogFade = 0;
-		float pad[2];
+		uint disableVanillaFog = 0;
+		float pad;
 	} settings;
 	static_assert(sizeof(Settings) == sizeof(float4) * 4, "Settings must match HLSL ExponentialHeightFogSettings.");
 };

--- a/src/Features/ExponentialHeightFog.h
+++ b/src/Features/ExponentialHeightFog.h
@@ -46,6 +46,9 @@ struct ExponentialHeightFog : Feature
 		float sunlightAttenuationAmount = 1.0f;
 		uint respectVanillaFogFade = 0;
 		uint disableVanillaFog = 0;
+		float4 fogInscatteringColor = { 0.0f, 0.0f, 0.0f, 1.0f };
+		float originalFogColorAmount = 1.0f;
+		float3 pad;
 	} settings;
-	static_assert(sizeof(Settings) == sizeof(float4) * 4, "Settings must match HLSL ExponentialHeightFogSettings.");
+	static_assert(sizeof(Settings) == sizeof(float4) * 6, "Settings must match HLSL ExponentialHeightFogSettings.");
 };

--- a/src/Features/ExponentialHeightFog.h
+++ b/src/Features/ExponentialHeightFog.h
@@ -43,9 +43,9 @@ struct ExponentialHeightFog : Feature
 		float directionalInscatteringAnisotropy = 0.7f;
 		float4 inscatteringTint = { 1.0f, 1.0f, 1.0f, 1.0f };
 		float cubemapMipLevel = 3.0f;
+		float sunlightAttenuationAmount = 1.0f;
 		uint respectVanillaFogFade = 0;
 		uint disableVanillaFog = 0;
-		float pad;
 	} settings;
 	static_assert(sizeof(Settings) == sizeof(float4) * 4, "Settings must match HLSL ExponentialHeightFogSettings.");
 };


### PR DESCRIPTION
This pull request introduces significant improvements and new features to the Exponential Height Fog system, focusing on enhanced physical realism, greater artistic control, and improved integration with vanilla fog. The most important changes include the addition of a physically-based inscattering model using the Henyey-Greenstein phase function, new settings for controlling fog color and sunlight attenuation, and options to blend or disable vanilla fog. The UI and serialization logic have also been updated to support these new parameters.

**Physically-based fog and inscattering improvements:**
- Implemented the Henyey-Greenstein phase function for directional inscattering, allowing for anisotropic (directional) light scattering effects and more realistic fog appearance. The new parameter `directionalInscatteringAnisotropy` replaces the old exponent-based model. [[1]](diffhunk://#diff-a1060e39823b6f37ca222362eeabe03522f0f58f584ab51d3bab7cacf42887ceR17-R30) [[2]](diffhunk://#diff-a1060e39823b6f37ca222362eeabe03522f0f58f584ab51d3bab7cacf42887ceR64-R82) [[3]](diffhunk://#diff-812c99694216d6c71752b796f8804075cf5652d1f32787207a1ff33e0f173c1eL260-R268) [[4]](diffhunk://#diff-b843170fa5b9d1eb707b2ee7074b88d4aa6a6d63726eeeafb64ec5eb5a01740aL14-R21) [[5]](diffhunk://#diff-b843170fa5b9d1eb707b2ee7074b88d4aa6a6d63726eeeafb64ec5eb5a01740aR44-R59) [[6]](diffhunk://#diff-b843170fa5b9d1eb707b2ee7074b88d4aa6a6d63726eeeafb64ec5eb5a01740aL96-R141) [[7]](diffhunk://#diff-f8bb73b0e64930cff61bcdc8403b774361a093fc16bccbffe325a53945ba393fL43-R53)

- Added new fog color blending controls: `fogInscatteringColor` (custom color added to fog), and `originalFogColorAmount` (controls blending between the original and custom fog color). These are exposed in the UI and weather variable registry. [[1]](diffhunk://#diff-a1060e39823b6f37ca222362eeabe03522f0f58f584ab51d3bab7cacf42887ceR64-R82) [[2]](diffhunk://#diff-812c99694216d6c71752b796f8804075cf5652d1f32787207a1ff33e0f173c1eL260-R268) [[3]](diffhunk://#diff-b843170fa5b9d1eb707b2ee7074b88d4aa6a6d63726eeeafb64ec5eb5a01740aR44-R59) [[4]](diffhunk://#diff-b843170fa5b9d1eb707b2ee7074b88d4aa6a6d63726eeeafb64ec5eb5a01740aR96-R110) [[5]](diffhunk://#diff-f8bb73b0e64930cff61bcdc8403b774361a093fc16bccbffe325a53945ba393fL43-R53)

**Sunlight and vanilla fog integration:**
- Introduced `sunlightAttenuationAmount` to control how much direct sunlight is attenuated by the exponential height fog, improving control over sunlight/fog interactions. [[1]](diffhunk://#diff-a1060e39823b6f37ca222362eeabe03522f0f58f584ab51d3bab7cacf42887ceL86-R115) [[2]](diffhunk://#diff-812c99694216d6c71752b796f8804075cf5652d1f32787207a1ff33e0f173c1eL260-R268) [[3]](diffhunk://#diff-b843170fa5b9d1eb707b2ee7074b88d4aa6a6d63726eeeafb64ec5eb5a01740aR44-R59) [[4]](diffhunk://#diff-b843170fa5b9d1eb707b2ee7074b88d4aa6a6d63726eeeafb64ec5eb5a01740aL96-R141) [[5]](diffhunk://#diff-f8bb73b0e64930cff61bcdc8403b774361a093fc16bccbffe325a53945ba393fL43-R53)

- Added `disableVanillaFog` option and blending logic, allowing users to disable vanilla fog entirely or blend it with exponential height fog. All affected shaders now respect this setting, and the UI exposes a checkbox with a tooltip. [[1]](diffhunk://#diff-a1060e39823b6f37ca222362eeabe03522f0f58f584ab51d3bab7cacf42887ceR17-R30) [[2]](diffhunk://#diff-812c99694216d6c71752b796f8804075cf5652d1f32787207a1ff33e0f173c1eL260-R268) [[3]](diffhunk://#diff-2fd4b9665d3c8ae4d680920b9ae4a64e4408e0bfd835e1fa591193f0761dc24dR853-R890) [[4]](diffhunk://#diff-3ac79c6c390032ba373a22747511347234226013eea9778989e33c65f1fe1aa8R197-R213) [[5]](diffhunk://#diff-fee9ea921e49c9a517b9ba5e6d3ff9bae2bd4dbbe5a91bfef21d64c4bb06b2a3R3090-R3111) [[6]](diffhunk://#diff-7658478ba5b493920e66baf995c3b454632d429f101e18835b52ab94fd121de8R1282-R1301) [[7]](diffhunk://#diff-7658478ba5b493920e66baf995c3b454632d429f101e18835b52ab94fd121de8R1333-R1351) [[8]](diffhunk://#diff-b843170fa5b9d1eb707b2ee7074b88d4aa6a6d63726eeeafb64ec5eb5a01740aR44-R59) [[9]](diffhunk://#diff-b843170fa5b9d1eb707b2ee7074b88d4aa6a6d63726eeeafb64ec5eb5a01740aR159-R168) [[10]](diffhunk://#diff-f8bb73b0e64930cff61bcdc8403b774361a093fc16bccbffe325a53945ba393fL43-R53)

**UI, serialization, and versioning updates:**
- Updated the UI to support new sliders and color pickers for the added settings, including detailed tooltips for advanced parameters.
- Extended serialization, weather variable registration, and versioning to include all new parameters. [[1]](diffhunk://#diff-12d2230645986e4bcffd45f16278bb1bf24c894a6120a28af5964d609429b858L2-R2) [[2]](diffhunk://#diff-b843170fa5b9d1eb707b2ee7074b88d4aa6a6d63726eeeafb64ec5eb5a01740aL14-R21) [[3]](diffhunk://#diff-b843170fa5b9d1eb707b2ee7074b88d4aa6a6d63726eeeafb64ec5eb5a01740aR96-R110) [[4]](diffhunk://#diff-b843170fa5b9d1eb707b2ee7074b88d4aa6a6d63726eeeafb64ec5eb5a01740aL96-R141) [[5]](diffhunk://#diff-b843170fa5b9d1eb707b2ee7074b88d4aa6a6d63726eeeafb64ec5eb5a01740aR159-R168)

These changes provide both improved physical accuracy and greater flexibility for artists and users configuring the fog system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fog inscattering color and original-fog mixing controls.
  * Directional inscattering anisotropy (Henyey–Greenstein) and sunlight attenuation amount.
  * "Disable Vanilla Fog" toggle to choose vanilla vs exponential fog behavior.

* **Improvements**
  * Updated fog blending to overlay/compose vanilla and exponential height fog more predictably.
  * More physically based directional inscattering and improved dynamic cubemap tinting.
* **Other**
  * Feature version bumped.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2301)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->