### PR TITLE
fix(interior sun): volumetric shadows compatibility 

### DIFF
--- a/features/Interior Sun/Shaders/Features/InteriorSun.ini
+++ b/features/Interior Sun/Shaders/Features/InteriorSun.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-0-0
+Version = 1-0-1
 
 [Nexus]
 autoupload = false

--- a/features/Volumetric Shadows/Shaders/Features/VolumetricShadows.ini
+++ b/features/Volumetric Shadows/Shaders/Features/VolumetricShadows.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 2-0-0
+Version = 2-0-1
 
 [Nexus]
 autoupload = false

--- a/package/Shaders/Common/ShadowSampling.hlsli
+++ b/package/Shaders/Common/ShadowSampling.hlsli
@@ -46,7 +46,7 @@ namespace ShadowSampling
 
 	bool HasDirectionalShadows()
 	{
-		return !SharedData::InInterior || SharedData::InInteriorWithSun;
+		return SharedData::HasDirectionalShadows;
 	}
 
 	float GetWorldShadow(float3 positionWS, float3 offset, uint eyeIndex)

--- a/package/Shaders/Common/ShadowSampling.hlsli
+++ b/package/Shaders/Common/ShadowSampling.hlsli
@@ -44,6 +44,11 @@ namespace ShadowSampling
 	static const float3 LightingSampleNormal = float3(0, 0, 1);
 	static const float3 ImageBasedLightingNormal = float3(0, 0, -1);
 
