### PR TITLE
feat(VR): DLSSperf — render engine at upscaled resolution

### DIFF
--- a/features/DLSSperf/Shaders/DLSSperf/BilinearCopyPS.hlsl
+++ b/features/DLSSperf/Shaders/DLSSperf/BilinearCopyPS.hlsl
@@ -1,0 +1,29 @@
+// BilinearCopyPS.hlsl — DLSSperf downscale pass
+// Box 3×3 filter: testTexture (3k) → kMAIN (1k)
+// For 3:1 downscale, each output pixel averages the 3×3 source region,
+// ensuring all DLSS output pixels contribute (vs bilinear's 2×2 coverage).
+// Reuses UpscaleVS.hlsl for fullscreen triangle generation (SV_VertexID)
+
+#include "Upscaling/UpscaleVS.hlsl"
+
+#if defined(PSHADER)
+
+typedef VS_OUTPUT PS_INPUT;
+
+SamplerState LinearSampler : register(s0);
+Texture2D<float4> SourceTex : register(t0);
+
+float4 main(PS_INPUT input) : SV_Target
+{
+	float2 srcSize;
+	SourceTex.GetDimensions(srcSize.x, srcSize.y);
+	float2 texelSize = 1.0 / srcSize;
+
+	float4 sum = 0;
+	[unroll] for (int y = -1; y <= 1; y++)
+		[unroll] for (int x = -1; x <= 1; x++)
+			sum += SourceTex.SampleLevel(LinearSampler, input.TexCoord + float2(x, y) * texelSize, 0);
+	return sum * (1.0 / 9.0);
+}
+
+#endif

--- a/src/Features/DLSSperf.cpp
+++ b/src/Features/DLSSperf.cpp
@@ -1,5 +1,6 @@
 #include "DLSSperf.h"
 #include "State.h"
+#include "Upscaling.h"
 
 // Quality mode → render-scale resolution is supplied by the FFX SDK helper
 // (same one Upscaling.cpp uses at ConfigureUpscaling), avoiding a duplicate

--- a/src/Features/DLSSperf.cpp
+++ b/src/Features/DLSSperf.cpp
@@ -38,8 +38,19 @@ void DLSSperf::InstallRenderTargetSizeHook()
 	// snapshot the corresponding scale at install time and never re-read it —
 	// the engine's RT allocations happen once, so a later UI quality change
 	// can't shrink/grow RTs anyway. (Requires a game restart, same as DLSS.)
-	const uint32_t qualityMode = globals::features::upscaling.settings.qualityMode;
+	//
+	// Validate before division: a bad/corrupt JSON could put qualityMode
+	// outside FFX's range, returning 0/inf/NaN; that would propagate to bogus
+	// renderEye dimensions and silently mis-size every engine RT. Fail closed
+	// — leave hookActive=false so the rest of DLSSperf is dormant and DLSS
+	// runs on dev's standard path. (CodeRabbit Major @ scs#2357.)
+	const uint32_t qualityModeRaw = globals::features::upscaling.settings.qualityMode;
+	const uint32_t qualityMode = std::clamp<uint32_t>(qualityModeRaw, 0, 4);  // FfxFsr3QualityMode range
 	const float scale = ffxFsr3GetUpscaleRatioFromQualityMode(static_cast<FfxFsr3QualityMode>(qualityMode));
+	if (!std::isfinite(scale) || scale <= 0.0f) {
+		logger::error("[DLSSperf] FFX returned invalid upscale ratio {} for qualityMode {} (raw {}); hook NOT installed", scale, qualityMode, qualityModeRaw);
+		return;
+	}
 	renderEyeWidth = std::max<uint32_t>(1, (uint32_t)(w / scale));
 	renderEyeHeight = std::max<uint32_t>(1, (uint32_t)(h / scale));
 
@@ -581,6 +592,18 @@ void DLSSperf::DownscaleToKMain()
 	ID3D11RasterizerState* savedRS = nullptr;
 	context->RSGetState(&savedRS);
 
+	// VS / PS / sampler save (CodeRabbit Major @ scs#2357 — DownscaleToKMain
+	// runs immediately before enginePost(); leaving our shader/sampler bound
+	// risks subsequent engine passes silently inheriting them if those passes
+	// don't explicitly set every slot. Pattern matches VRStereoOptimizations.
+	ID3D11VertexShader* savedVS = nullptr;
+	ID3D11PixelShader* savedPS = nullptr;
+	context->VSGetShader(&savedVS, nullptr, nullptr);
+	context->PSGetShader(&savedPS, nullptr, nullptr);
+
+	ID3D11SamplerState* savedPSSampler0 = nullptr;
+	context->PSGetSamplers(0, 1, &savedPSSampler0);
+
 	// IA: fullscreen triangle (no vertex/index buffers)
 	context->IASetInputLayout(nullptr);
 	context->IASetVertexBuffers(0, 0, nullptr, nullptr, nullptr);
@@ -628,6 +651,9 @@ void DLSSperf::DownscaleToKMain()
 	context->RSSetViewports(1, &savedVP);
 	context->OMSetBlendState(savedBlend, savedBlendFactor, savedSampleMask);
 	context->OMSetDepthStencilState(savedDSState, savedStencilRef);
+	context->VSSetShader(savedVS, nullptr, 0);
+	context->PSSetShader(savedPS, nullptr, 0);
+	context->PSSetSamplers(0, 1, &savedPSSampler0);
 	context->GSSetShader(savedGS, nullptr, 0);
 	context->HSSetShader(savedHS, nullptr, 0);
 	context->DSSetShader(savedDS, nullptr, 0);
@@ -648,6 +674,12 @@ void DLSSperf::DownscaleToKMain()
 		savedDS->Release();
 	if (savedRS)
 		savedRS->Release();
+	if (savedVS)
+		savedVS->Release();
+	if (savedPS)
+		savedPS->Release();
+	if (savedPSSampler0)
+		savedPSSampler0->Release();
 }
 
 void DLSSperf::HandlePostProcessing(const std::function<void()>& enginePost)

