### PR TITLE
fix(ssgi): use visibilitySpecular in specular depth-fade lerp

### DIFF
--- a/features/Screen Space GI/Shaders/Features/ScreenSpaceGI.ini
+++ b/features/Screen Space GI/Shaders/Features/ScreenSpaceGI.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 4-1-0
+Version = 4-1-1
 
 [Nexus]
 nexusmodid = 130375

--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl
@@ -331,7 +331,7 @@ void CalculateGI(
 	radianceSpecular = lerp(radianceSpecular, 0, depthFade);
 
 	visibilitySpecular *= rcpNumSlices;
-	visibilitySpecular = lerp(saturate(visibility), 0, depthFade);
+	visibilitySpecular = lerp(saturate(visibilitySpecular), 0, depthFade);
 #	endif
 #endif
 


### PR DESCRIPTION
### Bug

In `features/Screen Space GI/Shaders/ScreenSpaceGI/gi.cs.hlsl`, inside the `GI_SPECULAR` branch, the depth-fade lerp on line 334 reads `saturate(visibility)` instead of `saturate(visibilitySpecular)`:

```hlsl
visibilitySpecular *= rcpNumSlices;
visibilitySpecular = lerp(saturate(visibility), 0, depthFade);  // reads AO, should read visibilitySpecular
```

This overwrites the narrow-cone specular visibility (accumulated from `bitmaskGISpecular` at line 313, kept separate from the diffuse `bitmask` at line 312 specifically so it can use a tighter cone in `maskedBitsGISpecular`) with the diffuse-cone AO. The preceding `visibilitySpecular *= rcpNumSlices` becomes dead since the result is never read.

Net effect when `EnableExperimentalSpecularGI` is on: `texGiSpecular.a` (consumed downstream via `radianceDisocc` history accumulation and bound to the (Experimental) HQ Specular IL passes) carries the diffuse AO instead of the specular-cone visibility, partially defeating the feature.

### Fix

Mirror the AO block five lines above (line 326), which does the same `lerp(saturate(<var>), 0, depthFade)` on its own variable. One-character symbol rename.

### Notes

Spotted while "porting" Screen Space CS to Fallout 4 thought it worth bringing up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect depth-fade attenuation for specular reflections in Screen Space GI, ensuring proper visual fading of specular occlusion with distance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->