### PR TITLE
fix(ci): accept VS installer reboot-required exit code

### DIFF
--- a/.github/actions/setup-build-environment/action.yaml
+++ b/.github/actions/setup-build-environment/action.yaml
@@ -40,8 +40,12 @@ runs:
                   "--add", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64", `
                   "--add", "Microsoft.VisualStudio.Component.Windows11SDK.26100" `
                   -Wait -NoNewWindow -PassThru
-              if ($proc.ExitCode -ne 0) {
+              $successExitCodes = @(0, 3010) # 3010 = ERROR_SUCCESS_REBOOT_REQUIRED
+              if ($successExitCodes -notcontains $proc.ExitCode) {
                   throw "Visual Studio Build Tools installer failed with exit code $($proc.ExitCode)."
+              }
+              if ($proc.ExitCode -eq 3010) {
+                  Write-Warning "Visual Studio Build Tools installer requested a reboot; continuing on GitHub runner."
               }
               Remove-Item $installerPath -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
This pull request improves the robustness of the Visual Studio Build Tools installation step in the GitHub Actions build environment. It now correctly handles cases where the installer requests a reboot, ensuring that the CI process does not fail unnecessarily.

Error handling and installer feedback:

* Updated the PowerShell script in `.github/actions/setup-build-environment/action.yaml` to treat both exit codes `0` (success) and `3010` (success with reboot required) as successful installations, and to log a warning if a reboot is requested rather than failing the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build environment setup to handle system reboot scenarios gracefully. The setup process now treats reboot-required conditions as successful outcomes with warnings, rather than failures, increasing build reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2337)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->