### PR TITLE
revert: "fix(dynamic cubemap): blend native cubemap fallback"

### DIFF
--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/InferCubemapCS.hlsl
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/InferCubemapCS.hlsl
@@ -90,8 +90,7 @@ float3 GetSamplingVector(uint3 ThreadID, in RWTexture2DArray<float4> OutputTextu
 	}
 
 #if defined(REFLECTIONS)
-	float fallbackWeight = saturate(mipLevel / 7.0) * SharedData::cubemapCreatorSettings.ReflectionFallbackAmount;
-	color.rgb = lerp(color.rgb, Color::IrradianceToLinear(ReflectionsTexture.SampleLevel(LinearSampler, uv, 0.0).rgb), fallbackWeight);
+	color.rgb = lerp(color.rgb, Color::IrradianceToLinear(ReflectionsTexture.SampleLevel(LinearSampler, uv, 0.0).rgb), saturate(mipLevel / 7.0));
 #else
 	color.rgb = lerp(color.rgb, color.rgb * DefaultCubemap.SampleLevel(LinearSampler, uv, 0.0).xyz, saturate(mipLevel / 7.0));
 #endif

--- a/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
+++ b/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 2-3-2
+Version = 2-3-1
 
 [Nexus]
 autoupload = false

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -60,13 +60,9 @@ namespace SharedData
 	struct CubemapCreatorSettings
 	{
 		uint Enabled;
-		uint EnabledSSR;
-		float2 pad0;
+		float3 pad0;
 
 		float4 CubemapColor;
-
-		float ReflectionFallbackAmount;
-		float3 pad1;
 	};
 
 	struct TerraOccSettings

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -12,8 +12,7 @@ constexpr auto MIPLEVELS = 8;
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	DynamicCubemaps::Settings,
 	EnabledSSR,
-	EnabledCreator,
-	ReflectionFallbackAmount);
+	EnabledCreator);
 
 std::vector<std::pair<std::string_view, std::string_view>> DynamicCubemaps::GetShaderDefineOptions()
 {
@@ -27,14 +26,6 @@ std::vector<std::pair<std::string_view, std::string_view>> DynamicCubemaps::GetS
 
 void DynamicCubemaps::DrawSettings()
 {
-	if (ImGui::TreeNodeEx("Native Cubemap Fallback", ImGuiTreeNodeFlags_DefaultOpen)) {
-		ImGui::SliderFloat("Fallback Amount", &settings.ReflectionFallbackAmount, kReflectionFallbackMin, kReflectionFallbackMax, "%.2f", ImGuiSliderFlags_AlwaysClamp);
-		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text("Controls how much the game's reflection cubemap fills missing dynamic reflection directions.");
-		}
-		ImGui::TreePop();
-	}
-
 	if (ImGui::TreeNodeEx("Screen Space Reflections", ImGuiTreeNodeFlags_DefaultOpen)) {
 		recompileFlag |= ImGui::Checkbox("Enable Screen Space Reflections", reinterpret_cast<bool*>(&settings.EnabledSSR));
 		if (auto _tt = Util::HoverTooltipWrapper()) {
@@ -140,7 +131,6 @@ void DynamicCubemaps::DrawSettings()
 void DynamicCubemaps::LoadSettings(json& o_json)
 {
 	settings = o_json;
-	settings.ReflectionFallbackAmount = std::clamp(settings.ReflectionFallbackAmount, kReflectionFallbackMin, kReflectionFallbackMax);
 	if (REL::Module::IsVR()) {
 		Util::LoadGameSettings(iniVRCubeMapSettings);
 	}

--- a/src/Features/DynamicCubemaps.h
+++ b/src/Features/DynamicCubemaps.h
@@ -12,10 +12,6 @@ public:
 struct DynamicCubemaps : Feature
 {
 public:
-	static constexpr float kReflectionFallbackMin = 0.0f;
-	static constexpr float kReflectionFallbackMax = 1.0f;
-	static constexpr float kReflectionFallbackDefault = 0.5f;
-
 	const std::string defaultDynamicCubeMapSavePath = "Data\\textures\\DynamicCubemaps";
 
 	// Specular irradiance
@@ -120,10 +116,7 @@ public:
 		uint EnabledSSR = true;
 		uint pad0[2];
 		float4 CubemapColor{ 1.0f, 1.0f, 1.0f, 0.0f };
-		float ReflectionFallbackAmount = kReflectionFallbackDefault;
-		float pad1[3];
 	};
-	STATIC_ASSERT_ALIGNAS_16(Settings);
 
 	Settings settings;
 	bool enabledAtBoot = false;


### PR DESCRIPTION
Reverts community-shaders/skyrim-community-shaders#2328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reflection fallback behavior in dynamic cubemaps with automatic blend calculation.
  * Removed user-configurable fallback amount setting from the configuration menu.

* **Chores**
  * Updated feature version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->