### PR TITLE
feat(skylighting): cache per-probe sun shadow visibility

### DIFF
--- a/features/Skylighting/Shaders/Features/Skylighting.ini
+++ b/features/Skylighting/Shaders/Features/Skylighting.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-3-0
+Version = 1-4-0
 
 [Nexus]
 nexusmodid = 139352

--- a/features/Skylighting/Shaders/Skylighting/Skylighting.hlsli
+++ b/features/Skylighting/Shaders/Skylighting/Skylighting.hlsli
@@ -2,6 +2,7 @@
 #define __SKYLIGHTING_DEPENDENCY_HLSL__
 
 #include "Common/Math.hlsli"
+#include "Common/Random.hlsli"
 #include "Common/Shading.hlsli"
 #include "Common/SharedData.hlsli"
 #include "Common/Spherical Harmonics/SphericalHarmonics.hlsli"
@@ -12,6 +13,10 @@ namespace Skylighting
 	Texture3D<sh2> SkylightingProbeArray : register(SKYLIGHTING_PROBE_REGISTER);
 #elif defined(PSHADER)
 	Texture3D<sh2> SkylightingProbeArray : register(t50);
+#endif
+
+#if defined(PSHADER)
+	Texture3D<float> ShadowVisibilityProbeArray : register(t53);
 #endif
 
 	const static sh2 UNIT_SH = float4(sqrt(4.0 * Math::PI), 0, 0, 0);
@@ -75,7 +80,7 @@ namespace Skylighting
 #endif
 
 #if defined(PSHADER) || defined(SKYLIGHTING_PROBE_REGISTER)
-	sh2 Sample(float3 positionMS, float3 normalWS)
+	sh2 Sample(float3 positionMS, float3 normalWS, float2 screenPosition)
 	{
 		sh2 scaledUnitSH = UNIT_SH / 1e-10;
 
@@ -83,6 +88,11 @@ namespace Skylighting
 			return scaledUnitSH;
 
 		positionMS.xyz += normalWS * CELL_SIZE * 0.5;  // Receiver normal bias
+
+		if (SharedData::FrameCount) {
+			float3 offset = float3(Random::pcg3d(uint3(screenPosition.xy, SharedData::FrameCount))) / 4294967295.0 * 2.0 - 1.0;
+			positionMS.xyz += offset * CELL_SIZE * 0.5;
+		}
 
 		float3 positionMSAdjusted = positionMS - SharedData::skylightingSettings.PosOffset.xyz;
 		float3 uvw = positionMSAdjusted / ARRAY_SIZE + .5;
@@ -125,25 +135,19 @@ namespace Skylighting
 		return SphericalHarmonics::Scale(sum, rcp(wsum + EPSILON_WEIGHT_SUM));
 	}
 
-	// Compute skylighting diffuse for a receiver biased to face upward (grass/foliage).
-	// The result is pre-divided by vertexAO so that a subsequent multiply by vertexAO
-	// yields min(skylightingDiffuse, vertexAO). Pass vertexAO = 1 to skip this compensation.
-	float GetVertexSkylightingDiffuse(float3 positionMS, float3 normalWS, float vertexAO)
+	float GetSkylightingDiffuse(sh2 skylightingSH, float3 positionMS, float3 evalNormal, float vertexAO = 1.0)
 	{
 		if (SharedData::InInterior)
 			return 1.0;
 
+		float3 biasedNormal = normalize(float3(evalNormal.xy, max(0.0, evalNormal.z)));
 		float fadeOutFactor = GetFadeOutFactor(positionMS);
-
-		float3 biasedNormal = normalWS;
-		biasedNormal.z = max(0.0, biasedNormal.z);
-		biasedNormal = normalize(biasedNormal);
-
-		sh2 skylightingSH = Sample(positionMS, normalWS);
 		float skylightingDiffuse = EvaluateDiffuse(skylightingSH, biasedNormal, fadeOutFactor);
 
-		return saturate(skylightingDiffuse / max(vertexAO, 1e-5));
+		return saturate(skylightingDiffuse / max(vertexAO, EPSILON_DIVISION));
 	}
