### PR TITLE
fix(unified water): restore vanilla LOD ownership after attach

### DIFF
--- a/features/Unified Water/Shaders/Features/UnifiedWater.ini
+++ b/features/Unified Water/Shaders/Features/UnifiedWater.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-0-1
+Version = 1-0-2
 
 [Nexus]
 autoupload = false

--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -5,15 +5,43 @@
 #include "Util.h"
 
 #include <imgui_internal.h>
+#include <vector>
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	UnifiedWater::Settings,
-	UseOptimisedMeshes)
+	UseOptimisedMeshes,
+	PurgeLODWaterAfterLoad)
+
+static constexpr int32_t kRestoredLODTrimFrames = 60;
+static constexpr int32_t kRestoredLODTrimExtraCells = 12;
 
 static bool IsChildWorldSpace(const RE::TESWorldSpace* ws)
 {
 	return ws && ws->parentWorld &&
 	       ws->parentUseFlags.all(RE::TESWorldSpace::ParentUseFlag::kUseLODData);
+}
+
+static bool IsLODCompatibleWorldSpace(const RE::TESWorldSpace* source, const RE::TESWorldSpace* destination)
+{
+	if (!source || !destination)
+		return false;
+
+	if (source == destination)
+		return true;
+
+	if (IsChildWorldSpace(destination) && destination->parentWorld == source)
+		return true;
+
+	if (IsChildWorldSpace(source) && source->parentWorld == destination)
+		return true;
+
+	return false;
+}
+
+static RE::TESWorldSpace* GetCurrentExteriorWorldSpace()
+{
+	const auto tes = globals::game::tes ? globals::game::tes : RE::TES::GetSingleton();
+	return tes ? tes->GetRuntimeData2().worldSpace : nullptr;
 }
 
 // Engine behavior: CellState value 6 is the transition/attached state.
@@ -44,6 +72,28 @@ static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY, b
 	}
 
 	return false;
+}
+
+static uint32_t ClearWaterNodeChildren(RE::NiNode* node, RE::TESWaterSystem* waterSystem)
+{
+	if (!node)
+		return 0;
+
+	uint32_t removed = 0;
+	auto count = node->GetChildren().size();
+	while (count > 0) {
+		const auto child = node->GetChildren()[count - 1];
+		if (const auto childNode = child ? child->AsNode() : nullptr)
+			removed += ClearWaterNodeChildren(childNode, waterSystem);
+
+		if (child && waterSystem)
+			waterSystem->RemoveWater(child.get());
+
+		node->DetachChildAt(--count);
+		removed++;
+	}
+
+	return removed;
 }
 
 struct CullCompletionState
@@ -107,6 +157,52 @@ static bool CullAllWaterLODParents(RE::NiNode* waterLOD, RE::TES* tes = nullptr)
 	return aggregate.IsComplete();
 }
 
+static uint32_t RemoveWaterLODNearCurrentGrid(RE::NiNode* waterLOD, RE::TES* tes, RE::TESWaterSystem* waterSystem)
+{
+	if (!waterLOD || !tes || !tes->gridCells)
+		return 0;
+
+	const int32_t radius = static_cast<int32_t>(tes->gridCells->length >> 1) + kRestoredLODTrimExtraCells;
+	const int32_t centerX = tes->currentGridX;
+	const int32_t centerY = tes->currentGridY;
+
+	uint32_t removed = 0;
+	for (const auto& waterParentPtr : waterLOD->GetChildren()) {
+		const auto waterParent = waterParentPtr ? waterParentPtr->AsNode() : nullptr;
+		if (!waterParent)
+			continue;
+
+		auto count = waterParent->GetChildren().size();
+		while (count > 0) {
+			const auto child = waterParent->GetChildren()[count - 1];
+			if (!child) {
+				count--;
+				continue;
+			}
+
+			int32_t x, y;
+			Util::WorldToCell(child->world.translate, x, y);
+			const int32_t deltaX = x > centerX ? x - centerX : centerX - x;
+			const int32_t deltaY = y > centerY ? y - centerY : centerY - y;
+			if (deltaX > radius || deltaY > radius) {
+				count--;
+				continue;
+			}
+
+			if (const auto childNode = child->AsNode())
+				removed += ClearWaterNodeChildren(childNode, waterSystem);
+
+			if (waterSystem)
+				waterSystem->RemoveWater(child.get());
+
+			waterParent->DetachChildAt(--count);
+			removed++;
+		}
+	}
+
+	return removed;
+}
+
 void UnifiedWater::TryCompleteDeferredChildWorldspaceCull(RE::TES* tes)
 {
 	if (!pendingChildWsCull.load(std::memory_order_acquire) ||
@@ -123,9 +219,269 @@ void UnifiedWater::TryCompleteDeferredChildWorldspaceCull(RE::TES* tes)
 		pendingChildWsCull.store(false, std::memory_order_release);
 }
 
+uint32_t UnifiedWater::PurgeLODWater()
+{
+	if (!gWaterLOD || !*gWaterLOD)
+		return 0;
+
+	return ClearWaterNodeChildren(*gWaterLOD, globals::game::waterSystem);
+}
+
+uint32_t UnifiedWater::ClearDetachedLODWater()
+{
+	uint32_t removed = 0;
+	const auto waterSystem = globals::game::waterSystem;
+	for (const auto& child : detachedLODWaterChildren) {
+		if (!child)
+			continue;
+
+		if (const auto childNode = child->AsNode())
+			removed += ClearWaterNodeChildren(childNode, waterSystem);
+
+		if (waterSystem)
+			waterSystem->RemoveWater(child.get());
+
+		removed++;
+	}
+
+	detachedLODWaterChildren.clear();
+	detachedLODWaterWorldSpace = nullptr;
+	return removed;
+}
+
+uint32_t UnifiedWater::DetachLODWaterForLoad()
+{
+	if (!settings.PurgeLODWaterAfterLoad || !gWaterLOD || !*gWaterLOD || !detachedLODWaterChildren.empty())
+		return 0;
+
+	auto sourceWorldSpace = GetCurrentExteriorWorldSpace();
+	if (!sourceWorldSpace)
+		sourceWorldSpace = currentPlayerWorldSpace.load(std::memory_order_acquire);
+	if (!sourceWorldSpace || Util::IsInterior())
+		return 0;
+
+	auto count = (*gWaterLOD)->GetChildren().size();
+	while (count > 0) {
+		const auto child = (*gWaterLOD)->GetChildren()[count - 1];
+		if (child)
+			detachedLODWaterChildren.push_back(child);
+
+		(*gWaterLOD)->DetachChildAt(--count);
+	}
+
+	if (detachedLODWaterChildren.empty())
+		return 0;
+
+	detachedLODWaterWorldSpace = sourceWorldSpace;
+	logger::info(
+		"[Unified Water] Detached LOD water for load from {}: detached {}",
+		sourceWorldSpace->GetFormEditorID(),
+		detachedLODWaterChildren.size());
+	return static_cast<uint32_t>(detachedLODWaterChildren.size());
+}
+
+uint32_t UnifiedWater::RestoreDetachedLODWater(RE::TESWorldSpace* destinationWorldSpace)
+{
+	if (detachedLODWaterChildren.empty() || !destinationWorldSpace || !gWaterLOD || !*gWaterLOD)
+		return 0;
+
+	if (!IsLODCompatibleWorldSpace(detachedLODWaterWorldSpace, destinationWorldSpace)) {
+		const auto removed = ClearDetachedLODWater();
+		logger::info(
+			"[Unified Water] Discarded detached LOD water after load into {}: removed {}",
+			destinationWorldSpace->GetFormEditorID(),
+			removed);
+		return 0;
+	}
+
+	uint32_t restored = 0;
+	for (const auto& child : detachedLODWaterChildren) {
+		if (child) {
+			(*gWaterLOD)->AttachChild(child.get(), true);
+			restored++;
+		}
+	}
+
+	logger::info(
+		"[Unified Water] Restored LOD water after load into {}: restored {} from {}",
+		destinationWorldSpace->GetFormEditorID(),
+		restored,
+		detachedLODWaterWorldSpace ? detachedLODWaterWorldSpace->GetFormEditorID() : "<none>");
+
+	detachedLODWaterChildren.clear();
+	detachedLODWaterWorldSpace = nullptr;
+	pendingRestoredLODTrimFrames.store(kRestoredLODTrimFrames, std::memory_order_release);
+	pendingRestoredLODTrimChildWorldspace.store(IsChildWorldSpace(destinationWorldSpace), std::memory_order_release);
+	return restored;
+}
+
+void UnifiedWater::ResolveDetachedLODWaterAfterLoad(RE::TESWorldSpace* destinationWorldSpace)
+{
+	if (detachedLODWaterChildren.empty())
+		return;
+
+	if (!destinationWorldSpace)
+		destinationWorldSpace = GetCurrentExteriorWorldSpace();
+	if (!destinationWorldSpace)
+		destinationWorldSpace = currentPlayerWorldSpace.load(std::memory_order_acquire);
+
+	if (!destinationWorldSpace || Util::IsInterior())
+		return;
+
+	RestoreDetachedLODWater(destinationWorldSpace);
+}
+
+void UnifiedWater::TryTrimRestoredLODWater()
+{
+	auto frames = pendingRestoredLODTrimFrames.load(std::memory_order_acquire);
+	if (frames <= 0)
+		return;
+
+	if (frames > 1) {
+		pendingRestoredLODTrimFrames.store(frames - 1, std::memory_order_release);
+		return;
+	}
+
+	const auto tes = globals::game::tes ? globals::game::tes : RE::TES::GetSingleton();
+	const auto waterSystem = globals::game::waterSystem;
+	const auto worldSpace = tes ? tes->GetRuntimeData2().worldSpace : currentPlayerWorldSpace.load(std::memory_order_acquire);
+	if (!tes || !tes->gridCells || !worldSpace || !gWaterLOD || !*gWaterLOD || !waterSystem) {
+		pendingRestoredLODTrimFrames.store(frames - 1, std::memory_order_release);
+		return;
+	}
+
+	if (pendingRestoredLODTrimChildWorldspace.load(std::memory_order_acquire)) {
+		const bool complete = CullAllWaterLODParents(*gWaterLOD, tes);
+		if (complete)
+			pendingRestoredLODTrimChildWorldspace.store(false, std::memory_order_release);
+		pendingRestoredLODTrimFrames.store(complete ? 0 : frames - 1, std::memory_order_release);
+		if (complete)
+			logger::info("[Unified Water] Culled restored LOD water after child-worldspace load in {}", worldSpace->GetFormEditorID());
+		return;
+	}
+
+	const auto removed = RemoveWaterLODNearCurrentGrid(*gWaterLOD, tes, waterSystem);
+	pendingRestoredLODTrimFrames.store(0, std::memory_order_release);
+	logger::info(
+		"[Unified Water] Trimmed restored LOD water after load in {}: removed {} near current grid",
+		worldSpace->GetFormEditorID(),
+		removed);
+}
+
+bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSystem* waterSystem, bool runOriginalAttach)
+{
+	if (!waterSystem || !waterCache || !gWaterLOD || !*gWaterLOD) {
+		if (runOriginalAttach)
+			BGSTerrainBlock_Attach::func(block);
+		return false;
+	}
+
+	std::vector<std::pair<RE::BSTriShape*, const WaterCache::Instruction*>> built;
+	bool attaching = false;
+
+	if (block && block->loaded && block->chunk && block->water && (runOriginalAttach ? !block->attached : block->attached)) {
+		block->chunk->DetachChild2(block->water);
+		(*gWaterLOD)->DetachChild(block->water);
+		block->water->local.translate = block->chunk->local.translate;
+
+		RE::NiUpdateData updateData;
+		block->water->UpdateUpwardPass(updateData);
+
+		ClearWaterNodeChildren(block->water, waterSystem);
+		block->waterAttached = false;
+
+		attaching = true;
+
+		const auto node = block->node;
+		const auto worldSpace = node && node->manager ? node->manager->worldSpace : nullptr;
+		if (!node || !worldSpace) {
+			if (runOriginalAttach)
+				BGSTerrainBlock_Attach::func(block);
+			return false;
+		}
+
+		const auto lodLevel = node->GetLODLevel();
+		const auto instructions = waterCache->GetInstructions(worldSpace, lodLevel, node->baseCellX, node->baseCellY);
+		if (!instructions) {
+			logger::warn("[Unified Water] No instructions found for {} chunk at {}, {}", worldSpace->GetFormEditorID(), node->baseCellX, node->baseCellY);
+			if (runOriginalAttach)
+				BGSTerrainBlock_Attach::func(block);
+			return false;
+		}
+
+		for (auto& instruction : *instructions) {
+			if (!instruction.form.ptr)
+				continue;
+
+			RE::NiCloningProcess cloningProcess;
+
+			const auto targetShape = lodLevel > 4 || settings.UseOptimisedMeshes ? optimisedWaterMesh : waterMesh;
+			RE::BSTriShape* shape = targetShape->CreateClone(cloningProcess)->AsTriShape();
+
+			const auto posX = (instruction.x - node->baseCellX) * 4096.0f + instruction.size * 2048.0f;
+			const auto posY = (instruction.y - node->baseCellY) * 4096.0f + instruction.size * 2048.0f;
+			shape->local.scale = static_cast<float>(instruction.size);
+			shape->local.translate = { posX, posY, instruction.waterHeight };
+
+			block->water->AttachChild(shape, true);
+			built.emplace_back(shape, &instruction);
+
+			block->waterAttached = true;
+		}
+	}
+
+	if (runOriginalAttach)
+		BGSTerrainBlock_Attach::func(block);
+
+	if (!attaching || !block->waterAttached)
+		return false;
+
+	for (auto& [shape, instruction] : built) {
+		waterSystem->AddWater(shape, instruction->form.ptr, instruction->waterHeight, nullptr, true, false);
+
+		if (const auto prop = shape->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
+			const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
+			REX::EnumSet waterFlags = static_cast<RE::BSWaterShaderProperty::WaterFlag>(0b10000100);
+			waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kUseCubemapReflections;
+			waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kUseReflections;
+			if (instruction->form.ptr->flags.any(RE::TESWaterForm::Flag::kEnableFlowmap))
+				waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kEnableFlowmap;
+			if (instruction->form.ptr->flags.any(RE::TESWaterForm::Flag::kBlendNormals))
+				waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kBlendNormals;
+			waterShaderProp->waterFlags = waterFlags;
+		}
+
+		// Remove from WaterSystem, will manage it ourselves
+		if (!waterSystem->waterObjects.empty()) {
+			waterSystem->waterObjects.pop_back();
+		}
+	}
+
+	(*gWaterLOD)->AttachChild(block->water, true);
+	waterSystem->Enable();
+
+	// BGSTerrainNode_UpdateWaterMeshSubVisibility never fires in child worldspaces.
+	// Cull newly built tiles here; full deferred retries are handled by
+	// TryCompleteDeferredChildWorldspaceCull().
+	if (IsChildWorldSpace(currentPlayerWorldSpace.load(std::memory_order_acquire))) {
+		const auto tes = cachedTes.load(std::memory_order_acquire);
+		if (tes && tes->gridCells) {
+			for (const auto& [shape, instruction] : built) {
+				const bool cull = ShouldCullAtCell(tes, instruction->x, instruction->y);
+				shape->SetAppCulled(cull);
+			}
+		}
+	}
+
+	return true;
+}
+
 void UnifiedWater::LoadSettings(json& o_json)
 {
 	settings = o_json;
+	logger::info(
+		"[Unified Water] Interior-load LOD water quarantine is {}",
+		settings.PurgeLODWaterAfterLoad ? "enabled" : "disabled");
 }
 
 void UnifiedWater::SaveSettings(json& o_json)
