### PR TITLE
fix(ll): adjust default and fix non hdr gamma

### DIFF
--- a/package/Shaders/ISHDR.hlsl
+++ b/package/Shaders/ISHDR.hlsl
@@ -216,6 +216,8 @@ PS_OUTPUT main(PS_INPUT input)
 			outputColor = Color::LinearToGammaSafe(outputColor);
 	} else {
 		outputColor = max(0, outputColor);
+		if (ENABLE_LL)
+			outputColor = Color::LinearToGammaSafe(outputColor);
 		outputColor = FrameBuffer::ToSRGBColor(outputColor);
 	}
 

--- a/src/Features/LinearLighting.h
+++ b/src/Features/LinearLighting.h
@@ -41,12 +41,12 @@ struct LinearLighting : Feature
 		float vlGamma = 1.8f;
 
 		// Lighting multipliers
-		float vanillaDiffuseColorMult = 1.5f;
+		float vanillaDiffuseColorMult = 1.0f;
 		float directionalLightMult = 1.0f;
 		float pointLightMult = 1.0f;
-		float ambientMult = 0.67f;
+		float ambientMult = 1.0f;
 		float emitColorMult = 1.0f;
-		float glowmapMult = 0.5f;
+		float glowmapMult = 0.66f;
 
 		// Effect multipliers
 		float effectLightingMult = 0.32f;


### PR DESCRIPTION
This pull request introduces adjustments to the Linear Lighting feature's multipliers and corrects color space conversion handling in the shader pipeline. These changes aim to improve lighting accuracy and ensure proper color output when linear lighting is enabled.

**Linear Lighting configuration adjustments:**
- Set `vanillaDiffuseColorMult` to 1.0 (was 1.5), reducing diffuse color intensity for more accurate lighting.
- Set `ambientMult` to 1.0 (was 0.67), increasing ambient light contribution.
- Set `glowmapMult` to 0.66 (was 0.5), increasing the glowmap effect.

**Shader pipeline improvements:**
- In `PS_OUTPUT main(PS_INPUT input)` in `ISHDR.hlsl`, added a conditional step to apply `Color::LinearToGammaSafe` conversion when `ENABLE_LL` is enabled, ensuring correct gamma correction for linear lighting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected color conversion behavior in HDR rendering output to properly apply gamma correction based on lighting settings status.

* **Improvements**
  * Fine-tuned linear lighting system multiplier values affecting diffuse color, ambient brightness, and glow contributions to enhance overall visual rendering quality and lighting accuracy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2325)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->