+
+
 
 	sh2 SampleNoBias(float3 positionMS)
 	{
@@ -188,6 +192,55 @@ namespace Skylighting
 		}
 
 		return SphericalHarmonics::Scale(sum, rcp(wsum + EPSILON_WEIGHT_SUM));
+	}
+#endif
+
+#if defined(PSHADER)
+	float SampleShadowVisibility(float3 positionMS, float3 normalWS, float2 screenPosition)
+	{
+		if (SharedData::InInterior)
+			return 1.0;
+
+		positionMS.xyz += normalWS * CELL_SIZE * 0.5;
+
+		if (SharedData::FrameCount) {
+			float3 offset = float3(Random::pcg3d(uint3(screenPosition.xy, SharedData::FrameCount))) / 4294967295.0 * 2.0 - 1.0;
+			positionMS.xyz += offset * CELL_SIZE * 0.5;
+		}
+
+		float3 positionMSAdjusted = positionMS - SharedData::skylightingSettings.PosOffset.xyz;
+		float3 uvw = positionMSAdjusted / ARRAY_SIZE + .5;
+
+		if (any(uvw < 0) || any(uvw > 1))
+			return 1.0;
+
+		float3 cellVxCoord = uvw * ARRAY_DIM;
+		int3 cell000 = floor(cellVxCoord - 0.5);
+		float3 trilinearPos = cellVxCoord - 0.5 - cell000;
+
+		float sum = 0;
+		float wsum = 0;
+		[unroll] for (int i = 0; i < 2; i++)
+			[unroll] for (int j = 0; j < 2; j++)
+				[unroll] for (int k = 0; k < 2; k++)
+		{
+			int3 offset = int3(i, j, k);
+			int3 cellID = cell000 + offset;
+
+			if (any(cellID < 0) || any((uint3)cellID >= ARRAY_DIM))
+				continue;
+
+			float3 trilinearWeights = 1 - abs(offset - trilinearPos);
+			float w = trilinearWeights.x * trilinearWeights.y * trilinearWeights.z;
+
+			uint3 cellTexID = (cellID + SharedData::skylightingSettings.ArrayOrigin.xyz) % ARRAY_DIM;
+			sum += ShadowVisibilityProbeArray[cellTexID] * w;
+			wsum += w;
+		}
+
+		float fadeOut = GetFadeOutFactor(positionMS);
+		float shadow = sum / max(wsum, 0.0001);
+		return lerp(1.0, shadow, fadeOut);
 	}
 #endif
 }

--- a/features/Skylighting/Shaders/Skylighting/UpdateProbesCS.hlsl
+++ b/features/Skylighting/Shaders/Skylighting/UpdateProbesCS.hlsl
@@ -1,12 +1,61 @@
+#include "Common/FrameBuffer.hlsli"
 #include "Common/Math.hlsli"
 #include "Skylighting/Skylighting.hlsli"
 
 Texture2D<unorm float> srcOcclusionDepth : register(t0);
+Texture2DArray<float4> ShadowCascadeMap : register(t1);
+
+struct DirectionalShadowLightData
+{
+	column_major float4x4 ShadowProj[2];
+	column_major float4x4 InvShadowProj[2];
+	float2 EndSplitDistances;
+	float2 StartSplitDistances;
+	float4 CascadeDepthParams;
+};
+StructuredBuffer<DirectionalShadowLightData> DirectionalShadowLights : register(t2);
 
 RWTexture3D<sh2> outProbeArray : register(u0);
 RWTexture3D<uint> outAccumFramesArray : register(u1);
+RWTexture3D<uint> outShadowBitmask : register(u2);
+RWTexture3D<float> outShadowVisibility : register(u3);
 
 SamplerComparisonState comparisonSampler : register(s0);
