### PR TITLE
fix(foliage): flip foliage normal and fix sss

### DIFF
--- a/package/Shaders/Common/PBR.hlsli
+++ b/package/Shaders/Common/PBR.hlsli
@@ -172,6 +172,7 @@ namespace PBR
 			}
 
 			[branch] if ((PBRFlags & Flags::Subsurface) != 0)
+#	if !defined(TREE_ANIM)
 			{
 				const float subsurfacePower = 12.234;
 				float forwardScatter = exp2(saturate(-VdotL) * subsurfacePower - subsurfacePower);
@@ -179,6 +180,12 @@ namespace PBR
 				float subsurface = lerp(backScatter, 1, forwardScatter) * (1.0 - material.Thickness);
 				lightingOutput.transmission += material.SubsurfaceColor * subsurface * softLightColor * BRDF::Diffuse_Lambert() * kD;
 			}
+#	else
+			{
+				float subsurfaceFoliage = saturate(-NdotL) * (1.0 - material.Thickness);
+				lightingOutput.transmission += material.SubsurfaceColor * subsurfaceFoliage * detailedLightColor * BRDF::Diffuse_Lambert() * kD;
+			}
+#	endif
 			else if ((PBRFlags & Flags::TwoLayer) != 0)
 			{
 				float coatNdotL = satNdotL;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2012,6 +2012,11 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float3x3 tbnTr = ReconstructTBN(input.WorldPosition.xyz, worldNormal, screenUV);
 #	else
 	float3 worldNormal = normalize(mul(tbn, normal.xyz));
+#		if defined(TREE_ANIM)
+	float3 viewNormal = normalize(FrameBuffer::WorldToView(worldNormal, false, eyeIndex));
+	viewNormal = float3(viewNormal.xy, -abs(viewNormal.z));
+	worldNormal = normalize(FrameBuffer::ViewToWorld(viewNormal, false, eyeIndex));
+#		endif
 
 #		if defined(SPARKLE)
 	float3 projectedNormal = normalize(mul(tbn, float3(ProjectedUVParams2.xx * normal.xy, normal.z)));
@@ -2512,7 +2517,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	}
 
 #	if defined(SCREEN_SPACE_SHADOWS) && defined(DEFERRED)
-	if (!SharedData::InInterior)
+	if (!SharedData::InInterior && dirLightAngle >= 0.0)
 		dirDetailedShadow *= ScreenSpaceShadows::GetScreenSpaceShadow(input.Position.xyz, screenUV, screenNoise, eyeIndex);
 #	endif
 


### PR DESCRIPTION
This pull request introduces improvements to subsurface lighting and normal handling in tree animation shaders, as well as a small fix for screen space shadowing. The changes enhance the realism of foliage rendering and prevent potential shadow artifacts.

**Tree Animation and Subsurface Lighting:**

* [`package/Shaders/Common/PBR.hlsli`](diffhunk://#diff-41774ff79a8b75c6ccf9d0491dba60c4c20e6e57c9e4e311c593978ce139ff5eR175-R188): Added a special-case branch for subsurface lighting when `TREE_ANIM` is defined, using a simplified calculation tailored for animated foliage.
* [`package/Shaders/Lighting.hlsl`](diffhunk://#diff-fee9ea921e49c9a517b9ba5e6d3ff9bae2bd4dbbe5a91bfef21d64c4bb06b2a3R2015-R2019): When `TREE_ANIM` is defined, transforms the surface normal to ensure consistent lighting for animated tree geometry by adjusting the normal in view space and converting it back to world space.

**Screen Space Shadows:**

* [`package/Shaders/Lighting.hlsl`](diffhunk://#diff-fee9ea921e49c9a517b9ba5e6d3ff9bae2bd4dbbe5a91bfef21d64c4bb06b2a3L2515-R2520): Adds a check to only apply screen space shadows if the directional light angle is non-negative, preventing shadow artifacts in certain interior or edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Visual Improvements**
  * Improved foliage and vegetation lighting in direct light conditions
  * Enhanced shadow rendering with directional lighting awareness in outdoor environments

* **Performance**
  * Optimized shader compilation for specific rendering scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2344)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->