@@ -157,6 +513,13 @@ void UnifiedWater::DrawSettings()
 
 		if (ImGui::Button("Regenerate Caches") && waterCache)
 			waterCache->RegenerateCaches();
+
+		ImGui::Checkbox("Refresh LOD Water Around Interior Loads", &settings.PurgeLODWaterAfterLoad);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text(
+				"Detaches existing Unified Water LOD before exterior teardown,\n"
+				"restores it on the next compatible exterior, then trims the local destination area.");
+		}
 
 		ImGui::TreePop();
 	}
@@ -283,6 +646,8 @@ void UnifiedWater::DataLoaded()
 	while (waterCache->IsBuildRunning()) {
 		std::this_thread::sleep_for(100ms);
 	}
+
+	MenuOpenCloseEventHandler::Register();
 }
 
 bool UnifiedWater::LoadOrderChanged()
@@ -334,6 +699,41 @@ bool UnifiedWater::LoadOrderChanged()
 	}
 
 	return hash != existingHash;
+}
+
+RE::BSEventNotifyControl UnifiedWater::MenuOpenCloseEventHandler::ProcessEvent(
+	const RE::MenuOpenCloseEvent* a_event,
+	RE::BSTEventSource<RE::MenuOpenCloseEvent>*)
+{
+	if (a_event && a_event->menuName == RE::LoadingMenu::MENU_NAME) {
+		if (a_event->opening)
+			globals::features::unifiedWater.DetachLODWaterForLoad();
+		else
+			globals::features::unifiedWater.ResolveDetachedLODWaterAfterLoad();
+	}
+
+	return RE::BSEventNotifyControl::kContinue;
+}
+
+bool UnifiedWater::MenuOpenCloseEventHandler::Register()
+{
+	static MenuOpenCloseEventHandler singleton;
+
+	const auto ui = globals::game::ui;
+	if (!ui) {
+		logger::error("[Unified Water] UI event source not found; interior-load LOD water quarantine disabled");
+		return false;
+	}
+
+	const auto eventSource = ui->GetEventSource<RE::MenuOpenCloseEvent>();
+	if (!eventSource) {
+		logger::error("[Unified Water] MenuOpenCloseEvent source not found; interior-load LOD water quarantine disabled");
+		return false;
+	}
+
+	eventSource->AddEventSink(&singleton);
+	logger::info("[Unified Water] Registered MenuOpenCloseEventHandler");
+	return true;
 }
 
 void UnifiedWater::SetFlowmapTex() const
@@ -446,6 +846,8 @@ void UnifiedWater::TES_SetWorldSpace::thunk(RE::TES* tes, RE::TESWorldSpace* wor
 	}
 
 	uw.waterCache->SetCurrentWorldSpace(worldSpace);
+	if (worldSpace && isExterior)
+		uw.ResolveDetachedLODWaterAfterLoad(worldSpace);
 
 	if (enteringChild) {
 		// BGSTerrainBlock_Attach calls Enable() on block attach.
@@ -465,9 +867,11 @@ void UnifiedWater::TES_SetWorldSpace::thunk(RE::TES* tes, RE::TESWorldSpace* wor
 
 void UnifiedWater::TES_DestroySkyCell::thunk(RE::TES* tes)
 {
+	auto& uw = globals::features::unifiedWater;
+	uw.DetachLODWaterForLoad();
+
 	func(tes);
 
-	auto& uw = globals::features::unifiedWater;
 	uw.currentPlayerWorldSpace.store(nullptr, std::memory_order_release);
 	uw.pendingChildWsCull.store(false, std::memory_order_release);
 	uw.cachedTes.store(nullptr, std::memory_order_release);
@@ -501,99 +905,7 @@ void UnifiedWater::BGSTerrainBlock_Attach::thunk(RE::BGSTerrainBlock* block)
 	// Additional game-thread retry path for deferred child-WS cull completion.
 	uw.TryCompleteDeferredChildWorldspaceCull(uw.cachedTes.load(std::memory_order_acquire));
 
-	std::vector<std::pair<RE::BSTriShape*, const WaterCache::Instruction*>> built;
-	bool attaching = false;
-
-	if (block && block->loaded && !block->attached && block->chunk && block->water) {
-		block->chunk->DetachChild2(block->water);
-		block->water->local.translate = block->chunk->local.translate;
-
-		RE::NiUpdateData updateData;
-		block->water->UpdateUpwardPass(updateData);
-
-		const auto water = block->water;
-		for (auto& child : water->GetChildren()) {
-			if (child) {
-				waterSystem->RemoveWater(child.get());
-				water->DetachChild(child.get());
-			}
-		}
-
-		attaching = true;
-
-		const auto node = block->node;
-		const auto lodLevel = node->GetLODLevel();
-		const auto worldSpace = block->node->manager->worldSpace;
-
-		const auto instructions = uw.waterCache->GetInstructions(worldSpace, lodLevel, node->baseCellX, node->baseCellY);
-		if (!instructions) {
-			logger::warn("[Unified Water] No instructions found for {} chunk at {}, {}", worldSpace->GetFormEditorID(), node->baseCellX, node->baseCellY);
-			func(block);
-			return;
-		}
-
-		for (auto& instruction : *instructions) {
-			if (!instruction.form.ptr)
-				continue;
-
-			RE::NiCloningProcess cloningProcess;
-
-			const auto targetShape = lodLevel > 4 || uw.settings.UseOptimisedMeshes ? uw.optimisedWaterMesh : uw.waterMesh;
-			RE::BSTriShape* shape = targetShape->CreateClone(cloningProcess)->AsTriShape();
-
-			const auto posX = (instruction.x - node->baseCellX) * 4096.0f + instruction.size * 2048.0f;
-			const auto posY = (instruction.y - node->baseCellY) * 4096.0f + instruction.size * 2048.0f;
-			shape->local.scale = static_cast<float>(instruction.size);
-			shape->local.translate = { posX, posY, instruction.waterHeight };
-
-			water->AttachChild(shape, true);
-			built.emplace_back(shape, &instruction);
-
-			block->waterAttached = true;
-		}
-	}
-
-	func(block);
-
-	if (!attaching || !block->waterAttached)
-		return;
-
-	for (auto& [shape, instruction] : built) {
-		waterSystem->AddWater(shape, instruction->form.ptr, instruction->waterHeight, nullptr, true, false);
-
-		if (const auto prop = shape->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
-			const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
-			REX::EnumSet waterFlags = static_cast<RE::BSWaterShaderProperty::WaterFlag>(0b10000100);
-			waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kUseCubemapReflections;
-			waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kUseReflections;
-			if (instruction->form.ptr->flags.any(RE::TESWaterForm::Flag::kEnableFlowmap))
-				waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kEnableFlowmap;
-			if (instruction->form.ptr->flags.any(RE::TESWaterForm::Flag::kBlendNormals))
-				waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kBlendNormals;
-			waterShaderProp->waterFlags = waterFlags;
-		}
-
-		// Remove from WaterSystem, will manage it ourselves
-		if (!waterSystem->waterObjects.empty()) {
-			waterSystem->waterObjects.pop_back();
-		}
-	}
-
-	(*uw.gWaterLOD)->AttachChild(block->water, true);
-	waterSystem->Enable();
-
-	// BGSTerrainNode_UpdateWaterMeshSubVisibility never fires in child worldspaces.
-	// Cull newly built tiles here; full deferred retries are handled by
-	// TryCompleteDeferredChildWorldspaceCull().
-	if (IsChildWorldSpace(uw.currentPlayerWorldSpace.load(std::memory_order_acquire))) {
-		const auto tes = uw.cachedTes.load(std::memory_order_acquire);
-		if (tes && tes->gridCells) {
-			for (const auto& [shape, instruction] : built) {
-				const bool cull = ShouldCullAtCell(tes, instruction->x, instruction->y);
-				shape->SetAppCulled(cull);
-			}
-		}
-	}
+	uw.BuildWaterForBlock(block, waterSystem, true);
 }
 
 void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
@@ -680,6 +992,7 @@ void UnifiedWater::TESWaterSystem_UpdateDisplacementMeshPosition::thunk(RE::TESW
 	// Needed when entering child worldspaces with already-attached LOD blocks,
 	// where BGSTerrainBlock_Attach/UpdateWaterMeshSubVisibility may not run.
 	uw.TryCompleteDeferredChildWorldspaceCull(uw.cachedTes.load(std::memory_order_acquire));
+	uw.TryTrimRestoredLODWater();
 
 	if (!uw.flowmap)
 		return;

--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -5,26 +5,19 @@
 #include "Util.h"
 
 #include <imgui_internal.h>
+#include <cmath>
+#include <unordered_map>
+#include <vector>
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	UnifiedWater::Settings,
 	UseOptimisedMeshes)
 
-static constexpr float kWaterLODHeightOffset = -4.0f;
-
-static bool IsChildWorldSpace(const RE::TESWorldSpace* ws)
-{
-	return ws && ws->parentWorld &&
-	       ws->parentUseFlags.all(RE::TESWorldSpace::ParentUseFlag::kUseLODData);
-}
-
 // Engine behavior: CellState value 6 is the transition/attached state.
 static constexpr auto kTransitionAttachedCellState = static_cast<RE::TESObjectCELL::CellState>(6);
 
-static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY, bool* isInGrid = nullptr)
+static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY)
 {
-	if (isInGrid)
-		*isInGrid = false;
 	if (!tes || !tes->gridCells)
 		return false;
 
@@ -38,9 +31,6 @@ static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY, b
 	if (x < 0 || y < 0 || x >= length || y >= length)
 		return false;
 
-	if (isInGrid)
-		*isInGrid = true;
-
 	if (const auto cell = gridCells->GetCell(x, y)) {
 		return cell->cellState.any(RE::TESObjectCELL::CellState::kAttached, kTransitionAttachedCellState);
 	}
@@ -48,81 +38,278 @@ static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY, b
 	return false;
 }
 
-struct CullCompletionState
+static void AddLODWater(RE::TESWaterSystem* waterSystem, RE::BSTriShape* waterShape, RE::TESWorldSpace* worldSpace, RE::NiNode* lodRoot, RE::NiNode* waterParent)
 {
-	bool foundAttachedCell = false;
-	bool hasPotentiallyAttachableChild = false;
+	using func_t = void (*)(RE::TESWaterSystem*, RE::BSTriShape*, RE::TESWorldSpace*, RE::NiNode*, RE::NiNode*, bool);
+	static REL::Relocation<func_t> func{ REL::RelocationID(31404, 32209) };
 
-	bool IsComplete() const
+	func(waterSystem, waterShape, worldSpace, lodRoot, waterParent, true);
+}
+
+static void RemoveLODWater(RE::TESWaterSystem* waterSystem, RE::BSTriShape* waterShape, RE::NiNode* lodRoot)
+{
+	using func_t = void (*)(RE::TESWaterSystem*, RE::BSTriShape*, RE::NiNode*);
+	static REL::Relocation<func_t> func{ REL::RelocationID(31405, 32210) };
+
+	func(waterSystem, waterShape, lodRoot);
+}
+
+static void ClearWaterNodeChildren(RE::NiNode* node, RE::TESWaterSystem* waterSystem)
+{
+	if (!node)
+		return;
+
+	auto count = node->GetChildren().size();
+	while (count > 0) {
+		const auto child = node->GetChildren()[count - 1];
+		if (const auto childNode = child ? child->AsNode() : nullptr)
+			ClearWaterNodeChildren(childNode, waterSystem);
+
+		if (child && waterSystem)
+			waterSystem->RemoveWater(child.get());
+
+		node->DetachChildAt(--count);
+	}
+}
+
+static void DetachAllChildOccurrences(RE::NiNode* node, const RE::NiAVObject* childToDetach)
+{
+	if (!node || !childToDetach)
+		return;
+
+	auto count = node->GetChildren().size();
+	while (count > 0) {
+		const auto child = node->GetChildren()[count - 1];
+		if (child.get() == childToDetach) {
+			node->DetachChildAt(--count);
+		} else {
+			count--;
+		}
+	}
+}
+
+struct WaterPositionKey
+{
+	int32_t x = 0;
+	int32_t y = 0;
+	int32_t z = 0;
+	int32_t scale = 0;
+};
+
+static bool operator==(const WaterPositionKey& lhs, const WaterPositionKey& rhs)
+{
+	return lhs.x == rhs.x && lhs.y == rhs.y && lhs.z == rhs.z && lhs.scale == rhs.scale;
+}
+
+struct WaterPositionKeyHash
+{
+	size_t operator()(const WaterPositionKey& key) const noexcept
 	{
-		return foundAttachedCell && !hasPotentiallyAttachableChild;
+		size_t hash = std::hash<int32_t>{}(key.x);
+		hash ^= std::hash<int32_t>{}(key.y) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+		hash ^= std::hash<int32_t>{}(key.z) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+		hash ^= std::hash<int32_t>{}(key.scale) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+		return hash;
 	}
 };
 