+
+static const float3 noise3D[32] = {
+	float3(0.247, -0.583, 0.891),
+	float3(-0.672, 0.315, -0.428),
+	float3(0.934, 0.762, -0.153),
+	float3(-0.391, -0.847, 0.526),
+	float3(0.618, 0.094, 0.739),
+	float3(-0.825, -0.271, -0.683),
+	float3(0.152, 0.968, 0.347),
+	float3(0.503, -0.714, -0.592),
+	float3(-0.436, 0.629, 0.814),
+	float3(0.887, -0.198, 0.461),
+	float3(-0.759, 0.852, -0.305),
+	float3(0.321, -0.476, -0.921),
+	float3(-0.094, 0.543, -0.768),
+	float3(0.776, 0.418, 0.632),
+	float3(-0.538, -0.695, 0.279),
+	float3(0.649, -0.921, 0.186),
+	float3(-0.913, 0.127, 0.574),
+	float3(0.285, 0.806, -0.447),
+	float3(0.471, -0.352, 0.698),
+	float3(-0.627, -0.194, -0.856),
+	float3(0.834, 0.591, -0.712),
+	float3(-0.173, -0.968, -0.421),
+	float3(0.562, 0.239, -0.785),
+	float3(-0.745, 0.487, 0.316),
+	float3(0.108, -0.631, 0.894),
+	float3(0.926, -0.845, -0.267),
+	float3(-0.384, 0.712, -0.539),
+	float3(0.697, 0.163, 0.825),
+	float3(-0.851, -0.429, 0.641),
+	float3(0.214, 0.934, 0.372),
+	float3(0.578, -0.762, -0.614),
+	float3(-0.469, 0.381, 0.947)
+};
 
 [numthreads(8, 8, 1)] void main(uint3 dtid : SV_DispatchThreadID) {
 	const float fadeInThreshold = 15;
@@ -39,8 +88,60 @@ SamplerComparisonState comparisonSampler : register(s0);
 
 		outProbeArray[dtid] = occlusionSH;
 		outAccumFramesArray[dtid] = accumFrames;
+
+		// Shadow cascade sampling with bitmask accumulation and Gaussian spatial blur
+		{
+			float shadowSample = 1.0;
+
+			if (SharedData::HasDirectionalShadows && !SharedData::InInterior) {
+				DirectionalShadowLightData shadowData = DirectionalShadowLights[0];
+
+				uint bitIndex = (accumFrames - 1) % 32;
+				float3 jitteredMS = cellCentreMS + noise3D[bitIndex] * Skylighting::CELL_SIZE;
+
+				float ndcDepth = FrameBuffer::GetShadowDepth(jitteredMS, 0);
+				float linearDepth = SharedData::GetScreenDepth(ndcDepth);
+
+				if (linearDepth > 0 && linearDepth < shadowData.EndSplitDistances.y) {
+					float3 positionWS = jitteredMS + FrameBuffer::CameraPosAdjust[0].xyz;
+
+					float cascadeSelect = saturate((linearDepth - shadowData.StartSplitDistances.y) /
+						(shadowData.EndSplitDistances.x - shadowData.StartSplitDistances.y));
+					uint cascadeIndex = uint(cascadeSelect);
+
+					float3 positionLS = mul(shadowData.ShadowProj[cascadeIndex], float4(positionWS, 1)).xyz;
+
+					if (all(positionLS.xy >= 0) && all(positionLS.xy <= 1)) {
+						shadowSample = ShadowCascadeMap.SampleCmpLevelZero(comparisonSampler, float3(positionLS.xy, cascadeIndex), positionLS.z);
+					}
+
+					float fade = saturate(linearDepth / shadowData.EndSplitDistances.y);
+					float fadeFactor = 1.0 - pow(fade * fade, 8);
+					shadowSample = lerp(1.0, shadowSample, fadeFactor);
+				}
+
+				uint bitmask = isValid ? outShadowBitmask[dtid] : 0;
+				bitmask &= ~(1u << bitIndex);
+				if (shadowSample > 0.5)
+					bitmask |= (1u << bitIndex);
+
+				outShadowBitmask[dtid] = bitmask;
+
+				uint validBits = min(accumFrames, 32u);
+				float shadow = float(countbits(bitmask)) / float(validBits);
+				shadow = lerp(1.0, shadow, min(fadeInThreshold, accumFrames) / fadeInThreshold);
+				outShadowVisibility[dtid] = shadow;
+			} else {
+				if (!isValid) {
+					outShadowBitmask[dtid] = 0;
+					outShadowVisibility[dtid] = 1.0;
+				}
+			}
+		}
 	} else if (!isValid) {
 		outProbeArray[dtid] = unitSH;
 		outAccumFramesArray[dtid] = 0;
+		outShadowBitmask[dtid] = 0;
+		outShadowVisibility[dtid] = 1.0;
 	}
 }

