### PR TITLE
fix(ll): reduce sky dither noise

### DIFF
--- a/package/Shaders/Sky.hlsl
+++ b/package/Shaders/Sky.hlsl
@@ -253,12 +253,13 @@ PS_OUTPUT main(PS_INPUT input)
 		TexNoiseGradSampler.Sample(SampNoiseGradSampler, noiseGradUv).x * 0.03125 + -0.0078125;
 
 #			ifdef TEX
-	float3 sunGlareColor = Color::Sky(input.Color.xyz) * baseColor.xyz;
+	float3 skyVertColor = ENABLE_LL ? (input.Color.xyz + noiseGrad) : input.Color.xyz;
+	float3 sunGlareColor = Color::Sky(skyVertColor) * baseColor.xyz;
 	// Dither/noise term is the legacy sky path contribution for gradient smoothing.
-	psout.Color.xyz = (sunGlareColor + skyScale) + noiseGrad;
+	psout.Color.xyz = (sunGlareColor + skyScale) + (ENABLE_LL ? 0.0 : noiseGrad);
 	psout.Color.w = baseColor.w * input.Color.w;
 #			else
-	psout.Color.xyz = (skyScale + Color::Sky(input.Color.xyz)) + noiseGrad;
+	psout.Color.xyz = skyScale + Color::Sky(input.Color.xyz + noiseGrad);
 	psout.Color.w = input.Color.w;
 #			endif  // TEX
 


### PR DESCRIPTION
This pull request updates the sky rendering logic in `Sky.hlsl` to improve how noise and color blending are handled, especially in relation to the `ENABLE_LL` flag. The changes refine how noise gradients are applied and how vertex colors are computed for more accurate and flexible sky shading.

**Sky rendering improvements:**

* The calculation of the vertex color now conditionally adds the `noiseGrad` value to `input.Color.xyz` only if `ENABLE_LL` is true, allowing for more control over color blending in different rendering modes.
* The addition of the noise gradient to the output color is now also conditional on `ENABLE_LL`, ensuring that noise is only applied when appropriate.
* When the `TEX` flag is not defined, the noise gradient is now added directly to the input color before calling `Color::Sky`, changing the order of operations for improved gradient smoothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced sky rendering visual quality through refined dithering effects in certain rendering scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2342)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->