### PR TITLE
fix(dynamic cubemap): blend native cubemap fallback

### DIFF
--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/InferCubemapCS.hlsl
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/InferCubemapCS.hlsl
@@ -90,7 +90,8 @@ float3 GetSamplingVector(uint3 ThreadID, in RWTexture2DArray<float4> OutputTextu
 	}
 
 #if defined(REFLECTIONS)
-	color.rgb = lerp(color.rgb, Color::IrradianceToLinear(ReflectionsTexture.SampleLevel(LinearSampler, uv, 0.0).rgb), saturate(mipLevel / 7.0));
+	float fallbackWeight = saturate(mipLevel / 7.0) * SharedData::cubemapCreatorSettings.ReflectionFallbackAmount;
+	color.rgb = lerp(color.rgb, Color::IrradianceToLinear(ReflectionsTexture.SampleLevel(LinearSampler, uv, 0.0).rgb), fallbackWeight);
 #else
 	color.rgb = lerp(color.rgb, color.rgb * DefaultCubemap.SampleLevel(LinearSampler, uv, 0.0).xyz, saturate(mipLevel / 7.0));
 #endif

--- a/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
+++ b/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 2-3-1
+Version = 2-3-2
 
 [Nexus]
 autoupload = false

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -58,9 +58,13 @@ namespace SharedData
 	struct CubemapCreatorSettings
 	{
 		uint Enabled;
-		float3 pad0;
+		uint EnabledSSR;
+		float2 pad0;
 
 		float4 CubemapColor;
+
+		float ReflectionFallbackAmount;
+		float3 pad1;
 	};
 
 	struct TerraOccSettings

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -12,7 +12,8 @@ constexpr auto MIPLEVELS = 8;
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	DynamicCubemaps::Settings,
 	EnabledSSR,
-	EnabledCreator);
+	EnabledCreator,
+	ReflectionFallbackAmount);
 
 std::vector<std::pair<std::string_view, std::string_view>> DynamicCubemaps::GetShaderDefineOptions()
 {
@@ -26,6 +27,11 @@ std::vector<std::pair<std::string_view, std::string_view>> DynamicCubemaps::GetS
 
 void DynamicCubemaps::DrawSettings()
 {
+	ImGui::SliderFloat("Native Cubemap Fallback", &settings.ReflectionFallbackAmount, kReflectionFallbackMin, kReflectionFallbackMax, "%.2f", ImGuiSliderFlags_AlwaysClamp);
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text("Controls how much the game's reflection cubemap fills missing dynamic reflection directions.");
+	}
+
 	if (ImGui::TreeNodeEx("Screen Space Reflections", ImGuiTreeNodeFlags_DefaultOpen)) {
 		recompileFlag |= ImGui::Checkbox("Enable Screen Space Reflections", reinterpret_cast<bool*>(&settings.EnabledSSR));
 		if (auto _tt = Util::HoverTooltipWrapper()) {
@@ -131,6 +137,7 @@ void DynamicCubemaps::DrawSettings()
 void DynamicCubemaps::LoadSettings(json& o_json)
 {
 	settings = o_json;
+	settings.ReflectionFallbackAmount = std::clamp(settings.ReflectionFallbackAmount, kReflectionFallbackMin, kReflectionFallbackMax);
 	if (REL::Module::IsVR()) {
 		Util::LoadGameSettings(iniVRCubeMapSettings);
 	}

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -27,9 +27,12 @@ std::vector<std::pair<std::string_view, std::string_view>> DynamicCubemaps::GetS
 
 void DynamicCubemaps::DrawSettings()
 {
-	ImGui::SliderFloat("Native Cubemap Fallback", &settings.ReflectionFallbackAmount, kReflectionFallbackMin, kReflectionFallbackMax, "%.2f", ImGuiSliderFlags_AlwaysClamp);
-	if (auto _tt = Util::HoverTooltipWrapper()) {
-		ImGui::Text("Controls how much the game's reflection cubemap fills missing dynamic reflection directions.");
+	if (ImGui::TreeNodeEx("Native Cubemap Fallback", ImGuiTreeNodeFlags_DefaultOpen)) {
+		ImGui::SliderFloat("Fallback Amount", &settings.ReflectionFallbackAmount, kReflectionFallbackMin, kReflectionFallbackMax, "%.2f", ImGuiSliderFlags_AlwaysClamp);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Controls how much the game's reflection cubemap fills missing dynamic reflection directions.");
+		}
+		ImGui::TreePop();
 	}
 
 	if (ImGui::TreeNodeEx("Screen Space Reflections", ImGuiTreeNodeFlags_DefaultOpen)) {

--- a/src/Features/DynamicCubemaps.h
+++ b/src/Features/DynamicCubemaps.h
@@ -12,6 +12,10 @@ public:
 struct DynamicCubemaps : Feature
 {
 public:
+	static constexpr float kReflectionFallbackMin = 0.0f;
+	static constexpr float kReflectionFallbackMax = 1.0f;
+	static constexpr float kReflectionFallbackDefault = 0.5f;
+
 	const std::string defaultDynamicCubeMapSavePath = "Data\\textures\\DynamicCubemaps";
 
 	// Specular irradiance
@@ -116,7 +120,10 @@ public:
 		uint EnabledSSR = true;
 		uint pad0[2];
 		float4 CubemapColor{ 1.0f, 1.0f, 1.0f, 0.0f };
+		float ReflectionFallbackAmount = kReflectionFallbackDefault;
+		float pad1[3];
 	};
+	STATIC_ASSERT_ALIGNAS_16(Settings);
 
 	Settings settings;
 	bool enabledAtBoot = false;


### PR DESCRIPTION
Blends native cubemap fallback in dynamic cubemap reflections %50 and adds a slider in the UI. 

Before (player is under shaded area):
<img width="1920" height="1080" alt="Skyrim Special Edition 5_11_2026 9_36_47 PM" src="https://github.com/user-attachments/assets/201cacdc-e660-4f16-bff0-a654725e8c18" />

After (player is under shaded area):
<img width="1920" height="1080" alt="Skyrim Special Edition 5_11_2026 11_33_48 PM" src="https://github.com/user-attachments/assets/f054b5d5-a218-4d2b-bbd5-5e95309377c7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Native Cubemap Fallback" slider (with tooltip) to control blending of inferred and sampled reflections; value is clamped and applied at runtime.
  * Added an option to enable/disable screen-space reflections (SSR) in the Dynamic Cubemaps settings.

* **Chores**
  * Bumped shader feature version.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2328)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->