+	bool HasDirectionalShadows()
+	{
+		return !SharedData::InInterior || SharedData::InInteriorWithSun;
+	}
+
 	float GetWorldShadow(float3 positionWS, float3 offset, uint eyeIndex)
 	{
 		if (SharedData::InInterior || SharedData::HideSky || SharedData::InMapMenu)
@@ -101,17 +106,26 @@ namespace ShadowSampling
 		worldShadow *= rcpSampleCount;
 
 #if defined(VOLUMETRIC_SHADOWS)
-		float vsmSurfaceShadow;
-		float shadow = VolumetricShadows::GetVSMShadow3D(startPosition, endPosition, noise, sampleCount, eyeIndex, vsmSurfaceShadow);
-		surfaceShadow *= vsmSurfaceShadow;
-		return worldShadow * shadow;
+		if (HasDirectionalShadows()) {
+			float vsmSurfaceShadow;
+			float shadow = VolumetricShadows::GetVSMShadow3D(startPosition, endPosition, noise, sampleCount, eyeIndex, vsmSurfaceShadow);
+			surfaceShadow *= vsmSurfaceShadow;
+			return worldShadow * shadow;
+		}
 #else
 		return worldShadow;
 #endif
+
+		return worldShadow;
 	}
 
 	float GetLightingShadow(float3 worldPosition, uint eyeIndex, out float detailedShadow)
 	{
+		if (!HasDirectionalShadows()) {
+			detailedShadow = 1.0;
+			return 1.0;
+		}
+
 #if defined(VOLUMETRIC_SHADOWS)
 		float shadow = VolumetricShadows::GetVSMShadow2D(worldPosition, eyeIndex, detailedShadow);
 		return shadow;

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -20,11 +20,13 @@ namespace SharedData
 		float Timer;
 		uint FrameCount;
 		uint FrameCountAlwaysActive;
-		bool InInterior;          // If the area lacks a directional shadow light e.g. the sun or moon
+		bool InInterior;          // If the current cell is an interior
+		bool InInteriorWithSun;   // Interior Sun has enabled directional lighting and shadows for this interior
 		bool InMapMenu;           // If the world/local map is open (note that the renderer is still deferred here)
 		bool HideSky;             // HideSky flag in WorldSpace, e.g. Blackreach
 		float MipBias;            // Offset to mip level for TAA sharpness
 		float WaterSystemHeight;  // TES::GetWaterHeight at eye-0 in camera-relative Z; -FLT_MAX when no water body found (VR only)
+		float3 pad0;
 		float4 AmbientSHR;
 		float4 AmbientSHG;
 		float4 AmbientSHB;

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -21,7 +21,7 @@ namespace SharedData
 		uint FrameCount;
 		uint FrameCountAlwaysActive;
 		bool InInterior;          // If the current cell is an interior
-		bool InInteriorWithSun;   // Interior Sun has enabled directional lighting and shadows for this interior
+		bool HasDirectionalShadows;
 		bool InMapMenu;           // If the world/local map is open (note that the renderer is still deferred here)
 		bool HideSky;             // HideSky flag in WorldSpace, e.g. Blackreach
 		float MipBias;            // Offset to mip level for TAA sharpness

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -563,7 +563,7 @@ float3 GetLightingColor(float3 msPosition, float3 worldPosition, float2 screenPo
 
 	const bool inWorld = (Permutation::ExtraShaderDescriptor & Permutation::ExtraFlags::InWorld);
 
-	if (inWorld && !SharedData::InInterior)
+	if (inWorld && ShadowSampling::HasDirectionalShadows())
 		dirShadow = ShadowSampling::Get3DFilteredShadow(worldPosition.xyz, viewDirection, screenPosition, eyeIndex, unusedSurfaceShadow);
 
 	shadowVariance = 1.0 - sqrt(saturate(fwidth(dirShadow)));

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2496,7 +2496,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float dirVSMDetailedShadow = 1.0;
 
 #	if defined(VOLUMETRIC_SHADOWS)
-	if (inWorld && !inReflection && !SharedData::InInterior)
+	if (inWorld && !inReflection && ShadowSampling::HasDirectionalShadows())
 		dirSoftShadow = ShadowSampling::GetLightingShadow(input.WorldPosition.xyz, eyeIndex, dirVSMDetailedShadow);
 #	endif
 

--- a/src/Features/InteriorSun.h
+++ b/src/Features/InteriorSun.h
@@ -97,6 +97,7 @@ public:
 	};
 
 	static bool IsInteriorWithSun(const RE::TESObjectCELL* cell);
+	bool IsActiveInteriorSun() const { return loaded && isInteriorWithSun.load(); }
 	virtual bool IsCore() const override { return true; };
 
 private:

--- a/src/Features/VolumetricShadows.cpp
+++ b/src/Features/VolumetricShadows.cpp
@@ -1,6 +1,5 @@
 #include "VolumetricShadows.h"
 
-#include "InteriorSun.h"
 #include "State.h"
 #include "Utils/D3D.h"
 
@@ -80,7 +79,7 @@ void VolumetricShadows::CopyShadowLightData()
 	auto context = globals::d3d::context;
 
 	{
-		if (Util::IsInterior() && !globals::features::interiorSun.IsActiveInteriorSun()) {
+		if (!globals::state->HasDirectionalShadows()) {
 			SetSharedShadowMapSRV(context, nullptr);
 			return;
 		}

--- a/src/Features/VolumetricShadows.cpp
+++ b/src/Features/VolumetricShadows.cpp
@@ -1,5 +1,6 @@
 #include "VolumetricShadows.h"
 
+#include "InteriorSun.h"
 #include "State.h"
 #include "Utils/D3D.h"
 
@@ -79,6 +80,11 @@ void VolumetricShadows::CopyShadowLightData()
 	auto context = globals::d3d::context;
 
 	{
+		if (Util::IsInterior() && !globals::features::interiorSun.IsActiveInteriorSun()) {
+			SetSharedShadowMapSRV(context, nullptr);
+			return;
+		}
+
 		context->PSGetShaderResources(4, 1, &shadowView);
 
 		// Downsample shadow texture array to fixed 512x512 (mip1: 256x256)
@@ -283,13 +289,18 @@ void VolumetricShadows::CopyShadowLightData()
 			}
 		}
 
-		ID3D11ShaderResourceView* srv = shadowView ? (shadowCopySRV ? shadowCopySRV : shadowView) : nullptr;
-		context->PSSetShaderResources(18, 1, &srv);
+		auto* srv = shadowView ? (shadowCopySRV ? shadowCopySRV : shadowView) : nullptr;
+		SetSharedShadowMapSRV(context, srv);
 
 		if (shadowView)
 			shadowView->Release();
 		shadowView = nullptr;
 	}
+}
+
+void VolumetricShadows::SetSharedShadowMapSRV(ID3D11DeviceContext* a_context, ID3D11ShaderResourceView* a_srv)
+{
+	a_context->PSSetShaderResources(kSharedShadowMapShaderSlot, 1, &a_srv);
 }
 
 void VolumetricShadows::DrawSettings()