-// Cull waterParent children using tes->gridCells attachment state.
-// Pass tes explicitly when globals::game::tes is not ready (e.g., TES_SetWorldSpace).
-static CullCompletionState CullWaterParentByGridCells(RE::NiNode* waterParent, RE::TES* tes = nullptr)
+static int32_t QuantizeWaterPosition(float value)
 {
-	if (!tes)
-		tes = globals::game::tes;
-	if (!tes || !waterParent)
+	return static_cast<int32_t>(std::lround(value));
+}
+
+static WaterPositionKey GetWaterPositionKey(const RE::NiAVObject* object)
+{
+	if (!object)
 		return {};
 
-	CullCompletionState state;
+	return {
+		QuantizeWaterPosition(object->world.translate.x),
+		QuantizeWaterPosition(object->world.translate.y),
+		QuantizeWaterPosition(object->world.translate.z),
+		QuantizeWaterPosition(object->world.scale * 1000.0f),
+	};
+}
+
+static bool IsChildOfNode(const RE::NiAVObject* object, const RE::NiNode* root)
+{
+	if (!object || !root)
+		return false;
+
+	for (auto parent = object->parent; parent; parent = parent->parent) {
+		if (parent == root)
+			return true;
+	}
+
+	return object == root;
+}
+
+static RE::BSTriShape* SelectDuplicateWaterSystemShapeToRemove(RE::BSTriShape* existing, RE::BSTriShape* candidate, RE::NiNode* lodRoot)
+{
+	if (!existing)
+		return candidate;
+	if (!candidate)
+		return existing;
+
+	const bool existingIsLOD = IsChildOfNode(existing, lodRoot);
+	const bool candidateIsLOD = IsChildOfNode(candidate, lodRoot);
+	if (existingIsLOD != candidateIsLOD)
+		return existingIsLOD ? existing : candidate;
+
+	return candidate;
+}
+
+static void RemoveDuplicateWaterSystemObjects(RE::TESWaterSystem* waterSystem, RE::NiNode* lodRoot)
+{
+	if (!waterSystem)
+		return;
+
+	static thread_local std::unordered_map<WaterPositionKey, RE::BSTriShape*, WaterPositionKeyHash> shapeByPosition;
+	static thread_local std::vector<RE::BSTriShape*> duplicateShapes;
+
+	shapeByPosition.clear();
+	duplicateShapes.clear();
+
+	const auto objectCount = waterSystem->waterObjects.size();
+	if (shapeByPosition.bucket_count() < objectCount)
+		shapeByPosition.reserve(objectCount);
+	if (duplicateShapes.capacity() < objectCount)
+		duplicateShapes.reserve(objectCount);
+
+	for (const auto& waterObject : waterSystem->waterObjects) {
+		const auto shape = waterObject ? waterObject->shape.get() : nullptr;
+		if (!shape)
+			continue;
+
+		const auto key = GetWaterPositionKey(shape);
+		const auto [it, inserted] = shapeByPosition.try_emplace(key, shape);
+		if (inserted)
+			continue;
+
+		const auto existing = it->second;
+		const auto duplicate = SelectDuplicateWaterSystemShapeToRemove(existing, shape, lodRoot);
+		if (duplicate == existing)
+			it->second = shape;
+
+		duplicateShapes.push_back(duplicate);
+	}
+
+	for (const auto shape : duplicateShapes) {
+		if (!shape)
+			continue;
+
+		shape->SetAppCulled(true);
+		waterSystem->RemoveWater(shape);
+	}
+}
+
+static void CullWaterParentByGridCells(RE::NiNode* waterParent)
+{
+	const auto tes = globals::game::tes;
+	if (!tes || !waterParent)
+		return;
 
 	for (const auto& child : waterParent->GetChildren()) {
 		if (!child)
 			continue;
 		int32_t x, y;
 		Util::WorldToCell(child->world.translate, x, y);
-		bool isInGrid = false;
-		const bool cull = ShouldCullAtCell(tes, x, y, &isInGrid);
-		if (cull)
-			state.foundAttachedCell = true;
-		else if (isInGrid)
-			state.hasPotentiallyAttachableChild = true;
+		const bool cull = ShouldCullAtCell(tes, x, y);
 		child->SetAppCulled(cull);
 	}
-
-	return state;
 }
 
-// Cull all tiles under every water LOD parent.
-static bool CullAllWaterLODParents(RE::NiNode* waterLOD, RE::TES* tes = nullptr)
+bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSystem* waterSystem)
 {
-	if (!waterLOD)
+	if (!waterSystem || !waterCache || !gWaterLOD || !*gWaterLOD) {
+		BGSTerrainBlock_Attach::func(block);
 		return false;
-
-	CullCompletionState aggregate;
-
-	for (const auto& waterParentPtr : waterLOD->GetChildren()) {
-		if (!waterParentPtr)
-			continue;
-		const auto waterParent = waterParentPtr->AsNode();
-		if (!waterParent)
-			continue;
-		const auto state = CullWaterParentByGridCells(waterParent, tes);
-		aggregate.foundAttachedCell = aggregate.foundAttachedCell || state.foundAttachedCell;
-		aggregate.hasPotentiallyAttachableChild = aggregate.hasPotentiallyAttachableChild || state.hasPotentiallyAttachableChild;
 	}
 
-	return aggregate.IsComplete();
-}
+	std::vector<std::pair<RE::BSTriShape*, const WaterCache::Instruction*>> built;
+	bool attaching = false;
+	RE::TESWorldSpace* worldSpace = nullptr;
 
-void UnifiedWater::TryCompleteDeferredChildWorldspaceCull(RE::TES* tes)
-{
-	if (!pendingChildWsCull.load(std::memory_order_acquire) ||
-		!IsChildWorldSpace(currentPlayerWorldSpace.load(std::memory_order_acquire)) ||
-		!gWaterLOD || !*gWaterLOD)
-		return;
+	if (block && block->loaded && block->chunk && block->water && !block->attached) {
+		block->chunk->DetachChild2(block->water);
+		DetachAllChildOccurrences(*gWaterLOD, block->water);
+		block->water->local.translate = block->chunk->local.translate;
 
-	if (!tes)
-		tes = cachedTes.load(std::memory_order_acquire);
-	if (!tes || !tes->gridCells)
-		return;
+		RE::NiUpdateData updateData;
+		block->water->UpdateUpwardPass(updateData);
 
-	if (CullAllWaterLODParents(*gWaterLOD, tes))
-		pendingChildWsCull.store(false, std::memory_order_release);
+		ClearWaterNodeChildren(block->water, waterSystem);
+		block->waterAttached = false;
+
+		attaching = true;
+
+		const auto node = block->node;
+		worldSpace = node && node->manager ? node->manager->worldSpace : nullptr;
+		if (!node || !worldSpace) {
+			BGSTerrainBlock_Attach::func(block);
+			return false;
+		}
+
+		const auto lodLevel = node->GetLODLevel();
+		const auto instructions = waterCache->GetInstructions(worldSpace, lodLevel, node->baseCellX, node->baseCellY);
+		if (!instructions) {
+			logger::warn("[Unified Water] No instructions found for {} chunk at {}, {}", worldSpace->GetFormEditorID(), node->baseCellX, node->baseCellY);
+			BGSTerrainBlock_Attach::func(block);
+			return false;
+		}
+
+		for (auto& instruction : *instructions) {
+			if (!instruction.form.ptr)
+				continue;
+
+			RE::NiCloningProcess cloningProcess;
+
+			const auto targetShape = lodLevel > 4 || settings.UseOptimisedMeshes ? optimisedWaterMesh : waterMesh;
+			RE::BSTriShape* shape = targetShape->CreateClone(cloningProcess)->AsTriShape();
+
+			const auto posX = (instruction.x - node->baseCellX) * 4096.0f + instruction.size * 2048.0f;
+			const auto posY = (instruction.y - node->baseCellY) * 4096.0f + instruction.size * 2048.0f;
+			shape->local.scale = static_cast<float>(instruction.size);
+			shape->local.translate = { posX, posY, instruction.waterHeight };
+
+			block->water->AttachChild(shape, true);
+			built.emplace_back(shape, &instruction);
+
+			block->waterAttached = true;
+		}
+	}
+
+	BGSTerrainBlock_Attach::func(block);
+
+	if (!attaching || !block->waterAttached)
+		return false;
+
+	for (auto& [shape, instruction] : built) {
+		AddLODWater(waterSystem, shape, worldSpace, *gWaterLOD, block->water);
+
+		if (const auto prop = shape->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
+			const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
+			REX::EnumSet waterFlags = static_cast<RE::BSWaterShaderProperty::WaterFlag>(0b10000100);
+			waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kUseCubemapReflections;
+			waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kUseReflections;
+			if (instruction->form.ptr->flags.any(RE::TESWaterForm::Flag::kEnableFlowmap))
+				waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kEnableFlowmap;
+			if (instruction->form.ptr->flags.any(RE::TESWaterForm::Flag::kBlendNormals))
+				waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kBlendNormals;
+			waterShaderProp->waterFlags = waterFlags;
+		}
+
+		// Vanilla AddLODWater routes through TESWaterSystem::AddWater and attaches
+		// the water parent to gWaterLOD. Use the matching vanilla LOD remove wrapper
+		// to unwind the water-system side state, then reattach the parent once below.
+		RemoveLODWater(waterSystem, shape, *gWaterLOD);
+	}
+
+	DetachAllChildOccurrences(*gWaterLOD, block->water);
+	(*gWaterLOD)->AttachChild(block->water, true);
+	waterSystem->Enable();
+
+	return true;
 }
 
 void UnifiedWater::LoadSettings(json& o_json)
@@ -357,9 +544,6 @@ void UnifiedWater::SetFlowmapTex() const
 
 void UnifiedWater::PostPostLoad()
 {
-	stl::detour_thunk<TES_SetWorldSpace>(REL::RelocationID(13170, 13315));
-	stl::detour_thunk<TES_DestroySkyCell>(REL::RelocationID(20029, 20463));
-
 	stl::write_thunk_call<TESWaterSystem_InitializeWater_SetWaterShaderMaterialParams>(REL::RelocationID(31388, 32179).address() + REL::Relocate(0x360, 0x3BC, 0x35B));
 	stl::write_vfunc<0x4, BSWaterShaderMaterial_ComputeCRC32>(RE::VTABLE_BSWaterShaderMaterial[0]);
 
@@ -429,56 +613,6 @@ int32_t UnifiedWater::BSWaterShaderMaterial_ComputeCRC32::thunk(RE::BSWaterShade
 	return func(material, srcHash);
 }
 
-void UnifiedWater::TES_SetWorldSpace::thunk(RE::TES* tes, RE::TESWorldSpace* worldSpace, bool isExterior)
-{
-	const bool enteringChild = IsChildWorldSpace(worldSpace);
-
-	// Set before func so attachment hooks fired inside func see the new worldspace.
-	auto& uw = globals::features::unifiedWater;
-	uw.currentPlayerWorldSpace.store(worldSpace, std::memory_order_release);
-	uw.cachedTes.store(tes, std::memory_order_release);
-	if (!enteringChild)
-		uw.pendingChildWsCull.store(false, std::memory_order_release);  // leaving child WS: discard any stale pending cull
-
-	func(tes, worldSpace, isExterior);
-
-	if (!uw.waterCache) {
-		uw.pendingChildWsCull.store(false, std::memory_order_release);
-		return;
-	}
-
-	uw.waterCache->SetCurrentWorldSpace(worldSpace);
-
-	if (enteringChild) {
-		// BGSTerrainBlock_Attach calls Enable() on block attach.
-		// Child-worldspace transitions can keep old LOD blocks attached, so re-enable here.
-		if (const auto waterSystem = globals::game::waterSystem)
-			waterSystem->Enable();
-
-		// Try an immediate cull with tes (globals::game::tes may still be null).
-		// Newly transitioned cells are often not attached yet, so deferred retries are still needed.
-		if (uw.gWaterLOD && *uw.gWaterLOD && tes && tes->gridCells)
-			CullAllWaterLODParents(*uw.gWaterLOD, tes);
-
-		// Keep deferred retries enabled until attached cells are observed and culled.
-		uw.pendingChildWsCull.store(true, std::memory_order_release);
-	}
-}
-
-void UnifiedWater::TES_DestroySkyCell::thunk(RE::TES* tes)
-{
-	func(tes);
-
-	auto& uw = globals::features::unifiedWater;
-	uw.currentPlayerWorldSpace.store(nullptr, std::memory_order_release);
-	uw.pendingChildWsCull.store(false, std::memory_order_release);
-	uw.cachedTes.store(nullptr, std::memory_order_release);
-	if (!uw.waterCache)
-		return;
-
-	uw.waterCache->SetCurrentWorldSpace(nullptr);
-}
-
 void UnifiedWater::BGSTerrainNode_UpdateWaterMeshSubVisibility::thunk(const RE::BGSTerrainNode* node, RE::BSMultiBoundNode* waterParent)
 {
 	if (!node || !waterParent)
@@ -500,113 +634,15 @@ void UnifiedWater::BGSTerrainBlock_Attach::thunk(RE::BGSTerrainBlock* block)
 		return;
 	}
 
-	// Additional game-thread retry path for deferred child-WS cull completion.
-	uw.TryCompleteDeferredChildWorldspaceCull(uw.cachedTes.load(std::memory_order_acquire));
-
-	std::vector<std::pair<RE::BSTriShape*, const WaterCache::Instruction*>> built;
-	bool attaching = false;
-
-	if (block && block->loaded && !block->attached && block->chunk && block->water) {
-		block->chunk->DetachChild2(block->water);
-		block->water->local.translate = block->chunk->local.translate;
-
-		RE::NiUpdateData updateData;
-		block->water->UpdateUpwardPass(updateData);
-
-		const auto water = block->water;
-		for (auto& child : water->GetChildren()) {
-			if (child) {
-				waterSystem->RemoveWater(child.get());
-				water->DetachChild(child.get());
-			}
-		}
-
-		attaching = true;
-
-		const auto node = block->node;
-		const auto lodLevel = node->GetLODLevel();
-		const auto worldSpace = block->node->manager->worldSpace;
-
-		const auto instructions = uw.waterCache->GetInstructions(worldSpace, lodLevel, node->baseCellX, node->baseCellY);
-		if (!instructions) {
-			logger::warn("[Unified Water] No instructions found for {} chunk at {}, {}", worldSpace->GetFormEditorID(), node->baseCellX, node->baseCellY);
-			func(block);
-			return;
-		}
-
-		for (auto& instruction : *instructions) {
-			if (!instruction.form.ptr)
-				continue;
-
-			RE::NiCloningProcess cloningProcess;
-
-			const auto targetShape = lodLevel > 4 || uw.settings.UseOptimisedMeshes ? uw.optimisedWaterMesh : uw.waterMesh;
-			RE::BSTriShape* shape = targetShape->CreateClone(cloningProcess)->AsTriShape();
-
-			const auto posX = (instruction.x - node->baseCellX) * 4096.0f + instruction.size * 2048.0f;
-			const auto posY = (instruction.y - node->baseCellY) * 4096.0f + instruction.size * 2048.0f;
-			shape->local.scale = static_cast<float>(instruction.size);
-			shape->local.translate = { posX, posY, instruction.waterHeight + kWaterLODHeightOffset };
-
-			water->AttachChild(shape, true);
-			built.emplace_back(shape, &instruction);
-
-			block->waterAttached = true;
-		}
-	}
-
-	func(block);
-
-	if (!attaching || !block->waterAttached)
-		return;
-
-	for (auto& [shape, instruction] : built) {
-		waterSystem->AddWater(shape, instruction->form.ptr, instruction->waterHeight, nullptr, true, false);
-
-		if (const auto prop = shape->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
-			const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
-			REX::EnumSet waterFlags = static_cast<RE::BSWaterShaderProperty::WaterFlag>(0b10000100);
-			waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kUseCubemapReflections;
-			waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kUseReflections;
-			if (instruction->form.ptr->flags.any(RE::TESWaterForm::Flag::kEnableFlowmap))
-				waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kEnableFlowmap;
-			if (instruction->form.ptr->flags.any(RE::TESWaterForm::Flag::kBlendNormals))
-				waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kBlendNormals;
-			waterShaderProp->waterFlags = waterFlags;
-		}
-
-		// Remove from WaterSystem, will manage it ourselves
-		if (!waterSystem->waterObjects.empty()) {
-			waterSystem->waterObjects.pop_back();
-		}
-	}
-
-	(*uw.gWaterLOD)->AttachChild(block->water, true);
-	waterSystem->Enable();
-
-	// BGSTerrainNode_UpdateWaterMeshSubVisibility never fires in child worldspaces.
-	// Cull newly built tiles here; full deferred retries are handled by
-	// TryCompleteDeferredChildWorldspaceCull().
-	if (IsChildWorldSpace(uw.currentPlayerWorldSpace.load(std::memory_order_acquire))) {
-		const auto tes = uw.cachedTes.load(std::memory_order_acquire);
-		if (tes && tes->gridCells) {
-			for (const auto& [shape, instruction] : built) {
-				const bool cull = ShouldCullAtCell(tes, instruction->x, instruction->y);
-				shape->SetAppCulled(cull);
-			}
-		}
-	}
+	uw.BuildWaterForBlock(block, waterSystem);
 }
 
 void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 {
 	auto& uw = globals::features::unifiedWater;
-	const auto water = block->water;
-	block->water = nullptr;
+	const auto water = block ? block->water : nullptr;
 
 	func(block);
-
-	block->water = water;
 
 	if (water) {
 		auto count = water->GetChildren().size();
@@ -614,7 +650,7 @@ void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 			water->DetachChildAt(--count);
 		}
 
-		(*uw.gWaterLOD)->DetachChild(water);
+		DetachAllChildOccurrences(*uw.gWaterLOD, water);
 		block->waterAttached = false;
 	}
 }