--- a/package/Shaders/DeferredCompositeCS.hlsl
+++ b/package/Shaders/DeferredCompositeCS.hlsl
@@ -154,7 +154,7 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, inout float ao, out float3 il,
 #			else
 		float3 positionMS = positionWS.xyz;
 #			endif
-		sh2 skylightingSH = Skylighting::Sample(positionMS.xyz, normalWS);
+		sh2 skylightingSH = Skylighting::Sample(positionMS.xyz, normalWS, float2(dispatchID.xy));
 		float skylightingDiffuse = Skylighting::EvaluateDiffuse(skylightingSH, normalWS);
 		directionalAmbientColor = ImageBasedLighting::GetDiffuseIBLOccluded(vanillaDALC, -normalWS, skylightingDiffuse) * albedo;
 #		else
@@ -224,7 +224,7 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, inout float ao, out float3 il,
 		float3 positionMS = positionWS.xyz;
 #		endif
 
-		sh2 skylightingSH = Skylighting::Sample(positionMS.xyz, R);
+		sh2 skylightingSH = Skylighting::Sample(positionMS.xyz, R, float2(dispatchID.xy));
 		float skylightingSpecular = Skylighting::EvaluateSpecular(skylightingSH, specularLobe);
 #	endif
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2369,9 +2369,9 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float3 positionMSSkylight = input.WorldPosition.xyz;
 #		endif
 #		if defined(DEFERRED)
-	sh2 skylightingSH = Skylighting::Sample(positionMSSkylight, worldNormal);
+	sh2 skylightingSH = Skylighting::Sample(positionMSSkylight, worldNormal, input.Position.xy);
 #		else
-	sh2 skylightingSH = inWorld ? Skylighting::Sample(positionMSSkylight, worldNormal) : Skylighting::UNIT_SH;
+	sh2 skylightingSH = inWorld ? Skylighting::Sample(positionMSSkylight, worldNormal, input.Position.xy) : Skylighting::UNIT_SH;
 #		endif
 
 #	endif

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -642,7 +642,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float3 positionMSSkylight = input.WorldPosition.xyz;
 #					endif
 	float vertexAO = max(max(vertexColor.r, vertexColor.g), vertexColor.b);
-	float skylightingDiffuse = Skylighting::GetVertexSkylightingDiffuse(positionMSSkylight, normal, vertexAO);
+	sh2 skylightingSH = Skylighting::Sample(positionMSSkylight, normal, input.HPosition.xy);
+	float skylightingDiffuse = Skylighting::GetSkylightingDiffuse(skylightingSH, positionMSSkylight, normal, vertexAO);
 #				endif  // SKYLIGHTING
 
 	float3 albedo = baseColor.xyz * vertexColor;
@@ -909,7 +910,8 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 positionMSSkylight = input.WorldPosition.xyz;
 #				endif
 	float vertexAO = max(max(vertexColor.r, vertexColor.g), vertexColor.b);
-	float skylightingDiffuse = Skylighting::GetVertexSkylightingDiffuse(positionMSSkylight, normal, vertexAO);
+	sh2 skylightingSH = Skylighting::Sample(positionMSSkylight, normal, input.HPosition.xy);
+	float skylightingDiffuse = Skylighting::GetSkylightingDiffuse(skylightingSH, positionMSSkylight, normal, vertexAO);
 #			endif  // SKYLIGHTING
 
 	float3 directionalAmbientColor = Color::Ambient(max(0, SharedData::GetAmbient(normal)));

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -1,5 +1,6 @@
 #include "Skylighting.h"
 
+#include "Deferred.h"
 #include "ShaderCache.h"
 #include "State.h"
 #include "Utils/D3D.h"
@@ -30,6 +31,11 @@ void Skylighting::ResetSkylighting()
 	auto context = globals::d3d::context;
 	UINT clr[1] = { 0 };
 	context->ClearUnorderedAccessViewUint(texAccumFramesArray->uav.get(), clr);
+	context->ClearUnorderedAccessViewUint(texShadowBitmask->uav.get(), clr);
+
+	float clrf[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
+	context->ClearUnorderedAccessViewFloat(texShadowVisibility->uav.get(), clrf);
+
 	queuedResetSkylighting = false;
 }
 
