### PR TITLE
docs: update feature Nexus mod links

### DIFF
--- a/src/Features/ExponentialHeightFog.h
+++ b/src/Features/ExponentialHeightFog.h
@@ -5,7 +5,6 @@ struct ExponentialHeightFog : Feature
 	virtual bool SupportsVR() override { return true; };
 	virtual inline std::string GetName() override { return "Exponential Height Fog"; }
 	virtual inline std::string GetShortName() override { return "ExponentialHeightFog"; }
-	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL("999999"); }
 	virtual std::string_view GetCategory() const override { return FeatureCategories::kLighting; }
 
 	virtual inline std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/ExponentialHeightFog.h
+++ b/src/Features/ExponentialHeightFog.h
@@ -2,9 +2,14 @@
 
 struct ExponentialHeightFog : Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "180146";
+
+public:
 	virtual bool SupportsVR() override { return true; };
 	virtual inline std::string GetName() override { return "Exponential Height Fog"; }
 	virtual inline std::string GetShortName() override { return "ExponentialHeightFog"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual std::string_view GetCategory() const override { return FeatureCategories::kLighting; }
 
 	virtual inline std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/ExtendedTranslucency.h
+++ b/src/Features/ExtendedTranslucency.h
@@ -5,11 +5,8 @@
 
 struct ExtendedTranslucency final : Feature
 {
-	static constexpr std::string_view MOD_ID = "150755"sv;
-
 	virtual inline std::string GetName() override { return "Extended Translucency"; }
 	virtual inline std::string GetShortName() override { return "ExtendedTranslucency"; }
-	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "EXTENDED_TRANSLUCENCY"sv; }
 	virtual inline std::string_view GetCategory() const override { return FeatureCategories::kMaterials; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override;

--- a/src/Features/GrassCollision.h
+++ b/src/Features/GrassCollision.h
@@ -4,13 +4,9 @@
 
 struct GrassCollision : Feature
 {
-private:
-	static constexpr std::string_view MOD_ID = "87816";
-
 public:
 	virtual inline std::string GetName() override { return "Grass Collision"; }
 	virtual inline std::string GetShortName() override { return "GrassCollision"; }
-	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "GRASS_COLLISION"; }
 	virtual std::string_view GetCategory() const override { return FeatureCategories::kGrass; }
 

--- a/src/Features/GrassLighting.h
+++ b/src/Features/GrassLighting.h
@@ -4,13 +4,9 @@
 
 struct GrassLighting : Feature
 {
-private:
-	static constexpr std::string_view MOD_ID = "86502";
-
 public:
 	virtual inline std::string GetName() override { return "Grass Lighting"; }
 	virtual inline std::string GetShortName() override { return "GrassLighting"; }
-	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "GRASS_LIGHTING"; }
 	virtual bool HasShaderDefine(RE::BSShader::Type shaderType) override { return shaderType == RE::BSShader::Type::Grass; };
 	virtual std::string_view GetCategory() const override { return FeatureCategories::kGrass; }

--- a/src/Features/InteriorSun.h
+++ b/src/Features/InteriorSun.h
@@ -3,9 +3,6 @@
 
 struct InteriorSun : Feature
 {
-private:
-	static constexpr std::string_view MOD_ID = "153541";
-
 public:
 	virtual inline std::string GetName() override { return "Interior Sun"; }
 	virtual inline std::string GetShortName() override { return "InteriorSun"; }

--- a/src/Features/InverseSquareLighting.h
+++ b/src/Features/InverseSquareLighting.h
@@ -4,9 +4,6 @@
 
 struct InverseSquareLighting : Feature
 {
-private:
-	static constexpr std::string_view MOD_ID = "153542";
-
 public:
 	virtual inline std::string GetName() override { return "Inverse Square Lighting"; }
 

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -5,13 +5,9 @@
 
 struct LightLimitFix : OverlayFeature
 {
-private:
-	static constexpr std::string_view MOD_ID = "99548";
-
 public:
 	virtual inline std::string GetName() override { return "Light Limit Fix"; }
 	virtual inline std::string GetShortName() override { return "LightLimitFix"; }
-	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "LIGHT_LIMIT_FIX"; }
 	virtual std::string_view GetCategory() const override { return FeatureCategories::kLighting; }
 

--- a/src/Features/ScreenSpaceShadows.h
+++ b/src/Features/ScreenSpaceShadows.h
@@ -4,13 +4,9 @@
 
 struct ScreenSpaceShadows : Feature
 {
-private:
-	static constexpr std::string_view MOD_ID = "93209";
-
 public:
 	virtual inline std::string GetName() override { return "Screen Space Shadows"; }
 	virtual inline std::string GetShortName() override { return "ScreenSpaceShadows"; }
-	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "SCREEN_SPACE_SHADOWS"; }
 	virtual std::string_view GetCategory() const override { return FeatureCategories::kLighting; }
 

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -9,6 +9,7 @@ private:
 public:
 	virtual inline std::string GetName() override { return "Sky Sync"; }
 	virtual inline std::string GetShortName() override { return "SkySync"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual std::string_view GetCategory() const override { return FeatureCategories::kSky; }
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/SubsurfaceScattering.h
+++ b/src/Features/SubsurfaceScattering.h
@@ -6,9 +6,6 @@
 
 struct SubsurfaceScattering : Feature
 {
-private:
-	static constexpr std::string_view MOD_ID = "114114";
-
 public:
 	struct DiffusionProfile
 	{
@@ -70,7 +67,6 @@ public:
 
 	virtual inline std::string GetName() override { return "Subsurface Scattering"; }
 	virtual inline std::string GetShortName() override { return "SubsurfaceScattering"; }
-	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "SSS"; }
 	virtual std::string_view GetCategory() const override { return FeatureCategories::kCharacters; }
 

--- a/src/Features/TerrainBlending.h
+++ b/src/Features/TerrainBlending.h
@@ -2,9 +2,13 @@
 
 struct TerrainBlending : Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "157076";
+
 public:
 	virtual inline std::string GetName() override { return "Terrain Blending"; }
 	virtual inline std::string GetShortName() override { return "TerrainBlending"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "TERRAIN_BLENDING"; }
 	virtual std::string_view GetCategory() const override { return FeatureCategories::kLandscapeAndTextures; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/TerrainShadows.h
+++ b/src/Features/TerrainShadows.h
@@ -5,13 +5,9 @@
 
 struct TerrainShadows : public Feature
 {
-private:
-	static constexpr std::string_view MOD_ID = "135817";
-
 public:
 	virtual inline std::string GetName() override { return "Terrain Shadows"; }
 	virtual inline std::string GetShortName() override { return "TerrainShadows"; }
-	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "TERRAIN_SHADOWS"; }
 	virtual std::string_view GetCategory() const override { return FeatureCategories::kLandscapeAndTextures; }
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -17,10 +17,14 @@
  */
 struct Upscaling : Feature
 {
+private:
+	static constexpr std::string_view MOD_ID = "156952";
+
 public:
 	// Feature interface
 	virtual inline std::string GetName() override { return "Upscaling"; }
 	virtual inline std::string GetShortName() override { return "Upscaling"; }
+	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline bool SupportsVR() override { return true; }
 	virtual inline bool IsCore() const override { return false; }
 	virtual inline std::string_view GetCategory() const override { return FeatureCategories::kDisplay; }

--- a/src/Features/WaterEffects.h
+++ b/src/Features/WaterEffects.h
@@ -4,14 +4,10 @@
 
 struct WaterEffects : Feature
 {
-private:
-	static constexpr std::string_view MOD_ID = "112762";
-
 public:
 	winrt::com_ptr<ID3D11ShaderResourceView> causticsView;
 	virtual inline std::string GetName() override { return "Water Effects"; }
 	virtual inline std::string GetShortName() override { return "WaterEffects"; }
-	virtual inline std::string GetFeatureModLink() override { return MakeNexusModURL(MOD_ID); }
 	virtual inline std::string_view GetShaderDefineName() override { return "WATER_EFFECTS"; }
 	virtual std::string_view GetCategory() const override { return FeatureCategories::kWater; }
 


### PR DESCRIPTION
Was looking to remove the dummy Exponential Height Fog download link but realized that these haven't really been kept up to date.

Why do we need to maintain them?
These links are exposed if the feature is not installed. Practically speaking no one should have uninstalled core features but in the weird case that they delete the INI, they shouldn't need to see a link. Technically we can gate in the UI, but relying on a gate everywhere is a bit fragile (even if it should be regardless).

- Add links for Sky Sync, Terrain Blending, Upscaling
- Removes links for core features and dummy links

If we decide to split a feature out of core again then we'd need to re-add the link. If we prefer to keep the core links for some reason I can revert those.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized feature mod linking across the system. Multiple components were reorganized to consolidate how features connect to Nexus mod pages. Changes include enhanced mod linking capabilities for select features while others adopted streamlined approaches, creating more consistent and coordinated mod reference integration across the feature set.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->