@@ -622,30 +658,6 @@ void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 void UnifiedWater::BSWaterShader_SetupGeometry::thunk(RE::BSShader* waterShader, RE::BSRenderPass* pass)
 {
 	auto& uw = globals::features::unifiedWater;
-
-	// Fix BSWaterShaderProperty.plane after interior->exterior transitions.
-	// The plane feeds ReflectPlane in the PerGeometry cbuffer. When corrupted (e.g., plane.constant = 0
-	// or garbage), the shader's refractionPlaneMul calculation produces extreme values causing flickering.
-	// This primarily affects flowmapped water because it uses more complex refraction depth calculations.
-	if (const auto prop = pass->geometry->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
-		const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
-		const float waterHeight = pass->geometry->world.translate.z;
-
-		// Validate and fix the plane if it's corrupted.
-		// A valid water plane has normal pointing up (0,0,1) and constant = water height.
-		// After interior->exterior transitions, plane.constant can be 0 or stale values.
-		const bool planeNonFinite =
-			!std::isfinite(waterShaderProp->plane.normal.x) ||
-			!std::isfinite(waterShaderProp->plane.normal.y) ||
-			!std::isfinite(waterShaderProp->plane.normal.z) ||
-			!std::isfinite(waterShaderProp->plane.constant);
-		const bool planeNormalBad = std::abs(waterShaderProp->plane.normal.x) > 0.01f || std::abs(waterShaderProp->plane.normal.y) > 0.01f || std::abs(waterShaderProp->plane.normal.z - 1.0f) > 0.01f;
-		const bool planeConstantBad = std::abs(waterShaderProp->plane.constant - waterHeight) > 1.0f;
-		if (planeNonFinite || planeNormalBad || planeConstantBad) {
-			waterShaderProp->plane.normal = { 0.0f, 0.0f, 1.0f };
-			waterShaderProp->plane.constant = waterHeight;
-		}
-	}
 
 	if (uw.flowmap) {
 		// ObjectUV.xyz below, xy contains width and height, z contains mesh scale
@@ -677,11 +689,7 @@ void UnifiedWater::TESWaterSystem_UpdateDisplacementMeshPosition::thunk(RE::TESW
 	func(waterSystem);
 
 	auto& uw = globals::features::unifiedWater;
-
-	// Game-thread fallback for deferred child-worldspace cull completion.
-	// Needed when entering child worldspaces with already-attached LOD blocks,
-	// where BGSTerrainBlock_Attach/UpdateWaterMeshSubVisibility may not run.
-	uw.TryCompleteDeferredChildWorldspaceCull(uw.cachedTes.load(std::memory_order_acquire));
+	RemoveDuplicateWaterSystemObjects(waterSystem, uw.gWaterLOD ? *uw.gWaterLOD : nullptr);
 
 	if (!uw.flowmap)
 		return;

--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -5,52 +5,19 @@
 #include "Util.h"
 
 #include <imgui_internal.h>
+#include <cmath>
+#include <unordered_map>
 #include <vector>
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	UnifiedWater::Settings,
-	UseOptimisedMeshes,
-	PurgeLODWaterAfterLoad)
-
-static constexpr int32_t kRestoredLODTrimFrames = 60;
-static constexpr int32_t kRestoredLODTrimExtraCells = 12;
-
-static bool IsChildWorldSpace(const RE::TESWorldSpace* ws)
-{
-	return ws && ws->parentWorld &&
-	       ws->parentUseFlags.all(RE::TESWorldSpace::ParentUseFlag::kUseLODData);
-}
-
-static bool IsLODCompatibleWorldSpace(const RE::TESWorldSpace* source, const RE::TESWorldSpace* destination)
-{
-	if (!source || !destination)
-		return false;
-
-	if (source == destination)
-		return true;
-
-	if (IsChildWorldSpace(destination) && destination->parentWorld == source)
-		return true;
-
-	if (IsChildWorldSpace(source) && source->parentWorld == destination)
-		return true;
-
-	return false;
-}
-
-static RE::TESWorldSpace* GetCurrentExteriorWorldSpace()
-{
-	const auto tes = globals::game::tes ? globals::game::tes : RE::TES::GetSingleton();
-	return tes ? tes->GetRuntimeData2().worldSpace : nullptr;
-}
+	UseOptimisedMeshes)
 
 // Engine behavior: CellState value 6 is the transition/attached state.
 static constexpr auto kTransitionAttachedCellState = static_cast<RE::TESObjectCELL::CellState>(6);
 
-static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY, bool* isInGrid = nullptr)
+static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY)
 {
-	if (isInGrid)
-		*isInGrid = false;
 	if (!tes || !tes->gridCells)
 		return false;
 
@@ -64,14 +31,27 @@ static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY, b
 	if (x < 0 || y < 0 || x >= length || y >= length)
 		return false;
 
-	if (isInGrid)
-		*isInGrid = true;
-
 	if (const auto cell = gridCells->GetCell(x, y)) {
 		return cell->cellState.any(RE::TESObjectCELL::CellState::kAttached, kTransitionAttachedCellState);
 	}
 
 	return false;
+}
+
+static void AddLODWater(RE::TESWaterSystem* waterSystem, RE::BSTriShape* waterShape, RE::TESWorldSpace* worldSpace, RE::NiNode* lodRoot, RE::NiNode* waterParent)
+{
+	using func_t = void (*)(RE::TESWaterSystem*, RE::BSTriShape*, RE::TESWorldSpace*, RE::NiNode*, RE::NiNode*, bool);
+	static REL::Relocation<func_t> func{ REL::RelocationID(31404, 32209) };
+
+	func(waterSystem, waterShape, worldSpace, lodRoot, waterParent, true);
+}
+
+static void RemoveLODWater(RE::TESWaterSystem* waterSystem, RE::BSTriShape* waterShape, RE::NiNode* lodRoot)
+{
+	using func_t = void (*)(RE::TESWaterSystem*, RE::BSTriShape*, RE::NiNode*);
+	static REL::Relocation<func_t> func{ REL::RelocationID(31405, 32210) };
+
+	func(waterSystem, waterShape, lodRoot);
 }
 
 static uint32_t ClearWaterNodeChildren(RE::NiNode* node, RE::TESWaterSystem* waterSystem)
@@ -96,276 +76,157 @@ static uint32_t ClearWaterNodeChildren(RE::NiNode* node, RE::TESWaterSystem* wat
 	return removed;
 }
 
-struct CullCompletionState
+static uint32_t DetachAllChildOccurrences(RE::NiNode* node, const RE::NiAVObject* childToDetach)
 {
-	bool foundAttachedCell = false;
-	bool hasPotentiallyAttachableChild = false;
+	if (!node || !childToDetach)
+		return 0;
 
-	bool IsComplete() const
+	uint32_t detached = 0;
+	auto count = node->GetChildren().size();
+	while (count > 0) {
+		const auto child = node->GetChildren()[count - 1];
+		if (child.get() == childToDetach) {
+			node->DetachChildAt(--count);
+			detached++;
+		} else {
+			count--;
+		}
+	}
+
+	return detached;
+}
+
+struct WaterPositionKey
+{
+	int32_t x = 0;
+	int32_t y = 0;
+	int32_t z = 0;
+	int32_t scale = 0;
+};
+
+static bool operator==(const WaterPositionKey& lhs, const WaterPositionKey& rhs)
+{
+	return lhs.x == rhs.x && lhs.y == rhs.y && lhs.z == rhs.z && lhs.scale == rhs.scale;
+}
+
+struct WaterPositionKeyHash
+{
+	size_t operator()(const WaterPositionKey& key) const noexcept
 	{
-		return foundAttachedCell && !hasPotentiallyAttachableChild;
+		size_t hash = std::hash<int32_t>{}(key.x);
+		hash ^= std::hash<int32_t>{}(key.y) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+		hash ^= std::hash<int32_t>{}(key.z) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+		hash ^= std::hash<int32_t>{}(key.scale) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+		return hash;
 	}
 };
 
