### PR TITLE
fix(unified water): reduce transition flicker

### DIFF
--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -305,6 +305,7 @@ bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSy
 		RemoveLODWater(waterSystem, shape, *gWaterLOD);
 	}
 
+	RemoveDuplicateWaterSystemObjects(waterSystem, *gWaterLOD);
 	DetachAllChildOccurrences(*gWaterLOD, block->water);
 	(*gWaterLOD)->AttachChild(block->water, true);
 	waterSystem->Enable();
@@ -645,13 +646,12 @@ void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 	func(block);
 
 	if (water) {
-		auto count = water->GetChildren().size();
-		while (count > 0) {
-			water->DetachChildAt(--count);
-		}
+		ClearWaterNodeChildren(water, globals::game::waterSystem);
 
-		DetachAllChildOccurrences(*uw.gWaterLOD, water);
-		block->waterAttached = false;
+		if (uw.gWaterLOD && *uw.gWaterLOD)
+			DetachAllChildOccurrences(*uw.gWaterLOD, water);
+		if (block)
+			block->waterAttached = false;
 	}
 }
 
@@ -659,7 +659,20 @@ void UnifiedWater::BSWaterShader_SetupGeometry::thunk(RE::BSShader* waterShader,
 {
 	auto& uw = globals::features::unifiedWater;
 
-	if (uw.flowmap) {
+	if (pass && pass->geometry) {
+		// Re-stabilize BSWaterShaderProperty.plane every draw. After interior/exterior
+		// transitions the cached plane can be stale for exactly one of two overlapping
+		// water surfaces, which presents as heavy flicker rather than missing water.
+		if (const auto prop = pass->geometry->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
+			const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
+			const float waterHeight = pass->geometry->world.translate.z;
+
+			waterShaderProp->plane.normal = { 0.0f, 0.0f, 1.0f };
+			waterShaderProp->plane.constant = waterHeight;
+		}
+	}
+
+	if (uw.flowmap && pass && pass->geometry) {
 		// ObjectUV.xyz below, xy contains width and height, z contains mesh scale
 		// Previously flowmap size was in x, yz contained flowmap offset for water displacement mesh
 		*uw.gFlowMapSize = uw.flowmap->GetWidth();                                            // ObjectUV.x


### PR DESCRIPTION
Small follow-up to the recent Unified Water LOD ownership change.

On my setup, LOD water no longer disappeared, but after going into an interior and back out some water surfaces could flicker heavily until the area was reloaded. This keeps the current vanilla LOD ownership path, but cleans up some stale water state around terrain block transitions.

Changes:
- clear detached water children through `TESWaterSystem` instead of only detaching the scene children
- run the duplicate water cleanup after the `AddLODWater` / `RemoveLODWater` handoff
- refresh `BSWaterShaderProperty::plane` during water setup so stale transition data does not survive on one of the overlapping surfaces

Testing:
- built `ALL-VS2022` locally
- shader tests passed, 166 assertions
- tested an equivalent v1.5.2 build in game by repeating exterior -> interior -> exterior transitions; the water stayed visible and the transition flicker stopped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved water surface flicker during terrain transitions and after LOD changes by re-stabilizing surface calculations each draw.
  * Reduced visual glitches and duplicated water artifacts by cleaning up redundant water instances, ensuring proper detachment of water nodes, and tightening flowmap/displacement setup for more consistent rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->