### PR TITLE
fix(dynamic cubemaps): reset on more load-related menus

### DIFF
--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -186,12 +186,24 @@ void DynamicCubemaps::PostPostLoad()
 
 RE::BSEventNotifyControl MenuOpenCloseEventHandler::ProcessEvent(const RE::MenuOpenCloseEvent* a_event, RE::BSTEventSource<RE::MenuOpenCloseEvent>*)
 {
-	// When entering a new cell, reset the capture
-	if (a_event->menuName == RE::LoadingMenu::MENU_NAME) {
-		if (!a_event->opening) {
+	// Reset the capture around menus that bracket loading screens or scene
+	// transitions (cell loads, fast travel, character creation, game start).
+	// Reset on both open and close because the surrounding environment can
+	// change either when the menu appears (e.g. MapMenu camera shift) or when
+	// it closes (e.g. LoadingMenu completes a cell transition).
+	static const std::array<std::string_view, 5> kResetMenus = {
+		RE::LoadingMenu::MENU_NAME,
+		RE::MainMenu::MENU_NAME,
+		RE::MapMenu::MENU_NAME,
+		RE::RaceSexMenu::MENU_NAME,
+		RE::TitleSequenceMenu::MENU_NAME,
+	};
+	for (const auto& name : kResetMenus) {
+		if (a_event->menuName == name) {
 			auto& dynamicCubemaps = globals::features::dynamicCubemaps;
 			dynamicCubemaps.resetCapture[0] = true;
 			dynamicCubemaps.resetCapture[1] = true;
+			break;
 		}
 	}
 	return RE::BSEventNotifyControl::kContinue;


### PR DESCRIPTION
Reset the cubemap capture on Main, Map, RaceSex and TitleSequence menus
in addition to LoadingMenu, and trigger on both open and close. These
menus bracket cell transitions, fast travel, character creation and
game start, so the captured environment is stale on either edge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed dynamic cubemaps capture state to properly reset when opening or closing UI menus, improving visual consistency and accuracy during menu interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->