-// Cull waterParent children using tes->gridCells attachment state.
-// Pass tes explicitly when globals::game::tes is not ready (e.g., TES_SetWorldSpace).
-static CullCompletionState CullWaterParentByGridCells(RE::NiNode* waterParent, RE::TES* tes = nullptr)
+static int32_t QuantizeWaterPosition(float value)
 {
-	if (!tes)
-		tes = globals::game::tes;
-	if (!tes || !waterParent)
+	return static_cast<int32_t>(std::lround(value));
+}
+
+static WaterPositionKey GetWaterPositionKey(const RE::NiAVObject* object)
+{
+	if (!object)
 		return {};
 
-	CullCompletionState state;
+	return {
+		QuantizeWaterPosition(object->world.translate.x),
+		QuantizeWaterPosition(object->world.translate.y),
+		QuantizeWaterPosition(object->world.translate.z),
+		QuantizeWaterPosition(object->world.scale * 1000.0f),
+	};
+}
+
+static bool IsChildOfNode(const RE::NiAVObject* object, const RE::NiNode* root)
+{
+	if (!object || !root)
+		return false;
+
+	for (auto parent = object->parent; parent; parent = parent->parent) {
+		if (parent == root)
+			return true;
+	}
+
+	return object == root;
+}
+
+static RE::BSTriShape* SelectDuplicateWaterSystemShapeToRemove(RE::BSTriShape* existing, RE::BSTriShape* candidate, RE::NiNode* lodRoot)
+{
+	if (!existing)
+		return candidate;
+	if (!candidate)
+		return existing;
+
+	const bool existingIsLOD = IsChildOfNode(existing, lodRoot);
+	const bool candidateIsLOD = IsChildOfNode(candidate, lodRoot);
+	if (existingIsLOD != candidateIsLOD)
+		return existingIsLOD ? existing : candidate;
+
+	return candidate;
+}
+
+static uint32_t RemoveDuplicateWaterSystemObjects(RE::TESWaterSystem* waterSystem, RE::NiNode* lodRoot)
+{
+	if (!waterSystem)
+		return 0;
+
+	static thread_local std::unordered_map<WaterPositionKey, RE::BSTriShape*, WaterPositionKeyHash> shapeByPosition;
+	static thread_local std::vector<RE::BSTriShape*> duplicateShapes;
+
+	shapeByPosition.clear();
+	duplicateShapes.clear();
+
+	const auto objectCount = waterSystem->waterObjects.size();
+	if (shapeByPosition.bucket_count() < objectCount)
+		shapeByPosition.reserve(objectCount);
+	if (duplicateShapes.capacity() < objectCount)
+		duplicateShapes.reserve(objectCount);
+
+	for (const auto& waterObject : waterSystem->waterObjects) {
+		const auto shape = waterObject ? waterObject->shape.get() : nullptr;
+		if (!shape)
+			continue;
+
+		const auto key = GetWaterPositionKey(shape);
+		const auto [it, inserted] = shapeByPosition.try_emplace(key, shape);
+		if (inserted)
+			continue;
+
+		const auto existing = it->second;
+		const auto duplicate = SelectDuplicateWaterSystemShapeToRemove(existing, shape, lodRoot);
+		if (duplicate == existing)
+			it->second = shape;
+
+		duplicateShapes.push_back(duplicate);
+	}
+
+	for (const auto shape : duplicateShapes) {
+		if (!shape)
+			continue;
+
+		shape->SetAppCulled(true);
+		waterSystem->RemoveWater(shape);
+	}
+
+	return static_cast<uint32_t>(duplicateShapes.size());
+}
+
+static void CullWaterParentByGridCells(RE::NiNode* waterParent)
+{
+	const auto tes = globals::game::tes;
+	if (!tes || !waterParent)
+		return;
 
 	for (const auto& child : waterParent->GetChildren()) {
 		if (!child)
 			continue;
 		int32_t x, y;
 		Util::WorldToCell(child->world.translate, x, y);
-		bool isInGrid = false;
-		const bool cull = ShouldCullAtCell(tes, x, y, &isInGrid);
-		if (cull)
-			state.foundAttachedCell = true;
-		else if (isInGrid)
-			state.hasPotentiallyAttachableChild = true;
+		const bool cull = ShouldCullAtCell(tes, x, y);
 		child->SetAppCulled(cull);
 	}
-
-	return state;
-}
-
-// Cull all tiles under every water LOD parent.
-static bool CullAllWaterLODParents(RE::NiNode* waterLOD, RE::TES* tes = nullptr)
-{
-	if (!waterLOD)
-		return false;
-
-	CullCompletionState aggregate;
-
-	for (const auto& waterParentPtr : waterLOD->GetChildren()) {
-		if (!waterParentPtr)
-			continue;
-		const auto waterParent = waterParentPtr->AsNode();
-		if (!waterParent)
-			continue;
-		const auto state = CullWaterParentByGridCells(waterParent, tes);
-		aggregate.foundAttachedCell = aggregate.foundAttachedCell || state.foundAttachedCell;
-		aggregate.hasPotentiallyAttachableChild = aggregate.hasPotentiallyAttachableChild || state.hasPotentiallyAttachableChild;
-	}
-
-	return aggregate.IsComplete();
-}
-
-static uint32_t RemoveWaterLODNearCurrentGrid(RE::NiNode* waterLOD, RE::TES* tes, RE::TESWaterSystem* waterSystem)
-{
-	if (!waterLOD || !tes || !tes->gridCells)
-		return 0;
-
-	const int32_t radius = static_cast<int32_t>(tes->gridCells->length >> 1) + kRestoredLODTrimExtraCells;
-	const int32_t centerX = tes->currentGridX;
-	const int32_t centerY = tes->currentGridY;
-
-	uint32_t removed = 0;
-	for (const auto& waterParentPtr : waterLOD->GetChildren()) {
-		const auto waterParent = waterParentPtr ? waterParentPtr->AsNode() : nullptr;
-		if (!waterParent)
-			continue;
-
-		auto count = waterParent->GetChildren().size();
-		while (count > 0) {
-			const auto child = waterParent->GetChildren()[count - 1];
-			if (!child) {
-				count--;
-				continue;
-			}
-
-			int32_t x, y;
-			Util::WorldToCell(child->world.translate, x, y);
-			const int32_t deltaX = x > centerX ? x - centerX : centerX - x;
-			const int32_t deltaY = y > centerY ? y - centerY : centerY - y;
-			if (deltaX > radius || deltaY > radius) {
-				count--;
-				continue;
-			}
-
-			if (const auto childNode = child->AsNode())
-				removed += ClearWaterNodeChildren(childNode, waterSystem);
-
-			if (waterSystem)
-				waterSystem->RemoveWater(child.get());
-
-			waterParent->DetachChildAt(--count);
-			removed++;
-		}
-	}
-
-	return removed;
-}
-
-void UnifiedWater::TryCompleteDeferredChildWorldspaceCull(RE::TES* tes)
-{
-	if (!pendingChildWsCull.load(std::memory_order_acquire) ||
-		!IsChildWorldSpace(currentPlayerWorldSpace.load(std::memory_order_acquire)) ||
-		!gWaterLOD || !*gWaterLOD)
-		return;
-
-	if (!tes)
-		tes = cachedTes.load(std::memory_order_acquire);
-	if (!tes || !tes->gridCells)
-		return;
-
-	if (CullAllWaterLODParents(*gWaterLOD, tes))
-		pendingChildWsCull.store(false, std::memory_order_release);
-}
-
-uint32_t UnifiedWater::PurgeLODWater()
-{
-	if (!gWaterLOD || !*gWaterLOD)
-		return 0;
-
-	return ClearWaterNodeChildren(*gWaterLOD, globals::game::waterSystem);
-}
-
-uint32_t UnifiedWater::ClearDetachedLODWater()
-{
-	uint32_t removed = 0;
-	const auto waterSystem = globals::game::waterSystem;
-	for (const auto& child : detachedLODWaterChildren) {
-		if (!child)
-			continue;
-
-		if (const auto childNode = child->AsNode())
-			removed += ClearWaterNodeChildren(childNode, waterSystem);
-
-		if (waterSystem)
-			waterSystem->RemoveWater(child.get());
-
-		removed++;
-	}
-
-	detachedLODWaterChildren.clear();
-	detachedLODWaterWorldSpace = nullptr;
-	return removed;
-}
-
-uint32_t UnifiedWater::DetachLODWaterForLoad()
-{
-	if (!settings.PurgeLODWaterAfterLoad || !gWaterLOD || !*gWaterLOD || !detachedLODWaterChildren.empty())
-		return 0;
-
-	auto sourceWorldSpace = GetCurrentExteriorWorldSpace();
-	if (!sourceWorldSpace)
-		sourceWorldSpace = currentPlayerWorldSpace.load(std::memory_order_acquire);
-	if (!sourceWorldSpace || Util::IsInterior())
-		return 0;
-
-	auto count = (*gWaterLOD)->GetChildren().size();
-	while (count > 0) {
-		const auto child = (*gWaterLOD)->GetChildren()[count - 1];
-		if (child)
-			detachedLODWaterChildren.push_back(child);
-
-		(*gWaterLOD)->DetachChildAt(--count);
-	}
-
-	if (detachedLODWaterChildren.empty())
-		return 0;
-
-	detachedLODWaterWorldSpace = sourceWorldSpace;
-	logger::info(
-		"[Unified Water] Detached LOD water for load from {}: detached {}",
-		sourceWorldSpace->GetFormEditorID(),
-		detachedLODWaterChildren.size());
-	return static_cast<uint32_t>(detachedLODWaterChildren.size());
-}
-
-uint32_t UnifiedWater::RestoreDetachedLODWater(RE::TESWorldSpace* destinationWorldSpace)
-{
-	if (detachedLODWaterChildren.empty() || !destinationWorldSpace || !gWaterLOD || !*gWaterLOD)
-		return 0;
-
-	if (!IsLODCompatibleWorldSpace(detachedLODWaterWorldSpace, destinationWorldSpace)) {
-		const auto removed = ClearDetachedLODWater();
-		logger::info(
-			"[Unified Water] Discarded detached LOD water after load into {}: removed {}",
-			destinationWorldSpace->GetFormEditorID(),
-			removed);
-		return 0;
-	}
-
-	uint32_t restored = 0;
-	for (const auto& child : detachedLODWaterChildren) {
-		if (child) {
-			(*gWaterLOD)->AttachChild(child.get(), true);
-			restored++;
-		}
-	}
-
-	logger::info(
-		"[Unified Water] Restored LOD water after load into {}: restored {} from {}",
-		destinationWorldSpace->GetFormEditorID(),
-		restored,
-		detachedLODWaterWorldSpace ? detachedLODWaterWorldSpace->GetFormEditorID() : "<none>");
-
-	detachedLODWaterChildren.clear();
-	detachedLODWaterWorldSpace = nullptr;
-	pendingRestoredLODTrimFrames.store(kRestoredLODTrimFrames, std::memory_order_release);
-	pendingRestoredLODTrimChildWorldspace.store(IsChildWorldSpace(destinationWorldSpace), std::memory_order_release);
-	return restored;
-}
-
-void UnifiedWater::ResolveDetachedLODWaterAfterLoad(RE::TESWorldSpace* destinationWorldSpace)
-{
-	if (detachedLODWaterChildren.empty())
-		return;
-
-	if (!destinationWorldSpace)
-		destinationWorldSpace = GetCurrentExteriorWorldSpace();
-	if (!destinationWorldSpace)
-		destinationWorldSpace = currentPlayerWorldSpace.load(std::memory_order_acquire);
-
-	if (!destinationWorldSpace || Util::IsInterior())
-		return;
-
-	RestoreDetachedLODWater(destinationWorldSpace);
-}
-
-void UnifiedWater::TryTrimRestoredLODWater()
-{
-	auto frames = pendingRestoredLODTrimFrames.load(std::memory_order_acquire);
-	if (frames <= 0)
-		return;
-
-	if (frames > 1) {
-		pendingRestoredLODTrimFrames.store(frames - 1, std::memory_order_release);
-		return;
-	}
-
-	const auto tes = globals::game::tes ? globals::game::tes : RE::TES::GetSingleton();
-	const auto waterSystem = globals::game::waterSystem;
-	const auto worldSpace = tes ? tes->GetRuntimeData2().worldSpace : currentPlayerWorldSpace.load(std::memory_order_acquire);
-	if (!tes || !tes->gridCells || !worldSpace || !gWaterLOD || !*gWaterLOD || !waterSystem) {
-		pendingRestoredLODTrimFrames.store(frames - 1, std::memory_order_release);
-		return;
-	}
-
-	if (pendingRestoredLODTrimChildWorldspace.load(std::memory_order_acquire)) {
-		const bool complete = CullAllWaterLODParents(*gWaterLOD, tes);
-		if (complete)
-			pendingRestoredLODTrimChildWorldspace.store(false, std::memory_order_release);
-		pendingRestoredLODTrimFrames.store(complete ? 0 : frames - 1, std::memory_order_release);
-		if (complete)
-			logger::info("[Unified Water] Culled restored LOD water after child-worldspace load in {}", worldSpace->GetFormEditorID());
-		return;
-	}
-
-	const auto removed = RemoveWaterLODNearCurrentGrid(*gWaterLOD, tes, waterSystem);
-	pendingRestoredLODTrimFrames.store(0, std::memory_order_release);
-	logger::info(
-		"[Unified Water] Trimmed restored LOD water after load in {}: removed {} near current grid",
-		worldSpace->GetFormEditorID(),
-		removed);
 }
 
 bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSystem* waterSystem, bool runOriginalAttach)
@@ -378,10 +239,11 @@ bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSy
 
 	std::vector<std::pair<RE::BSTriShape*, const WaterCache::Instruction*>> built;
 	bool attaching = false;
+	RE::TESWorldSpace* worldSpace = nullptr;
 
 	if (block && block->loaded && block->chunk && block->water && (runOriginalAttach ? !block->attached : block->attached)) {
 		block->chunk->DetachChild2(block->water);
-		(*gWaterLOD)->DetachChild(block->water);
+		DetachAllChildOccurrences(*gWaterLOD, block->water);
 		block->water->local.translate = block->chunk->local.translate;
 
 		RE::NiUpdateData updateData;
@@ -393,7 +255,7 @@ bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSy
 		attaching = true;
 
 		const auto node = block->node;
-		const auto worldSpace = node && node->manager ? node->manager->worldSpace : nullptr;
+		worldSpace = node && node->manager ? node->manager->worldSpace : nullptr;
 		if (!node || !worldSpace) {
 			if (runOriginalAttach)
 				BGSTerrainBlock_Attach::func(block);
@@ -437,7 +299,7 @@ bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSy
 		return false;
 
 	for (auto& [shape, instruction] : built) {
-		waterSystem->AddWater(shape, instruction->form.ptr, instruction->waterHeight, nullptr, true, false);
+		AddLODWater(waterSystem, shape, worldSpace, *gWaterLOD, block->water);
 
 		if (const auto prop = shape->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
 			const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
@@ -451,27 +313,15 @@ bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSy
 			waterShaderProp->waterFlags = waterFlags;
 		}
 
-		// Remove from WaterSystem, will manage it ourselves
-		if (!waterSystem->waterObjects.empty()) {
-			waterSystem->waterObjects.pop_back();
-		}
+		// Vanilla AddLODWater routes through TESWaterSystem::AddWater and attaches
+		// the water parent to gWaterLOD. Use the matching vanilla LOD remove wrapper
+		// to unwind the water-system side state, then reattach the parent once below.
+		RemoveLODWater(waterSystem, shape, *gWaterLOD);
 	}
 
+	DetachAllChildOccurrences(*gWaterLOD, block->water);
 	(*gWaterLOD)->AttachChild(block->water, true);
 	waterSystem->Enable();
-
-	// BGSTerrainNode_UpdateWaterMeshSubVisibility never fires in child worldspaces.
-	// Cull newly built tiles here; full deferred retries are handled by
-	// TryCompleteDeferredChildWorldspaceCull().
-	if (IsChildWorldSpace(currentPlayerWorldSpace.load(std::memory_order_acquire))) {
-		const auto tes = cachedTes.load(std::memory_order_acquire);
-		if (tes && tes->gridCells) {
-			for (const auto& [shape, instruction] : built) {
-				const bool cull = ShouldCullAtCell(tes, instruction->x, instruction->y);
-				shape->SetAppCulled(cull);
-			}
-		}
-	}
 
 	return true;
 }
@@ -479,9 +329,6 @@ bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSy
 void UnifiedWater::LoadSettings(json& o_json)
 {
 	settings = o_json;
-	logger::info(
-		"[Unified Water] Interior-load LOD water quarantine is {}",
-		settings.PurgeLODWaterAfterLoad ? "enabled" : "disabled");
 }
 
 void UnifiedWater::SaveSettings(json& o_json)
@@ -513,13 +360,6 @@ void UnifiedWater::DrawSettings()
 
 		if (ImGui::Button("Regenerate Caches") && waterCache)
 			waterCache->RegenerateCaches();
-
-		ImGui::Checkbox("Refresh LOD Water Around Interior Loads", &settings.PurgeLODWaterAfterLoad);
-		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text(
-				"Detaches existing Unified Water LOD before exterior teardown,\n"
-				"restores it on the next compatible exterior, then trims the local destination area.");
-		}
 
 		ImGui::TreePop();
 	}
@@ -646,8 +486,6 @@ void UnifiedWater::DataLoaded()
 	while (waterCache->IsBuildRunning()) {
 		std::this_thread::sleep_for(100ms);
 	}
-
-	MenuOpenCloseEventHandler::Register();
 }
 
 bool UnifiedWater::LoadOrderChanged()
@@ -701,41 +539,6 @@ bool UnifiedWater::LoadOrderChanged()
 	return hash != existingHash;
 }
 
-RE::BSEventNotifyControl UnifiedWater::MenuOpenCloseEventHandler::ProcessEvent(
-	const RE::MenuOpenCloseEvent* a_event,
-	RE::BSTEventSource<RE::MenuOpenCloseEvent>*)
-{
-	if (a_event && a_event->menuName == RE::LoadingMenu::MENU_NAME) {
-		if (a_event->opening)
-			globals::features::unifiedWater.DetachLODWaterForLoad();
-		else
-			globals::features::unifiedWater.ResolveDetachedLODWaterAfterLoad();
-	}
-
-	return RE::BSEventNotifyControl::kContinue;
-}
-
-bool UnifiedWater::MenuOpenCloseEventHandler::Register()
-{
-	static MenuOpenCloseEventHandler singleton;
-
-	const auto ui = globals::game::ui;
-	if (!ui) {
-		logger::error("[Unified Water] UI event source not found; interior-load LOD water quarantine disabled");
-		return false;
-	}
-
-	const auto eventSource = ui->GetEventSource<RE::MenuOpenCloseEvent>();
-	if (!eventSource) {
-		logger::error("[Unified Water] MenuOpenCloseEvent source not found; interior-load LOD water quarantine disabled");
-		return false;
-	}
-
-	eventSource->AddEventSink(&singleton);
-	logger::info("[Unified Water] Registered MenuOpenCloseEventHandler");
-	return true;
-}
-
 void UnifiedWater::SetFlowmapTex() const
 {
 	RE::NiPointer<RE::NiSourceTexture> tex;
@@ -755,9 +558,6 @@ void UnifiedWater::SetFlowmapTex() const
 
 void UnifiedWater::PostPostLoad()
 {
-	stl::detour_thunk<TES_SetWorldSpace>(REL::RelocationID(13170, 13315));
-	stl::detour_thunk<TES_DestroySkyCell>(REL::RelocationID(20029, 20463));
-
 	stl::write_thunk_call<TESWaterSystem_InitializeWater_SetWaterShaderMaterialParams>(REL::RelocationID(31388, 32179).address() + REL::Relocate(0x360, 0x3BC, 0x35B));
 	stl::write_vfunc<0x4, BSWaterShaderMaterial_ComputeCRC32>(RE::VTABLE_BSWaterShaderMaterial[0]);
 
@@ -827,60 +627,6 @@ int32_t UnifiedWater::BSWaterShaderMaterial_ComputeCRC32::thunk(RE::BSWaterShade
 	return func(material, srcHash);
 }
 
-void UnifiedWater::TES_SetWorldSpace::thunk(RE::TES* tes, RE::TESWorldSpace* worldSpace, bool isExterior)
-{
-	const bool enteringChild = IsChildWorldSpace(worldSpace);
-
-	// Set before func so attachment hooks fired inside func see the new worldspace.
-	auto& uw = globals::features::unifiedWater;
-	uw.currentPlayerWorldSpace.store(worldSpace, std::memory_order_release);
-	uw.cachedTes.store(tes, std::memory_order_release);
-	if (!enteringChild)
-		uw.pendingChildWsCull.store(false, std::memory_order_release);  // leaving child WS: discard any stale pending cull
-
-	func(tes, worldSpace, isExterior);
-
-	if (!uw.waterCache) {
-		uw.pendingChildWsCull.store(false, std::memory_order_release);
-		return;
-	}
-
-	uw.waterCache->SetCurrentWorldSpace(worldSpace);
-	if (worldSpace && isExterior)
-		uw.ResolveDetachedLODWaterAfterLoad(worldSpace);
-
-	if (enteringChild) {
-		// BGSTerrainBlock_Attach calls Enable() on block attach.
-		// Child-worldspace transitions can keep old LOD blocks attached, so re-enable here.
-		if (const auto waterSystem = globals::game::waterSystem)
-			waterSystem->Enable();
-
-		// Try an immediate cull with tes (globals::game::tes may still be null).
-		// Newly transitioned cells are often not attached yet, so deferred retries are still needed.
-		if (uw.gWaterLOD && *uw.gWaterLOD && tes && tes->gridCells)
-			CullAllWaterLODParents(*uw.gWaterLOD, tes);
-
-		// Keep deferred retries enabled until attached cells are observed and culled.
-		uw.pendingChildWsCull.store(true, std::memory_order_release);
-	}
-}
-
-void UnifiedWater::TES_DestroySkyCell::thunk(RE::TES* tes)
-{
-	auto& uw = globals::features::unifiedWater;
-	uw.DetachLODWaterForLoad();
-
-	func(tes);
-
-	uw.currentPlayerWorldSpace.store(nullptr, std::memory_order_release);
-	uw.pendingChildWsCull.store(false, std::memory_order_release);
-	uw.cachedTes.store(nullptr, std::memory_order_release);
-	if (!uw.waterCache)
-		return;
-
-	uw.waterCache->SetCurrentWorldSpace(nullptr);
-}
-
 void UnifiedWater::BGSTerrainNode_UpdateWaterMeshSubVisibility::thunk(const RE::BGSTerrainNode* node, RE::BSMultiBoundNode* waterParent)
 {
 	if (!node || !waterParent)
@@ -902,21 +648,15 @@ void UnifiedWater::BGSTerrainBlock_Attach::thunk(RE::BGSTerrainBlock* block)
 		return;
 	}
 
-	// Additional game-thread retry path for deferred child-WS cull completion.
-	uw.TryCompleteDeferredChildWorldspaceCull(uw.cachedTes.load(std::memory_order_acquire));
-
 	uw.BuildWaterForBlock(block, waterSystem, true);
 }
 
 void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 {
 	auto& uw = globals::features::unifiedWater;
-	const auto water = block->water;
-	block->water = nullptr;
+	const auto water = block ? block->water : nullptr;
 
 	func(block);
-
-	block->water = water;
 
 	if (water) {
 		auto count = water->GetChildren().size();
@@ -924,7 +664,7 @@ void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 			water->DetachChildAt(--count);
 		}
 
-		(*uw.gWaterLOD)->DetachChild(water);
+		DetachAllChildOccurrences(*uw.gWaterLOD, water);
 		block->waterAttached = false;
 	}
 }
