### PR TITLE
fix(screenshot): bounds-check staging texture mapped region

### DIFF
--- a/src/Features/ScreenshotFeature.cpp
+++ b/src/Features/ScreenshotFeature.cpp
@@ -10,6 +10,7 @@
 #include "Utils/FileSystem.h"
 #include <DirectXTex.h>
 #include <PCH.h>
+#include <algorithm>
 #include <cstring>
 #include <filesystem>
 #include <format>
@@ -66,6 +67,10 @@ namespace
 		if (FAILED(context->Map(stagingTexture, 0, D3D11_MAP_READ, 0, &mapped))) {
 			return false;
 		}
+		if (!mapped.pData || mapped.RowPitch == 0) {
+			context->Unmap(stagingTexture, 0);
+			return false;
+		}
 
 		const HRESULT initHr = image.Initialize2D(format, width, height, 1, 1);
 		if (FAILED(initHr)) {
@@ -79,12 +84,32 @@ namespace
 			return false;
 		}
 
+		// Driver-mapped region can be smaller than height * mapped.RowPitch
+		// (alignment quirks, partial mappings). Cap by mapped.DepthPitch and
+		// clamp each row's copy to whichever of source/dest pitches is smaller -
+		// stepping past either side hits unmapped memory and the worker crashes
+		// inside rep movsb (see crash 2026-05-19).
+		const size_t bytesPerRow = std::min<size_t>(destImage->rowPitch, mapped.RowPitch);
+		const size_t mappedDepth = mapped.DepthPitch != 0 ? mapped.DepthPitch :
+		                                                    mapped.RowPitch * destImage->height;
+		const size_t maxRowsBySize = mapped.RowPitch > 0 ? (mappedDepth / mapped.RowPitch) : 0;
+		const size_t rowsToCopy = std::min<size_t>(destImage->height, maxRowsBySize);
+
 		auto* destPixels = image.GetPixels();
-		for (size_t row = 0; row < destImage->height; ++row) {
+		const auto* srcPixels = static_cast<const uint8_t*>(mapped.pData);
+
+		// Initialize2D leaves the pixel buffer uninitialized. If the mapped
+		// region is short (rowsToCopy < height) or narrow (bytesPerRow <
+		// destImage->rowPitch), the gaps would otherwise read back as
+		// undefined memory and SaveToWICFile would encode garbage. Zero-fill
+		// up front so any uncopied bytes encode as deterministic black.
+		std::memset(destPixels, 0, image.GetPixelsSize());
+
+		for (size_t row = 0; row < rowsToCopy; ++row) {
 			memcpy(
 				destPixels + row * destImage->rowPitch,
-				static_cast<const uint8_t*>(mapped.pData) + row * mapped.RowPitch,
-				destImage->rowPitch);
+				srcPixels + row * mapped.RowPitch,
+				bytesPerRow);
 		}
 
 		context->Unmap(stagingTexture, 0);


### PR DESCRIPTION
## Summary

Crash 2026-05-19 01:20:48 — `EXCEPTION_ACCESS_VIOLATION` inside `rep movsb` at `ScreenshotFeature.cpp:84`. The worker thread's per-row `memcpy` ran past the driver-mapped region of the staging texture; the source pointer hit unreadable memory at a page boundary (`0x7FFA329B3DFF`).

## Root cause

`PopulateScratchImageFromStagingTexture` assumed:
1. `mapped.RowPitch * destImage->height` always covered the full mapped subresource.
2. `destImage->rowPitch` was always `<= mapped.RowPitch`.

Neither is guaranteed. Drivers can return a smaller mapped region for alignment reasons, and DirectXTex can compute a destination row pitch that exceeds the source pitch on some formats. Either case made the inner `memcpy` step past valid memory.

## Fix

- Reject the call early if `Map()` returns success with a null `pData` or zero `RowPitch`.
- Cap row count by `mapped.DepthPitch / mapped.RowPitch` (falling back to the prior assumption only when `DepthPitch == 0`).
- Copy the smaller of `destImage->rowPitch` and `mapped.RowPitch` per row.

No-op for the common case where the driver returns expected values.

Cherrypicked from alandtse fork

Fixes https://github.com/community-shaders/skyrim-community-shaders/issues/2376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot reliability with enhanced validation and safer memory handling during image readback operations to prevent potential data corruption.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->