@@ -50,6 +56,7 @@ void Skylighting::DrawSettings()
 	ImGui::SliderAngle("Max Zenith Angle", &settings.MaxZenith, 0, 90);
 	if (auto _tt = Util::HoverTooltipWrapper())
 		ImGui::Text("Smaller angles creates more focused top-down shadow.");
+
 }
 
 void Skylighting::SetupResources()
@@ -110,6 +117,18 @@ void Skylighting::SetupResources()
 		texAccumFramesArray = new Texture3D(texDesc, "Skylighting::AccumFramesArray");
 		texAccumFramesArray->CreateSRV(srvDesc);
 		texAccumFramesArray->CreateUAV(uavDesc);
+
+		texDesc.Format = srvDesc.Format = uavDesc.Format = DXGI_FORMAT_R32_UINT;
+
+		texShadowBitmask = new Texture3D(texDesc, "Skylighting::ShadowBitmask");
+		texShadowBitmask->CreateSRV(srvDesc);
+		texShadowBitmask->CreateUAV(uavDesc);
+
+		texDesc.Format = srvDesc.Format = uavDesc.Format = DXGI_FORMAT_R16_FLOAT;
+
+		texShadowVisibility = new Texture3D(texDesc, "Skylighting::ShadowVisibility");
+		texShadowVisibility->CreateSRV(srvDesc);
+		texShadowVisibility->CreateUAV(uavDesc);
 	}
 
 	{
@@ -217,9 +236,20 @@ void Skylighting::Prepass()
 	auto context = globals::d3d::context;
 
 	{
-		std::array<ID3D11ShaderResourceView*, 1> srvs = { texOcclusion->srv.get() };
-		std::array<ID3D11UnorderedAccessView*, 2> uavs = { texProbeArray->uav.get(), texAccumFramesArray->uav.get() };
-		std::array<ID3D11SamplerState*, 1> samplers = { comparisonSampler.get() };
+		std::array<ID3D11ShaderResourceView*, 3> srvs = {
+			texOcclusion->srv.get(),
+			shadowCascadeSRV,
+			globals::deferred->directionalShadowLights->srv.get()
+		};
+		std::array<ID3D11UnorderedAccessView*, 4> uavs = {
+			texProbeArray->uav.get(),
+			texAccumFramesArray->uav.get(),
+			texShadowBitmask->uav.get(),
+			texShadowVisibility->uav.get()
+		};
+		std::array<ID3D11SamplerState*, 1> samplers = {
+			comparisonSampler.get()
+		};
 
 		// Update probe array
 		{
@@ -247,6 +277,9 @@ void Skylighting::Prepass()
 	{
 		ID3D11ShaderResourceView* srv = texProbeArray->srv.get();
 		context->PSSetShaderResources(50, 1, &srv);
+
+		srv = texShadowVisibility->srv.get();
+		context->PSSetShaderResources(53, 1, &srv);
 	}
 }
 
@@ -611,6 +644,16 @@ void Skylighting::RenderOcclusion()
 			}
 		}
 	}
+}
+
+void Skylighting::CaptureShadowCascadeSRV()
+{
+	auto context = globals::d3d::context;
+	ID3D11ShaderResourceView* srv = nullptr;
+	context->PSGetShaderResources(4, 1, &srv);
+	if (shadowCascadeSRV)
+		shadowCascadeSRV->Release();
+	shadowCascadeSRV = srv;
 }
 
 void Skylighting::Main_Precipitation_RenderOcclusion::thunk()

--- a/src/Features/Skylighting.h
+++ b/src/Features/Skylighting.h
@@ -73,6 +73,10 @@ public:
 	Texture2D* texOcclusion = nullptr;
 	Texture3D* texProbeArray = nullptr;
 	Texture3D* texAccumFramesArray = nullptr;
+	Texture3D* texShadowBitmask = nullptr;
+	Texture3D* texShadowVisibility = nullptr;
+
+	ID3D11ShaderResourceView* shadowCascadeSRV = nullptr;
 
 	winrt::com_ptr<ID3D11ComputeShader> probeUpdateCompute = nullptr;
 
@@ -88,6 +92,7 @@ public:
 	uint frameCount = 0;
 
 	void ResetSkylighting();
