### PR TITLE
feat(truepbr): add vertex ambient occlusion slider

### DIFF
--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -20,7 +20,7 @@ namespace SharedData
 		float Timer;
 		uint FrameCount;
 		uint FrameCountAlwaysActive;
-		bool InInterior;          // If the current cell is an interior
+		bool InInterior;  // If the current cell is an interior
 		bool HasDirectionalShadows;
 		bool InMapMenu;           // If the world/local map is open (note that the renderer is still deferred here)
 		bool HideSky;             // HideSky flag in WorldSpace, e.g. Blackreach
@@ -269,6 +269,12 @@ namespace SharedData
 		float3 pad;
 	};
 
+	struct TruePBRSettings
+	{
+		uint DisableVertexAO;
+		uint3 pad;
+	};
+
 	cbuffer FeatureData : register(b6)
 	{
 		GrassLightingSettings grassLightingSettings;
@@ -287,6 +293,7 @@ namespace SharedData
 		LinearLightingSettings linearLightingSettings;
 		TerrainBlendingSettings terrainBlendingSettings;
 		ExponentialHeightFogSettings exponentialHeightFogSettings;
+		TruePBRSettings truePBRSettings;
 	};
 
 	Texture2D<float4> DepthTexture : register(t17);

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -271,7 +271,7 @@ namespace SharedData
 
 	struct TruePBRSettings
 	{
-		uint DisableVertexAO;
+		float VertexAOStrength;
 		uint3 pad;
 	};
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2891,8 +2891,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float3 vertexColor = input.Color.xyz;
 	float vertexAO = max(max(vertexColor.r, vertexColor.g), vertexColor.b);
 #		if defined(TRUE_PBR)
-	if (SharedData::truePBRSettings.DisableVertexAO)
-		vertexAO = 1;
+	vertexAO = lerp(1, vertexAO, SharedData::truePBRSettings.VertexAOStrength);
 	vertexColor = 1;
 #		endif
 	// Modify skylightingDiffuse such that skylightingDiffuse * vertexAO = min(skylightingDiffuse, vertexAO)

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2156,6 +2156,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	// Apply vertex color to base color so PBR metals use it
 	float3 pbrVertexColor = Color::SrgbToLinear(input.Color.xyz);
