### PR TITLE
ci: pin artifact pattern + warn on missing artifacts

### DIFF
--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -194,6 +194,41 @@ jobs:
                   # and features whose standalone artifact is absent from the release.
                   upload_data = [row for row in data
                                  if row.get('auto_upload', True) and artifact_in_release(row)]
+                  # Drift detector: a feature opted in to auto_upload but its
+                  # artifact pattern doesn't match anything on the release.
+                  # This is almost always a metadata bug (folder name vs
+                  # nexusfilename mismatch — see HDR Display in v1.5.2).
+                  # Surface it loudly via GHA warning + step summary so it
+                  # cannot silently drop a feature from a release again.
+                  missing = [row for row in data
+                             if row.get('auto_upload') is True
+                             and not row.get('is_core')
+                             and not artifact_in_release(row)]
+                  if missing:
+                      summary_path = os.environ.get('GITHUB_STEP_SUMMARY')
+                      lines = ['## ⚠️ Auto-upload features missing artifacts', '',
+                               '| Feature | Pattern | Mod ID |',
+                               '|---------|---------|--------|']
+                      for row in missing:
+                          name = row.get('name', '?')
+                          pat = row.get('artifact_pattern', '?')
+                          mod_id = row.get('nexus_mod_id', '?')
+                          lines.append(f'| `{name}` | `{pat}` | {mod_id} |')
+                          # Annotation appears inline in the run UI.
+                          print(f'::warning title=Nexus auto-upload missing artifact::'
+                                f'{name} (mod {mod_id}) marked autoupload=true but no '
+                                f'release asset matches pattern {pat!r}. Likely cause: '
+                                f'folder name differs from nexusfilename — set '
+                                f'nexusartifactpattern explicitly in the feature .ini.')
+                      lines += ['',
+                                'These features are marked `autoupload = true` in their '
+                                '`.ini` but no release asset matched their derived '
+                                'artifact pattern. They will be skipped from this Nexus '
+                                'upload. Add `nexusartifactpattern = <Folder.Name-*.7z>` '
+                                'to the feature .ini to override the default derivation.']
+                      if summary_path:
+                          with open(summary_path, 'a') as f:
+                              f.write('\n'.join(lines) + '\n')
                   has_uploads = bool(upload_data)
                   with open('nexus-matrix.json', 'w') as f:
                       json.dump({'include': data}, f)

--- a/features/HDR Display/Shaders/Features/HDRDisplay.ini
+++ b/features/HDR Display/Shaders/Features/HDRDisplay.ini
@@ -5,3 +5,11 @@ Version = 1-0-1
 nexusmodid = 179371
 nexusfilename = HDR
 autoupload = true
+# nexusartifactpattern overrides the default artifact glob, which derives
+# from `nexusfilename.replace(' ', '.')` and would resolve to `HDR-*.7z`.
+# The actual build artifact is named after the feature folder ("HDR Display"),
+# which on the GitHub release becomes `HDR.Display-2026-...7z` (GitHub
+# converts spaces to dots in asset names). Without this override, the Nexus
+# upload matrix silently drops HDR — see v1.5.2 release where the dry-run
+# excluded it (run 25901650094).
+nexusartifactpattern = HDR.Display-*.7z

--- a/features/Screen-Space Shadows/Shaders/Features/ScreenSpaceShadows.ini
+++ b/features/Screen-Space Shadows/Shaders/Features/ScreenSpaceShadows.ini
@@ -5,3 +5,9 @@ Version = 2-1-0
 nexusmodid = 93209
 nexusfilename = Screen Space Shadows
 autoupload = true
+# nexusartifactpattern overrides the default artifact glob, which derives
+# from `nexusfilename.replace(' ', '.')` and would resolve to
+# `Screen.Space.Shadows-*.7z`. The actual build artifact is named after the
+# feature folder ("Screen-Space Shadows", with a hyphen), which on the
+# GitHub release becomes `Screen-Space.Shadows-*.7z`.
+nexusartifactpattern = Screen-Space.Shadows-*.7z


### PR DESCRIPTION
Two related fixes surfaced by the v1.5.2 Nexus dry-run ([run 25901650094](https://github.com/community-shaders/skyrim-community-shaders/actions/runs/25901650094)) which silently excluded HDR from upload despite it having `autoupload = true` and a real version bump.

## 1. Explicit `nexusartifactpattern` overrides where folder name and `nexusfilename` diverge

The default artifact pattern in `feature_version_audit.py` is derived from `nexusfilename.replace(' ', '.')`. The actual `.7z` filename is derived from the **feature folder name** (CMake convention). Where these differ, `fnmatch` never matches the asset on the GitHub release, the row is dropped from the upload matrix, and the feature silently fails to ship to Nexus.

Audited all `autoupload = true` features. Two mismatches found and fixed:

| Feature | Folder | `nexusfilename` | Real asset | Old derived pattern |
|---|---|---|---|---|
| HDR Display | `HDR Display` | `HDR` | `HDR.Display-*.7z` | `HDR-*.7z` ❌ |
| Screen-Space Shadows | `Screen-Space Shadows` | `Screen Space Shadows` | `Screen-Space.Shadows-*.7z` | `Screen.Space.Shadows-*.7z` ❌ |

Both now carry an explicit `nexusartifactpattern = ...` line in `[Nexus]`, with an inline comment explaining why. The workflow already supports this override (`feature_version_audit.py` checks `nexusartifactpattern` / `nexus_artifact_pattern` / `artifact_pattern` keys before falling back to the default).

## 2. Loud warning when an `autoupload=true` feature has no matching artifact

Adds a drift detector to `nexus-upload.yaml`'s `prepare-nexus-matrix` step. Any non-core row with `autoupload=true` whose `artifact_pattern` matches **zero** release assets now emits both:
- A `::warning::` GHA annotation (shows inline in the run UI), and
- A summary-table entry under \"⚠️ Auto-upload features missing artifacts\" in the step summary.

This means future folder-vs-nexusfilename drift (or genuine packaging bugs that drop a `.7z`) becomes immediately visible at the dry-run gate instead of being discovered post-release. Upload still proceeds for matched features — this is detection, not a hard failure, since legitimate \"feature exists in metadata but isn't packaged in this build\" cases need to keep working.

## What this does NOT do

- Does **not** retroactively upload v1.5.2 HDR — that was already unblocked by manually renaming the asset on the release before the upload (`HDR.Display-...7z` → `HDR-...7z`). v1.5.2 Nexus upload [run 25902137804](https://github.com/community-shaders/skyrim-community-shaders/actions/runs/25902137804) shipped all 4 features successfully.
- Does **not** touch the audit tool's default-derivation logic. Could be a follow-up to derive from folder name instead of `nexusfilename` and remove the need for overrides — but that's a wider change and the explicit override is more readable per-feature anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HDR Display and Screen-Space Shadows features to upload properly with corrected artifact patterns.

* **Chores**
  * Enhanced CI/CD workflow with improved detection for features with missing artifacts, providing clearer warnings when upload issues are identified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2350)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->