### PR TITLE
ci: stamp file_description with CS release + compat matrix

### DIFF
--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -147,6 +147,11 @@ jobs:
                   if [ -n "$INPUT_ARTIFACT_PATTERN" ]; then
                     ARGS+=( --core-artifact-pattern "$INPUT_ARTIFACT_PATTERN" )
                   fi
+                  # Strip the leading 'v' so we get e.g. "1.5.2" — the value
+                  # is rendered into Nexus file descriptions, where the
+                  # bare semver is what users see in the UI.
+                  RELEASE_VER="${RELEASE_TAG#v}"
+                  ARGS+=( --release-version "$RELEASE_VER" )
                   python tools/feature_version_audit.py "${ARGS[@]}"
 
                   # Fetch the specific release by tag — avoids pagination issues with
@@ -388,6 +393,11 @@ jobs:
             mod_version: ${{ matrix.mod_version || needs.prepare-nexus-matrix.outputs.version }}
             mod_filename: ${{ matrix.mod_filename }}
             changelog: ${{ inputs.changelog || matrix.changelog || '' }}
+            # file_description anchors each .7z to the CS release it shipped
+            # with. Empty string falls back to the upstream default
+            # ("See mod description for details.") so non-release dispatches
+            # without an audit-tool-built matrix still work.
+            file_description: ${{ matrix.file_description || '' }}
             check_existing: true
         secrets:
             UNEX_NEXUSMODS_SESSION_COOKIE: ${{ secrets.UNEX_NEXUSMODS_SESSION_COOKIE }}

--- a/tools/feature_version_audit.py
+++ b/tools/feature_version_audit.py
@@ -918,7 +918,63 @@ def format_metadata_summary(feature_metadata):
     return lines, metadata_issues
 
 
