### PR TITLE
ci: replace RELEASE_PAT with GitHub App token

### DIFF
--- a/.github/workflows/auto-rebase-prs.yaml
+++ b/.github/workflows/auto-rebase-prs.yaml
@@ -8,8 +8,9 @@ name: "Auto-rebase open PRs"
 # by maintainers" checked. The action silently skips PRs missing either,
 # and skips conflicts.
 #
-# Token: RELEASE_PAT (classic PAT, `repo` + `workflow`). `workflow` is
-# required because rebased PRs may include `.github/workflows/` diffs.
+# Token: GitHub App token (APP_ID + APP_PRIVATE_KEY). The app must have
+# Contents R/W, Pull requests R/W, and Workflows R/W permissions so that
+# rebased PRs containing `.github/workflows/` diffs can be pushed.
 
 on:
     push:
@@ -35,17 +36,24 @@ jobs:
     rebase:
         runs-on: ubuntu-latest
         steps:
+            - name: Generate app token
+              uses: actions/create-github-app-token@v1
+              id: app-token
+              with:
+                  app-id: ${{ secrets.APP_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
             - name: Checkout
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-                  token: ${{ secrets.RELEASE_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
 
             - name: Resolve single-PR head spec (if pr_number given)
               id: resolve_head
               if: inputs.pr_number != ''
               env:
-                  GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   PR_NUMBER: ${{ inputs.pr_number }}
               run: |
                   set -euo pipefail
@@ -75,7 +83,7 @@ jobs:
               if: inputs.pr_number == '' || steps.resolve_head.outputs.head != ''
               uses: peter-evans/rebase@v3
               with:
-                  token: ${{ secrets.RELEASE_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   base: dev
                   head: ${{ steps.resolve_head.outputs.head }}
                   exclude-drafts: true

--- a/.github/workflows/release-hotfix.yaml
+++ b/.github/workflows/release-hotfix.yaml
@@ -58,12 +58,19 @@ jobs:
     hotfix:
         runs-on: ubuntu-latest
         steps:
+            - name: Generate app token
+              uses: actions/create-github-app-token@v1
+              id: app-token
+              with:
+                  app-id: ${{ secrets.APP_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
             - name: Checkout
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   persist-credentials: false
-                  token: ${{ secrets.RELEASE_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
 
             - name: Configure git identity
               run: |
@@ -226,7 +233,7 @@ jobs:
             - name: Close superseded staging PRs and branches
               if: ${{ !inputs.dry_run && steps.cherry.outputs.picked_count != '0' }}
               env:
-                  GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
                   set -euo pipefail
                   HOTFIX='${{ steps.plan.outputs.hotfix_branch }}'
@@ -246,7 +253,7 @@ jobs:
             - name: Push maintenance branch (if new) and staging branch
               if: ${{ !inputs.dry_run && steps.cherry.outputs.picked_count != '0' }}
               env:
-                  GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+                  GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
                   set -euo pipefail
                   REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"

--- a/.github/workflows/release-semantic.yaml
+++ b/.github/workflows/release-semantic.yaml
@@ -30,6 +30,13 @@ jobs:
     release:
         runs-on: ubuntu-latest
         steps:
+            - name: Generate app token
+              uses: actions/create-github-app-token@v1
+              id: app-token
+              with:
+                  app-id: ${{ secrets.APP_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
             - name: Checkout repository
               uses: actions/checkout@v6
               with:
@@ -37,9 +44,9 @@ jobs:
                   persist-credentials: false
                   # Token used for the working checkout. The actual pushes
                   # (FF main, semantic-release commit/tag, FF dev) all go
-                  # through RELEASE_PAT below so they can bypass branch
+                  # through the app token below so they can bypass branch
                   # protection and fire downstream workflows.
-                  token: ${{ secrets.RELEASE_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
 
             - name: Configure git identity
               run: |
@@ -107,7 +114,7 @@ jobs:
             - name: Fast-forward main to ff_target
               if: ${{ inputs.ff_target != '' }}
               env:
-                  TOKEN: ${{ secrets.RELEASE_PAT }}
+                  TOKEN: ${{ steps.app-token.outputs.token }}
                   FF_TARGET: ${{ inputs.ff_target }}
               run: |
                   set -euo pipefail
@@ -136,17 +143,17 @@ jobs:
                       @semantic-release/github
                   tag_format: "v${version}"
               env:
-                  # RELEASE_PAT required for two reasons:
+                  # App token required for two reasons:
                   # 1. Allows pushing the version commit and tag to the protected
                   #    target branch (GITHUB_TOKEN cannot bypass branch protection).
-                  # 2. A PAT-sourced tag push triggers downstream workflows
+                  # 2. An app-token tag push triggers downstream workflows
                   #    (release-build.yaml); GITHUB_TOKEN pushes do not.
-                  GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+                  GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
             - name: Reconcile dev with release commit (promotion mode, dev source only)
               if: ${{ inputs.ff_target != '' && steps.semantic.outputs.new_release_published == 'true' && steps.validate.outputs.source == 'dev' }}
               env:
-                  TOKEN: ${{ secrets.RELEASE_PAT }}
+                  TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
                   set -euo pipefail
                   git fetch origin main dev
@@ -177,7 +184,7 @@ jobs:
             - name: Rebase-reconcile dev with release commit (promotion mode, hotfix-staging source)
               if: ${{ inputs.ff_target != '' && steps.semantic.outputs.new_release_published == 'true' && steps.validate.outputs.source != 'dev' && steps.validate.outputs.source != '' }}
               env:
-                  TOKEN: ${{ secrets.RELEASE_PAT }}
+                  TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
                   set -euo pipefail
                   git fetch origin main dev


### PR DESCRIPTION
Switches release-semantic, release-hotfix, and auto-rebase-prs
workflows from a personal PAT (RELEASE_PAT) to a GitHub App token
generated via actions/create-github-app-token@v1. Secrets APP_ID
and APP_PRIVATE_KEY must be set at the org level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security in CI/CD workflows by updating authentication mechanisms to use improved token management practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->