### PR TITLE
ci: use GITHUB_TOKEN to create hotfix candidate PR

### DIFF
--- a/.github/workflows/release-hotfix.yaml
+++ b/.github/workflows/release-hotfix.yaml
@@ -258,7 +258,15 @@ jobs:
             - name: Open PR against hotfix branch
               if: ${{ !inputs.dry_run && steps.cherry.outputs.picked_count != '0' }}
               env:
-                  GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+                  # Use GITHUB_TOKEN (not RELEASE_PAT). The workflow declares
+                  # `permissions: pull-requests: write`, which is sufficient
+                  # for creating the candidate PR — no branch-protection
+                  # bypass is required here, so there's no need to spend
+                  # RELEASE_PAT's broader scope (and avoids depending on the
+                  # PAT having pull_requests:write granted, which a previous
+                  # run hit: "Resource not accessible by personal access
+                  # token (createPullRequest)").
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   # Pass via env (not ${{ }} interpolation) so the literal
                   # backticks inside SOURCE_DESC don't get re-evaluated by
                   # bash as command substitution.


### PR DESCRIPTION
[Run 25715374303](https://github.com/community-shaders/skyrim-community-shaders/actions/runs/25715374303) failed at *Open PR against hotfix branch* with:

```
pull request create failed: GraphQL: Resource not accessible by personal access token (createPullRequest)
```

The step was using `RELEASE_PAT`, which apparently lacks `pull_requests: write` on this repo. Rather than expand the PAT's scope, switch this single step to `GITHUB_TOKEN` — the workflow already declares:

```yaml
permissions:
    contents: write
    pull-requests: write
```

so `GITHUB_TOKEN` has exactly the scope needed for `gh pr create`.

`RELEASE_PAT` is intentionally left in place on the two steps that genuinely need it:
- *Push maintenance branch (if new) and staging branch* — needs to bypass branch protection on `hotfix/X.Y.x`, which `GITHUB_TOKEN` cannot do.
- *Close superseded staging PRs and branches* — succeeded in run 25715374303 with the PAT, so leaving it untouched.

Minimal change, scoped to the failing step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved hotfix release workflow reliability by updating token configuration and documentation. This prevents workflow failures related to authentication permissions during the PR creation step.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2327)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->