### PR TITLE
ci: fix Release: Hotfix Candidate PR step

### DIFF
--- a/.github/workflows/release-hotfix.yaml
+++ b/.github/workflows/release-hotfix.yaml
@@ -259,6 +259,10 @@ jobs:
               if: ${{ !inputs.dry_run && steps.cherry.outputs.picked_count != '0' }}
               env:
                   GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+                  # Pass via env (not ${{ }} interpolation) so the literal
+                  # backticks inside SOURCE_DESC don't get re-evaluated by
+                  # bash as command substitution.
+                  SOURCE_DESC: ${{ steps.cherry.outputs.source_desc }}
               run: |
                   set -euo pipefail
                   HOTFIX='${{ steps.plan.outputs.hotfix_branch }}'
@@ -272,7 +276,7 @@ jobs:
                   {
                     echo "Automated hotfix candidate built off \`${BASE}\`."
                     echo ""
-                    echo "- **${PICKED}** commit(s) cherry-picked from \`dev\` (${{ steps.cherry.outputs.source_desc }})"
+                    echo "- **${PICKED}** commit(s) cherry-picked from \`dev\` (${SOURCE_DESC})"
                     [[ "${DEDUP}" != "0" ]] && echo "- ${DEDUP} already applied to \`${HOTFIX}\` (skipped, see below)"
                     [[ "${SKIPPED_BREAKING}" != "0" ]] && echo "- ${SKIPPED_BREAKING} breaking change(s) skipped (see below)"
                     [[ "${CONFLICTS}" != "0" ]] && echo "- ⚠️ **${CONFLICTS}** commit(s) failed to cherry-pick (see below)"
@@ -307,6 +311,13 @@ jobs:
                     echo ""
                     echo "See: [Hotfix Release Process](https://github.com/${{ github.repository }}/wiki/Developers#hotfix-release-process)"
                   } > /tmp/pr-body.md
+
+                  # Best-effort: ensure the hotfix label exists so --label
+                  # doesn't fail the workflow on repos that haven't created it.
+                  gh label create hotfix \
+                    --repo '${{ github.repository }}' \
+                    --color ededed \
+                    --description "Hotfix candidate" 2>/dev/null || true
 
                   gh pr create \
                     --repo '${{ github.repository }}' \


### PR DESCRIPTION
Two bugs surfaced by [run 25649556508](https://github.com/community-shaders/skyrim-community-shaders/actions/runs/25649556508):

1. **Backtick command-substitution in PR body.** `source_desc` (set on line 175) contains literal backticks. When inlined via `${{ steps.cherry.outputs.source_desc }}` into the bash heredoc on line 275, bash interprets them as command substitution — `fix-only: command not found`, `v1.5.1: command not found`. Fix: pass via step `env:` so the value reaches bash as a normal variable expansion that doesn't re-evaluate the contents.

2. **Missing `hotfix` label.** `gh pr create --label hotfix` failed with `could not add label: 'hotfix' not found`. Fix: best-effort `gh label create hotfix` before `gh pr create`, swallowing the error if the label already exists.

Both fixes are scoped to the failing step. No behavior change beyond unblocking the candidate PR open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the hotfix release workflow with enhanced environment variable handling during pull request creation to ensure consistent and proper text formatting in PR descriptions.
  * Added automatic hotfix label creation and management to the release workflow, ensuring the required label exists on target repositories before PR creation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2324)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->