-def build_nexus_upload_matrix(feature_metadata, core_mod_id, core_filename, core_artifact_pattern, base_ref=None):
+def _build_compat_bullets(feature_metadata, base_ref):
+    """Compatibility bullets for the core file_description.
+
+    Lists every Nexus auto_upload feature with its current mod_version,
+    annotating rows whose version is unchanged from `base_ref` so users
+    can see at a glance which features moved and which carried over.
+    Sorted by display name for stable diff-friendly output.
+
+    Returns a list of strings like:
+        ['• Cloud Shadows 1.4.0',
+         '• HDR 1.0.1',
+         '• Upscaling 1.3.1',
+         '• Wetness Effects 1.0.0 (unchanged)']
+    Returns [] if there are no auto_upload features.
+    """
+    bullets = []
+    for info in sorted(feature_metadata, key=lambda x: (x.get('mod_filename') or x['name']).lower()):
+        if info.get('is_core') or not info.get('mod_id'):
+            continue
+        ini_path = get_feature_ini(info['name'])
+        if not ini_path:
+            continue
+        ini_meta = get_feature_ini_metadata(ini_path)
+        if not ini_meta.get('auto_upload', False):
+            continue
+        cur_tuple = get_version_from_ini(ini_path)
+        if not cur_tuple:
+            continue
+        cur_ver = '.'.join(str(v) for v in cur_tuple)
+        display = ini_meta.get('mod_filename') or info.get('mod_filename') or info['name']
+        suffix = ''
+        if base_ref:
+            prior = get_prior_version(ini_path, base_ref)
+            if prior is not None and prior == cur_tuple:
+                suffix = ' (unchanged)'
+        bullets.append(f'• {display} {cur_ver}{suffix}')
+    return bullets
+
+
+def build_nexus_upload_matrix(feature_metadata, core_mod_id, core_filename, core_artifact_pattern, base_ref=None, release_version=None):
+    """Build the Nexus upload matrix.
+
+    `release_version` is the Community Shaders version being released
+    (e.g. "1.5.2"). When provided, each row gets a `file_description`
+    that anchors the upload to this CS release — replacing the upstream
+    "See mod description for details." default. Empty when omitted so
+    the upstream default is preserved.
+    """
+    compat_bullets = _build_compat_bullets(feature_metadata, base_ref) if release_version else []
+    if release_version and compat_bullets:
+        core_description = (
+            f'Community Shaders {release_version} — feature versions in this release:\n'
+            + '\n'.join(compat_bullets)
+        )
+    else:
+        core_description = ''
+
     rows = [
         {
             'name': 'core',
@@ -927,6 +983,7 @@ def build_nexus_upload_matrix(feature_metadata, core_mod_id, core_filename, core
             'nexus_mod_id': core_mod_id,
             'mod_filename': core_filename,
             'changelog': '',  # filled by workflow from GitHub release body
+            'file_description': core_description,
         }
     ]
     def sanitize_name(name):
@@ -963,6 +1020,15 @@ def build_nexus_upload_matrix(feature_metadata, core_mod_id, core_filename, core
         # Auto-upload is opt-in; missing metadata should not enable uploads.
         auto_upload = ini_metadata.get('auto_upload', False)
 
+        # Per-feature file_description anchors this .7z to the CS release
+        # it shipped with. We don't know forward compatibility (the next CS
+        # may or may not re-bundle this version), so the description is a
+        # single-CS-version stamp and never gets revised — Nexus uploads
+        # are skipped via check_existing once a version is on file.
+        file_description = ''
+        if release_version and mod_version:
+            file_description = f'{mod_filename} {mod_version} — released for Community Shaders {release_version}.'
+
         row = {
             'name': name,
             'artifact_pattern': artifact_pattern,
@@ -970,6 +1036,7 @@ def build_nexus_upload_matrix(feature_metadata, core_mod_id, core_filename, core
             'nexus_mod_id': mod_id,
             'mod_filename': mod_filename,
             'auto_upload': auto_upload,
+            'file_description': file_description,
         }
         if mod_version:
             row['mod_version'] = mod_version
@@ -1119,6 +1186,7 @@ def main():
     parser.add_argument('--core-mod-id', type=str, default='86492', help='Core Nexus mod ID for the generated upload matrix')
     parser.add_argument('--core-filename', type=str, default='Community Shaders', help='Core Nexus filename for the generated upload matrix')
     parser.add_argument('--core-artifact-pattern', type=str, default='CommunityShaders-*.7z', help='Core artifact pattern for the generated upload matrix')
+    parser.add_argument('--release-version', type=str, default=None, help='Community Shaders release version (e.g. "1.5.2") used to anchor file_description on each upload row. When omitted, file_description is empty and the upstream Nexus action default ("See mod description for details.") is preserved.')
     args = parser.parse_args()
 
     global HEAD_REF
@@ -1185,6 +1253,7 @@ def main():
             args.core_filename,
             args.core_artifact_pattern,
             base_ref=base_ref,
+            release_version=args.release_version,
         )
         output_path = args.matrix_output
         with open(output_path, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
A common complaint on Nexus comments after every CS release is *which feature versions go with this Community Shaders version?* Today, every uploaded `.7z` carries the upstream-default file description "See mod description for details." — which doesn't actually help the user match versions.

This PR replaces that default with version-anchored content, populated by the audit tool from the same INI metadata it already reads.

## What users will see

**Core (Community Shaders) file row:**

```
Community Shaders 1.5.2 — feature versions in this release:
• Cloud Shadows 1.4.0
• Grass Collision 3.0.4
• Grass Lighting 2.0.2
• Hair Specular 1.1.0 (unchanged)
• HDR 1.0.1
• Screen Space GI 4.1.0 (unchanged)
• Screen Space Shadows 2.1.0 (unchanged)
• Sky Sync 1.1.0 (unchanged)
• Skylighting 1.3.0 (unchanged)
• Subsurface Scattering 3.0.2 (unchanged)
• Terrain Blending 1.1.0 (unchanged)
• Terrain Helper 1.0.0 (unchanged)
• Terrain Variation 1.0.1 (unchanged)
• Upscaling 1.4.0
• Wetness Effects 3.1.0 (unchanged)
```

(Sample output from `python tools/feature_version_audit.py --export-nexus-matrix --base v1.5.1 --release-version 1.5.2 --all-features`.)

The `(unchanged)` annotation appears when the feature's `Version` in its `.ini` matches the same `.ini` at the previous stable tag — so users can see at a glance which features actually moved versus which carried over.

**Each feature file row:**

```
Cloud Shadows 1.4.0 — released for Community Shaders 1.5.2.
```

Anchors each `.7z` to the CS release it shipped with. Answers the inverse question ("which CS does this Cloud Shadows file go with?") right on the file row.

## Why no forward-looking ranges

Considered making this a range (e.g., `Cloud Shadows 1.4.0 — released for CS 1.5.2 to 1.5.4`). Decided against it:

1. **The forward end isn't knowable at upload time.** When CS 1.5.3 next ships and Cloud Shadows hasn't bumped, the "real" range becomes 1.5.2 to 1.5.3 — but the upload action uses `check_existing: true` and *skips* the upload, so the file row's description never gets revisited.
2. **Maintaining a forward range would need a separate "refresh descriptions" workflow** that runs after each CS release and updates already-uploaded file descriptions in place. Doable later (`unex` supports this independently of file upload), but extra surface and not needed for the v1 ask.
3. **Single-version stamp is accurate forever** and never lies. If we add range maintenance later, it's purely additive — no rework.

## Implementation

`tools/feature_version_audit.py`:

- New `--release-version` CLI arg (e.g. `1.5.2`).
- `build_nexus_upload_matrix` accepts `release_version=...`. When provided, populates a `file_description` field on every row. New helper `_build_compat_bullets` walks the same metadata used elsewhere in the file, marks rows as `(unchanged)` using the existing `get_prior_version` helper against `--base`.
- When `--release-version` is omitted (e.g. ad-hoc manual dispatches without a built-from-tag context), `file_description` is empty and the upstream Nexus action default is preserved — backward compatible.

`.github/workflows/nexus-upload.yaml`:

- Passes `--release-version "$RELEASE_VER"` (the release tag with the leading `v` stripped) to the audit tool.
- Forwards `matrix.file_description` into `alandtse/nexus-workflows/upload-nexus.yml`'s existing `file_description` input.

## What this does NOT do

- Does **not** change the per-feature `changelog` (still derived from commits since base).
- Does **not** change the GitHub release body (still semantic-release output).
- Does **not** revisit already-uploaded file descriptions on Nexus.
- Does **not** introduce range tracking — see "Why no forward-looking ranges" above.

## Stacking

Independent of #2350 (artifact-pattern overrides + missing-artifact warning). They can land in either order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced release package descriptions on Nexus to include version information and feature compatibility details, providing clearer visibility when browsing available releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2351)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->