### PR TITLE
ci: fix shader unit test

### DIFF
--- a/tests/shaders/CMakeLists.txt
+++ b/tests/shaders/CMakeLists.txt
@@ -67,9 +67,13 @@ set_property(TARGET shader_tests PROPERTY CXX_STANDARD 23)
 set_property(TARGET shader_tests PROPERTY CXX_STANDARD_REQUIRED ON)
 
 if(MSVC)
-    # Suppress C4864 in tuplet (via ShaderTestFramework) for VS 2026 migration
     if(TARGET ShaderTestFramework)
+        # Suppress C4864 in tuplet (via ShaderTestFramework) for VS 2026 migration
         target_compile_options(ShaderTestFramework PUBLIC /wd4864)
+        # Suppress C5285 in float16_fetch (via ShaderTestFramework) - MSVC 14.51+ forbids
+        # specializing std::is_floating_point_v/is_arithmetic_v/is_signed_v per N5014,
+        # but float16_t.hpp needs these specializations for its float16_t type.
+        target_compile_options(ShaderTestFramework PUBLIC /wd5285)
     endif()
 endif()
 


### PR DESCRIPTION
This pull request updates the MSVC compiler warning suppression settings for the `ShaderTestFramework` target in the shader tests CMake configuration. The main change is the addition of a new warning suppression to handle compatibility with recent MSVC versions.

**Build system updates for MSVC compatibility:**

* Added suppression of warning C5285 for `ShaderTestFramework` to address issues with specializing certain standard type traits (`std::is_floating_point_v`, etc.) in `float16_t.hpp`, as required by MSVC 14.51+ and per C++ standard changes (N5014).
* Retained suppression of warning C4864 for `ShaderTestFramework` to support ongoing migration to Visual Studio 2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated shader unit test build configuration for Windows/MSVC environments to improve compiler warning handling and build stability.

* **Chores**
  * Refined build settings for shader testing framework to better support Windows development environments and ensure consistent compilation across MSVC versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2341)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->