### PR TITLE
fix(truepbr): apply MATO rbg scalars through cbuffer

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -602,6 +602,8 @@ cbuffer PerMaterial : register(b1)
 	uint PBRFlags : packoffset(c15.x);
 	float3 PBRParams1 : packoffset(c15.y);  // roughness scale, displacement scale, specular level
 	float4 PBRParams2 : packoffset(c16);    // subsurface color, subsurface opacity
+
+	float3 MaterialObjectRGBScale : packoffset(c17);  // RGB multipliers for material objects
 };
 
 cbuffer PerGeometry : register(b2)
@@ -2064,6 +2066,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float3 projBaseColor = Color::ColorToLinear(Triplanar::SampleStochastic(TexProjDiffuseSampler, SampProjDiffuseSampler, projWorldPos, triWeights, diffuseNormalScale, screenNoise).xyz) * Color::ColorToLinear(ProjectedUVParams2.xyz);
 		projectedMaterialWeight = smoothstep(0, 1, 5 * (0.1 + projWeight));
 #			if defined(TRUE_PBR)
+		projBaseColor = max(0, projBaseColor.xyz * MaterialObjectRGBScale);
 		projBaseColor = max(0, EnvmapData.x * projBaseColor);
 		rawRMAOS.xyw = lerp(rawRMAOS.xyw, float3(ParallaxOccData.x, 0, ParallaxOccData.y), projectedMaterialWeight);
 		float4 projectedGlintParameters = 0;

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -803,6 +803,7 @@ namespace SIE
 				{ "LandscapeTexture4GlintParameters", lightingPSConstants.LandscapeTexture4GlintParameters },
 				{ "LandscapeTexture5GlintParameters", lightingPSConstants.LandscapeTexture5GlintParameters },
 				{ "LandscapeTexture6GlintParameters", lightingPSConstants.LandscapeTexture6GlintParameters },
+				{ "MaterialObjectRGBScale", lightingPSConstants.MaterialObjectRGBScale },
 			};
 
 			auto& bloodSplatterVS = result[static_cast<size_t>(RE::BSShader::Type::BloodSplatter)]

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -58,6 +58,7 @@ namespace ShaderConstants
 				.LandscapeTexture4GlintParameters = 55,
 				.LandscapeTexture5GlintParameters = 56,
 				.LandscapeTexture6GlintParameters = 57,
+				.MaterialObjectRGBScale = 58,	// RGB multipliers for material objects
 
 				.ShadowSampleParam = 18,
 				.EndSplitDistances = 19,
@@ -120,6 +121,8 @@ namespace ShaderConstants
 		const int32_t LandscapeTexture4GlintParameters = 47;
 		const int32_t LandscapeTexture5GlintParameters = 48;
 		const int32_t LandscapeTexture6GlintParameters = 49;
+
+		const int32_t MaterialObjectRGBScale = 50;  // RGB multipliers for material objects
 
 		const int32_t ShadowSampleParam = -1;
 		const int32_t EndSplitDistances = -1;

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -936,7 +936,7 @@ bool TruePBR::BSLightingShader_SetupMaterial(RE::BSLightingShader* shader, RE::B
 				PBRProjectedUVParams1[0] = pbrMaterial->GetProjectedMaterialBaseColorScale()[0];
 				PBRProjectedUVParams1[1] = pbrMaterial->GetProjectedMaterialBaseColorScale()[1];
 				PBRProjectedUVParams1[2] = pbrMaterial->GetProjectedMaterialBaseColorScale()[2];
-				shadowState->SetPSConstant(PBRProjectedUVParams1, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.EnvmapData);
+				shadowState->SetPSConstant(PBRProjectedUVParams1, RE::BSGraphics::ConstantGroupLevel::PerMaterial, lightingPSConstants.MaterialObjectRGBScale);
 
 				std::array<float, 4> PBRProjectedUVParams2;
 				PBRProjectedUVParams2[0] = pbrMaterial->GetProjectedMaterialRoughness();


### PR DESCRIPTION
Previously, MATO RGB slider values from the TruePBR section of the menu were being passed to Lighting.hlsl via the PS constant EnvmapData, which meant only R was valid, and G and B were either corrupting the intended use for those slots, or were lost entirely. 
This change creates a new dedicated PS constant specifically for the RGB slider scalars, which then is multiplied with the projected material color in the Lighting shader. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated material color scaling handling in physically-based rendering shader processing.
  * Enhanced material parameter management for RGB color scale application in projected UV material workflows.
  * Restructured shader constant indexing to support the new material scaling parameter across rendering pipeline.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2310)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->