--- a/src/Features/DLSSperf.cpp
+++ b/src/Features/DLSSperf.cpp
@@ -1,0 +1,678 @@
+#include "DLSSperf.h"
+#include "State.h"
+
+// Quality mode → render-scale resolution is supplied by the FFX SDK helper
+// (same one Upscaling.cpp uses at ConfigureUpscaling), avoiding a duplicate
+// scale table here. Decoupled from the original PR's DlssEnhancer::Bridge so
+// DLSSperf can ship without the larger enhancer framework.
+#include <FidelityFX/host/ffx_fsr3.h>
+
+void DLSSperf::InstallRenderTargetSizeHook()
+{
+	if (!globals::game::isVR)
+		return;
+
+	if (hookActive)
+		return;
+
+	// Eager capture — get real HMD resolution BEFORE installing hook
+	auto* openvr = RE::BSOpenVR::GetSingleton();
+	if (!openvr || !openvr->vrSystem) {
+		logger::error("[DLSSperf] BSOpenVR or vrSystem not available — hook NOT installed");
+		return;
+	}
+
+	uint32_t w = 0, h = 0;
+	openvr->vrSystem->GetRecommendedRenderTargetSize(&w, &h);
+	if (w == 0 || h == 0) {
+		logger::error("[DLSSperf] GetRecommendedRenderTargetSize returned {}x{} — hook NOT installed", w, h);
+		return;
+	}
+
+	displayEyeWidth = w;
+	displayEyeHeight = h;
+
+	// BSShaderRenderTargets::Create runs after SKSE feature settings load, so
+	// upscaling.settings.qualityMode here reflects the user-saved value. We
+	// snapshot the corresponding scale at install time and never re-read it —
+	// the engine's RT allocations happen once, so a later UI quality change
+	// can't shrink/grow RTs anyway. (Requires a game restart, same as DLSS.)
+	const uint32_t qualityMode = globals::features::upscaling.settings.qualityMode;
+	const float scale = ffxFsr3GetUpscaleRatioFromQualityMode(static_cast<FfxFsr3QualityMode>(qualityMode));
+	renderEyeWidth = std::max<uint32_t>(1, (uint32_t)(w / scale));
+	renderEyeHeight = std::max<uint32_t>(1, (uint32_t)(h / scale));
+
+	stl::write_vfunc<0x12, GetRenderTargetSize_Hook>(RE::VTABLE_BSOpenVR[0]);
+	hookActive = true;
+}
+
+void DLSSperf::GetRenderTargetSize_Hook::thunk(RE::BSOpenVR* a_this, uint32_t* a_width, uint32_t* a_height)
+{
+	// Call original to get real HMD resolution
+	func(a_this, a_width, a_height);
+
+	auto& dlssPerf = globals::features::dlssPerf;
+
+	*a_width = dlssPerf.renderEyeWidth;
+	*a_height = dlssPerf.renderEyeHeight;
+}
+
+void DLSSperf::SetupResources()
+{
+	if (!globals::game::isVR)
+		return;
+
+	auto renderer = globals::game::renderer;
+	auto& mainRT = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];
+	if (!mainRT.texture) {
+		logger::error("[DLSSperf] kMAIN texture not available in SetupResources");
+		return;
+	}
+
+	D3D11_TEXTURE2D_DESC mainDesc{};
+	static_cast<ID3D11Texture2D*>(mainRT.texture)->GetDesc(&mainDesc);
+
+	D3D11_TEXTURE2D_DESC desc{};
+	if (hookActive) {
+		desc.Width = displayEyeWidth * 2;
+		desc.Height = displayEyeHeight;
+	} else {
+		desc.Width = mainDesc.Width;
+		desc.Height = mainDesc.Height;
+	}
+	desc.MipLevels = 1;
+	desc.ArraySize = 1;
+	desc.Format = mainDesc.Format;
+	desc.SampleDesc.Count = 1;
+	desc.Usage = D3D11_USAGE_DEFAULT;
+	desc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET | D3D11_BIND_UNORDERED_ACCESS;
+
+	auto device = globals::d3d::device;
+	HRESULT hr = device->CreateTexture2D(&desc, nullptr, testTexture.put());
+	if (FAILED(hr)) {
+		logger::error("[DLSSperf] Failed to create test texture: {:#x}", (uint32_t)hr);
+		return;
+	}
+
+	D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc{};
+	srvDesc.Format = desc.Format;
+	srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+	srvDesc.Texture2D.MipLevels = 1;
+	srvDesc.Texture2D.MostDetailedMip = 0;
+	hr = device->CreateShaderResourceView(testTexture.get(), &srvDesc, testTextureSRV.put());
+	if (FAILED(hr)) {
+		logger::error("[DLSSperf] Failed to create test texture SRV: {:#x}", (uint32_t)hr);
+		testTexture = nullptr;
+		testTextureUAV = nullptr;
+		return;
+	}
+
+	// UAV for testTexture
+	{
+		D3D11_UNORDERED_ACCESS_VIEW_DESC uavDesc{};
+		uavDesc.Format = desc.Format;
+		uavDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D;
+		uavDesc.Texture2D.MipSlice = 0;
+		hr = device->CreateUnorderedAccessView(testTexture.get(), &uavDesc, testTextureUAV.put());
+		if (FAILED(hr)) {
+			logger::error("[DLSSperf] Failed to create testTexture UAV: {:#x}", (uint32_t)hr);
+		}
+	}
+
+	// RTV for testTexture (ISRefraction output)
+	if (hookActive) {
+		D3D11_RENDER_TARGET_VIEW_DESC rtvDesc{};
+		rtvDesc.Format = desc.Format;
+		rtvDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+		rtvDesc.Texture2D.MipSlice = 0;
+		hr = device->CreateRenderTargetView(testTexture.get(), &rtvDesc, testTextureRTV.put());
+		if (FAILED(hr)) {
+			logger::error("[DLSSperf] Failed to create testTexture RTV: {:#x}", (uint32_t)hr);
+		}
+	}
+
+	// refraTempTex: copy of testTexture for ISRefraction input
+	if (hookActive) {
+		D3D11_TEXTURE2D_DESC refraDesc = desc;
+		refraDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+
+		hr = device->CreateTexture2D(&refraDesc, nullptr, refraTempTex.put());
+		if (FAILED(hr)) {
+			logger::error("[DLSSperf] Failed to create refraTempTex: {:#x}", (uint32_t)hr);
+		} else {
+			D3D11_SHADER_RESOURCE_VIEW_DESC refraSrvDesc{};
+			refraSrvDesc.Format = refraDesc.Format;
+			refraSrvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+			refraSrvDesc.Texture2D.MipLevels = 1;
+			refraSrvDesc.Texture2D.MostDetailedMip = 0;
+			hr = device->CreateShaderResourceView(refraTempTex.get(), &refraSrvDesc, refraTempSRV.put());
+			if (FAILED(hr)) {
+				logger::error("[DLSSperf] Failed to create refraTempSRV: {:#x}", (uint32_t)hr);
+				refraTempTex = nullptr;
+			}
+		}
+	}
+
+	// Fake DepthStencil at DisplayRes, matching engine kMAIN DS format.
+	if (hookActive) {
+		auto& dsData = renderer->GetDepthStencilData();
+		auto* mainDSTex = dsData.depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN].texture;
+		if (mainDSTex) {
+			D3D11_TEXTURE2D_DESC dsDesc{};
+			mainDSTex->GetDesc(&dsDesc);
+
+			D3D11_TEXTURE2D_DESC fakeDesc = dsDesc;
+			fakeDesc.Width = displayEyeWidth * 2;
+			fakeDesc.Height = displayEyeHeight;
+
+			HRESULT hr2 = device->CreateTexture2D(&fakeDesc, nullptr, fakeDS.put());
+			if (FAILED(hr2)) {
+				logger::error("[DLSSperf] Failed to create fake DS texture: {:#x}", (uint32_t)hr2);
+			} else {
+				// Create DSV — format depends on typeless base format
+				D3D11_DEPTH_STENCIL_VIEW_DESC dsvDesc{};
+				dsvDesc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2D;
+				dsvDesc.Texture2D.MipSlice = 0;
+
+				// Map typeless→typed DSV format
+				if (fakeDesc.Format == DXGI_FORMAT_R32G8X24_TYPELESS)
+					dsvDesc.Format = DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
+				else if (fakeDesc.Format == DXGI_FORMAT_R24G8_TYPELESS)
+					dsvDesc.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
+				else if (fakeDesc.Format == DXGI_FORMAT_R32_TYPELESS)
+					dsvDesc.Format = DXGI_FORMAT_D32_FLOAT;
+				else if (fakeDesc.Format == DXGI_FORMAT_R16_TYPELESS)
+					dsvDesc.Format = DXGI_FORMAT_D16_UNORM;
+				else
+					dsvDesc.Format = fakeDesc.Format;  // fallback: hope it's already a DS format
+
+				hr2 = device->CreateDepthStencilView(fakeDS.get(), &dsvDesc, fakeDSV.put());
+				if (FAILED(hr2)) {
+					logger::error("[DLSSperf] Failed to create fake DSV: {:#x}", (uint32_t)hr2);
+					fakeDS = nullptr;
+				}
+			}
+		} else {
+			logger::warn("[DLSSperf] kMAIN DS texture not available, skipping fake DS creation");
+		}
+	}
+
+	if (hookActive && fakeDSV) {
+		auto* ctx = globals::d3d::context;
+		ctx->ClearDepthStencilView(fakeDSV.get(), D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
+	}
+
+	// IS shader hooks (must be installed AFTER FrameAnnotations)
+	if (hookActive && !tonemapHookInstalled) {
+		stl::write_vfunc<0x1, TonemapRender_Hook>(RE::VTABLE_BSImagespaceShaderHDRTonemapBlendCinematic[3]);
+		tonemapHookInstalled = true;
+	}
+
+	if (hookActive && !refractionHookInstalled && testTextureRTV && refraTempSRV) {
+		stl::write_vfunc<0x1, RefractionRender_Hook>(RE::VTABLE_BSImagespaceShaderRefraction[3]);
+		refractionHookInstalled = true;
+	}
+
+	if (hookActive && !uiPassHookInstalled && fakeDSV) {
+		stl::write_vfunc<0x2A, UIPassDispatch_Hook>(RE::VTABLE_BSShaderAccumulator[0]);
+		uiPassHookInstalled = true;
+	}
+
+	// PlayerView end hook: chains after FrameAnnotations' Main_RenderPlayerView.
+	// Clears postChainDone so Present-前 UI and next frame use normal VP.
+	if (hookActive && !playerViewHookInstalled) {
+		stl::detour_thunk<PlayerViewRender_Hook>(REL::RelocationID(35560, 36559));
+		playerViewHookInstalled = true;
+	}
+
+	// Downscale shaders
+	if (hookActive && !bilinearCopyPS) {
+		bilinearCopyPS.attach(static_cast<ID3D11PixelShader*>(
+			Util::CompileShader(L"Data/Shaders/DLSSperf/BilinearCopyPS.hlsl", { { "PSHADER", "" } }, "ps_5_0")));
+		if (!bilinearCopyPS)
+			logger::error("[DLSSperf] Failed to compile BilinearCopyPS");
+	}
+	if (hookActive && !bilinearCopyVS) {
+		bilinearCopyVS.attach(static_cast<ID3D11VertexShader*>(
+			Util::CompileShader(L"Data/Shaders/Upscaling/UpscaleVS.hlsl", { { "VSHADER", "" } }, "vs_5_0")));
+		if (!bilinearCopyVS)
+			logger::error("[DLSSperf] Failed to compile BilinearCopyVS");
+	}
+	if (hookActive && !linearSampler) {
+		D3D11_SAMPLER_DESC sd{};
+		sd.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+		sd.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+		sd.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+		sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+		sd.MaxAnisotropy = 1;
+		sd.MaxLOD = D3D11_FLOAT32_MAX;
+		if (FAILED(device->CreateSamplerState(&sd, linearSampler.put())))
+			logger::error("[DLSSperf] Failed to create linear sampler");
+	}
+}
+
+// ============================================================================
+// TonemapRender_Hook: IS shader hook for ISHDRTonemapBlendCinematic
+// ============================================================================
+// Installed via stl::write_vfunc<0x1> on vtable[3], chains after FrameAnnotations.
+// Inner layer of two-layer swap: swaps kMAIN SRV → testTextureSRV and
+// kMAIN DS → fakeDS before tonemap Render(), restores after.
+
+void DLSSperf::TonemapRender_Hook::thunk(void* imageSpaceShader, RE::BSTriShape* shape, RE::ImageSpaceEffectParam* param)
+{
+	auto& dlssPerf = globals::features::dlssPerf;
+
+	if (!dlssPerf.hookActive || !dlssPerf.testTextureSRV || !dlssPerf.fakeDSV) {
+		func(imageSpaceShader, shape, param);
+		return;
+	}
+
+	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
+	auto& rtData = renderer->GetRuntimeData();
+	auto& dsData = renderer->GetDepthStencilData();
+
+	// --- Swap kMAIN SRV → testTextureSRV (so tonemap reads 3k upscaled color) ---
+	auto& kmainRT = rtData.renderTargets[RE::RENDER_TARGETS::kMAIN];
+	dlssPerf.savedKMainSRV = kmainRT.SRV;
+	kmainRT.SRV = dlssPerf.testTextureSRV.get();
+
+	// --- Also swap kMAIN_COPY SRV (refraction path reads this instead of kMAIN) ---
+	auto& kmainCopyRT = rtData.renderTargets[RE::RENDER_TARGETS::kMAIN_COPY];
+	dlssPerf.savedKMainCopySRV = kmainCopyRT.SRV;
+	kmainCopyRT.SRV = dlssPerf.testTextureSRV.get();
+
+	// --- Swap kMAIN DS views → fakeDS (so 3k RT doesn't mismatch 1k DS) ---
+	auto& kmainDS = dsData.depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
+	for (int i = 0; i < 8; i++) {
+		dlssPerf.savedKMainViews[i] = kmainDS.views[i];
+		if (kmainDS.views[i])
+			kmainDS.views[i] = dlssPerf.fakeDSV.get();
+	}
+	for (int i = 0; i < 8; i++) {
+		dlssPerf.savedKMainReadOnlyViews[i] = kmainDS.readOnlyViews[i];
+		if (kmainDS.readOnlyViews[i])
+			kmainDS.readOnlyViews[i] = dlssPerf.fakeDSV.get();
+	}
+
+	// --- Call original (or FrameAnnotations chain) ---
+	func(imageSpaceShader, shape, param);
+
+	// --- Restore kMAIN SRV ---
+	kmainRT.SRV = dlssPerf.savedKMainSRV;
+	dlssPerf.savedKMainSRV = nullptr;
+
+	// --- Restore kMAIN_COPY SRV ---
+	kmainCopyRT.SRV = dlssPerf.savedKMainCopySRV;
+	dlssPerf.savedKMainCopySRV = nullptr;
+
+	// --- Restore kMAIN DS views ---
+	for (int i = 0; i < 8; i++)
+		kmainDS.views[i] = dlssPerf.savedKMainViews[i];
+	for (int i = 0; i < 8; i++)
+		kmainDS.readOnlyViews[i] = dlssPerf.savedKMainReadOnlyViews[i];
+}
+
+// ============================================================================
+// RefractionRender_Hook: IS shader hook for ISRefraction
+// ============================================================================
+// Strategy: let func() run normally (1k refraction, kMAIN→kMAIN_COPY).
+// After func() returns, D3D11 state is sticky (PS/CB/sampler/IA all still bound).
+// We replay the draw with our own RT (testTexture 3k), VP (3k), and SRV (refraTempTex 3k).
+
+void DLSSperf::RefractionRender_Hook::thunk(void* imageSpaceShader, RE::BSTriShape* shape, RE::ImageSpaceEffectParam* param)
+{
+	auto& dlssPerf = globals::features::dlssPerf;
+
+	if (!dlssPerf.hookActive || !dlssPerf.testTextureRTV || !dlssPerf.refraTempSRV) {
+		func(imageSpaceShader, shape, param);
+		return;
+	}
+
+	// --- Pass 1: engine's normal 1k refraction (untouched) ---
+	func(imageSpaceShader, shape, param);
+
+	// --- Pass 2: our 3k refraction replay ---
+	// func() left PS/CB/sampler/IA/VB/IB all bound on the D3D context.
+	// We only change RT, VP, and t0 SRV, then DrawIndexed with the same geometry.
+
+	auto* context = globals::d3d::context;
+
+	// Save current RT so we can restore after our draw
+	ID3D11RenderTargetView* savedRTV = nullptr;
+	ID3D11DepthStencilView* savedDSV = nullptr;
+	context->OMGetRenderTargets(1, &savedRTV, &savedDSV);
+
+	// Save current VP
+	D3D11_VIEWPORT savedVP = {};
+	UINT numVP = 1;
+	context->RSGetViewports(&numVP, &savedVP);
+
+	// Save current t0 SRV (kMAIN.SRV used by ISRefraction as scene input)
+	ID3D11ShaderResourceView* savedSRV0 = nullptr;
+	context->PSGetShaderResources(0, 1, &savedSRV0);
+
+	// Set 3k output: testTexture RTV, no DS needed for fullscreen IS shader
+	ID3D11RenderTargetView* rtv3k = dlssPerf.testTextureRTV.get();
+	context->OMSetRenderTargets(1, &rtv3k, nullptr);
+
+	// Set 3k VP
+	D3D11_VIEWPORT vp3k = {};
+	vp3k.TopLeftX = 0.0f;
+	vp3k.TopLeftY = 0.0f;
+	vp3k.Width = static_cast<float>(dlssPerf.displayEyeWidth * 2);
+	vp3k.Height = static_cast<float>(dlssPerf.displayEyeHeight);
+	vp3k.MinDepth = 0.0f;
+	vp3k.MaxDepth = 1.0f;
+	context->RSSetViewports(1, &vp3k);
+
+	// Set 3k input: refraTempTex as t0 (scene color for refraction sampling)
+	ID3D11ShaderResourceView* srv3k = dlssPerf.refraTempSRV.get();
+	context->PSSetShaderResources(0, 1, &srv3k);
+
+	// Draw with the same geometry (BSTriShape fullscreen quad, IA still bound)
+	context->DrawIndexed(6, 0, 0);
+
+	// --- Restore D3D state so engine continues normally ---
+	context->OMSetRenderTargets(1, &savedRTV, savedDSV);
+	context->RSSetViewports(1, &savedVP);
+	context->PSSetShaderResources(0, 1, &savedSRV0);
+
+	// Release COM refs from Get calls
+	if (savedRTV)
+		savedRTV->Release();
+	if (savedDSV)
+		savedDSV->Release();
+	if (savedSRV0)
+		savedSRV0->Release();
+}
+
+// ============================================================================
+// UIPassDispatch_Hook: swap KMAIN DS → fakeDS for UI pass (renderMode==24)
+// ============================================================================
+// UI pass draws VR HUD to kMENUBG (now 3k). Engine binds KMAIN(DS) as DS,
+// which is still 1k → size mismatch. Swap to fakeDS (3k) before, restore after.
+
+void DLSSperf::UIPassDispatch_Hook::thunk(RE::BSGraphics::BSShaderAccumulator* shaderAccumulator, uint32_t renderFlags)
+{
+	auto& dlssPerf = globals::features::dlssPerf;
+
+	// Only intercept renderMode==24 (UI pass) when hook is active
+	auto& rtData = shaderAccumulator->GetRuntimeData();
+	if (!dlssPerf.hookActive || !dlssPerf.fakeDSV || rtData.renderMode != 24) {
+		func(shaderAccumulator, renderFlags);
+		return;
+	}
+
+	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
+	auto& dsData = renderer->GetDepthStencilData();
+	auto& kmainDS = dsData.depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];
+
+	// Save original KMAIN DS views and swap to fakeDS
+	ID3D11DepthStencilView* savedViews[8] = {};
+	ID3D11DepthStencilView* savedReadOnlyViews[8] = {};
+	for (int i = 0; i < 8; i++) {
+		savedViews[i] = kmainDS.views[i];
+		if (kmainDS.views[i])
+			kmainDS.views[i] = dlssPerf.fakeDSV.get();
+	}
+	for (int i = 0; i < 8; i++) {
+		savedReadOnlyViews[i] = kmainDS.readOnlyViews[i];
+		if (kmainDS.readOnlyViews[i])
+			kmainDS.readOnlyViews[i] = dlssPerf.fakeDSV.get();
+	}
+
+	// Force engine to re-bind DS from struct
+	globals::game::stateUpdateFlags->set(RE::BSGraphics::ShaderFlags::DIRTY_RENDERTARGET);
+
+	// Force 3k VP: engine may not call UpdateViewPort during UI pass,
+	// so we directly set shadowState viewport to DisplayRes and mark dirty.
+	auto* ss = globals::game::shadowState;
+	D3D11_VIEWPORT savedVP = {};
+	if (ss) {
+		auto& vp = ss->GetVRRuntimeData().viewPort;
+		savedVP = vp;
+		vp.TopLeftX = 0.0f;
+		vp.TopLeftY = 0.0f;
+		vp.Width = static_cast<float>(dlssPerf.displayEyeWidth * 2);
+		vp.Height = static_cast<float>(dlssPerf.displayEyeHeight);
+		vp.MinDepth = 0.0f;
+		vp.MaxDepth = 1.0f;
+		globals::game::stateUpdateFlags->set(RE::BSGraphics::ShaderFlags::DIRTY_VIEWPORT);
+	}
+
+	// Skip VP compression in UpdateViewPort hook during UI pass
+	dlssPerf.postInterceptActive = true;
+
+	func(shaderAccumulator, renderFlags);
+
+	dlssPerf.postInterceptActive = false;
+
+	// Restore viewport
+	if (ss) {
+		ss->GetVRRuntimeData().viewPort = savedVP;
+		globals::game::stateUpdateFlags->set(RE::BSGraphics::ShaderFlags::DIRTY_VIEWPORT);
+	}
+
+	// Restore original KMAIN DS views
+	for (int i = 0; i < 8; i++)
+		kmainDS.views[i] = savedViews[i];
+	for (int i = 0; i < 8; i++)
+		kmainDS.readOnlyViews[i] = savedReadOnlyViews[i];
+
+	// Re-dirty so subsequent passes get correct DS
+	globals::game::stateUpdateFlags->set(RE::BSGraphics::ShaderFlags::DIRTY_RENDERTARGET);
+}
+
+// ============================================================================
+// PlayerViewRender_Hook: clear postChainDone at PlayerView end
+// ============================================================================
+// PlayerView covers the entire VR pipeline (World→Post→UI→Submit).
+// After func() returns, clear postChainDone so the Present-前 UI chain
+// and the next frame use normal VP compression.
+
+void DLSSperf::PlayerViewRender_Hook::thunk(void* a1, bool a2, bool a3)
+{
+	func(a1, a2, a3);
+
+	globals::features::dlssPerf.ClearPostChainDone();
+}
+
+// ============================================================================
+// BeginPostIntercept / EndPostIntercept
+// ============================================================================
+// Outer layer of two-layer swap: swaps kMAIN_COPY DS → fakeDS before the
+// entire Post chain (covers the copy step #10 which binds kMAIN_COPY DS).
+// Inner layer (tonemap hook) handles kMAIN DS + kMAIN SRV for step #9.
+
+void DLSSperf::BeginPostIntercept()
+{
+	if (!hookActive || !fakeDSV)
+		return;
+
+	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
+	auto& dsData = renderer->GetDepthStencilData();
+	auto& kmainCopyDS = dsData.depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN_COPY];
+
+	postInterceptActive = true;
+
+	// Swap kMAIN_COPY DS views → fakeDS
+	for (int i = 0; i < 8; i++) {
+		savedKMainCopyViews[i] = kmainCopyDS.views[i];
+		if (kmainCopyDS.views[i])
+			kmainCopyDS.views[i] = fakeDSV.get();
+	}
+	for (int i = 0; i < 8; i++) {
+		savedKMainCopyReadOnlyViews[i] = kmainCopyDS.readOnlyViews[i];
+		if (kmainCopyDS.readOnlyViews[i])
+			kmainCopyDS.readOnlyViews[i] = fakeDSV.get();
+	}
+}
+
+void DLSSperf::EndPostIntercept()
+{
+	if (!hookActive || !fakeDSV)
+		return;
+
+	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
+	auto& dsData = renderer->GetDepthStencilData();
+	auto& kmainCopyDS = dsData.depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN_COPY];
+
+	postInterceptActive = false;
+	postChainDone = true;
+
+	// Restore kMAIN_COPY DS views
+	for (int i = 0; i < 8; i++)
+		kmainCopyDS.views[i] = savedKMainCopyViews[i];
+	for (int i = 0; i < 8; i++)
+		kmainCopyDS.readOnlyViews[i] = savedKMainCopyReadOnlyViews[i];
+}
+
+// ============================================================================
+// DownscaleToKMain: Box 3×3 downscale testTexture (3k) → kMAIN (1k)
+// ============================================================================
+// Called before the Post chain so the HDR pyramid builds from AA'd DLSS output
+// instead of the raw 1k render, eliminating shimmer in bloom/exposure.
+// Only kMAIN needs writing:
+//   - No refraction: kMAIN is the pyramid input directly.
+//   - With refraction: engine composites kMAIN → kMAIN_COPY, which enters pyramid.
+
+void DLSSperf::DownscaleToKMain()
+{
+	if (!hookActive || !testTextureSRV || !bilinearCopyPS || !bilinearCopyVS || !linearSampler)
+		return;
+
+	auto renderer = globals::game::renderer;
+	auto context = globals::d3d::context;
+	auto& rtData = renderer->GetRuntimeData();
+
+	auto& kmain = rtData.renderTargets[RE::RENDER_TARGETS::kMAIN];
+
+	if (!kmain.RTV)
+		return;
+
+	// Save all D3D state that we overwrite
+	ID3D11RenderTargetView* savedRTV = nullptr;
+	ID3D11DepthStencilView* savedDSV = nullptr;
+	context->OMGetRenderTargets(1, &savedRTV, &savedDSV);
+
+	D3D11_VIEWPORT savedVP = {};
+	UINT numVP = 1;
+	context->RSGetViewports(&numVP, &savedVP);
+
+	ID3D11BlendState* savedBlend = nullptr;
+	FLOAT savedBlendFactor[4] = {};
+	UINT savedSampleMask = 0;
+	context->OMGetBlendState(&savedBlend, savedBlendFactor, &savedSampleMask);
+
+	ID3D11DepthStencilState* savedDSState = nullptr;
+	UINT savedStencilRef = 0;
+	context->OMGetDepthStencilState(&savedDSState, &savedStencilRef);
+
+	ID3D11GeometryShader* savedGS = nullptr;
+	context->GSGetShader(&savedGS, nullptr, nullptr);
+
+	ID3D11HullShader* savedHS = nullptr;
+	context->HSGetShader(&savedHS, nullptr, nullptr);
+
+	ID3D11DomainShader* savedDS = nullptr;
+	context->DSGetShader(&savedDS, nullptr, nullptr);
+
+	ID3D11RasterizerState* savedRS = nullptr;
+	context->RSGetState(&savedRS);
+
+	// IA: fullscreen triangle (no vertex/index buffers)
+	context->IASetInputLayout(nullptr);
+	context->IASetVertexBuffers(0, 0, nullptr, nullptr, nullptr);
+	context->IASetIndexBuffer(nullptr, DXGI_FORMAT_UNKNOWN, 0);
+	context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+	// Shaders — clear GS/HS/DS to prevent pipeline interference
+	context->VSSetShader(bilinearCopyVS.get(), nullptr, 0);
+	context->PSSetShader(bilinearCopyPS.get(), nullptr, 0);
+	context->GSSetShader(nullptr, nullptr, 0);
+	context->HSSetShader(nullptr, nullptr, 0);
+	context->DSSetShader(nullptr, nullptr, 0);
+
+	// Input: testTexture SRV (3k DLSS output, AA'd)
+	ID3D11ShaderResourceView* srvs[] = { testTextureSRV.get() };
+	context->PSSetShaderResources(0, 1, srvs);
+
+	ID3D11SamplerState* samplers[] = { linearSampler.get() };
+	context->PSSetSamplers(0, 1, samplers);
+
+	// Opaque overwrite: no blending, no depth test, default rasterizer
+	context->OMSetBlendState(nullptr, nullptr, 0xffffffff);
+	context->OMSetDepthStencilState(nullptr, 0);
+	context->RSSetState(nullptr);
+
+	// Viewport at RenderRes SBS (1k)
+	D3D11_VIEWPORT vp = {};
+	vp.Width = static_cast<float>(renderEyeWidth * 2);
+	vp.Height = static_cast<float>(renderEyeHeight);
+	vp.MinDepth = 0.0f;
+	vp.MaxDepth = 1.0f;
+	context->RSSetViewports(1, &vp);
+
+	// Draw to kMAIN
+	ID3D11RenderTargetView* rtv = kmain.RTV;
+	context->OMSetRenderTargets(1, &rtv, nullptr);
+	context->Draw(3, 0);
+
+	// Unbind SRV to prevent SRV↔RT hazard in subsequent engine passes
+	ID3D11ShaderResourceView* nullSRV[] = { nullptr };
+	context->PSSetShaderResources(0, 1, nullSRV);
+
+	// Restore
+	context->OMSetRenderTargets(1, &savedRTV, savedDSV);
+	context->RSSetViewports(1, &savedVP);
+	context->OMSetBlendState(savedBlend, savedBlendFactor, savedSampleMask);
+	context->OMSetDepthStencilState(savedDSState, savedStencilRef);
+	context->GSSetShader(savedGS, nullptr, 0);
+	context->HSSetShader(savedHS, nullptr, 0);
+	context->DSSetShader(savedDS, nullptr, 0);
+	context->RSSetState(savedRS);
+	if (savedRTV)
+		savedRTV->Release();
+	if (savedDSV)
+		savedDSV->Release();
+	if (savedBlend)
+		savedBlend->Release();
+	if (savedDSState)
+		savedDSState->Release();
+	if (savedGS)
+		savedGS->Release();
+	if (savedHS)
+		savedHS->Release();
+	if (savedDS)
+		savedDS->Release();
+	if (savedRS)
+		savedRS->Release();
+}
+
+void DLSSperf::HandlePostProcessing(const std::function<void()>& enginePost)
+{
+	// Copy testTexture → refraTempTex before Post, so ISRefraction can read 3k scene
+	if (refraTempTex) {
+		globals::d3d::context->CopyResource(refraTempTex.get(), testTexture.get());
+	}
+
+	// Downscale testTexture (3k AA'd) → kMAIN (1k) so the HDR pyramid and
+	// bloom compute from anti-aliased content instead of raw 1k render.
+	DownscaleToKMain();
+
+	// Outer layer: swap kMAIN_COPY DS + SRV for refraction path coverage
+	BeginPostIntercept();
+
+	// Run full engine Post chain; IS shader hook handles tonemap step (#9) swap/restore
+	enginePost();
+
+	// Restore kMAIN_COPY DS
+	EndPostIntercept();
+}
+
+void DLSSperf::DrawSettings()
+{
+	// DLSSperf has no user-facing settings of its own — enablement is gated
+	// at install time by whether the BSShaderRenderTargets::Create hook ran
+	// successfully. A future PR may surface diagnostic info here.
+}