--- a/src/Features/VolumetricShadows.h
+++ b/src/Features/VolumetricShadows.h
@@ -12,6 +12,8 @@ public:
 	virtual bool IsCore() const override { return true; }
 	virtual bool IsInMenu() const override { return true; }
 
+	static constexpr uint32_t kSharedShadowMapShaderSlot = 18;
+
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{
 		return {
@@ -67,4 +69,7 @@ public:
 	virtual bool SupportsVR() override { return true; }
 
 	virtual void PostPostLoad() override;
+
+private:
+	static void SetSharedShadowMapSRV(ID3D11DeviceContext* a_context, ID3D11ShaderResourceView* a_srv);
 };

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -963,7 +963,7 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 		}
 
 		data.InInterior = Util::IsInterior();
-		data.InInteriorWithSun = globals::features::interiorSun.IsActiveInteriorSun();
+		data.HasDirectionalShadows = HasDirectionalShadows();
 
 		if (globals::game::sky)
 			data.HideSky = globals::game::sky->flags.any(RE::Sky::Flags::kHideSky);
@@ -1082,6 +1082,11 @@ void State::LoadTheme()
 			logger::warn("Fallback to 'Default' theme failed");
 		}
 	}
+}
+
+bool State::HasDirectionalShadows() const
+{
+	return !Util::IsInterior() || globals::features::interiorSun.IsActiveInteriorSun();
 }
 
 void State::SaveTheme()

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -8,6 +8,7 @@
 #include "FeatureIssues.h"
 #include "Features/CloudShadows.h"
 #include "Features/HDRDisplay.h"
+#include "Features/InteriorSun.h"
 #include "Features/PerformanceOverlay.h"
 #include "Features/TerrainBlending.h"
 #include "Features/TerrainHelper.h"
@@ -962,6 +963,7 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 		}
 
 		data.InInterior = Util::IsInterior();
+		data.InInteriorWithSun = globals::features::interiorSun.IsActiveInteriorSun();
 
 		if (globals::game::sky)
 			data.HideSky = globals::game::sky->flags.any(RE::Sky::Flags::kHideSky);

--- a/src/State.h
+++ b/src/State.h
@@ -246,10 +246,12 @@ public:
 		uint FrameCount;
 		uint FrameCountAlwaysActive;
 		uint InInterior;
+		uint InInteriorWithSun;
 		uint InMapMenu;
 		uint HideSky;
 		float MipBias;
 		float WaterSystemHeight;  // TES::GetWaterHeight at eye-0 in camera-relative Z; -NI_INFINITY when no water body found (VR only)
+		float3 pad0;
 		float4 AmbientSHR;
 		float4 AmbientSHG;
 		float4 AmbientSHB;

--- a/src/State.h
+++ b/src/State.h
@@ -212,6 +212,7 @@ public:
 
 	void UpdateSharedData(bool a_inWorld, bool a_prepass);
 	void UpdateSkyShaderPermutation(RE::BSRenderPass* a_pass);
+	bool HasDirectionalShadows() const;
 
 	struct PermutationCB
 	{
@@ -246,7 +247,7 @@ public:
 		uint FrameCount;
 		uint FrameCountAlwaysActive;
 		uint InInterior;
-		uint InInteriorWithSun;
+		uint HasDirectionalShadows;
 		uint InMapMenu;
 		uint HideSky;
 		float MipBias;


### PR DESCRIPTION
Adds compatibility for interior sun and volumetric shadows. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interior sun reports active state to rendering for more consistent interior lighting

* **Improvements**
  * Directional shadow evaluation refined to respect current scene state (improves correctness)
  * Volumetric shadow processing is skipped when directional shadows are disabled to reduce work

* **Chores**
  * Bumped Interior Sun shader feature to v1-0-1
  * Bumped Volumetric Shadows shader feature to v2-0-1

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2319)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->