### PR TITLE
fix(upscaling): preserve D3D12 proxy swap chain

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -133,7 +133,12 @@ HRESULT WINAPI hk_D3D11CreateDeviceAndSwapChainUpscaling(
 
 			if (upscaling.IsBackendInitialized()) {
 				upscaling.UpgradeBackendInterface((void**)&(*ppDevice));
-				upscaling.UpgradeBackendInterface((void**)&(*ppSwapChain));
+				// Don't wrap the swap chain with Streamline when using the D3D12
+				// proxy.  The proxy's GetDevice() returns the D3D11 device for
+				// IID_ID3D11Device, which other SKSE plugins (e.g. SkyrimPlatform)
+				// rely on.  Streamline's wrapper would bypass this override and
+				// forward to the underlying D3D12 swap chain, causing
+				// E_NOINTERFACE.  The proxy must remain the outermost layer.
 				upscaling.SetBackendD3DDevice(*ppDevice);
 				// Some features (notably Reflex/PCL) may report availability only after device bind.
 				upscaling.CheckBackendFeatures(pAdapter);

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -313,8 +313,10 @@ struct IDXGISwapChain_Present
 		// OMGetRenderTargets to find a target to render overlays into. Without this, they
 		// get nullptr (we unbound everything for the ApplyHDR resource hazard) and their
 		// UI elements are invisible.
-		if (hdrReady && !frameGenActive) {
-			hdr->ClearUIBuffer();  // restores kFRAMEBUFFER.RTV to original backbuffer RTV
+		if (hdrReady) {
+			if (!frameGenActive) {
+				hdr->ClearUIBuffer();  // restores kFRAMEBUFFER.RTV to original backbuffer RTV
+			}
 			auto& data = globals::game::renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGET::kFRAMEBUFFER];
 			globals::d3d::context->OMSetRenderTargets(1, &data.RTV, nullptr);
 		}


### PR DESCRIPTION
This helps with some scenarios where the chain can break and turn into a black screen.
Also helps with an specific issue at SkyMP where a server renders floating nicknames by directly hooking into the chain, making them invisible when CS is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed swap chain handling when frame generation uses D3D12 proxy path to prevent interface compatibility issues.

* **Refactor**
  * Improved conditional structure for HDR UI buffer operations to enhance code clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2335)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->