### PR TITLE
fix(upscaling): revert depth copy condition

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1919,16 +1919,9 @@ void Upscaling::UpscaleDepth()
 	{
 		TracyD3D11Zone(globals::state->tracyCtx, "Upscaling - Depth Upscale");
 
-		// Engine copies kMAIN→kMAIN_COPY during 3D scene rendering.
-		// In non-3D contexts (map, main menu, loading, pause) the engine skips its copy.
-		auto* ui = globals::game::ui;
-		const bool inMenuContext = globals::state->isMapMenuOpen ||
-		                           globals::state->isMainMenuOpen ||
-		                           globals::state->isLoadingMenuOpen ||
-		                           (ui && ui->GameIsPaused());
-		if (inMenuContext) {
-			copyIfNonAliased(depthCopy.texture, depth.texture);
-		}
+		// Sometimes this is not already copied e.g. map menu.
+		// Skip alias copies to reduce unnecessary copy churn.
+		copyIfNonAliased(depthCopy.texture, depth.texture);
 
 		// Clear stencil to be 0xFF
 		if (globals::game::isVR) {


### PR DESCRIPTION
reverted the added condition in https://github.com/community-shaders/skyrim-community-shaders/pull/2193
to fix frozen depth after upscaling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved depth texture consistency in upscaling operations to ensure uniform visual quality across all application states.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2309)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->