@@ -932,30 +672,6 @@ void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 void UnifiedWater::BSWaterShader_SetupGeometry::thunk(RE::BSShader* waterShader, RE::BSRenderPass* pass)
 {
 	auto& uw = globals::features::unifiedWater;
-
-	// Fix BSWaterShaderProperty.plane after interior->exterior transitions.
-	// The plane feeds ReflectPlane in the PerGeometry cbuffer. When corrupted (e.g., plane.constant = 0
-	// or garbage), the shader's refractionPlaneMul calculation produces extreme values causing flickering.
-	// This primarily affects flowmapped water because it uses more complex refraction depth calculations.
-	if (const auto prop = pass->geometry->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
-		const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
-		const float waterHeight = pass->geometry->world.translate.z;
-
-		// Validate and fix the plane if it's corrupted.
-		// A valid water plane has normal pointing up (0,0,1) and constant = water height.
-		// After interior->exterior transitions, plane.constant can be 0 or stale values.
-		const bool planeNonFinite =
-			!std::isfinite(waterShaderProp->plane.normal.x) ||
-			!std::isfinite(waterShaderProp->plane.normal.y) ||
-			!std::isfinite(waterShaderProp->plane.normal.z) ||
-			!std::isfinite(waterShaderProp->plane.constant);
-		const bool planeNormalBad = std::abs(waterShaderProp->plane.normal.x) > 0.01f || std::abs(waterShaderProp->plane.normal.y) > 0.01f || std::abs(waterShaderProp->plane.normal.z - 1.0f) > 0.01f;
-		const bool planeConstantBad = std::abs(waterShaderProp->plane.constant - waterHeight) > 1.0f;
-		if (planeNonFinite || planeNormalBad || planeConstantBad) {
-			waterShaderProp->plane.normal = { 0.0f, 0.0f, 1.0f };
-			waterShaderProp->plane.constant = waterHeight;
-		}
-	}
 
 	if (uw.flowmap) {
 		// ObjectUV.xyz below, xy contains width and height, z contains mesh scale
@@ -987,12 +703,7 @@ void UnifiedWater::TESWaterSystem_UpdateDisplacementMeshPosition::thunk(RE::TESW
 	func(waterSystem);
 
 	auto& uw = globals::features::unifiedWater;
-
-	// Game-thread fallback for deferred child-worldspace cull completion.
-	// Needed when entering child worldspaces with already-attached LOD blocks,
-	// where BGSTerrainBlock_Attach/UpdateWaterMeshSubVisibility may not run.
-	uw.TryCompleteDeferredChildWorldspaceCull(uw.cachedTes.load(std::memory_order_acquire));
-	uw.TryTrimRestoredLODWater();
+	RemoveDuplicateWaterSystemObjects(waterSystem, uw.gWaterLOD ? *uw.gWaterLOD : nullptr);
 
 	if (!uw.flowmap)
 		return;

--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -54,46 +54,38 @@ static void RemoveLODWater(RE::TESWaterSystem* waterSystem, RE::BSTriShape* wate
 	func(waterSystem, waterShape, lodRoot);
 }
 
-static uint32_t ClearWaterNodeChildren(RE::NiNode* node, RE::TESWaterSystem* waterSystem)
+static void ClearWaterNodeChildren(RE::NiNode* node, RE::TESWaterSystem* waterSystem)
 {
 	if (!node)
-		return 0;
+		return;
 
-	uint32_t removed = 0;
 	auto count = node->GetChildren().size();
 	while (count > 0) {
 		const auto child = node->GetChildren()[count - 1];
 		if (const auto childNode = child ? child->AsNode() : nullptr)
-			removed += ClearWaterNodeChildren(childNode, waterSystem);
+			ClearWaterNodeChildren(childNode, waterSystem);
 
 		if (child && waterSystem)
 			waterSystem->RemoveWater(child.get());
 
 		node->DetachChildAt(--count);
-		removed++;
 	}
-
-	return removed;
 }
 
-static uint32_t DetachAllChildOccurrences(RE::NiNode* node, const RE::NiAVObject* childToDetach)
+static void DetachAllChildOccurrences(RE::NiNode* node, const RE::NiAVObject* childToDetach)
 {
 	if (!node || !childToDetach)
-		return 0;
+		return;
 
-	uint32_t detached = 0;
 	auto count = node->GetChildren().size();
 	while (count > 0) {
 		const auto child = node->GetChildren()[count - 1];
 		if (child.get() == childToDetach) {
 			node->DetachChildAt(--count);
-			detached++;
 		} else {
 			count--;
 		}
 	}
-
-	return detached;
 }
 
 struct WaterPositionKey
@@ -167,10 +159,10 @@ static RE::BSTriShape* SelectDuplicateWaterSystemShapeToRemove(RE::BSTriShape* e
 	return candidate;
 }
 
-static uint32_t RemoveDuplicateWaterSystemObjects(RE::TESWaterSystem* waterSystem, RE::NiNode* lodRoot)
+static void RemoveDuplicateWaterSystemObjects(RE::TESWaterSystem* waterSystem, RE::NiNode* lodRoot)
 {
 	if (!waterSystem)
-		return 0;
+		return;
 
 	static thread_local std::unordered_map<WaterPositionKey, RE::BSTriShape*, WaterPositionKeyHash> shapeByPosition;
 	static thread_local std::vector<RE::BSTriShape*> duplicateShapes;
@@ -209,8 +201,6 @@ static uint32_t RemoveDuplicateWaterSystemObjects(RE::TESWaterSystem* waterSyste
 		shape->SetAppCulled(true);
 		waterSystem->RemoveWater(shape);
 	}
-
-	return static_cast<uint32_t>(duplicateShapes.size());
 }
 
 static void CullWaterParentByGridCells(RE::NiNode* waterParent)
@@ -229,11 +219,10 @@ static void CullWaterParentByGridCells(RE::NiNode* waterParent)
 	}
 }
 
-bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSystem* waterSystem, bool runOriginalAttach)
+bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSystem* waterSystem)
 {
 	if (!waterSystem || !waterCache || !gWaterLOD || !*gWaterLOD) {
-		if (runOriginalAttach)
-			BGSTerrainBlock_Attach::func(block);
+		BGSTerrainBlock_Attach::func(block);
 		return false;
 	}
 
@@ -241,7 +230,7 @@ bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSy
 	bool attaching = false;
 	RE::TESWorldSpace* worldSpace = nullptr;
 
-	if (block && block->loaded && block->chunk && block->water && (runOriginalAttach ? !block->attached : block->attached)) {
+	if (block && block->loaded && block->chunk && block->water && !block->attached) {
 		block->chunk->DetachChild2(block->water);
 		DetachAllChildOccurrences(*gWaterLOD, block->water);
 		block->water->local.translate = block->chunk->local.translate;
@@ -257,8 +246,7 @@ bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSy
 		const auto node = block->node;
 		worldSpace = node && node->manager ? node->manager->worldSpace : nullptr;
 		if (!node || !worldSpace) {
-			if (runOriginalAttach)
-				BGSTerrainBlock_Attach::func(block);
+			BGSTerrainBlock_Attach::func(block);
 			return false;
 		}
 
@@ -266,8 +254,7 @@ bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSy
 		const auto instructions = waterCache->GetInstructions(worldSpace, lodLevel, node->baseCellX, node->baseCellY);
 		if (!instructions) {
 			logger::warn("[Unified Water] No instructions found for {} chunk at {}, {}", worldSpace->GetFormEditorID(), node->baseCellX, node->baseCellY);
-			if (runOriginalAttach)
-				BGSTerrainBlock_Attach::func(block);
+			BGSTerrainBlock_Attach::func(block);
 			return false;
 		}
 
@@ -292,8 +279,7 @@ bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSy
 		}
 	}
 
-	if (runOriginalAttach)
-		BGSTerrainBlock_Attach::func(block);
+	BGSTerrainBlock_Attach::func(block);
 
 	if (!attaching || !block->waterAttached)
 		return false;
@@ -648,7 +634,7 @@ void UnifiedWater::BGSTerrainBlock_Attach::thunk(RE::BGSTerrainBlock* block)
 		return;
 	}
 
-	uw.BuildWaterForBlock(block, waterSystem, true);
+	uw.BuildWaterForBlock(block, waterSystem);
 }
 
 void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)

--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -5,19 +5,26 @@
 #include "Util.h"
 
 #include <imgui_internal.h>
-#include <cmath>
-#include <unordered_map>
-#include <vector>
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	UnifiedWater::Settings,
 	UseOptimisedMeshes)
 
+static constexpr float kWaterLODHeightOffset = -4.0f;
+
+static bool IsChildWorldSpace(const RE::TESWorldSpace* ws)
+{
+	return ws && ws->parentWorld &&
+	       ws->parentUseFlags.all(RE::TESWorldSpace::ParentUseFlag::kUseLODData);
+}
+
 // Engine behavior: CellState value 6 is the transition/attached state.
 static constexpr auto kTransitionAttachedCellState = static_cast<RE::TESObjectCELL::CellState>(6);
 
-static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY)
+static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY, bool* isInGrid = nullptr)
 {
+	if (isInGrid)
+		*isInGrid = false;
 	if (!tes || !tes->gridCells)
 		return false;
 
@@ -31,6 +38,9 @@ static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY)
 	if (x < 0 || y < 0 || x >= length || y >= length)
 		return false;
 
+	if (isInGrid)
+		*isInGrid = true;
+
 	if (const auto cell = gridCells->GetCell(x, y)) {
 		return cell->cellState.any(RE::TESObjectCELL::CellState::kAttached, kTransitionAttachedCellState);
 	}
@@ -38,278 +48,81 @@ static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY)
 	return false;
 }
 
-static void AddLODWater(RE::TESWaterSystem* waterSystem, RE::BSTriShape* waterShape, RE::TESWorldSpace* worldSpace, RE::NiNode* lodRoot, RE::NiNode* waterParent)
+struct CullCompletionState
 {
-	using func_t = void (*)(RE::TESWaterSystem*, RE::BSTriShape*, RE::TESWorldSpace*, RE::NiNode*, RE::NiNode*, bool);
-	static REL::Relocation<func_t> func{ REL::RelocationID(31404, 32209) };
+	bool foundAttachedCell = false;
+	bool hasPotentiallyAttachableChild = false;
 
-	func(waterSystem, waterShape, worldSpace, lodRoot, waterParent, true);
-}
-
-static void RemoveLODWater(RE::TESWaterSystem* waterSystem, RE::BSTriShape* waterShape, RE::NiNode* lodRoot)
-{
-	using func_t = void (*)(RE::TESWaterSystem*, RE::BSTriShape*, RE::NiNode*);
-	static REL::Relocation<func_t> func{ REL::RelocationID(31405, 32210) };
-
-	func(waterSystem, waterShape, lodRoot);
-}
-
-static void ClearWaterNodeChildren(RE::NiNode* node, RE::TESWaterSystem* waterSystem)
-{
-	if (!node)
-		return;
-
-	auto count = node->GetChildren().size();
-	while (count > 0) {
-		const auto child = node->GetChildren()[count - 1];
-		if (const auto childNode = child ? child->AsNode() : nullptr)
-			ClearWaterNodeChildren(childNode, waterSystem);
-
-		if (child && waterSystem)
-			waterSystem->RemoveWater(child.get());
-
-		node->DetachChildAt(--count);
-	}
-}
-
-static void DetachAllChildOccurrences(RE::NiNode* node, const RE::NiAVObject* childToDetach)
-{
-	if (!node || !childToDetach)
-		return;
-
-	auto count = node->GetChildren().size();
-	while (count > 0) {
-		const auto child = node->GetChildren()[count - 1];
-		if (child.get() == childToDetach) {
-			node->DetachChildAt(--count);
-		} else {
-			count--;
-		}
-	}
-}
-
-struct WaterPositionKey
-{
-	int32_t x = 0;
-	int32_t y = 0;
-	int32_t z = 0;
-	int32_t scale = 0;
-};
-
-static bool operator==(const WaterPositionKey& lhs, const WaterPositionKey& rhs)
-{
-	return lhs.x == rhs.x && lhs.y == rhs.y && lhs.z == rhs.z && lhs.scale == rhs.scale;
-}
-
-struct WaterPositionKeyHash
-{
-	size_t operator()(const WaterPositionKey& key) const noexcept
+	bool IsComplete() const
 	{
-		size_t hash = std::hash<int32_t>{}(key.x);
-		hash ^= std::hash<int32_t>{}(key.y) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		hash ^= std::hash<int32_t>{}(key.z) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		hash ^= std::hash<int32_t>{}(key.scale) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		return hash;
+		return foundAttachedCell && !hasPotentiallyAttachableChild;
 	}
 };
 
