### PR TITLE
ci: set GH_REPO for release-notes

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -116,8 +116,16 @@ jobs:
               # call silently failed and the `||` fallback wrote an empty
               # file, which then clobbered the existing release body when
               # ncipollo updated it (this happened on v1.5.1).
+              #
+              # GH_REPO is required because this job downloads artifacts but
+              # never runs actions/checkout. Without it `gh` falls back to
+              # `git remote` to infer the repo and dies with "fatal: not a
+              # git repository" — which then mismatches the `release not
+              # found` fallback grep and aborts the whole step (this
+              # happened on v1.5.2: run 25871339509).
               env:
                   GH_TOKEN: ${{ github.token }}
+                  GH_REPO: ${{ github.repository }}
               run: |
                   set -euo pipefail
 


### PR DESCRIPTION
[Run 25871339509](https://github.com/community-shaders/skyrim-community-shaders/actions/runs/25871339509) (Release: Build Artifacts on tag `v1.5.2`) failed at the *Generate combined release notes* step:

```
##[error]Failed to fetch release body for v1.5.2:
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The `release` job downloads artifacts but never runs `actions/checkout`, so `gh release view` falls back to `git remote` to infer the repo and dies. The existing `release not found` fallback grep doesn't match this error string, so the step exits 1 instead of treating an absent release as a clean empty-body case.

Fix: set `GH_REPO` in the step env so `gh` queries the API directly without the git fallback. Single-line, scoped to the broken step. No behavior change for the happy path.

Builds for `v1.5.2` themselves succeeded (Flatrim, vs2026, shader unit tests, VR all green). The draft release exists and is sitting empty of artifacts — once this lands, re-dispatching Build Artifacts will finalize it. (Note: the workflow file at the dispatched ref is what executes, so re-dispatching on tag `v1.5.2` won't pick up this fix; for v1.5.2 specifically, manual artifact upload to the draft is the unblock. This PR fixes the path for v1.5.3+.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of the release notes generation process in CI/CD pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2349)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->