--- a/src/Features/DLSSperf.h
+++ b/src/Features/DLSSperf.h
@@ -1,0 +1,171 @@
+#pragma once
+
+// ============================================================================
+// DLSSperf — render-target size hook + post-processing interception
+// ============================================================================
+//
+// Sub-feature of DlssEnhancer.  Hooks BSOpenVR::GetRenderTargetSize so all
+// engine render targets are allocated at a small RenderRes while DLSS writes
+// its output to a private DisplayRes testTexture.
+//
+//  Benefits:
+//   - VRAM and bandwidth savings proportional to the quality-mode scale ratio.
+//   - UpscaleRT is no longer needed.
+//   - Game menus are no longer occluded by the upscaler output.
+//
+//  Current limitation:
+//   Post-processing still runs on 1k kMAIN via a bilinear downsample of
+//   testTexture.  Performance is good and visual loss is minimal.  Once the
+//   post chain is rewritten to consume testTexture natively, the downsample
+//   can be removed.
+//
+// ============================================================================
+
+#include <functional>
+
+struct DLSSperf
+{
+	void SetupResources();
+	void DrawSettings();
+
+	// Phase 1: standalone test texture that receives Upscaling output instead of kMAIN.
+	// Returns nullptr when not ready.
+	ID3D11Texture2D* GetTestTexture() const { return testTexture.get(); }
+	ID3D11ShaderResourceView* GetTestTextureSRV() const { return testTextureSRV.get(); }
+	ID3D11UnorderedAccessView* GetTestTextureUAV() const { return testTextureUAV.get(); }
+	ID3D11Texture2D* GetRefraTempTex() const { return refraTempTex.get(); }
+	ID3D11ShaderResourceView* GetRefraTempSRV() const { return refraTempSRV.get(); }
+
+	// Phase 2: resolution hook status
+	bool IsHookActive() const { return hookActive; }
+	bool IsPostInterceptActive() const { return postInterceptActive; }
+	bool IsPostChainDone() const { return postChainDone; }
+	void ClearPostChainDone() { postChainDone = false; }
+	uint32_t GetDisplayEyeWidth() const { return displayEyeWidth; }
+	uint32_t GetDisplayEyeHeight() const { return displayEyeHeight; }
+	uint32_t GetRenderEyeWidth() const { return renderEyeWidth; }
+	uint32_t GetRenderEyeHeight() const { return renderEyeHeight; }
+
+	// Phase 3: real HMD display resolution in SBS format (e.g. 3072×1632)
+	// Used by Upscaling pipeline to override polluted screenSize (which equals RenderRes after hook)
+	float2 GetDisplayScreenSize() const
+	{
+		return { static_cast<float>(displayEyeWidth * 2), static_cast<float>(displayEyeHeight) };
+	}
+
+	// Phase 2: called from BSShaderRenderTargets_Create::thunk (before func())
+	// where BSOpenVR is guaranteed to be available
+	void InstallRenderTargetSizeHook();
+
+	// Hybrid Post: tonemap interception via IS shader hooks
+	// Call BeginPostIntercept() before func(), EndPostIntercept() after.
+	void BeginPostIntercept();
+	void EndPostIntercept();
+
+	// Downscale testTexture (3k AA'd DLSS output) → kMAIN (1k)
+	// so the HDR pyramid builds from anti-aliased content instead of raw 1k render.
+	// Only kMAIN: no-refra reads kMAIN directly; with-refra engine copies kMAIN→kMAIN_COPY.
+	void DownscaleToKMain();
+
+	// Post hybrid entry point: called from Upscaling's Main_PostProcessing::thunk.
+	// Wraps the engine Post chain with DLSSperf's two-layer struct swap.
+	bool ShouldHandlePost() const { return hookActive && testTexture; }
+	void HandlePostProcessing(const std::function<void()>& enginePost);
+
+	// Fake 3k DepthStencil for Post pass DS swap
+	ID3D11DepthStencilView* GetFakeDSV() const { return fakeDSV.get(); }
+
+private:
+	// Phase 1
+	winrt::com_ptr<ID3D11Texture2D> testTexture;
+	winrt::com_ptr<ID3D11ShaderResourceView> testTextureSRV;
+	winrt::com_ptr<ID3D11UnorderedAccessView> testTextureUAV;
+
+	// Phase 2: resolution hook state
+	bool hookActive = false;
+
+	// Post intercept phase flag: when true, VP post-correction is skipped
+	// so enlarged kTEMP/kTOTAL get correct 3k VP from engine.
+	bool postInterceptActive = false;
+
+	// Post-chain-done flag: set true after EndPostIntercept, cleared at
+	// PlayerView end by PlayerViewRender_Hook.  When true, UpdateViewPort
+	// hook expands VP to displayRes so draws after the Post chain
+	// (UI合成, scene fade, submit prep) use correct 3k VP.
+	bool postChainDone = false;
+
+	uint32_t displayEyeWidth = 0;
+	uint32_t displayEyeHeight = 0;
+	uint32_t renderEyeWidth = 0;
+	uint32_t renderEyeHeight = 0;
+
+	// Phase 2: vtable hook for BSOpenVR::GetRenderTargetSize (vfunc 0x12)
+	struct GetRenderTargetSize_Hook
+	{
+		static void thunk(RE::BSOpenVR* a_this, uint32_t* a_width, uint32_t* a_height);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	// IS shader hook: ISHDRTonemapBlendCinematic (Render vfunc 0x1 on vtable[3])
+	// Chains after FrameAnnotations (if active). Swaps kMAIN SRV + kMAIN DS before
+	// tonemap, restores after.
+	struct TonemapRender_Hook
+	{
+		static void thunk(void* imageSpaceShader, RE::BSTriShape* shape, RE::ImageSpaceEffectParam* param);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+	bool tonemapHookInstalled = false;
+
+	// IS shader hook: ISRefraction (Render vfunc 0x1 on vtable[3])
+	// Replay DrawIndexed: func() runs 1k refraction normally, then replays 3k draw with sticky D3D state.
+	struct RefractionRender_Hook
+	{
+		static void thunk(void* imageSpaceShader, RE::BSTriShape* shape, RE::ImageSpaceEffectParam* param);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+	bool refractionHookInstalled = false;
+
+	// UI pass hook: FinishAccumulatingDispatch (vfunc 0x2A on BSShaderAccumulator)
+	// When renderMode==24 (UI pass), swaps KMAIN DS → fakeDS so 3k kMENUBG gets 3k depth.
+	struct UIPassDispatch_Hook
+	{
+		static void thunk(RE::BSGraphics::BSShaderAccumulator* shaderAccumulator, uint32_t renderFlags);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+	bool uiPassHookInstalled = false;
+
+	// PlayerView end hook: Main_RenderPlayerView (REL 35560/36559)
+	// Clears postChainDone after the entire VR pipeline (World→Post→UI→Submit)
+	// so Present-前 UI chain and next frame use normal VP compression.
+	struct PlayerViewRender_Hook
+	{
+		static void thunk(void* a1, bool a2, bool a3);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+	bool playerViewHookInstalled = false;
+
+	// Refraction: 3k temp texture (copy of testTexture) for ISRefraction input
+	winrt::com_ptr<ID3D11Texture2D> refraTempTex;
+	winrt::com_ptr<ID3D11ShaderResourceView> refraTempSRV;
+	// Refraction: RTV for testTexture (ISRefraction 3k output target)
+	winrt::com_ptr<ID3D11RenderTargetView> testTextureRTV;
+
+	// Two-layer swap: saved pointers for restore
+	// Outer layer (BeginPost/EndPost): kMAIN_COPY DS + SRV
+	ID3D11DepthStencilView* savedKMainCopyViews[8] = {};
+	ID3D11DepthStencilView* savedKMainCopyReadOnlyViews[8] = {};
+	ID3D11ShaderResourceView* savedKMainCopySRV = nullptr;
+	// Inner layer (tonemap hook): kMAIN DS + kMAIN SRV
+	ID3D11DepthStencilView* savedKMainViews[8] = {};
+	ID3D11DepthStencilView* savedKMainReadOnlyViews[8] = {};
+	ID3D11ShaderResourceView* savedKMainSRV = nullptr;
+
+	// Fake 3k DepthStencil (DisplayRes, same format as engine kMAIN DS)
+	winrt::com_ptr<ID3D11Texture2D> fakeDS;
+	winrt::com_ptr<ID3D11DepthStencilView> fakeDSV;
+
+	// Downscale pass: Box 3×3 downscale testTexture (3k) → kMAIN (1k)
+	winrt::com_ptr<ID3D11PixelShader> bilinearCopyPS;
+	winrt::com_ptr<ID3D11VertexShader> bilinearCopyVS;
+	winrt::com_ptr<ID3D11SamplerState> linearSampler;
+};

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1,5 +1,6 @@
 #include "Upscaling.h"
 
+#include "DLSSperf.h"
 #include "Deferred.h"
 #include "HDRDisplay.h"
 #include "Hooks.h"
@@ -32,7 +33,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	reflexLowLatencyBoost,
 	reflexUseMarkersToOptimize,
 	reflexUseFPSLimit,
-	reflexFPSLimit);
+	reflexFPSLimit,
+	enableDLSSperf);
 
 decltype(&D3D11CreateDeviceAndSwapChain) ptrD3D11CreateDeviceAndSwapChainUpscaling;
 
@@ -419,6 +421,25 @@ void Upscaling::DrawSettings()
 		ImGui::TextUnformatted("Changing this requires a restart to take effect.");
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Streamline logging controls the verbosity of NVIDIA Streamline backend logs. Useful for debugging issues with DLSS/DLSS-G.");
+		}
+
+		// VR DLSSperf: opt-in performance feature. Engine renders at upscaled-
+		// render resolution instead of display resolution; the upscaler writes
+		// to a private DisplayRes texture. Saves VRAM/bandwidth proportional
+		// to the quality-mode scale ratio.
+		if (globals::game::isVR && upscaleMethod == UpscaleMethod::kDLSS) {
+			ImGui::Separator();
+			if (ImGui::Checkbox("Render engine at upscaled resolution (experimental)", &settings.enableDLSSperf)) {
+			}
+			ImGui::TextUnformatted("Changing this requires a restart to take effect.");
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text(
+					"VR DLSSperf: when enabled, the entire engine pipeline allocates render targets at\n"
+					"the upscaled-render resolution instead of display resolution. DLSS writes to a\n"
+					"private DisplayRes texture. Substantial VRAM and bandwidth savings, especially\n"
+					"at high HMD resolutions. Restart required.");
+			}
+			Util::Text::Warning("Warning: Requires restart");
 		}
 
 		// VR Debug visualization -- per-eye buffers and native inputs
@@ -1218,24 +1239,46 @@ void Upscaling::ConfigureUpscaling(RE::BSGraphics::State* a_viewport)
 	auto screenHeight = static_cast<int>(screenSize.y);
 
 	if (upscaleMethod != UpscaleMethod::kNONE && upscaleMethod != UpscaleMethod::kTAA) {
-		float resolutionScaleBase = 1.0f / ffxFsr3GetUpscaleRatioFromQualityMode((FfxFsr3QualityMode)settings.qualityMode);
+		// DLSSperf: when the BSOpenVR size hook is live, every engine RT was
+		// already allocated at RenderRes — so the DRS-style scale is identity.
+		// Jitter is still computed at the real DisplayRes phase ratio so DLSS
+		// has enough sub-pixel diversity for the upscale.
+		auto& dlssPerf = globals::features::dlssPerf;
+		if (dlssPerf.IsHookActive()) {
+			resolutionScale = { 1.0f, 1.0f };
 
-		auto renderWidth = static_cast<int>(screenWidth * resolutionScaleBase);
-		auto renderHeight = static_cast<int>(screenHeight * resolutionScaleBase);
+			auto renderWidth = static_cast<int>(dlssPerf.GetRenderEyeWidth());
+			auto displayWidth = static_cast<int>(dlssPerf.GetDisplayEyeWidth());
 
-		resolutionScale.x = static_cast<float>(renderWidth) / static_cast<float>(screenWidth);
-		resolutionScale.y = static_cast<float>(renderHeight) / static_cast<float>(screenHeight);
+			auto phaseCount = GetJitterPhaseCount(renderWidth, displayWidth);
+			GetJitterOffset(&jitter.x, &jitter.y, state->frameCount, phaseCount);
 
-		auto phaseCount = GetJitterPhaseCount(renderWidth, screenWidth);
+			if (globals::game::isVR)
+				a_viewport->projectionPosScaleX = -jitter.x / renderWidth;
+			else
+				a_viewport->projectionPosScaleX = -2.0f * jitter.x / renderWidth;
 
-		GetJitterOffset(&jitter.x, &jitter.y, state->frameCount, phaseCount);
+			a_viewport->projectionPosScaleY = 2.0f * jitter.y / static_cast<int>(dlssPerf.GetRenderEyeHeight());
+		} else {
+			float resolutionScaleBase = 1.0f / ffxFsr3GetUpscaleRatioFromQualityMode((FfxFsr3QualityMode)settings.qualityMode);
 
-		if (globals::game::isVR)
-			a_viewport->projectionPosScaleX = -jitter.x / renderWidth;
-		else
-			a_viewport->projectionPosScaleX = -2.0f * jitter.x / renderWidth;
+			auto renderWidth = static_cast<int>(screenWidth * resolutionScaleBase);
+			auto renderHeight = static_cast<int>(screenHeight * resolutionScaleBase);
 
-		a_viewport->projectionPosScaleY = 2.0f * jitter.y / renderHeight;
+			resolutionScale.x = static_cast<float>(renderWidth) / static_cast<float>(screenWidth);
+			resolutionScale.y = static_cast<float>(renderHeight) / static_cast<float>(screenHeight);
+
+			auto phaseCount = GetJitterPhaseCount(renderWidth, screenWidth);
+
+			GetJitterOffset(&jitter.x, &jitter.y, state->frameCount, phaseCount);
+
+			if (globals::game::isVR)
+				a_viewport->projectionPosScaleX = -jitter.x / renderWidth;
+			else
+				a_viewport->projectionPosScaleX = -2.0f * jitter.x / renderWidth;
+
+			a_viewport->projectionPosScaleY = 2.0f * jitter.y / renderHeight;
+		}
 	} else {
 		resolutionScale = { 1.0f, 1.0f };
 
@@ -2062,7 +2105,17 @@ void Upscaling::Main_PostProcessing::thunk(RE::ImageSpaceManager* a_this, uint32
 	if (hdrLoaded)
 		globals::features::hdrDisplay.RedirectFramebuffer();
 
-	func(a_this, a3, a_target, a_4, a_5);
+	// DLSSperf: hybrid Post — HandlePostProcessing performs a two-layer
+	// struct swap around the engine's func() so tonemap + refraction read
+	// the DisplayRes testTexture instead of the small kMAIN. The supplied
+	// lambda is the engine call we'd normally make directly.
+	if (globals::features::dlssPerf.ShouldHandlePost()) {
+		globals::features::dlssPerf.HandlePostProcessing([&]() {
+			func(a_this, a3, a_target, a_4, a_5);
+		});
+	} else {
+		func(a_this, a3, a_target, a_4, a_5);
+	}
 
 	// Restore kFRAMEBUFFER after ISHDR — hdrTexture now has the HDR scene
 	if (hdrLoaded)

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -64,6 +64,13 @@ public:
 		bool reflexUseMarkersToOptimize = false;
 		bool reflexUseFPSLimit = false;
 		float reflexFPSLimit = 60.0f;
+
+		// VR DLSSperf: opt-in. When set, BSShaderRenderTargets::Create installs
+		// the BSOpenVR render-target-size hook at engine init so the entire
+		// engine pipeline allocates render targets at upscaled-render resolution
+		// instead of display resolution. Saves VRAM/bandwidth proportional to
+		// the quality-mode scale ratio. Requires a game restart to take effect.
+		bool enableDLSSperf = false;
 	};
 
 	Settings settings;

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -2,6 +2,7 @@
 
 #include "Deferred.h"
 #include "Features/CloudShadows.h"
+#include "Features/DLSSperf.h"
 #include "Features/DynamicCubemaps.h"
 #include "Features/ExponentialHeightFog.h"
 #include "Features/ExtendedMaterials.h"
@@ -84,6 +85,7 @@ namespace globals
 		ExtendedTranslucency extendedTranslucency{};
 		Upscaling upscaling{};
 		HDRDisplay hdrDisplay{};
+		DLSSperf dlssPerf{};
 		RenderDoc renderDoc{};
 		ScreenshotFeature screenshotFeature{};
 		WeatherEditor weatherEditor{};
@@ -386,6 +388,55 @@ namespace globals
 	};
 
 	/**
+	 * @brief Hooked Draw — intercepts the scene-transition fade overlay in VR DLSSperf.
+	 *
+	 * vtable index 13 for ID3D11DeviceContext::Draw.
+	 * The engine's fade-in/fade-out overlay is a Draw(30) that fires after the Post chain
+	 * and before Submit. Under DLSSperf the draw's VP/vertices are computed at renderRes
+	 * while the RT (kTOTAL) is displayRes, causing a partial-screen "black stamp".
+	 * Fix: when postChainDone is set, force RSSetViewports to displayRes right before the draw.
+	 */
+	struct ID3D11DeviceContext_Draw
+	{
+		static void thunk(ID3D11DeviceContext* This, UINT VertexCount, UINT StartVertexLocation)
+		{
+			if (VertexCount == 30 && globals::game::isVR) {
+				auto& dlssPerf = globals::features::dlssPerf;
+				if (dlssPerf.IsHookActive() && dlssPerf.IsPostChainDone()) {
+					// Save the current viewport so we can restore it after the
+					// fade-overlay draw. RSGetViewports may return numVP=0 if no
+					// viewport was previously set; zero-init defends against
+					// reading uninitialized memory in that case.
+					UINT numVP = 1;
+					D3D11_VIEWPORT savedVP{};
+					This->RSGetViewports(&numVP, &savedVP);
+
+					// Inject displayRes VP for this draw only.
+					D3D11_VIEWPORT vp{};
+					vp.TopLeftX = 0.0f;
+					vp.TopLeftY = 0.0f;
+					vp.Width = static_cast<float>(dlssPerf.GetDisplayEyeWidth() * 2);
+					vp.Height = static_cast<float>(dlssPerf.GetDisplayEyeHeight());
+					vp.MinDepth = 0.0f;
+					vp.MaxDepth = 1.0f;
+					This->RSSetViewports(1, &vp);
+
+					func(This, VertexCount, StartVertexLocation);
+
+					// Restore the original viewport only if we actually captured
+					// one — otherwise we'd push undefined state.
+					if (numVP > 0) {
+						This->RSSetViewports(1, &savedVP);
+					}
+					return;
+				}
+			}
+			func(This, VertexCount, StartVertexLocation);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	/**
  * @brief Installs hooks on the Map and Unmap methods of the provided D3D11 device context.
  *
  * This enables interception of resource mapping and unmapping operations for frame buffer caching.
@@ -401,6 +452,12 @@ namespace globals
 			stl::detour_vfunc<33, ID3D11DeviceContext_OMSetRenderTargets>(a_context);
 			stl::detour_vfunc<36, ID3D11DeviceContext_OMSetDepthStencilState>(a_context);
 			stl::detour_vfunc<53, ID3D11DeviceContext_ClearDepthStencilView>(a_context);
+		}
+
+		// DLSSperf: intercept Draw to fix scene-fade VP at displayRes.
+		// Cheap: thunk early-outs unless VertexCount==30 + DLSSperf hook live.
+		if (globals::game::isVR) {
+			stl::detour_vfunc<13, ID3D11DeviceContext_Draw>(a_context);
 		}
 	}
 }

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -35,6 +35,7 @@ struct Upscaling;
 struct WeatherEditor;
 struct ExponentialHeightFog;
 struct HDRDisplay;
+struct DLSSperf;
 struct ScreenshotFeature;
 
 class State;
@@ -91,6 +92,7 @@ namespace globals
 		extern ExtendedTranslucency extendedTranslucency;
 		extern Upscaling upscaling;
 		extern HDRDisplay hdrDisplay;
+		extern DLSSperf dlssPerf;
 		extern RenderDoc renderDoc;
 		extern ScreenshotFeature screenshotFeature;
 		extern WeatherEditor weatherEditor;

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -10,6 +10,7 @@
 #include "State.h"
 #include "Util.h"
 
+#include "Features/DLSSperf.h"
 #include "Features/HDRDisplay.h"
 #include "Features/InteriorSun.h"
 #include "Features/LightLimitFix.h"
@@ -434,6 +435,57 @@ struct ID3D11Device_CreateSamplerState
 	static inline REL::Relocation<decltype(thunk)> func;
 };
 
+// DLSSperf: post-correction of the engine's viewport whenever it differs from
+// our enlarged RTs. The hook is no-op unless DLSSperf's BSOpenVR size hook
+// is live (set true only in VR with the user-enabled feature).
+struct BSGraphics_Renderer_UpdateViewPort
+{
+	static void thunk(RE::BSGraphics::Renderer* a_this, uint32_t a_width, uint32_t a_height, bool a_forceMatchRT)
+	{
+		func(a_this, a_width, a_height, a_forceMatchRT);
+
+		auto& dlssPerf = globals::features::dlssPerf;
+		if (!dlssPerf.IsHookActive())
+			return;
+
+		// During Post intercept, enlarged kTEMP/kTOTAL need 3k VP from engine.
+		// func() auto-detects from enlarged RTs → VP is already displayRes.
+		if (dlssPerf.IsPostInterceptActive())
+			return;
+
+		auto* ss = globals::game::shadowState;
+		if (!ss)
+			return;
+		auto& vp = ss->GetVRRuntimeData().viewPort;
+		const uint32_t displayW = dlssPerf.GetDisplayEyeWidth() * 2;
+		const uint32_t displayH = dlssPerf.GetDisplayEyeHeight();
+		const uint32_t renderW = dlssPerf.GetRenderEyeWidth() * 2;
+		const uint32_t renderH = dlssPerf.GetRenderEyeHeight();
+
+		// After Post chain: UI + submit-prep draws target enlarged kTOTAL
+		// (displayRes). Engine may call UpdateViewPort with renderRes, causing
+		// func() to set VP = renderRes. Expand back to displayRes. Note: the
+		// fade Draw(30) bypasses this path entirely — it uses direct D3D
+		// RSSetViewports and is handled by the Draw vfunc hook in Globals.cpp.
+		if (dlssPerf.IsPostChainDone()) {
+			if (static_cast<uint32_t>(vp.Width) == renderW &&
+				static_cast<uint32_t>(vp.Height) == renderH) {
+				vp.Width = static_cast<float>(displayW);
+				vp.Height = static_cast<float>(displayH);
+			}
+			return;
+		}
+
+		// Normal world/depth draws: compress displayRes → renderRes
+		if (static_cast<uint32_t>(vp.Width) == displayW &&
+			static_cast<uint32_t>(vp.Height) == displayH) {
+			vp.Width = static_cast<float>(renderW);
+			vp.Height = static_cast<float>(renderH);
+		}
+	}
+	static inline REL::Relocation<decltype(thunk)> func;
+};
+
 struct BSShaderRenderTargets_Create
 {
 	/**
@@ -445,12 +497,79 @@ struct BSShaderRenderTargets_Create
 		"Controls the number of focus shadows.",
 		REL::Relocate<uintptr_t>(0, 0, 0x1ed6368), 4, 0, 4 };
 
+	// DLSSperf: function pointer to the engine's CreateRenderTarget (set in
+	// Hooks::Install after CreateRenderTarget_Main is hooked). Used by the
+	// runtime E8 scanner that patches unhooked call sites within Create().
+	using CreateRTFn = void (*)(RE::BSGraphics::Renderer*, RE::RENDER_TARGETS::RENDER_TARGET, RE::BSGraphics::RenderTargetProperties*);
+	static inline CreateRTFn engineCreateRT = nullptr;
+
+	// Pre-creation enlargement flag and dimensions. When `s_enlargeRT` is set
+	// during the engine's BSShaderRenderTargets::Create call, every Color RT
+	// in the whitelist (kIMAGESPACE_TEMP_COPY / kTOTAL / kMENUBG) is allocated
+	// at displayRes instead of the screenSize the engine asked for.
+	static inline bool s_enlargeRT = false;
+	static inline uint32_t s_enlargeRTWidth = 0;
+	static inline uint32_t s_enlargeRTHeight = 0;
+	static inline int s_rtCallSitesPatched = 0;
+
+	// Conditionally enlarges a Color RT — whitelist of post-chain pyramids.
+	// Called by both pre-hooked CreateRenderTarget_* thunks and the runtime
+	// E8-scanned universal thunk so every call site inside Create() is covered.
+	static void DLSSperf_MaybeEnlargeRT(RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
+	{
+		if (!s_enlargeRT)
+			return;
+
+		switch (a_target) {
+		case RE::RENDER_TARGETS::kIMAGESPACE_TEMP_COPY:
+		case RE::RENDER_TARGETS::kTOTAL:
+		case RE::RENDER_TARGETS::kMENUBG:
+			a_properties->width = s_enlargeRTWidth;
+			a_properties->height = s_enlargeRTHeight;
+			break;
+		default:
+			break;
+		}
+	}
+
+	// Universal thunk for unhooked CreateRenderTarget call sites discovered
+	// by the E8 scanner in Hooks::Install. Mirrors what the per-site thunks do.
+	static void DLSSperf_CreateRT_Thunk(RE::BSGraphics::Renderer* a_this, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
+	{
+		DLSSperf_MaybeEnlargeRT(a_target, a_properties);
+		engineCreateRT(a_this, a_target, a_properties);
+	}
+
 	static void thunk()
 	{
 		Util::SetGameSettingValue<std::int32_t>("iNumFocusShadow:Display", iNumFocusShadow, 0);
+
+		// DLSSperf: install the BSOpenVR render-target-size hook before the
+		// engine creates its render targets. This is the only place where
+		// BSOpenVR is guaranteed available AND we can still influence RT
+		// allocation. Gated on user opt-in via Upscaling::Settings.
+		if (globals::game::isVR && globals::features::upscaling.settings.enableDLSSperf) {
+			globals::features::dlssPerf.InstallRenderTargetSizeHook();
+		}
+
+		// Pre-creation Color RT enlargement gate.
+		if (globals::features::dlssPerf.IsHookActive() && engineCreateRT && s_rtCallSitesPatched > 0) {
+			s_enlargeRTWidth = globals::features::dlssPerf.GetDisplayEyeWidth() * 2;
+			s_enlargeRTHeight = globals::features::dlssPerf.GetDisplayEyeHeight();
+			s_enlargeRT = true;
+		}
+
 		func();
+		s_enlargeRT = false;
+
 		globals::ReInit();
 		globals::state->Setup();
+
+		// DLSSperf is not in the Feature list (it's a worker driven by the
+		// upscaling toggle), so SetupResources runs here directly.
+		if (globals::features::dlssPerf.IsHookActive()) {
+			globals::features::dlssPerf.SetupResources();
+		}
 	}
 	static inline REL::Relocation<decltype(thunk)> func;
 };
@@ -583,6 +702,7 @@ namespace Hooks
 		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
 		{
 			globals::state->ModifyRenderTarget(a_target, a_properties);
+			BSShaderRenderTargets_Create::DLSSperf_MaybeEnlargeRT(a_target, a_properties);
 			func(This, a_target, a_properties);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
@@ -598,6 +718,7 @@ namespace Hooks
 		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
 		{
 			globals::state->ModifyRenderTarget(a_target, a_properties);
+			BSShaderRenderTargets_Create::DLSSperf_MaybeEnlargeRT(a_target, a_properties);
 			func(This, a_target, a_properties);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
@@ -608,6 +729,7 @@ namespace Hooks
 		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
 		{
 			globals::state->ModifyRenderTarget(a_target, a_properties);
+			BSShaderRenderTargets_Create::DLSSperf_MaybeEnlargeRT(a_target, a_properties);
 			func(This, a_target, a_properties);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
@@ -618,6 +740,7 @@ namespace Hooks
 		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
 		{
 			globals::state->ModifyRenderTarget(a_target, a_properties);
+			BSShaderRenderTargets_Create::DLSSperf_MaybeEnlargeRT(a_target, a_properties);
 			func(This, a_target, a_properties);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
@@ -629,6 +752,7 @@ namespace Hooks
 		{
 			auto properties = *a_properties;
 			properties.copyable = true;
+			BSShaderRenderTargets_Create::DLSSperf_MaybeEnlargeRT(a_target, &properties);
 			func(This, a_target, &properties);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
@@ -640,6 +764,7 @@ namespace Hooks
 		{
 			auto properties = *a_properties;
 			properties.copyable = true;
+			BSShaderRenderTargets_Create::DLSSperf_MaybeEnlargeRT(a_target, &properties);
 			func(This, a_target, &properties);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
@@ -921,6 +1046,12 @@ namespace Hooks
 		logger::info("Hooking BSGraphics::SetDirtyStates");
 		stl::detour_thunk<BSGraphics_SetDirtyStates>(REL::RelocationID(75580, 77386));
 
+		// DLSSperf: post-correction of viewports the engine sets at renderRes
+		// when the RT is enlarged to displayRes (and vice versa). Hook is
+		// no-op until DLSSperf::InstallRenderTargetSizeHook flips IsHookActive.
+		logger::info("Hooking BSGraphics::Renderer::UpdateViewPort");
+		stl::detour_thunk<BSGraphics_Renderer_UpdateViewPort>(REL::RelocationID(75455, 77240));
+
 		logger::info("Hooking BSGraphics::Renderer::InitD3D");
 		stl::write_thunk_call<BSGraphics_Renderer_Init_InitD3D>(REL::RelocationID(75595, 77226).address() + REL::Relocate(0x50, 0x2BC));
 
@@ -932,6 +1063,11 @@ namespace Hooks
 
 		logger::info("Hooking BSShaderRenderTargets::Create::CreateRenderTarget(s)");
 		stl::write_thunk_call<CreateRenderTarget_Main>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0x3F0, 0x3F3, 0x548));
+		// DLSSperf: capture the original CreateRenderTarget address from the
+		// first hooked thunk's REL::Relocation. The runtime E8 scanner below
+		// uses it both to locate unhooked call sites and as the fallback when
+		// the universal thunk dispatches through.
+		BSShaderRenderTargets_Create::engineCreateRT = reinterpret_cast<BSShaderRenderTargets_Create::CreateRTFn>(CreateRenderTarget_Main::func.address());
 		stl::write_thunk_call<CreateRenderTarget_Normals>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0x458, 0x45B, 0x5B0));
 		stl::write_thunk_call<CreateRenderTarget_NormalsSwap>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0x46B, 0x46E, 0x5C3));
 		stl::write_thunk_call<CreateRenderTarget_MotionVectors>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0x4F0, 0x4EF, 0x64E));
@@ -942,6 +1078,34 @@ namespace Hooks
 		stl::write_thunk_call<CreateDepthStencil_PrecipitationMask>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0x1245, 0x123B, 0x1917));
 		stl::write_thunk_call<CreateCubemapRenderTarget_Reflections>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0xA25, 0xA25, 0xCD2));
 		stl::write_thunk_call<CreateDepthStencil_Reflections>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0xA59, 0xA59, 0xD13));
+
+		// DLSSperf: runtime scan of BSShaderRenderTargets::Create for the
+		// remaining (unhooked) CreateRenderTarget call sites. The 6 sites
+		// patched by write_thunk_call above (Main, Normals, NormalsSwap,
+		// MotionVectors, RefractionNormals, UnderwaterMask) have been
+		// redirected and won't match engineCreateRT; only unhooked sites hit.
+		// Scope: 0x2500 bytes from Create's base — empirically covers every
+		// CreateRenderTarget call. Without this, enlargement only applies to
+		// the 6 hooked targets and other RTs (kIMAGESPACE_TEMP_COPY etc.)
+		// stay at renderRes, breaking the post-chain assumption.
+		if (BSShaderRenderTargets_Create::engineCreateRT) {
+			auto funcBase = REL::RelocationID(100458, 107175).address();
+			auto createRTAddr = reinterpret_cast<uintptr_t>(BSShaderRenderTargets_Create::engineCreateRT);
+			auto& trampoline = SKSE::GetTrampoline();
+
+			for (size_t offset = 0; offset < 0x2500; offset++) {
+				auto callAddr = funcBase + offset;
+				if (*reinterpret_cast<uint8_t*>(callAddr) == 0xE8) {
+					int32_t rel = *reinterpret_cast<int32_t*>(callAddr + 1);
+					uintptr_t target = callAddr + 5 + rel;
+					if (target == createRTAddr) {
+						trampoline.write_call<5>(callAddr, BSShaderRenderTargets_Create::DLSSperf_CreateRT_Thunk);
+						BSShaderRenderTargets_Create::s_rtCallSitesPatched++;
+					}
+				}
+			}
+			BSShaderRenderTargets_Create::s_rtCallSitesPatched += 6;
+		}
 
 #ifdef TRACY_ENABLE
 		stl::write_thunk_call<Main_Update>(REL::RelocationID(35551, 36544).address() + REL::Relocate(0x11F, 0x160));


### PR DESCRIPTION
## Summary

VR-only opt-in feature that hooks `BSOpenVR::GetRenderTargetSize` so the entire engine pipeline allocates render targets at upscaled-render resolution (RenderRes = HMD recommended size / DLSS quality scale) while DLSS writes its upscaled output into a private DisplayRes texture. The legacy "engine renders at DisplayRes, then we upscale down" round-trip disappears.

**User-visible benefit**: substantial VRAM and bandwidth savings proportional to the quality-mode scale ratio. Makes Ultra Performance preset (0.33×) viable at 6K HMDs on mid-range GPUs, instead of a low-resolution DLAA fallback. Game menus also stop being occluded by the upscaler output.

## What changes

Four commits, organized around the integration boundary:

| Commit | Files | What |
|---|---|---|
| 1 | `src/Features/DLSSperf.{h,cpp}`, `features/DLSSperf/Shaders/DLSSperf/BilinearCopyPS.hlsl` | The worker class — RT-size hook + Post-chain hybrid (BeginPostIntercept/EndPostIntercept) + bilinear downscale shader |
| 2 | `src/Globals.{h,cpp}` | `dlssPerf` instance + `ID3D11DeviceContext::Draw` vfunc-13 hook for the scene-fade overlay |
| 3 | `src/Hooks.cpp` | `BSGraphics::Renderer::UpdateViewPort` viewport-correction hook + RT enlargement gate in `BSShaderRenderTargets::Create` + 6 `MaybeEnlargeRT` injections + runtime E8 scanner for unhooked CreateRenderTarget call sites |
| 4 | `src/Features/Upscaling.{h,cpp}` | `Settings::enableDLSSperf` field + JSON load/save + UI checkbox (VR + DLSS only, restart required) + jitter branch in `ConfigureUpscaling` + `Main_PostProcessing` `HandlePostProcessing` wrap |

## Decoupling from the original PR

@YtzyFvra's #2096 routed DLSSperf through `DlssEnhancer::Bridge::BootSequence`. This PR removes that coupling so DLSSperf can ship without the larger DlssEnhancer framework:

- Quality mode is read directly from `Upscaling::Settings::qualityMode` at hook-install time (`BSShaderRenderTargets::Create` runs after settings load)
- Scale is computed via `ffxFsr3GetUpscaleRatioFromQualityMode` — the same helper `Upscaling.cpp` already uses in `ConfigureUpscaling`

## Bot review fix from #2096 baked in

Copilot flagged that `savedVP` was uninitialized before `RSGetViewports` in the Draw vfunc hook. Zero-init `D3D11_VIEWPORT savedVP{}` and skip the restore when `numVP == 0`.

## What's NOT in this PR (intentionally)

- The DlssEnhancer framework, subrect/foveated rendering (PR-3 of the decomposition, on my fork)
- The original PR's unrelated refactors that share its diff: `TruePBR` instance→pointer migration, `ScreenshotFeature` removal from features namespace, `RefreshTES` cleanup, `TESObjectLAND_SetupMaterial` / `BSLightingShader_SetupMaterial` hook changes — none of these are DLSSperf-specific

## Risks for review

1. **`Main_PostProcessing` wrap interaction with `HDRDisplay`**: the wrap sits between `HDRDisplay::RedirectFramebuffer` and `RestoreFramebuffer`. Order matters; not tested live with both enabled. Worth a VR test session.
2. **Runtime E8 scanner in `Hooks::Install`** writes to the SKSE trampoline. If another PR or feature also patches the same `CreateRenderTarget` call sites between the named thunks, ordering matters. Currently no known conflict.
3. **`enableDLSSperf` requires a game restart** to take effect (engine RT allocations happen once at init). UI surfaces a "Requires restart" warning.

## Test plan
- [x] Plugin C++ compile passes (`MSBuild ClCompile`, exit 0, no errors/warnings)
- [ ] CI shader validation (Flatrim + VR)
- [ ] CI build (vs2022 + vs2026)
- [ ] **VR validation needed**: enable in Skyrim VR, verify DLSS still produces correct output, no menu occlusion regression, no fade-overlay artifacts at scene transitions, no flicker on quality-mode change + restart
- [ ] Verify `testTexture` + `refraTempTex` lifecycle when toggling at runtime (load game with on, change setting off, restart, verify clean state)

## Credits
Decomposed from @YtzyFvra's #2096 (PR-2 of 4). All DLSSperf design/implementation is theirs; this PR adapts to ship standalone (Bridge decoupled, scoped to just the DLSSperf hunks of the original PR's diff). Co-authored on commits.

See [DLSS-PR-PLAN.md](https://github.com/alandtse/skyrim-community-shaders/blob/pr2-dlssperf/DLSS-PR-PLAN.md) for the full decomposition strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DLSSperf VR mode: enables upscaled rendering with lower VRAM/bandwidth use while preserving post-processing and refraction visuals.
  * Hybrid post-processing flow to maintain UI/tonemap/refraction correctness when using VR upscaling.

* **Configuration**
  * New VR-only toggle to enable DLSSperf optimization (requires game restart).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->