-static int32_t QuantizeWaterPosition(float value)
+// Cull waterParent children using tes->gridCells attachment state.
+// Pass tes explicitly when globals::game::tes is not ready (e.g., TES_SetWorldSpace).
+static CullCompletionState CullWaterParentByGridCells(RE::NiNode* waterParent, RE::TES* tes = nullptr)
 {
-	return static_cast<int32_t>(std::lround(value));
-}
-
-static WaterPositionKey GetWaterPositionKey(const RE::NiAVObject* object)
-{
-	if (!object)
+	if (!tes)
+		tes = globals::game::tes;
+	if (!tes || !waterParent)
 		return {};
 
-	return {
-		QuantizeWaterPosition(object->world.translate.x),
-		QuantizeWaterPosition(object->world.translate.y),
-		QuantizeWaterPosition(object->world.translate.z),
-		QuantizeWaterPosition(object->world.scale * 1000.0f),
-	};
-}
-
-static bool IsChildOfNode(const RE::NiAVObject* object, const RE::NiNode* root)
-{
-	if (!object || !root)
-		return false;
-
-	for (auto parent = object->parent; parent; parent = parent->parent) {
-		if (parent == root)
-			return true;
-	}
-
-	return object == root;
-}
-
-static RE::BSTriShape* SelectDuplicateWaterSystemShapeToRemove(RE::BSTriShape* existing, RE::BSTriShape* candidate, RE::NiNode* lodRoot)
-{
-	if (!existing)
-		return candidate;
-	if (!candidate)
-		return existing;
-
-	const bool existingIsLOD = IsChildOfNode(existing, lodRoot);
-	const bool candidateIsLOD = IsChildOfNode(candidate, lodRoot);
-	if (existingIsLOD != candidateIsLOD)
-		return existingIsLOD ? existing : candidate;
-
-	return candidate;
-}
-
-static void RemoveDuplicateWaterSystemObjects(RE::TESWaterSystem* waterSystem, RE::NiNode* lodRoot)
-{
-	if (!waterSystem)
-		return;
-
-	static thread_local std::unordered_map<WaterPositionKey, RE::BSTriShape*, WaterPositionKeyHash> shapeByPosition;
-	static thread_local std::vector<RE::BSTriShape*> duplicateShapes;
-
-	shapeByPosition.clear();
-	duplicateShapes.clear();
-
-	const auto objectCount = waterSystem->waterObjects.size();
-	if (shapeByPosition.bucket_count() < objectCount)
-		shapeByPosition.reserve(objectCount);
-	if (duplicateShapes.capacity() < objectCount)
-		duplicateShapes.reserve(objectCount);
-
-	for (const auto& waterObject : waterSystem->waterObjects) {
-		const auto shape = waterObject ? waterObject->shape.get() : nullptr;
-		if (!shape)
-			continue;
-
-		const auto key = GetWaterPositionKey(shape);
-		const auto [it, inserted] = shapeByPosition.try_emplace(key, shape);
-		if (inserted)
-			continue;
-
-		const auto existing = it->second;
-		const auto duplicate = SelectDuplicateWaterSystemShapeToRemove(existing, shape, lodRoot);
-		if (duplicate == existing)
-			it->second = shape;
-
-		duplicateShapes.push_back(duplicate);
-	}
-
-	for (const auto shape : duplicateShapes) {
-		if (!shape)
-			continue;
-
-		shape->SetAppCulled(true);
-		waterSystem->RemoveWater(shape);
-	}
-}
-
-static void CullWaterParentByGridCells(RE::NiNode* waterParent)
-{
-	const auto tes = globals::game::tes;
-	if (!tes || !waterParent)
-		return;
+	CullCompletionState state;
 
 	for (const auto& child : waterParent->GetChildren()) {
 		if (!child)
 			continue;
 		int32_t x, y;
 		Util::WorldToCell(child->world.translate, x, y);
-		const bool cull = ShouldCullAtCell(tes, x, y);
+		bool isInGrid = false;
+		const bool cull = ShouldCullAtCell(tes, x, y, &isInGrid);
+		if (cull)
+			state.foundAttachedCell = true;
+		else if (isInGrid)
+			state.hasPotentiallyAttachableChild = true;
 		child->SetAppCulled(cull);
 	}
+
+	return state;
 }
 
-bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSystem* waterSystem)
+// Cull all tiles under every water LOD parent.
+static bool CullAllWaterLODParents(RE::NiNode* waterLOD, RE::TES* tes = nullptr)
 {
-	if (!waterSystem || !waterCache || !gWaterLOD || !*gWaterLOD) {
-		BGSTerrainBlock_Attach::func(block);
-		return false;
-	}
-
-	std::vector<std::pair<RE::BSTriShape*, const WaterCache::Instruction*>> built;
-	bool attaching = false;
-	RE::TESWorldSpace* worldSpace = nullptr;
-
-	if (block && block->loaded && block->chunk && block->water && !block->attached) {
-		block->chunk->DetachChild2(block->water);
-		DetachAllChildOccurrences(*gWaterLOD, block->water);
-		block->water->local.translate = block->chunk->local.translate;
-
-		RE::NiUpdateData updateData;
-		block->water->UpdateUpwardPass(updateData);
-
-		ClearWaterNodeChildren(block->water, waterSystem);
-		block->waterAttached = false;
-
-		attaching = true;
-
-		const auto node = block->node;
-		worldSpace = node && node->manager ? node->manager->worldSpace : nullptr;
-		if (!node || !worldSpace) {
-			BGSTerrainBlock_Attach::func(block);
-			return false;
-		}
-
-		const auto lodLevel = node->GetLODLevel();
-		const auto instructions = waterCache->GetInstructions(worldSpace, lodLevel, node->baseCellX, node->baseCellY);
-		if (!instructions) {
-			logger::warn("[Unified Water] No instructions found for {} chunk at {}, {}", worldSpace->GetFormEditorID(), node->baseCellX, node->baseCellY);
-			BGSTerrainBlock_Attach::func(block);
-			return false;
-		}
-
-		for (auto& instruction : *instructions) {
-			if (!instruction.form.ptr)
-				continue;
-
-			RE::NiCloningProcess cloningProcess;
-
-			const auto targetShape = lodLevel > 4 || settings.UseOptimisedMeshes ? optimisedWaterMesh : waterMesh;
-			RE::BSTriShape* shape = targetShape->CreateClone(cloningProcess)->AsTriShape();
-
-			const auto posX = (instruction.x - node->baseCellX) * 4096.0f + instruction.size * 2048.0f;
-			const auto posY = (instruction.y - node->baseCellY) * 4096.0f + instruction.size * 2048.0f;
-			shape->local.scale = static_cast<float>(instruction.size);
-			shape->local.translate = { posX, posY, instruction.waterHeight };
-
-			block->water->AttachChild(shape, true);
-			built.emplace_back(shape, &instruction);
-
-			block->waterAttached = true;
-		}
-	}
-
-	BGSTerrainBlock_Attach::func(block);
-
-	if (!attaching || !block->waterAttached)
+	if (!waterLOD)
 		return false;
 
-	for (auto& [shape, instruction] : built) {
-		AddLODWater(waterSystem, shape, worldSpace, *gWaterLOD, block->water);
+	CullCompletionState aggregate;
 
-		if (const auto prop = shape->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
-			const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
-			REX::EnumSet waterFlags = static_cast<RE::BSWaterShaderProperty::WaterFlag>(0b10000100);
-			waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kUseCubemapReflections;
-			waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kUseReflections;
-			if (instruction->form.ptr->flags.any(RE::TESWaterForm::Flag::kEnableFlowmap))
-				waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kEnableFlowmap;
-			if (instruction->form.ptr->flags.any(RE::TESWaterForm::Flag::kBlendNormals))
-				waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kBlendNormals;
-			waterShaderProp->waterFlags = waterFlags;
-		}
-
-		// Vanilla AddLODWater routes through TESWaterSystem::AddWater and attaches
-		// the water parent to gWaterLOD. Use the matching vanilla LOD remove wrapper
-		// to unwind the water-system side state, then reattach the parent once below.
-		RemoveLODWater(waterSystem, shape, *gWaterLOD);
+	for (const auto& waterParentPtr : waterLOD->GetChildren()) {
+		if (!waterParentPtr)
+			continue;
+		const auto waterParent = waterParentPtr->AsNode();
+		if (!waterParent)
+			continue;
+		const auto state = CullWaterParentByGridCells(waterParent, tes);
+		aggregate.foundAttachedCell = aggregate.foundAttachedCell || state.foundAttachedCell;
+		aggregate.hasPotentiallyAttachableChild = aggregate.hasPotentiallyAttachableChild || state.hasPotentiallyAttachableChild;
 	}
 
-	DetachAllChildOccurrences(*gWaterLOD, block->water);
-	(*gWaterLOD)->AttachChild(block->water, true);
-	waterSystem->Enable();
+	return aggregate.IsComplete();
+}
 
-	return true;
+void UnifiedWater::TryCompleteDeferredChildWorldspaceCull(RE::TES* tes)
+{
+	if (!pendingChildWsCull.load(std::memory_order_acquire) ||
+		!IsChildWorldSpace(currentPlayerWorldSpace.load(std::memory_order_acquire)) ||
+		!gWaterLOD || !*gWaterLOD)
+		return;
+
+	if (!tes)
+		tes = cachedTes.load(std::memory_order_acquire);
+	if (!tes || !tes->gridCells)
+		return;
+
+	if (CullAllWaterLODParents(*gWaterLOD, tes))
+		pendingChildWsCull.store(false, std::memory_order_release);
 }
 
 void UnifiedWater::LoadSettings(json& o_json)
@@ -544,6 +357,9 @@ void UnifiedWater::SetFlowmapTex() const
 
 void UnifiedWater::PostPostLoad()
 {
+	stl::detour_thunk<TES_SetWorldSpace>(REL::RelocationID(13170, 13315));
+	stl::detour_thunk<TES_DestroySkyCell>(REL::RelocationID(20029, 20463));
+
 	stl::write_thunk_call<TESWaterSystem_InitializeWater_SetWaterShaderMaterialParams>(REL::RelocationID(31388, 32179).address() + REL::Relocate(0x360, 0x3BC, 0x35B));
 	stl::write_vfunc<0x4, BSWaterShaderMaterial_ComputeCRC32>(RE::VTABLE_BSWaterShaderMaterial[0]);
 
@@ -613,6 +429,56 @@ int32_t UnifiedWater::BSWaterShaderMaterial_ComputeCRC32::thunk(RE::BSWaterShade
 	return func(material, srcHash);
 }
 
+void UnifiedWater::TES_SetWorldSpace::thunk(RE::TES* tes, RE::TESWorldSpace* worldSpace, bool isExterior)
+{
+	const bool enteringChild = IsChildWorldSpace(worldSpace);
+
+	// Set before func so attachment hooks fired inside func see the new worldspace.
+	auto& uw = globals::features::unifiedWater;
+	uw.currentPlayerWorldSpace.store(worldSpace, std::memory_order_release);
+	uw.cachedTes.store(tes, std::memory_order_release);
+	if (!enteringChild)
+		uw.pendingChildWsCull.store(false, std::memory_order_release);  // leaving child WS: discard any stale pending cull
+
+	func(tes, worldSpace, isExterior);
+
+	if (!uw.waterCache) {
+		uw.pendingChildWsCull.store(false, std::memory_order_release);
+		return;
+	}
+
+	uw.waterCache->SetCurrentWorldSpace(worldSpace);
+
+	if (enteringChild) {
+		// BGSTerrainBlock_Attach calls Enable() on block attach.
+		// Child-worldspace transitions can keep old LOD blocks attached, so re-enable here.
+		if (const auto waterSystem = globals::game::waterSystem)
+			waterSystem->Enable();
+
+		// Try an immediate cull with tes (globals::game::tes may still be null).
+		// Newly transitioned cells are often not attached yet, so deferred retries are still needed.
+		if (uw.gWaterLOD && *uw.gWaterLOD && tes && tes->gridCells)
+			CullAllWaterLODParents(*uw.gWaterLOD, tes);
+
+		// Keep deferred retries enabled until attached cells are observed and culled.
+		uw.pendingChildWsCull.store(true, std::memory_order_release);
+	}
+}
+
+void UnifiedWater::TES_DestroySkyCell::thunk(RE::TES* tes)
+{
+	func(tes);
+
+	auto& uw = globals::features::unifiedWater;
+	uw.currentPlayerWorldSpace.store(nullptr, std::memory_order_release);
+	uw.pendingChildWsCull.store(false, std::memory_order_release);
+	uw.cachedTes.store(nullptr, std::memory_order_release);
+	if (!uw.waterCache)
+		return;
+
+	uw.waterCache->SetCurrentWorldSpace(nullptr);
+}
+
 void UnifiedWater::BGSTerrainNode_UpdateWaterMeshSubVisibility::thunk(const RE::BGSTerrainNode* node, RE::BSMultiBoundNode* waterParent)
 {
 	if (!node || !waterParent)
@@ -634,15 +500,113 @@ void UnifiedWater::BGSTerrainBlock_Attach::thunk(RE::BGSTerrainBlock* block)
 		return;
 	}
 
-	uw.BuildWaterForBlock(block, waterSystem);
+	// Additional game-thread retry path for deferred child-WS cull completion.
+	uw.TryCompleteDeferredChildWorldspaceCull(uw.cachedTes.load(std::memory_order_acquire));
+
+	std::vector<std::pair<RE::BSTriShape*, const WaterCache::Instruction*>> built;
+	bool attaching = false;
+
+	if (block && block->loaded && !block->attached && block->chunk && block->water) {
+		block->chunk->DetachChild2(block->water);
+		block->water->local.translate = block->chunk->local.translate;
+
+		RE::NiUpdateData updateData;
+		block->water->UpdateUpwardPass(updateData);
+
+		const auto water = block->water;
+		for (auto& child : water->GetChildren()) {
+			if (child) {
+				waterSystem->RemoveWater(child.get());
+				water->DetachChild(child.get());
+			}
+		}
+
+		attaching = true;
+
+		const auto node = block->node;
+		const auto lodLevel = node->GetLODLevel();
+		const auto worldSpace = block->node->manager->worldSpace;
+
+		const auto instructions = uw.waterCache->GetInstructions(worldSpace, lodLevel, node->baseCellX, node->baseCellY);
+		if (!instructions) {
+			logger::warn("[Unified Water] No instructions found for {} chunk at {}, {}", worldSpace->GetFormEditorID(), node->baseCellX, node->baseCellY);
+			func(block);
+			return;
+		}
+
+		for (auto& instruction : *instructions) {
+			if (!instruction.form.ptr)
+				continue;
+
+			RE::NiCloningProcess cloningProcess;
+
+			const auto targetShape = lodLevel > 4 || uw.settings.UseOptimisedMeshes ? uw.optimisedWaterMesh : uw.waterMesh;
+			RE::BSTriShape* shape = targetShape->CreateClone(cloningProcess)->AsTriShape();
+
+			const auto posX = (instruction.x - node->baseCellX) * 4096.0f + instruction.size * 2048.0f;
+			const auto posY = (instruction.y - node->baseCellY) * 4096.0f + instruction.size * 2048.0f;
+			shape->local.scale = static_cast<float>(instruction.size);
+			shape->local.translate = { posX, posY, instruction.waterHeight + kWaterLODHeightOffset };
+
+			water->AttachChild(shape, true);
+			built.emplace_back(shape, &instruction);
+
+			block->waterAttached = true;
+		}
+	}
+
+	func(block);
+
+	if (!attaching || !block->waterAttached)
+		return;
+
+	for (auto& [shape, instruction] : built) {
+		waterSystem->AddWater(shape, instruction->form.ptr, instruction->waterHeight, nullptr, true, false);
+
+		if (const auto prop = shape->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
+			const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
+			REX::EnumSet waterFlags = static_cast<RE::BSWaterShaderProperty::WaterFlag>(0b10000100);
+			waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kUseCubemapReflections;
+			waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kUseReflections;
+			if (instruction->form.ptr->flags.any(RE::TESWaterForm::Flag::kEnableFlowmap))
+				waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kEnableFlowmap;
+			if (instruction->form.ptr->flags.any(RE::TESWaterForm::Flag::kBlendNormals))
+				waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kBlendNormals;
+			waterShaderProp->waterFlags = waterFlags;
+		}
+
+		// Remove from WaterSystem, will manage it ourselves
+		if (!waterSystem->waterObjects.empty()) {
+			waterSystem->waterObjects.pop_back();
+		}
+	}
+
+	(*uw.gWaterLOD)->AttachChild(block->water, true);
+	waterSystem->Enable();
+
+	// BGSTerrainNode_UpdateWaterMeshSubVisibility never fires in child worldspaces.
+	// Cull newly built tiles here; full deferred retries are handled by
+	// TryCompleteDeferredChildWorldspaceCull().
+	if (IsChildWorldSpace(uw.currentPlayerWorldSpace.load(std::memory_order_acquire))) {
+		const auto tes = uw.cachedTes.load(std::memory_order_acquire);
+		if (tes && tes->gridCells) {
+			for (const auto& [shape, instruction] : built) {
+				const bool cull = ShouldCullAtCell(tes, instruction->x, instruction->y);
+				shape->SetAppCulled(cull);
+			}
+		}
+	}
 }
 
 void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 {
 	auto& uw = globals::features::unifiedWater;
-	const auto water = block ? block->water : nullptr;
+	const auto water = block->water;
+	block->water = nullptr;
 
 	func(block);
+
+	block->water = water;
 
 	if (water) {
 		auto count = water->GetChildren().size();
@@ -650,7 +614,7 @@ void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 			water->DetachChildAt(--count);
 		}
 
-		DetachAllChildOccurrences(*uw.gWaterLOD, water);
+		(*uw.gWaterLOD)->DetachChild(water);
 		block->waterAttached = false;
 	}
 }