+	void CaptureShadowCascadeSRV();
 
 	std::chrono::time_point<std::chrono::system_clock> lastUpdateTimer = std::chrono::system_clock::now();
 

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -10,6 +10,7 @@
 #include "Features/HDRDisplay.h"
 #include "Features/InteriorSun.h"
 #include "Features/PerformanceOverlay.h"
+#include "Features/Skylighting.h"
 #include "Features/TerrainBlending.h"
 #include "Features/TerrainHelper.h"
 #include "Features/Upscaling.h"
@@ -56,6 +57,7 @@ void State::Draw()
 	auto& truePBR = globals::features::truePBR;
 	auto context = globals::d3d::context;
 	auto& volumetricShadows = globals::features::volumetricShadows;
+	auto& skylighting = globals::features::skylighting;
 
 	if (shaderCache->IsEnabled()) {
 		// Process deferred cell transitions (interior detection)
@@ -96,6 +98,8 @@ void State::Draw()
 				if (currentPixelDescriptor & static_cast<uint32_t>(SIE::ShaderCache::UtilityShaderFlags::RenderShadowmask)) {
 					if (volumetricShadows.loaded)
 						volumetricShadows.CopyShadowLightData();
+					if (skylighting.loaded)
+						skylighting.CaptureShadowCascadeSRV();
 				}
 			}
 		}


### PR DESCRIPTION
Extracted from the `effect11sh2` branch as a standalone change.

## Summary

Augments the skylighting probe update with a second output: a 32-frame bitmask of sun shadow visibility per probe, accumulated from cascade shadow map samples with per-frame fixed-pattern offsets. The bitmask average becomes a smoothed shadow visibility value usable by other features without re-running shadow taps.

- Adds two new 3D textures: `texShadowBitmask` (`R32_UINT`) and `texShadowVisibility` (`R16_FLOAT`).
- Adds a new SRV slot `t53` for sampling visibility from the pixel shader (`ShadowVisibilityProbeArray`).
- Adds `Skylighting::CaptureShadowCascadeSRV()` that grabs the active cascade SRV during the shadowmask render pass so the next probe update has it (driven from `State::Draw`).
- `UpdateProbesCS` consumes the cascade map (`t1`) and per-frame directional shadow light data (`t2`) when `SharedData::HasDirectionalShadows` and not in interior.
- Adds a new entry point `SampleShadowVisibility(positionMS, normalWS, screenPos)` in `Skylighting.hlsli`.

### API refactor (caller updates included)

- `Skylighting::Sample(positionMS, normalWS)` → `Skylighting::Sample(positionMS, normalWS, float2 screenPosition)`. The screen position drives per-pixel jitter.
- `Skylighting::GetVertexSkylightingDiffuse(positionMS, normal, vertexAO)` → `Skylighting::GetSkylightingDiffuse(sh2 skylightingSH, positionMS, evalNormal, vertexAO = 1.0)`. Now takes a pre-sampled SH so callers can reuse it for both sampling and evaluation.
- All in-tree callers updated: `DeferredCompositeCS.hlsl` (×2), `Lighting.hlsl` (×2), `RunGrass.hlsl` (×2).

Bumps Skylighting feature version `1-3-0` → `1-4-0`.

## Notes

- `globals::profiler->BeginPass`/`EndPass` instrumentation that exists on `effect11sh2` was stripped, since the profiler infrastructure is not part of this PR.
- The new `texShadowBitmask` and `texShadowVisibility` are cleared in `ResetSkylighting()` alongside the existing accumulation texture.

## Test plan

- [ ] Build a Skyrim DLL and verify skylighting still renders correctly with the new SRV layout.
- [ ] Confirm `ShadowVisibilityProbeArray` is populated (sampleable from pixel shaders via the new helper) and that interiors return 1.0.
- [ ] Verify `Skylighting::Sample` and `GetSkylightingDiffuse` callers in `Lighting`/`RunGrass`/`DeferredCompositeCS` compile and behave correctly (test with both Lighting and Grass features enabled).
- [ ] Check VR — the cascade sampling path uses `FrameBuffer::GetShadowDepth` and `FrameBuffer::CameraPosAdjust[0]`; confirm no per-eye artifacts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Btbf7Mhc2JnnW2mjfoirkE)_