### PR TITLE
fix(terrain-helper): restore parallax vs TruePBR

### DIFF
--- a/features/Terrain Helper/Shaders/Features/TerrainHelper.ini
+++ b/features/Terrain Helper/Shaders/Features/TerrainHelper.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-0-0
+Version = 1-0-1
 
 [Nexus]
 nexusmodid = 143149

--- a/src/Features/TerrainHelper.cpp
+++ b/src/Features/TerrainHelper.cpp
@@ -200,12 +200,9 @@ struct TH_TESObjectLAND_SetupMaterial
 	{
 		bool result = func(land);
 
-		// TruePBR sets flag 8 on land cells it processes as PBR; skip TerrainHelper for those.
-		if (!land->data.flags.any(static_cast<RE::OBJ_LAND::Flag>(8))) {
-			auto& terrainHelper = globals::features::terrainHelper;
-			if (result && terrainHelper.loaded) {
-				terrainHelper.TESObjectLAND_SetupMaterial(land);
-			}
+		auto& terrainHelper = globals::features::terrainHelper;
+		if (result && terrainHelper.loaded) {
+			terrainHelper.TESObjectLAND_SetupMaterial(land);
 		}
 
 		return result;
@@ -227,11 +224,16 @@ struct TH_BSLightingShader_SetupMaterial
 	static inline REL::Relocation<decltype(thunk)> func;
 };
 
-void TerrainHelper::PostPostLoad()
+void TerrainHelper::Load()
 {
+	// Install TESObjectLAND hook early so TH is inner relative to TruePBR's PostPostLoad hook.
+	// This ensures TH reads the vanilla material hashKey before TruePBR replaces it with a PBR material.
 	logger::info("[Terrain Helper] Hooking TESObjectLAND");
 	stl::detour_thunk<TH_TESObjectLAND_SetupMaterial>(REL::RelocationID(18368, 18791));
+}
 
+void TerrainHelper::PostPostLoad()
+{
 	logger::info("[Terrain Helper] Hooking BSLightingShader::SetupMaterial");
 	stl::write_vfunc<0x4, TH_BSLightingShader_SetupMaterial>(RE::VTABLE_BSLightingShader[0]);
 }

--- a/src/Features/TerrainHelper.cpp
+++ b/src/Features/TerrainHelper.cpp
@@ -228,6 +228,8 @@ void TerrainHelper::Load()
 {
 	// Install TESObjectLAND hook early so TH is inner relative to TruePBR's PostPostLoad hook.
 	// This ensures TH reads the vanilla material hashKey before TruePBR replaces it with a PBR material.
+	// This intentionally matches TruePBR's REL::RelocationID(18368, 18791), so no extra
+	// VR gate is needed unless those offsets diverge.
 	logger::info("[Terrain Helper] Hooking TESObjectLAND");
 	stl::detour_thunk<TH_TESObjectLAND_SetupMaterial>(REL::RelocationID(18368, 18791));
 }

--- a/src/Features/TerrainHelper.h
+++ b/src/Features/TerrainHelper.h
@@ -37,6 +37,7 @@ public:
 	RE::BGSTextureSet* defaultLandTexture;
 	bool enabled = false;
 
+	virtual void Load() override;
 	virtual void DataLoaded() override;
 	virtual void PostPostLoad() override;
 	virtual bool SupportsVR() override { return true; };


### PR DESCRIPTION
## Summary

- TerrainHelper's `TESObjectLAND` hook was installed in `PostPostLoad()`, which
  runs after TruePBR (feature index 0) had already installed its own hook. With
  `stl::detour_thunk`, last-installed is outermost, so the call chain was
  `engine → TH_thunk → PBR_thunk → vanilla`. TH called `func(land)` first,
  which let PBR replace the geometry's `shaderProperty` with a new
  `BSLightingShaderMaterialPBRLandscape` and set `OBJ_LAND::Flag(8)`. TH's
  flag-8 guard then skipped the cell, leaving `extendedSlots` empty and
  parallax never activating — even on vanilla land — whenever a mod supplies
  the `DefaultPBRLand` EDID (which causes TruePBR to claim all default-textured
  quads as PBR).
- Fix: move TH's `TESObjectLAND` hook install to `Load()`, which runs at
  DLL-load time before any feature's `PostPostLoad()`. TH is now the inner
  hook (`engine → PBR_thunk → TH_thunk → vanilla`). TH reads the vanilla
  material's `hashKey` before TruePBR replaces the `shaderProperty`, stores
  parallax data for that key, and returns. TruePBR then runs and may replace
  the material with a PBR one. For PBR land, `BSLightingShader::SetupMaterial`
  is called with the PBR material's `hashKey`, which doesn't match TH's stored
  vanilla key → TH does nothing. For vanilla land, the key matches → parallax
  activates correctly.
- Remove the now-dead `OBJ_LAND::Flag(8)` guard from the hook thunk — flag 8
  is never set at the point TH runs in the new order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terrain material processing so all terrain types—including those previously skipped by special flags—consistently receive proper material updates; ensured initialization/hook ordering is preserved so material setup runs at the correct time.

* **Chores**
  * Bumped Terrain Helper shader configuration version to 1-0-1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->