@@ -658,6 +622,30 @@ void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 void UnifiedWater::BSWaterShader_SetupGeometry::thunk(RE::BSShader* waterShader, RE::BSRenderPass* pass)
 {
 	auto& uw = globals::features::unifiedWater;
+
+	// Fix BSWaterShaderProperty.plane after interior->exterior transitions.
+	// The plane feeds ReflectPlane in the PerGeometry cbuffer. When corrupted (e.g., plane.constant = 0
+	// or garbage), the shader's refractionPlaneMul calculation produces extreme values causing flickering.
+	// This primarily affects flowmapped water because it uses more complex refraction depth calculations.
+	if (const auto prop = pass->geometry->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
+		const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
+		const float waterHeight = pass->geometry->world.translate.z;
+
+		// Validate and fix the plane if it's corrupted.
+		// A valid water plane has normal pointing up (0,0,1) and constant = water height.
+		// After interior->exterior transitions, plane.constant can be 0 or stale values.
+		const bool planeNonFinite =
+			!std::isfinite(waterShaderProp->plane.normal.x) ||
+			!std::isfinite(waterShaderProp->plane.normal.y) ||
+			!std::isfinite(waterShaderProp->plane.normal.z) ||
+			!std::isfinite(waterShaderProp->plane.constant);
+		const bool planeNormalBad = std::abs(waterShaderProp->plane.normal.x) > 0.01f || std::abs(waterShaderProp->plane.normal.y) > 0.01f || std::abs(waterShaderProp->plane.normal.z - 1.0f) > 0.01f;
+		const bool planeConstantBad = std::abs(waterShaderProp->plane.constant - waterHeight) > 1.0f;
+		if (planeNonFinite || planeNormalBad || planeConstantBad) {
+			waterShaderProp->plane.normal = { 0.0f, 0.0f, 1.0f };
+			waterShaderProp->plane.constant = waterHeight;
+		}
+	}
 
 	if (uw.flowmap) {
 		// ObjectUV.xyz below, xy contains width and height, z contains mesh scale
@@ -689,7 +677,11 @@ void UnifiedWater::TESWaterSystem_UpdateDisplacementMeshPosition::thunk(RE::TESW
 	func(waterSystem);
 
 	auto& uw = globals::features::unifiedWater;
-	RemoveDuplicateWaterSystemObjects(waterSystem, uw.gWaterLOD ? *uw.gWaterLOD : nullptr);
+
+	// Game-thread fallback for deferred child-worldspace cull completion.
+	// Needed when entering child worldspaces with already-attached LOD blocks,
+	// where BGSTerrainBlock_Attach/UpdateWaterMeshSubVisibility may not run.
+	uw.TryCompleteDeferredChildWorldspaceCull(uw.cachedTes.load(std::memory_order_acquire));
 
 	if (!uw.flowmap)
 		return;

--- a/src/Features/UnifiedWater.h
+++ b/src/Features/UnifiedWater.h
@@ -3,7 +3,7 @@
 #include "UnifiedWater/Flowmap.h"
 #include "UnifiedWater/WaterCache.h"
 
-#include <atomic>
+#include <vector>
 
 struct UnifiedWater : OverlayFeature
 {
@@ -60,18 +60,6 @@ struct UnifiedWater : OverlayFeature
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
-	struct TES_SetWorldSpace
-	{
-		static void thunk(RE::TES* tes, RE::TESWorldSpace* worldSpace, bool isExterior);
-		static inline REL::Relocation<decltype(thunk)> func;
-	};
-
-	struct TES_DestroySkyCell
-	{
-		static void thunk(RE::TES* tes);
-		static inline REL::Relocation<decltype(thunk)> func;
-	};
-
 	struct BSWaterShader_SetupGeometry
 	{
 		static void thunk(RE::BSShader* waterShader, RE::BSRenderPass* pass);
@@ -113,12 +101,7 @@ private:
 	RE::NiPoint2* gDisplacementMeshPos = nullptr;
 	RE::NiPoint2* gDisplacementMeshFlowCellOffset = nullptr;
 
-	std::atomic<RE::TESWorldSpace*> currentPlayerWorldSpace{ nullptr };
-	std::atomic<bool> pendingChildWsCull{ false };
-	// Game-thread TES snapshot used by deferred child-worldspace cull fallbacks.
-	std::atomic<RE::TES*> cachedTes{ nullptr };
-
-	void TryCompleteDeferredChildWorldspaceCull(RE::TES* tes = nullptr);
+	bool BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSystem* waterSystem);
 
 	void SetFlowmapTex() const;
 	static bool LoadOrderChanged();

--- a/src/Features/UnifiedWater.h
+++ b/src/Features/UnifiedWater.h
@@ -4,6 +4,7 @@
 #include "UnifiedWater/WaterCache.h"
 
 #include <atomic>
+#include <vector>
 
 struct UnifiedWater : OverlayFeature
 {
@@ -26,6 +27,7 @@ struct UnifiedWater : OverlayFeature
 	struct Settings
 	{
 		bool UseOptimisedMeshes = true;
+		bool PurgeLODWaterAfterLoad = true;
 	};
 
 	Settings settings;
@@ -84,6 +86,13 @@ struct UnifiedWater : OverlayFeature
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
+	class MenuOpenCloseEventHandler : public RE::BSTEventSink<RE::MenuOpenCloseEvent>
+	{
+	public:
+		RE::BSEventNotifyControl ProcessEvent(const RE::MenuOpenCloseEvent* a_event, RE::BSTEventSource<RE::MenuOpenCloseEvent>*) override;
+		static bool Register();
+	};
+
 	virtual void DrawSettings() override;
 
 	virtual void DrawOverlay() override;
@@ -117,8 +126,19 @@ private:
 	std::atomic<bool> pendingChildWsCull{ false };
 	// Game-thread TES snapshot used by deferred child-worldspace cull fallbacks.
 	std::atomic<RE::TES*> cachedTes{ nullptr };
+	std::atomic<int32_t> pendingRestoredLODTrimFrames{ 0 };
+	std::atomic<bool> pendingRestoredLODTrimChildWorldspace{ false };
+	RE::TESWorldSpace* detachedLODWaterWorldSpace = nullptr;
+	std::vector<RE::NiPointer<RE::NiAVObject>> detachedLODWaterChildren;
 
 	void TryCompleteDeferredChildWorldspaceCull(RE::TES* tes = nullptr);
+	uint32_t PurgeLODWater();
+	uint32_t ClearDetachedLODWater();
+	uint32_t DetachLODWaterForLoad();
+	uint32_t RestoreDetachedLODWater(RE::TESWorldSpace* destinationWorldSpace);
+	void ResolveDetachedLODWaterAfterLoad(RE::TESWorldSpace* destinationWorldSpace = nullptr);
+	void TryTrimRestoredLODWater();
+	bool BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSystem* waterSystem, bool runOriginalAttach);
 
 	void SetFlowmapTex() const;
 	static bool LoadOrderChanged();

--- a/src/Features/UnifiedWater.h
+++ b/src/Features/UnifiedWater.h
@@ -3,7 +3,6 @@
 #include "UnifiedWater/Flowmap.h"
 #include "UnifiedWater/WaterCache.h"
 
-#include <atomic>
 #include <vector>
 
 struct UnifiedWater : OverlayFeature
@@ -27,7 +26,6 @@ struct UnifiedWater : OverlayFeature
 	struct Settings
 	{
 		bool UseOptimisedMeshes = true;
-		bool PurgeLODWaterAfterLoad = true;
 	};
 
 	Settings settings;
@@ -62,18 +60,6 @@ struct UnifiedWater : OverlayFeature
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
-	struct TES_SetWorldSpace
-	{
-		static void thunk(RE::TES* tes, RE::TESWorldSpace* worldSpace, bool isExterior);
-		static inline REL::Relocation<decltype(thunk)> func;
-	};
-
-	struct TES_DestroySkyCell
-	{
-		static void thunk(RE::TES* tes);
-		static inline REL::Relocation<decltype(thunk)> func;
-	};
-
 	struct BSWaterShader_SetupGeometry
 	{
 		static void thunk(RE::BSShader* waterShader, RE::BSRenderPass* pass);
@@ -84,13 +70,6 @@ struct UnifiedWater : OverlayFeature
 	{
 		static void thunk(RE::TESWaterSystem* waterSystem);
 		static inline REL::Relocation<decltype(thunk)> func;
-	};
-
-	class MenuOpenCloseEventHandler : public RE::BSTEventSink<RE::MenuOpenCloseEvent>
-	{
-	public:
-		RE::BSEventNotifyControl ProcessEvent(const RE::MenuOpenCloseEvent* a_event, RE::BSTEventSource<RE::MenuOpenCloseEvent>*) override;
-		static bool Register();
 	};
 
 	virtual void DrawSettings() override;
@@ -122,22 +101,6 @@ private:
 	RE::NiPoint2* gDisplacementMeshPos = nullptr;
 	RE::NiPoint2* gDisplacementMeshFlowCellOffset = nullptr;
 
-	std::atomic<RE::TESWorldSpace*> currentPlayerWorldSpace{ nullptr };
-	std::atomic<bool> pendingChildWsCull{ false };
-	// Game-thread TES snapshot used by deferred child-worldspace cull fallbacks.
-	std::atomic<RE::TES*> cachedTes{ nullptr };
-	std::atomic<int32_t> pendingRestoredLODTrimFrames{ 0 };
-	std::atomic<bool> pendingRestoredLODTrimChildWorldspace{ false };
-	RE::TESWorldSpace* detachedLODWaterWorldSpace = nullptr;
-	std::vector<RE::NiPointer<RE::NiAVObject>> detachedLODWaterChildren;
-
-	void TryCompleteDeferredChildWorldspaceCull(RE::TES* tes = nullptr);
-	uint32_t PurgeLODWater();
-	uint32_t ClearDetachedLODWater();
-	uint32_t DetachLODWaterForLoad();
-	uint32_t RestoreDetachedLODWater(RE::TESWorldSpace* destinationWorldSpace);
-	void ResolveDetachedLODWaterAfterLoad(RE::TESWorldSpace* destinationWorldSpace = nullptr);
-	void TryTrimRestoredLODWater();
 	bool BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSystem* waterSystem, bool runOriginalAttach);
 
 	void SetFlowmapTex() const;

--- a/src/Features/UnifiedWater.h
+++ b/src/Features/UnifiedWater.h
@@ -3,7 +3,7 @@
 #include "UnifiedWater/Flowmap.h"
 #include "UnifiedWater/WaterCache.h"
 
-#include <vector>
+#include <atomic>
 
 struct UnifiedWater : OverlayFeature
 {
@@ -60,6 +60,18 @@ struct UnifiedWater : OverlayFeature
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
+	struct TES_SetWorldSpace
+	{
+		static void thunk(RE::TES* tes, RE::TESWorldSpace* worldSpace, bool isExterior);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	struct TES_DestroySkyCell
+	{
+		static void thunk(RE::TES* tes);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
 	struct BSWaterShader_SetupGeometry
 	{
 		static void thunk(RE::BSShader* waterShader, RE::BSRenderPass* pass);
@@ -101,7 +113,12 @@ private:
 	RE::NiPoint2* gDisplacementMeshPos = nullptr;
 	RE::NiPoint2* gDisplacementMeshFlowCellOffset = nullptr;
 
-	bool BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSystem* waterSystem);
+	std::atomic<RE::TESWorldSpace*> currentPlayerWorldSpace{ nullptr };
+	std::atomic<bool> pendingChildWsCull{ false };
+	// Game-thread TES snapshot used by deferred child-worldspace cull fallbacks.
+	std::atomic<RE::TES*> cachedTes{ nullptr };
+
+	void TryCompleteDeferredChildWorldspaceCull(RE::TES* tes = nullptr);
 
 	void SetFlowmapTex() const;
 	static bool LoadOrderChanged();

--- a/src/Features/UnifiedWater.h
+++ b/src/Features/UnifiedWater.h
@@ -101,7 +101,7 @@ private:
 	RE::NiPoint2* gDisplacementMeshPos = nullptr;
 	RE::NiPoint2* gDisplacementMeshFlowCellOffset = nullptr;
 
-	bool BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSystem* waterSystem, bool runOriginalAttach);
+	bool BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSystem* waterSystem);
 
 	void SetFlowmapTex() const;
 	static bool LoadOrderChanged();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicated water meshes appearing during displacement updates
* **Performance Improvements**
  * Improved water culling and attachment for more efficient rendering
  * Streamlined water management to reduce overhead and improve stability
* **Configuration**
  * Shader feature version bumped to 1-0-2

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->