+	float pbrVertexAO = max(max(pbrVertexColor.x, pbrVertexColor.y), pbrVertexColor.z);
+	pbrVertexColor *= lerp(max(1 / pbrVertexAO, 0.001), 1, SharedData::truePBRSettings.VertexAOStrength);
 
 	if (!SharedData::linearLightingSettings.enableLinearLighting) {
 		baseColor.xyz = Color::SrgbToLinear(baseColor.xyz) * pbrVertexColor;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2890,11 +2890,13 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #	elif defined(SKYLIGHTING)
 	float3 vertexColor = input.Color.xyz;
 	float vertexAO = max(max(vertexColor.r, vertexColor.g), vertexColor.b);
-	// Modify skylightingDiffuse such that skylightingDiffuse * vertexAO = min(skylightingDiffuse, vertexAO)
-	skylightingDiffuse = saturate(skylightingDiffuse / max(vertexAO, 1e-5));
 #		if defined(TRUE_PBR)
+	if (SharedData::truePBRSettings.DisableVertexAO)
+		vertexAO = 1;
 	vertexColor = 1;
 #		endif
+	// Modify skylightingDiffuse such that skylightingDiffuse * vertexAO = min(skylightingDiffuse, vertexAO)
+	skylightingDiffuse = saturate(skylightingDiffuse / max(vertexAO, 1e-5));
 #	else
 #		if defined(TRUE_PBR)
 	float3 vertexColor = 1;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2156,7 +2156,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	// Apply vertex color to base color so PBR metals use it
 	float3 pbrVertexColor = Color::SrgbToLinear(input.Color.xyz);
 	float pbrVertexAO = max(max(pbrVertexColor.x, pbrVertexColor.y), pbrVertexColor.z);
-	pbrVertexColor *= lerp(max(1 / pbrVertexAO, 0.001), 1, SharedData::truePBRSettings.VertexAOStrength);
+	pbrVertexColor = pbrVertexAO == 0.0f ? 1.0f : pbrVertexColor * lerp(1 / max(pbrVertexAO, 0.001), 1, SharedData::truePBRSettings.VertexAOStrength);
 
 	if (!SharedData::linearLightingSettings.enableLinearLighting) {
 		baseColor.xyz = Color::SrgbToLinear(baseColor.xyz) * pbrVertexColor;
@@ -2816,17 +2816,19 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float3 glowColor = Color::Glowmap(TexGlowSampler.Sample(SampGlowSampler, uv).xyz);
 
 #		if defined(TRUE_PBR)
-		float3 vertexColor = Color::SrgbToLinear(input.Color.xyz);
+		float3 emitVertexColor = Color::SrgbToLinear(input.Color.xyz);
+		float emitVertexAO = max(max(emitVertexColor.r, emitVertexColor.g), emitVertexColor.b);
+		emitVertexColor = emitVertexAO == 0.0f ? 1.0f : emitVertexColor * lerp(1 / max(emitVertexAO, 1e-4), 1, SharedData::truePBRSettings.VertexAOStrength);
 
 		if (!SharedData::linearLightingSettings.enableLinearLighting) {
 			emitColor = Color::SrgbToLinear(emitColor);
 			glowColor = Color::SrgbToLinear(glowColor);
 			emitColor *= glowColor;
-			emitColor *= vertexColor;
+			emitColor *= emitVertexColor;
 			emitColor = Color::LinearToSrgb(emitColor);
 		} else {
 			emitColor *= glowColor;
-			emitColor *= vertexColor;
+			emitColor *= emitVertexColor;
 		}
 #		else
 		if (!SharedData::linearLightingSettings.enableLinearLighting) {

--- a/src/FeatureBuffer.cpp
+++ b/src/FeatureBuffer.cpp
@@ -16,6 +16,7 @@
 #include "Features/TerrainShadows.h"
 #include "Features/TerrainVariation.h"
 #include "Features/WetnessEffects.h"
+#include "TruePBR.h"
 
 template <class... Ts>
 std::pair<unsigned char*, size_t> _GetFeatureBufferData(Ts... feat_datas)
@@ -51,5 +52,6 @@ std::pair<unsigned char*, size_t> GetFeatureBufferData(bool a_inWorld)
 		globals::features::extendedTranslucency.GetCommonBufferData(),
 		globals::features::linearLighting.GetCommonBufferData(),
 		globals::features::terrainBlending.settings,
-		globals::features::exponentialHeightFog.settings);
+		globals::features::exponentialHeightFog.settings,
+		globals::features::truePBR.settings);
 }

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -40,6 +40,10 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	specularLevel,
 	glintParameters);
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+	TruePBR::Settings,
+	DisableVertexAO);
+
 #define CHECK_PBR_TEXTURE(textureName)                                                                         \
 	if (!(pbrMaterial->textureName)) {                                                                         \
 		logger::warn("[TruePBR] {} missing {}; treating as nonPBR", pbrMaterial->inputFilePath, #textureName); \
@@ -106,6 +110,11 @@ void SetupPBRLandscapeTextureParameters(BSLightingShaderMaterialPBRLandscape& ma
 
 void TruePBR::DrawSettings()
 {
+	if (ImGui::TreeNodeEx("Global Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
+		ImGui::Checkbox("Disable Vertex AO", (bool*)&settings.DisableVertexAO);
+		ImGui::TreePop();
+	}
+
 	if (ImGui::TreeNodeEx("Texture Set Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
 		if (Util::SearchableCombo("Texture Set", selectedPbrTextureSetName, pbrTextureSets)) {
 			selectedPbrTextureSet = &pbrTextureSets[selectedPbrTextureSetName];
@@ -298,6 +307,21 @@ void TruePBR::DrawSettings()
 		}
 		ImGui::TreePop();
 	}
+}
+
+void TruePBR::SaveSettings(json& o_json)
+{
+	o_json = settings;
+}
+
+void TruePBR::LoadSettings(json& o_json)
+{
+	settings = o_json;
+}
+
+void TruePBR::RestoreDefaultSettings()
+{
+	settings = {};
 }
 
 void TruePBR::SetupResources()

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -42,7 +42,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	TruePBR::Settings,
-	DisableVertexAO);
+	VertexAOStrength);
 
 #define CHECK_PBR_TEXTURE(textureName)                                                                         \
 	if (!(pbrMaterial->textureName)) {                                                                         \
@@ -111,7 +111,7 @@ void SetupPBRLandscapeTextureParameters(BSLightingShaderMaterialPBRLandscape& ma
 void TruePBR::DrawSettings()
 {
 	if (ImGui::TreeNodeEx("Global Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
-		ImGui::Checkbox("Disable Vertex AO", (bool*)&settings.DisableVertexAO);
+		ImGui::SliderFloat("Vertex AO Strength", &settings.VertexAOStrength, 0.f, 1.f, "%.2f");
 		ImGui::TreePop();
 	}
 

--- a/src/TruePBR.cpp
+++ b/src/TruePBR.cpp
@@ -111,7 +111,7 @@ void SetupPBRLandscapeTextureParameters(BSLightingShaderMaterialPBRLandscape& ma
 void TruePBR::DrawSettings()
 {
 	if (ImGui::TreeNodeEx("Global Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
-		ImGui::SliderFloat("Vertex AO Strength", &settings.VertexAOStrength, 0.f, 1.f, "%.2f");
+		ImGui::SliderFloat("Vertex AO Strength", &settings.VertexAOStrength, 0.f, 1.f, "%.2f", ImGuiSliderFlags_AlwaysClamp);
 		ImGui::TreePop();
 	}
 

--- a/src/TruePBR.h
+++ b/src/TruePBR.h
@@ -42,6 +42,19 @@ public:
 	virtual void Prepass() override;
 	virtual void PostPostLoad() override;
 	virtual void DataLoaded() override;
+
+	virtual void SaveSettings(json& o_json) override;
+	virtual void LoadSettings(json& o_json) override;
+	virtual void RestoreDefaultSettings() override;
+
+	struct alignas(16) Settings
+	{
+		uint DisableVertexAO = false;
+		uint pad[3];
+	};
+	STATIC_ASSERT_ALIGNAS_16(Settings);
+
+	Settings settings;
 	bool TESObjectLAND_SetupMaterial(RE::TESObjectLAND* land);
 	bool BSLightingShader_SetupMaterial(RE::BSLightingShader* shader, RE::BSLightingShaderMaterialBase const* material);
 

--- a/src/TruePBR.h
+++ b/src/TruePBR.h
@@ -49,7 +49,7 @@ public:
 
 	struct alignas(16) Settings
 	{
-		uint DisableVertexAO = false;
+		float VertexAOStrength = 1.0f;
 		uint pad[3];
 	};
 	STATIC_ASSERT_ALIGNAS_16(Settings);


### PR DESCRIPTION
This pull request introduces a configurable Vertex Ambient Occlusion (AO) strength parameter for the TruePBR rendering system, making AO blending more flexible and user-tunable. The main changes include adding a new `VertexAOStrength` setting, updating the shader and UI to use this parameter, and implementing serialization for the new setting.

**TruePBR Settings Enhancements:**

* Added a new `VertexAOStrength` parameter to `TruePBR::Settings`, exposed in the UI via an ImGui slider, allowing users to control the influence of vertex AO in the shader. [[1]](diffhunk://#diff-86936322985a16dce95379f8c7072011c1f2a8505bece2f4ba649828d01cd523R45-R57) [[2]](diffhunk://#diff-f51af4afd7c2296d788ec18ec676a6f85b07c6d2dd2d786185fc2729267e02adR113-R117)
* Implemented serialization and deserialization methods (`SaveSettings`, `LoadSettings`, `RestoreDefaultSettings`) for `TruePBR::Settings` to support saving/loading user preferences. [[1]](diffhunk://#diff-f51af4afd7c2296d788ec18ec676a6f85b07c6d2dd2d786185fc2729267e02adR312-R326) [[2]](diffhunk://#diff-86936322985a16dce95379f8c7072011c1f2a8505bece2f4ba649828d01cd523R45-R57)
* Registered the new setting with the feature buffer and JSON serialization system, ensuring it is included in configuration files and GPU constant buffers. [[1]](diffhunk://#diff-39e7c4f8e7de1d3e73dfc13cf8ea3ca9546b8b0fd699e232728e266ce161c4c7R19) [[2]](diffhunk://#diff-39e7c4f8e7de1d3e73dfc13cf8ea3ca9546b8b0fd699e232728e266ce161c4c7L54-R56) [[3]](diffhunk://#diff-f51af4afd7c2296d788ec18ec676a6f85b07c6d2dd2d786185fc2729267e02adR43-R46)

**Shader Integration:**

* Defined a new `TruePBRSettings` struct in `SharedData.hlsli` and added it to the `FeatureData` constant buffer, making `VertexAOStrength` available to shaders. [[1]](diffhunk://#diff-812c99694216d6c71752b796f8804075cf5652d1f32787207a1ff33e0f173c1eR272-R277) [[2]](diffhunk://#diff-812c99694216d6c71752b796f8804075cf5652d1f32787207a1ff33e0f173c1eR296)
* Updated the skylighting code path in `Lighting.hlsl` to blend vertex AO using the new `VertexAOStrength` parameter, providing finer control over AO application in TruePBR mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global "Vertex AO Strength" slider with save/load/restore defaults in the UI.

* **Visual / Lighting**
  * Vertex ambient occlusion now respects the Vertex AO Strength, affecting vertex-color remapping, skylighting diffuse response, and emissive scaling for more controllable vertex-based shading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2329)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->