### PR TITLE
fix(unified-water): cell transition flicker

### DIFF
--- a/features/Unified Water/Shaders/Features/UnifiedWater.ini
+++ b/features/Unified Water/Shaders/Features/UnifiedWater.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-0-1
+Version = 1-0-2
 
 [Nexus]
 autoupload = false

--- a/features/Unified Water/Shaders/Features/UnifiedWater.ini
+++ b/features/Unified Water/Shaders/Features/UnifiedWater.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-0-2
+Version = 1-0-1
 
 [Nexus]
 autoupload = false

--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -476,30 +476,6 @@ void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 void UnifiedWater::BSWaterShader_SetupGeometry::thunk(RE::BSShader* waterShader, RE::BSRenderPass* pass)
 {
 	const auto& singleton = globals::features::unifiedWater;
-	// Fix BSWaterShaderProperty.plane after interior->exterior transitions.
-	// The plane feeds ReflectPlane in the PerGeometry cbuffer. When corrupted (e.g., plane.constant = 0
-	// or garbage), the shader's refractionPlaneMul calculation produces extreme values causing flickering.
-	// This primarily affects flowmapped water because it uses more complex refraction depth calculations.
-	if (const auto prop = pass->geometry->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
-		const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
-		const float waterHeight = pass->geometry->world.translate.z;
-
-		// Validate and fix the plane if it's corrupted.
-		// A valid water plane has normal pointing up (0,0,1) and constant = water height.
-		// After interior->exterior transitions, plane.constant can be 0 or stale values.
-		const bool planeNonFinite =
-			!std::isfinite(waterShaderProp->plane.normal.x) ||
-			!std::isfinite(waterShaderProp->plane.normal.y) ||
-			!std::isfinite(waterShaderProp->plane.normal.z) ||
-			!std::isfinite(waterShaderProp->plane.constant);
-		const bool planeNormalBad = std::abs(waterShaderProp->plane.normal.x) > 0.01f || std::abs(waterShaderProp->plane.normal.y) > 0.01f || std::abs(waterShaderProp->plane.normal.z - 1.0f) > 0.01f;
-		const bool planeConstantBad = std::abs(waterShaderProp->plane.constant - waterHeight) > 1.0f;
-		if (planeNonFinite || planeNormalBad || planeConstantBad) {
-			waterShaderProp->plane.normal = { 0.0f, 0.0f, 1.0f };
-			waterShaderProp->plane.constant = waterHeight;
-		}
-	}
-
 	if (singleton.flowmap) {
 		// ObjectUV.xyz below, xy contains width and height, z contains mesh scale
 		// Previously flowmap size was in x, yz contained flowmap offset for water displacement mesh

--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -305,7 +305,6 @@ bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSy
 		RemoveLODWater(waterSystem, shape, *gWaterLOD);
 	}
 
-	RemoveDuplicateWaterSystemObjects(waterSystem, *gWaterLOD);
 	DetachAllChildOccurrences(*gWaterLOD, block->water);
 	(*gWaterLOD)->AttachChild(block->water, true);
 	waterSystem->Enable();
@@ -646,12 +645,13 @@ void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 	func(block);
 
 	if (water) {
-		ClearWaterNodeChildren(water, globals::game::waterSystem);
+		auto count = water->GetChildren().size();
+		while (count > 0) {
+			water->DetachChildAt(--count);
+		}
 
-		if (uw.gWaterLOD && *uw.gWaterLOD)
-			DetachAllChildOccurrences(*uw.gWaterLOD, water);
-		if (block)
-			block->waterAttached = false;
+		DetachAllChildOccurrences(*uw.gWaterLOD, water);
+		block->waterAttached = false;
 	}
 }
 
@@ -659,20 +659,7 @@ void UnifiedWater::BSWaterShader_SetupGeometry::thunk(RE::BSShader* waterShader,
 {
 	auto& uw = globals::features::unifiedWater;
 
-	if (pass && pass->geometry) {
-		// Re-stabilize BSWaterShaderProperty.plane every draw. After interior/exterior
-		// transitions the cached plane can be stale for exactly one of two overlapping
-		// water surfaces, which presents as heavy flicker rather than missing water.
-		if (const auto prop = pass->geometry->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
-			const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
-			const float waterHeight = pass->geometry->world.translate.z;
-
-			waterShaderProp->plane.normal = { 0.0f, 0.0f, 1.0f };
-			waterShaderProp->plane.constant = waterHeight;
-		}
-	}
-
-	if (uw.flowmap && pass && pass->geometry) {
+	if (uw.flowmap) {
 		// ObjectUV.xyz below, xy contains width and height, z contains mesh scale
 		// Previously flowmap size was in x, yz contained flowmap offset for water displacement mesh
 		*uw.gFlowMapSize = uw.flowmap->GetWidth();                                            // ObjectUV.x

--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -10,119 +10,6 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	UnifiedWater::Settings,
 	UseOptimisedMeshes)
 
-static bool IsChildWorldSpace(const RE::TESWorldSpace* ws)
-{
-	return ws && ws->parentWorld &&
-	       ws->parentUseFlags.all(RE::TESWorldSpace::ParentUseFlag::kUseLODData);
-}
-
-// Engine behavior: CellState value 6 is the transition/attached state.
-static constexpr auto kTransitionAttachedCellState = static_cast<RE::TESObjectCELL::CellState>(6);
-
-static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY, bool* isInGrid = nullptr)
-{
-	if (isInGrid)
-		*isInGrid = false;
-	if (!tes || !tes->gridCells)
-		return false;
-
-	const auto& gridCells = tes->gridCells;
-	const int32_t offsetX = tes->currentGridX - static_cast<int32_t>(gridCells->length >> 1);
-	const int32_t offsetY = tes->currentGridY - static_cast<int32_t>(gridCells->length >> 1);
-	const int32_t length = static_cast<int32_t>(gridCells->length);
-
-	const int32_t x = cellX - offsetX;
-	const int32_t y = cellY - offsetY;
-	if (x < 0 || y < 0 || x >= length || y >= length)
-		return false;
-
-	if (isInGrid)
-		*isInGrid = true;
-
-	if (const auto cell = gridCells->GetCell(x, y)) {
-		return cell->cellState.any(RE::TESObjectCELL::CellState::kAttached, kTransitionAttachedCellState);
-	}
-
-	return false;
-}
-
-struct CullCompletionState
-{
-	bool foundAttachedCell = false;
-	bool hasPotentiallyAttachableChild = false;
-
-	bool IsComplete() const
-	{
-		return foundAttachedCell && !hasPotentiallyAttachableChild;
-	}
-};
-
-// Cull waterParent children using tes->gridCells attachment state.
-// Pass tes explicitly when globals::game::tes is not ready (e.g., TES_SetWorldSpace).
-static CullCompletionState CullWaterParentByGridCells(RE::NiNode* waterParent, RE::TES* tes = nullptr)
-{
-	if (!tes)
-		tes = globals::game::tes;
-	if (!tes || !waterParent)
-		return {};
-
-	CullCompletionState state;
-
-	for (const auto& child : waterParent->GetChildren()) {
-		if (!child)
-			continue;
-		int32_t x, y;
-		Util::WorldToCell(child->world.translate, x, y);
-		bool isInGrid = false;
-		const bool cull = ShouldCullAtCell(tes, x, y, &isInGrid);
-		if (cull)
-			state.foundAttachedCell = true;
-		else if (isInGrid)
-			state.hasPotentiallyAttachableChild = true;
-		child->SetAppCulled(cull);
-	}
-
-	return state;
-}
-
-// Cull all tiles under every water LOD parent.
-static bool CullAllWaterLODParents(RE::NiNode* waterLOD, RE::TES* tes = nullptr)
-{
-	if (!waterLOD)
-		return false;
-
-	CullCompletionState aggregate;
-
-	for (const auto& waterParentPtr : waterLOD->GetChildren()) {
-		if (!waterParentPtr)
-			continue;
-		const auto waterParent = waterParentPtr->AsNode();
-		if (!waterParent)
-			continue;
-		const auto state = CullWaterParentByGridCells(waterParent, tes);
-		aggregate.foundAttachedCell = aggregate.foundAttachedCell || state.foundAttachedCell;
-		aggregate.hasPotentiallyAttachableChild = aggregate.hasPotentiallyAttachableChild || state.hasPotentiallyAttachableChild;
-	}
-
-	return aggregate.IsComplete();
-}
-
-void UnifiedWater::TryCompleteDeferredChildWorldspaceCull(RE::TES* tes)
-{
-	if (!pendingChildWsCull.load(std::memory_order_acquire) ||
-		!IsChildWorldSpace(currentPlayerWorldSpace.load(std::memory_order_acquire)) ||
-		!gWaterLOD || !*gWaterLOD)
-		return;
-
-	if (!tes)
-		tes = cachedTes.load(std::memory_order_acquire);
-	if (!tes || !tes->gridCells)
-		return;
-
-	if (CullAllWaterLODParents(*gWaterLOD, tes))
-		pendingChildWsCull.store(false, std::memory_order_release);
-}
-
 void UnifiedWater::LoadSettings(json& o_json)
 {
 	settings = o_json;
@@ -429,52 +316,16 @@ int32_t UnifiedWater::BSWaterShaderMaterial_ComputeCRC32::thunk(RE::BSWaterShade
 
 void UnifiedWater::TES_SetWorldSpace::thunk(RE::TES* tes, RE::TESWorldSpace* worldSpace, bool isExterior)
 {
-	const bool enteringChild = IsChildWorldSpace(worldSpace);
-
-	// Set before func so attachment hooks fired inside func see the new worldspace.
-	auto& uw = globals::features::unifiedWater;
-	uw.currentPlayerWorldSpace.store(worldSpace, std::memory_order_release);
-	uw.cachedTes.store(tes, std::memory_order_release);
-	if (!enteringChild)
-		uw.pendingChildWsCull.store(false, std::memory_order_release);  // leaving child WS: discard any stale pending cull
-
 	func(tes, worldSpace, isExterior);
 
-	if (!uw.waterCache) {
-		uw.pendingChildWsCull.store(false, std::memory_order_release);
-		return;
-	}
-
-	uw.waterCache->SetCurrentWorldSpace(worldSpace);
-
-	if (enteringChild) {
-		// BGSTerrainBlock_Attach calls Enable() on block attach.
-		// Child-worldspace transitions can keep old LOD blocks attached, so re-enable here.
-		if (const auto waterSystem = globals::game::waterSystem)
-			waterSystem->Enable();
-
-		// Try an immediate cull with tes (globals::game::tes may still be null).
-		// Newly transitioned cells are often not attached yet, so deferred retries are still needed.
-		if (uw.gWaterLOD && *uw.gWaterLOD && tes && tes->gridCells)
-			CullAllWaterLODParents(*uw.gWaterLOD, tes);
-
-		// Keep deferred retries enabled until attached cells are observed and culled.
-		uw.pendingChildWsCull.store(true, std::memory_order_release);
-	}
+	globals::features::unifiedWater.waterCache->SetCurrentWorldSpace(worldSpace);
 }
 
 void UnifiedWater::TES_DestroySkyCell::thunk(RE::TES* tes)
 {
 	func(tes);
 
-	auto& uw = globals::features::unifiedWater;
-	uw.currentPlayerWorldSpace.store(nullptr, std::memory_order_release);
-	uw.pendingChildWsCull.store(false, std::memory_order_release);
-	uw.cachedTes.store(nullptr, std::memory_order_release);
-	if (!uw.waterCache)
-		return;
-
-	uw.waterCache->SetCurrentWorldSpace(nullptr);
+	globals::features::unifiedWater.waterCache->SetCurrentWorldSpace(nullptr);
 }
 
 void UnifiedWater::BGSTerrainNode_UpdateWaterMeshSubVisibility::thunk(const RE::BGSTerrainNode* node, RE::BSMultiBoundNode* waterParent)
@@ -485,21 +336,40 @@ void UnifiedWater::BGSTerrainNode_UpdateWaterMeshSubVisibility::thunk(const RE::
 	if (node->GetLODLevel() != 4)
 		return;
 
-	CullWaterParentByGridCells(waterParent);
+	const auto tes = globals::game::tes;
+	if (!tes || !tes->gridCells)
+		return;
+
+	const auto& gridCells = tes->gridCells;
+
+	const int32_t offsetX = tes->currentGridX - static_cast<int32_t>(gridCells->length >> 1);
+	const int32_t offsetY = tes->currentGridY - static_cast<int32_t>(gridCells->length >> 1);
+	const int32_t length = static_cast<int32_t>(gridCells->length);
+
+	for (const auto& child : waterParent->GetChildren()) {
+		if (!child)
+			continue;
+
+		int32_t x, y;
+		Util::WorldToCell(child->world.translate, x, y);
+
+		x -= offsetX;
+		y -= offsetY;
+
+		bool cull = false;
+		if (x >= 0 && y >= 0 && x < length && y < length) {
+			if (const auto cell = gridCells->GetCell(x, y); cell && cell->cellState.any(RE::TESObjectCELL::CellState::kAttached, static_cast<RE::TESObjectCELL::CellState>(6)))
+				cull = true;
+		}
+
+		child->SetAppCulled(cull);
+	}
 }
 
 void UnifiedWater::BGSTerrainBlock_Attach::thunk(RE::BGSTerrainBlock* block)
 {
-	const auto waterSystem = globals::game::waterSystem;
-	auto& uw = globals::features::unifiedWater;
-
-	if (!waterSystem || !uw.waterCache || !uw.gWaterLOD || !*uw.gWaterLOD) {
-		func(block);
-		return;
-	}
-
-	// Additional game-thread retry path for deferred child-WS cull completion.
-	uw.TryCompleteDeferredChildWorldspaceCull(uw.cachedTes.load(std::memory_order_acquire));
+	const auto waterSystem = RE::TESWaterSystem::GetSingleton();
+	const auto& singleton = globals::features::unifiedWater;
 
 	std::vector<std::pair<RE::BSTriShape*, const WaterCache::Instruction*>> built;
 	bool attaching = false;
@@ -525,7 +395,7 @@ void UnifiedWater::BGSTerrainBlock_Attach::thunk(RE::BGSTerrainBlock* block)
 		const auto lodLevel = node->GetLODLevel();
 		const auto worldSpace = block->node->manager->worldSpace;
 
-		const auto instructions = uw.waterCache->GetInstructions(worldSpace, lodLevel, node->baseCellX, node->baseCellY);
+		const auto instructions = singleton.waterCache->GetInstructions(worldSpace, lodLevel, node->baseCellX, node->baseCellY);
 		if (!instructions) {
 			logger::warn("[Unified Water] No instructions found for {} chunk at {}, {}", worldSpace->GetFormEditorID(), node->baseCellX, node->baseCellY);
 			func(block);
@@ -538,7 +408,7 @@ void UnifiedWater::BGSTerrainBlock_Attach::thunk(RE::BGSTerrainBlock* block)
 
 			RE::NiCloningProcess cloningProcess;
 
-			const auto targetShape = lodLevel > 4 || uw.settings.UseOptimisedMeshes ? uw.optimisedWaterMesh : uw.waterMesh;
+			const auto targetShape = lodLevel > 4 || singleton.settings.UseOptimisedMeshes ? singleton.optimisedWaterMesh : singleton.waterMesh;
 			RE::BSTriShape* shape = targetShape->CreateClone(cloningProcess)->AsTriShape();
 
 			const auto posX = (instruction.x - node->baseCellX) * 4096.0f + instruction.size * 2048.0f;
@@ -579,26 +449,12 @@ void UnifiedWater::BGSTerrainBlock_Attach::thunk(RE::BGSTerrainBlock* block)
 		}
 	}
 
-	(*uw.gWaterLOD)->AttachChild(block->water, true);
+	(*singleton.gWaterLOD)->AttachChild(block->water, true);
 	waterSystem->Enable();
-
-	// BGSTerrainNode_UpdateWaterMeshSubVisibility never fires in child worldspaces.
-	// Cull newly built tiles here; full deferred retries are handled by
-	// TryCompleteDeferredChildWorldspaceCull().
-	if (IsChildWorldSpace(uw.currentPlayerWorldSpace.load(std::memory_order_acquire))) {
-		const auto tes = uw.cachedTes.load(std::memory_order_acquire);
-		if (tes && tes->gridCells) {
-			for (const auto& [shape, instruction] : built) {
-				const bool cull = ShouldCullAtCell(tes, instruction->x, instruction->y);
-				shape->SetAppCulled(cull);
-			}
-		}
-	}
 }
 
 void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 {
-	auto& uw = globals::features::unifiedWater;
 	const auto water = block->water;
 	block->water = nullptr;
 
@@ -612,15 +468,14 @@ void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 			water->DetachChildAt(--count);
 		}
 
-		(*uw.gWaterLOD)->DetachChild(water);
+		(*globals::features::unifiedWater.gWaterLOD)->DetachChild(water);
 		block->waterAttached = false;
 	}
 }
 
 void UnifiedWater::BSWaterShader_SetupGeometry::thunk(RE::BSShader* waterShader, RE::BSRenderPass* pass)
 {
-	auto& uw = globals::features::unifiedWater;
-
+	const auto& singleton = globals::features::unifiedWater;
 	// Fix BSWaterShaderProperty.plane after interior->exterior transitions.
 	// The plane feeds ReflectPlane in the PerGeometry cbuffer. When corrupted (e.g., plane.constant = 0
 	// or garbage), the shader's refractionPlaneMul calculation produces extreme values causing flickering.
@@ -645,12 +500,12 @@ void UnifiedWater::BSWaterShader_SetupGeometry::thunk(RE::BSShader* waterShader,
 		}
 	}
 
-	if (uw.flowmap) {
+	if (singleton.flowmap) {
 		// ObjectUV.xyz below, xy contains width and height, z contains mesh scale
 		// Previously flowmap size was in x, yz contained flowmap offset for water displacement mesh
-		*uw.gFlowMapSize = uw.flowmap->GetWidth();                                            // ObjectUV.x
-		uw.gDisplacementMeshFlowCellOffset->x = static_cast<float>(uw.flowmap->GetHeight());  // ObjectUV.y
-		uw.gDisplacementMeshFlowCellOffset->y = 1.0f - pass->geometry->local.scale;           // ObjectUV.z (counters 1 - x in SetupGeometry)
+		*singleton.gFlowMapSize = singleton.flowmap->GetWidth();                                            // ObjectUV.x
+		singleton.gDisplacementMeshFlowCellOffset->x = static_cast<float>(singleton.flowmap->GetHeight());  // ObjectUV.y
+		singleton.gDisplacementMeshFlowCellOffset->y = 1.0f - pass->geometry->local.scale;                  // ObjectUV.z (counters 1 - x in SetupGeometry)
 
 		if (const auto prop = pass->geometry->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
 			const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
@@ -660,10 +515,10 @@ void UnifiedWater::BSWaterShader_SetupGeometry::thunk(RE::BSShader* waterShader,
 			// xy is world cell flowmap based (0,0 is corner of flow map), zw is world cell
 			// Funky maths here to counter what's being done in SetupGeometry
 			// Previously these values were relative to the 5x5 flow grid centered on the player
-			waterShaderProp->flowX = x + uw.flowmap->GetOffsetX();                                                     // CellTexCoordOffset.x
-			waterShaderProp->flowY = y + uw.flowmap->GetOffsetY() + uw.flowmap->GetWidth() - uw.flowmap->GetHeight();  // CellTexCoordOffset.y
-			waterShaderProp->cellX = x;                                                                                // CellTexCoordOffset.z
-			waterShaderProp->cellY = y;                                                                                // CellTexCoordOffset.w
+			waterShaderProp->flowX = x + singleton.flowmap->GetOffsetX();                                                                   // CellTexCoordOffset.x
+			waterShaderProp->flowY = y + singleton.flowmap->GetOffsetY() + singleton.flowmap->GetWidth() - singleton.flowmap->GetHeight();  // CellTexCoordOffset.y
+			waterShaderProp->cellX = x;                                                                                                     // CellTexCoordOffset.z
+			waterShaderProp->cellY = y;                                                                                                     // CellTexCoordOffset.w
 		}
 	}
 
@@ -674,23 +529,17 @@ void UnifiedWater::TESWaterSystem_UpdateDisplacementMeshPosition::thunk(RE::TESW
 {
 	func(waterSystem);
 
-	auto& uw = globals::features::unifiedWater;
-
-	// Game-thread fallback for deferred child-worldspace cull completion.
-	// Needed when entering child worldspaces with already-attached LOD blocks,
-	// where BGSTerrainBlock_Attach/UpdateWaterMeshSubVisibility may not run.
-	uw.TryCompleteDeferredChildWorldspaceCull(uw.cachedTes.load(std::memory_order_acquire));
-
-	if (!uw.flowmap)
+	const auto& singleton = globals::features::unifiedWater;
+	if (!singleton.flowmap)
 		return;
 
-	const float posX = uw.gDisplacementMeshPos->x / 4096.0f;
-	const float posY = uw.gDisplacementMeshPos->y / 4096.0f;
-	const float offsetX = static_cast<float>(uw.flowmap->GetOffsetX());
-	const float offsetY = static_cast<float>(uw.flowmap->GetOffsetY());
-	const float height = static_cast<float>(uw.flowmap->GetHeight());
+	const float posX = singleton.gDisplacementMeshPos->x / 4096.0f;
+	const float posY = singleton.gDisplacementMeshPos->y / 4096.0f;
+	const float offsetX = static_cast<float>(singleton.flowmap->GetOffsetX());
+	const float offsetY = static_cast<float>(singleton.flowmap->GetOffsetY());
+	const float height = static_cast<float>(singleton.flowmap->GetHeight());
 
 	// CellTexCoordOffset.xyzw below - applies to displacement water only
 	// Previously the values were calculated relative to the 5x5 flow grid
-	*uw.gDisplacementCellTexCoordOffset = float4(posX + offsetX, height - (posY + offsetY), posX, 1 - posY);
+	*singleton.gDisplacementCellTexCoordOffset = float4(posX + offsetX, height - (posY + offsetY), posX, 1 - posY);
 }

--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -249,13 +249,17 @@ void UnifiedWater::PostPostLoad()
 	stl::write_vfunc<0x4, BSWaterShaderMaterial_ComputeCRC32>(RE::VTABLE_BSWaterShaderMaterial[0]);
 
 	stl::detour_thunk<BGSTerrainBlock_Attach>(REL::RelocationID(30934, 31737));
+
 	// Skip iterating attached meshes and calling TESWaterSystem::AddLODWater, this is handled in Attach now
 	const auto addLoopOffset = REL::RelocationID(30934, 31737).address() + REL::Relocate(0x109, 0x109);
-	if (REL::Module::IsAE())
+	const auto addLoopOffset2 = REL::RelocationID(30978, 31751).address() + REL::Relocate(0x54, 0xEA);
+	if (REL::Module::IsAE()) {
 		REL::safe_write(addLoopOffset, &REL::JMP8, 1);
-	else {
+		REL::safe_write(addLoopOffset2, &REL::JMP8, 1);
+	} else {
 		constexpr std::uint8_t patch[2] = { REL::NOP, REL::JMP32 };
 		REL::safe_write(addLoopOffset, patch, 2);
+		REL::safe_write(addLoopOffset2, patch, 2);
 	}
 
 	stl::detour_thunk<BGSTerrainBlock_Detach>(REL::RelocationID(30936, 31739));

--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -5,19 +5,24 @@
 #include "Util.h"
 
 #include <imgui_internal.h>
-#include <cmath>
-#include <unordered_map>
-#include <vector>
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	UnifiedWater::Settings,
 	UseOptimisedMeshes)
 
+static bool IsChildWorldSpace(const RE::TESWorldSpace* ws)
+{
+	return ws && ws->parentWorld &&
+	       ws->parentUseFlags.all(RE::TESWorldSpace::ParentUseFlag::kUseLODData);
+}
+
 // Engine behavior: CellState value 6 is the transition/attached state.
 static constexpr auto kTransitionAttachedCellState = static_cast<RE::TESObjectCELL::CellState>(6);
 
-static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY)
+static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY, bool* isInGrid = nullptr)
 {
+	if (isInGrid)
+		*isInGrid = false;
 	if (!tes || !tes->gridCells)
 		return false;
 
@@ -31,6 +36,9 @@ static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY)
 	if (x < 0 || y < 0 || x >= length || y >= length)
 		return false;
 
+	if (isInGrid)
+		*isInGrid = true;
+
 	if (const auto cell = gridCells->GetCell(x, y)) {
 		return cell->cellState.any(RE::TESObjectCELL::CellState::kAttached, kTransitionAttachedCellState);
 	}
@@ -38,278 +46,81 @@ static bool ShouldCullAtCell(const RE::TES* tes, int32_t cellX, int32_t cellY)
 	return false;
 }
 
-static void AddLODWater(RE::TESWaterSystem* waterSystem, RE::BSTriShape* waterShape, RE::TESWorldSpace* worldSpace, RE::NiNode* lodRoot, RE::NiNode* waterParent)
+struct CullCompletionState
 {
-	using func_t = void (*)(RE::TESWaterSystem*, RE::BSTriShape*, RE::TESWorldSpace*, RE::NiNode*, RE::NiNode*, bool);
-	static REL::Relocation<func_t> func{ REL::RelocationID(31404, 32209) };
+	bool foundAttachedCell = false;
+	bool hasPotentiallyAttachableChild = false;
 
-	func(waterSystem, waterShape, worldSpace, lodRoot, waterParent, true);
-}
-
-static void RemoveLODWater(RE::TESWaterSystem* waterSystem, RE::BSTriShape* waterShape, RE::NiNode* lodRoot)
-{
-	using func_t = void (*)(RE::TESWaterSystem*, RE::BSTriShape*, RE::NiNode*);
-	static REL::Relocation<func_t> func{ REL::RelocationID(31405, 32210) };
-
-	func(waterSystem, waterShape, lodRoot);
-}
-
-static void ClearWaterNodeChildren(RE::NiNode* node, RE::TESWaterSystem* waterSystem)
-{
-	if (!node)
-		return;
-
-	auto count = node->GetChildren().size();
-	while (count > 0) {
-		const auto child = node->GetChildren()[count - 1];
-		if (const auto childNode = child ? child->AsNode() : nullptr)
-			ClearWaterNodeChildren(childNode, waterSystem);
-
-		if (child && waterSystem)
-			waterSystem->RemoveWater(child.get());
-
-		node->DetachChildAt(--count);
-	}
-}
-
-static void DetachAllChildOccurrences(RE::NiNode* node, const RE::NiAVObject* childToDetach)
-{
-	if (!node || !childToDetach)
-		return;
-
-	auto count = node->GetChildren().size();
-	while (count > 0) {
-		const auto child = node->GetChildren()[count - 1];
-		if (child.get() == childToDetach) {
-			node->DetachChildAt(--count);
-		} else {
-			count--;
-		}
-	}
-}
-
-struct WaterPositionKey
-{
-	int32_t x = 0;
-	int32_t y = 0;
-	int32_t z = 0;
-	int32_t scale = 0;
-};
-
-static bool operator==(const WaterPositionKey& lhs, const WaterPositionKey& rhs)
-{
-	return lhs.x == rhs.x && lhs.y == rhs.y && lhs.z == rhs.z && lhs.scale == rhs.scale;
-}
-
-struct WaterPositionKeyHash
-{
-	size_t operator()(const WaterPositionKey& key) const noexcept
+	bool IsComplete() const
 	{
-		size_t hash = std::hash<int32_t>{}(key.x);
-		hash ^= std::hash<int32_t>{}(key.y) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		hash ^= std::hash<int32_t>{}(key.z) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		hash ^= std::hash<int32_t>{}(key.scale) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		return hash;
+		return foundAttachedCell && !hasPotentiallyAttachableChild;
 	}
 };
 
-static int32_t QuantizeWaterPosition(float value)
+// Cull waterParent children using tes->gridCells attachment state.
+// Pass tes explicitly when globals::game::tes is not ready (e.g., TES_SetWorldSpace).
+static CullCompletionState CullWaterParentByGridCells(RE::NiNode* waterParent, RE::TES* tes = nullptr)
 {
-	return static_cast<int32_t>(std::lround(value));
-}
-
-static WaterPositionKey GetWaterPositionKey(const RE::NiAVObject* object)
-{
-	if (!object)
+	if (!tes)
+		tes = globals::game::tes;
+	if (!tes || !waterParent)
 		return {};
 
-	return {
-		QuantizeWaterPosition(object->world.translate.x),
-		QuantizeWaterPosition(object->world.translate.y),
-		QuantizeWaterPosition(object->world.translate.z),
-		QuantizeWaterPosition(object->world.scale * 1000.0f),
-	};
-}
-
-static bool IsChildOfNode(const RE::NiAVObject* object, const RE::NiNode* root)
-{
-	if (!object || !root)
-		return false;
-
-	for (auto parent = object->parent; parent; parent = parent->parent) {
-		if (parent == root)
-			return true;
-	}
-
-	return object == root;
-}
-
-static RE::BSTriShape* SelectDuplicateWaterSystemShapeToRemove(RE::BSTriShape* existing, RE::BSTriShape* candidate, RE::NiNode* lodRoot)
-{
-	if (!existing)
-		return candidate;
-	if (!candidate)
-		return existing;
-
-	const bool existingIsLOD = IsChildOfNode(existing, lodRoot);
-	const bool candidateIsLOD = IsChildOfNode(candidate, lodRoot);
-	if (existingIsLOD != candidateIsLOD)
-		return existingIsLOD ? existing : candidate;
-
-	return candidate;
-}
-
-static void RemoveDuplicateWaterSystemObjects(RE::TESWaterSystem* waterSystem, RE::NiNode* lodRoot)
-{
-	if (!waterSystem)
-		return;
-
-	static thread_local std::unordered_map<WaterPositionKey, RE::BSTriShape*, WaterPositionKeyHash> shapeByPosition;
-	static thread_local std::vector<RE::BSTriShape*> duplicateShapes;
-
-	shapeByPosition.clear();
-	duplicateShapes.clear();
-
-	const auto objectCount = waterSystem->waterObjects.size();
-	if (shapeByPosition.bucket_count() < objectCount)
-		shapeByPosition.reserve(objectCount);
-	if (duplicateShapes.capacity() < objectCount)
-		duplicateShapes.reserve(objectCount);
-
-	for (const auto& waterObject : waterSystem->waterObjects) {
-		const auto shape = waterObject ? waterObject->shape.get() : nullptr;
-		if (!shape)
-			continue;
-
-		const auto key = GetWaterPositionKey(shape);
-		const auto [it, inserted] = shapeByPosition.try_emplace(key, shape);
-		if (inserted)
-			continue;
-
-		const auto existing = it->second;
-		const auto duplicate = SelectDuplicateWaterSystemShapeToRemove(existing, shape, lodRoot);
-		if (duplicate == existing)
-			it->second = shape;
-
-		duplicateShapes.push_back(duplicate);
-	}
-
-	for (const auto shape : duplicateShapes) {
-		if (!shape)
-			continue;
-
-		shape->SetAppCulled(true);
-		waterSystem->RemoveWater(shape);
-	}
-}
-
-static void CullWaterParentByGridCells(RE::NiNode* waterParent)
-{
-	const auto tes = globals::game::tes;
-	if (!tes || !waterParent)
-		return;
+	CullCompletionState state;
 
 	for (const auto& child : waterParent->GetChildren()) {
 		if (!child)
 			continue;
 		int32_t x, y;
 		Util::WorldToCell(child->world.translate, x, y);
-		const bool cull = ShouldCullAtCell(tes, x, y);
+		bool isInGrid = false;
+		const bool cull = ShouldCullAtCell(tes, x, y, &isInGrid);
+		if (cull)
+			state.foundAttachedCell = true;
+		else if (isInGrid)
+			state.hasPotentiallyAttachableChild = true;
 		child->SetAppCulled(cull);
 	}
+
+	return state;
 }
 
-bool UnifiedWater::BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSystem* waterSystem)
+// Cull all tiles under every water LOD parent.
+static bool CullAllWaterLODParents(RE::NiNode* waterLOD, RE::TES* tes = nullptr)
 {
-	if (!waterSystem || !waterCache || !gWaterLOD || !*gWaterLOD) {
-		BGSTerrainBlock_Attach::func(block);
-		return false;
-	}
-
-	std::vector<std::pair<RE::BSTriShape*, const WaterCache::Instruction*>> built;
-	bool attaching = false;
-	RE::TESWorldSpace* worldSpace = nullptr;
-
-	if (block && block->loaded && block->chunk && block->water && !block->attached) {
-		block->chunk->DetachChild2(block->water);
-		DetachAllChildOccurrences(*gWaterLOD, block->water);
-		block->water->local.translate = block->chunk->local.translate;
-
-		RE::NiUpdateData updateData;
-		block->water->UpdateUpwardPass(updateData);
-
-		ClearWaterNodeChildren(block->water, waterSystem);
-		block->waterAttached = false;
-
-		attaching = true;
-
-		const auto node = block->node;
-		worldSpace = node && node->manager ? node->manager->worldSpace : nullptr;
-		if (!node || !worldSpace) {
-			BGSTerrainBlock_Attach::func(block);
-			return false;
-		}
-
-		const auto lodLevel = node->GetLODLevel();
-		const auto instructions = waterCache->GetInstructions(worldSpace, lodLevel, node->baseCellX, node->baseCellY);
-		if (!instructions) {
-			logger::warn("[Unified Water] No instructions found for {} chunk at {}, {}", worldSpace->GetFormEditorID(), node->baseCellX, node->baseCellY);
-			BGSTerrainBlock_Attach::func(block);
-			return false;
-		}
-
-		for (auto& instruction : *instructions) {
-			if (!instruction.form.ptr)
-				continue;
-
-			RE::NiCloningProcess cloningProcess;
-
-			const auto targetShape = lodLevel > 4 || settings.UseOptimisedMeshes ? optimisedWaterMesh : waterMesh;
-			RE::BSTriShape* shape = targetShape->CreateClone(cloningProcess)->AsTriShape();
-
-			const auto posX = (instruction.x - node->baseCellX) * 4096.0f + instruction.size * 2048.0f;
-			const auto posY = (instruction.y - node->baseCellY) * 4096.0f + instruction.size * 2048.0f;
-			shape->local.scale = static_cast<float>(instruction.size);
-			shape->local.translate = { posX, posY, instruction.waterHeight };
-
-			block->water->AttachChild(shape, true);
-			built.emplace_back(shape, &instruction);
-
-			block->waterAttached = true;
-		}
-	}
-
-	BGSTerrainBlock_Attach::func(block);
-
-	if (!attaching || !block->waterAttached)
+	if (!waterLOD)
 		return false;
 
-	for (auto& [shape, instruction] : built) {
-		AddLODWater(waterSystem, shape, worldSpace, *gWaterLOD, block->water);
+	CullCompletionState aggregate;
 
-		if (const auto prop = shape->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
-			const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
-			REX::EnumSet waterFlags = static_cast<RE::BSWaterShaderProperty::WaterFlag>(0b10000100);
-			waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kUseCubemapReflections;
-			waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kUseReflections;
-			if (instruction->form.ptr->flags.any(RE::TESWaterForm::Flag::kEnableFlowmap))
-				waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kEnableFlowmap;
-			if (instruction->form.ptr->flags.any(RE::TESWaterForm::Flag::kBlendNormals))
-				waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kBlendNormals;
-			waterShaderProp->waterFlags = waterFlags;
-		}
-
-		// Vanilla AddLODWater routes through TESWaterSystem::AddWater and attaches
-		// the water parent to gWaterLOD. Use the matching vanilla LOD remove wrapper
-		// to unwind the water-system side state, then reattach the parent once below.
-		RemoveLODWater(waterSystem, shape, *gWaterLOD);
+	for (const auto& waterParentPtr : waterLOD->GetChildren()) {
+		if (!waterParentPtr)
+			continue;
+		const auto waterParent = waterParentPtr->AsNode();
+		if (!waterParent)
+			continue;
+		const auto state = CullWaterParentByGridCells(waterParent, tes);
+		aggregate.foundAttachedCell = aggregate.foundAttachedCell || state.foundAttachedCell;
+		aggregate.hasPotentiallyAttachableChild = aggregate.hasPotentiallyAttachableChild || state.hasPotentiallyAttachableChild;
 	}
 
-	DetachAllChildOccurrences(*gWaterLOD, block->water);
-	(*gWaterLOD)->AttachChild(block->water, true);
-	waterSystem->Enable();
+	return aggregate.IsComplete();
+}
 
-	return true;
+void UnifiedWater::TryCompleteDeferredChildWorldspaceCull(RE::TES* tes)
+{
+	if (!pendingChildWsCull.load(std::memory_order_acquire) ||
+		!IsChildWorldSpace(currentPlayerWorldSpace.load(std::memory_order_acquire)) ||
+		!gWaterLOD || !*gWaterLOD)
+		return;
+
+	if (!tes)
+		tes = cachedTes.load(std::memory_order_acquire);
+	if (!tes || !tes->gridCells)
+		return;
+
+	if (CullAllWaterLODParents(*gWaterLOD, tes))
+		pendingChildWsCull.store(false, std::memory_order_release);
 }
 
 void UnifiedWater::LoadSettings(json& o_json)
@@ -544,6 +355,9 @@ void UnifiedWater::SetFlowmapTex() const
 
 void UnifiedWater::PostPostLoad()
 {
+	stl::detour_thunk<TES_SetWorldSpace>(REL::RelocationID(13170, 13315));
+	stl::detour_thunk<TES_DestroySkyCell>(REL::RelocationID(20029, 20463));
+
 	stl::write_thunk_call<TESWaterSystem_InitializeWater_SetWaterShaderMaterialParams>(REL::RelocationID(31388, 32179).address() + REL::Relocate(0x360, 0x3BC, 0x35B));
 	stl::write_vfunc<0x4, BSWaterShaderMaterial_ComputeCRC32>(RE::VTABLE_BSWaterShaderMaterial[0]);
 
@@ -613,6 +427,56 @@ int32_t UnifiedWater::BSWaterShaderMaterial_ComputeCRC32::thunk(RE::BSWaterShade
 	return func(material, srcHash);
 }
 
+void UnifiedWater::TES_SetWorldSpace::thunk(RE::TES* tes, RE::TESWorldSpace* worldSpace, bool isExterior)
+{
+	const bool enteringChild = IsChildWorldSpace(worldSpace);
+
+	// Set before func so attachment hooks fired inside func see the new worldspace.
+	auto& uw = globals::features::unifiedWater;
+	uw.currentPlayerWorldSpace.store(worldSpace, std::memory_order_release);
+	uw.cachedTes.store(tes, std::memory_order_release);
+	if (!enteringChild)
+		uw.pendingChildWsCull.store(false, std::memory_order_release);  // leaving child WS: discard any stale pending cull
+
+	func(tes, worldSpace, isExterior);
+
+	if (!uw.waterCache) {
+		uw.pendingChildWsCull.store(false, std::memory_order_release);
+		return;
+	}
+
+	uw.waterCache->SetCurrentWorldSpace(worldSpace);
+
+	if (enteringChild) {
+		// BGSTerrainBlock_Attach calls Enable() on block attach.
+		// Child-worldspace transitions can keep old LOD blocks attached, so re-enable here.
+		if (const auto waterSystem = globals::game::waterSystem)
+			waterSystem->Enable();
+
+		// Try an immediate cull with tes (globals::game::tes may still be null).
+		// Newly transitioned cells are often not attached yet, so deferred retries are still needed.
+		if (uw.gWaterLOD && *uw.gWaterLOD && tes && tes->gridCells)
+			CullAllWaterLODParents(*uw.gWaterLOD, tes);
+
+		// Keep deferred retries enabled until attached cells are observed and culled.
+		uw.pendingChildWsCull.store(true, std::memory_order_release);
+	}
+}
+
+void UnifiedWater::TES_DestroySkyCell::thunk(RE::TES* tes)
+{
+	func(tes);
+
+	auto& uw = globals::features::unifiedWater;
+	uw.currentPlayerWorldSpace.store(nullptr, std::memory_order_release);
+	uw.pendingChildWsCull.store(false, std::memory_order_release);
+	uw.cachedTes.store(nullptr, std::memory_order_release);
+	if (!uw.waterCache)
+		return;
+
+	uw.waterCache->SetCurrentWorldSpace(nullptr);
+}
+
 void UnifiedWater::BGSTerrainNode_UpdateWaterMeshSubVisibility::thunk(const RE::BGSTerrainNode* node, RE::BSMultiBoundNode* waterParent)
 {
 	if (!node || !waterParent)
@@ -634,15 +498,113 @@ void UnifiedWater::BGSTerrainBlock_Attach::thunk(RE::BGSTerrainBlock* block)
 		return;
 	}
 
-	uw.BuildWaterForBlock(block, waterSystem);
+	// Additional game-thread retry path for deferred child-WS cull completion.
+	uw.TryCompleteDeferredChildWorldspaceCull(uw.cachedTes.load(std::memory_order_acquire));
+
+	std::vector<std::pair<RE::BSTriShape*, const WaterCache::Instruction*>> built;
+	bool attaching = false;
+
+	if (block && block->loaded && !block->attached && block->chunk && block->water) {
+		block->chunk->DetachChild2(block->water);
+		block->water->local.translate = block->chunk->local.translate;
+
+		RE::NiUpdateData updateData;
+		block->water->UpdateUpwardPass(updateData);
+
+		const auto water = block->water;
+		for (auto& child : water->GetChildren()) {
+			if (child) {
+				waterSystem->RemoveWater(child.get());
+				water->DetachChild(child.get());
+			}
+		}
+
+		attaching = true;
+
+		const auto node = block->node;
+		const auto lodLevel = node->GetLODLevel();
+		const auto worldSpace = block->node->manager->worldSpace;
+
+		const auto instructions = uw.waterCache->GetInstructions(worldSpace, lodLevel, node->baseCellX, node->baseCellY);
+		if (!instructions) {
+			logger::warn("[Unified Water] No instructions found for {} chunk at {}, {}", worldSpace->GetFormEditorID(), node->baseCellX, node->baseCellY);
+			func(block);
+			return;
+		}
+
+		for (auto& instruction : *instructions) {
+			if (!instruction.form.ptr)
+				continue;
+
+			RE::NiCloningProcess cloningProcess;
+
+			const auto targetShape = lodLevel > 4 || uw.settings.UseOptimisedMeshes ? uw.optimisedWaterMesh : uw.waterMesh;
+			RE::BSTriShape* shape = targetShape->CreateClone(cloningProcess)->AsTriShape();
+
+			const auto posX = (instruction.x - node->baseCellX) * 4096.0f + instruction.size * 2048.0f;
+			const auto posY = (instruction.y - node->baseCellY) * 4096.0f + instruction.size * 2048.0f;
+			shape->local.scale = static_cast<float>(instruction.size);
+			shape->local.translate = { posX, posY, instruction.waterHeight };
+
+			water->AttachChild(shape, true);
+			built.emplace_back(shape, &instruction);
+
+			block->waterAttached = true;
+		}
+	}
+
+	func(block);
+
+	if (!attaching || !block->waterAttached)
+		return;
+
+	for (auto& [shape, instruction] : built) {
+		waterSystem->AddWater(shape, instruction->form.ptr, instruction->waterHeight, nullptr, true, false);
+
+		if (const auto prop = shape->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
+			const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
+			REX::EnumSet waterFlags = static_cast<RE::BSWaterShaderProperty::WaterFlag>(0b10000100);
+			waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kUseCubemapReflections;
+			waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kUseReflections;
+			if (instruction->form.ptr->flags.any(RE::TESWaterForm::Flag::kEnableFlowmap))
+				waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kEnableFlowmap;
+			if (instruction->form.ptr->flags.any(RE::TESWaterForm::Flag::kBlendNormals))
+				waterFlags |= RE::BSWaterShaderProperty::WaterFlag::kBlendNormals;
+			waterShaderProp->waterFlags = waterFlags;
+		}
+
+		// Remove from WaterSystem, will manage it ourselves
+		if (!waterSystem->waterObjects.empty()) {
+			waterSystem->waterObjects.pop_back();
+		}
+	}
+
+	(*uw.gWaterLOD)->AttachChild(block->water, true);
+	waterSystem->Enable();
+
+	// BGSTerrainNode_UpdateWaterMeshSubVisibility never fires in child worldspaces.
+	// Cull newly built tiles here; full deferred retries are handled by
+	// TryCompleteDeferredChildWorldspaceCull().
+	if (IsChildWorldSpace(uw.currentPlayerWorldSpace.load(std::memory_order_acquire))) {
+		const auto tes = uw.cachedTes.load(std::memory_order_acquire);
+		if (tes && tes->gridCells) {
+			for (const auto& [shape, instruction] : built) {
+				const bool cull = ShouldCullAtCell(tes, instruction->x, instruction->y);
+				shape->SetAppCulled(cull);
+			}
+		}
+	}
 }
 
 void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 {
 	auto& uw = globals::features::unifiedWater;
-	const auto water = block ? block->water : nullptr;
+	const auto water = block->water;
+	block->water = nullptr;
 
 	func(block);
+
+	block->water = water;
 
 	if (water) {
 		auto count = water->GetChildren().size();
@@ -650,7 +612,7 @@ void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 			water->DetachChildAt(--count);
 		}
 
-		DetachAllChildOccurrences(*uw.gWaterLOD, water);
+		(*uw.gWaterLOD)->DetachChild(water);
 		block->waterAttached = false;
 	}
 }
@@ -658,6 +620,30 @@ void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 void UnifiedWater::BSWaterShader_SetupGeometry::thunk(RE::BSShader* waterShader, RE::BSRenderPass* pass)
 {
 	auto& uw = globals::features::unifiedWater;
+
+	// Fix BSWaterShaderProperty.plane after interior->exterior transitions.
+	// The plane feeds ReflectPlane in the PerGeometry cbuffer. When corrupted (e.g., plane.constant = 0
+	// or garbage), the shader's refractionPlaneMul calculation produces extreme values causing flickering.
+	// This primarily affects flowmapped water because it uses more complex refraction depth calculations.
+	if (const auto prop = pass->geometry->GetGeometryRuntimeData().shaderProperty.get(); prop && prop->GetRTTI() == globals::rtti::BSWaterShaderPropertyRTTI.get()) {
+		const auto waterShaderProp = static_cast<RE::BSWaterShaderProperty*>(prop);
+		const float waterHeight = pass->geometry->world.translate.z;
+
+		// Validate and fix the plane if it's corrupted.
+		// A valid water plane has normal pointing up (0,0,1) and constant = water height.
+		// After interior->exterior transitions, plane.constant can be 0 or stale values.
+		const bool planeNonFinite =
+			!std::isfinite(waterShaderProp->plane.normal.x) ||
+			!std::isfinite(waterShaderProp->plane.normal.y) ||
+			!std::isfinite(waterShaderProp->plane.normal.z) ||
+			!std::isfinite(waterShaderProp->plane.constant);
+		const bool planeNormalBad = std::abs(waterShaderProp->plane.normal.x) > 0.01f || std::abs(waterShaderProp->plane.normal.y) > 0.01f || std::abs(waterShaderProp->plane.normal.z - 1.0f) > 0.01f;
+		const bool planeConstantBad = std::abs(waterShaderProp->plane.constant - waterHeight) > 1.0f;
+		if (planeNonFinite || planeNormalBad || planeConstantBad) {
+			waterShaderProp->plane.normal = { 0.0f, 0.0f, 1.0f };
+			waterShaderProp->plane.constant = waterHeight;
+		}
+	}
 
 	if (uw.flowmap) {
 		// ObjectUV.xyz below, xy contains width and height, z contains mesh scale
@@ -689,7 +675,11 @@ void UnifiedWater::TESWaterSystem_UpdateDisplacementMeshPosition::thunk(RE::TESW
 	func(waterSystem);
 
 	auto& uw = globals::features::unifiedWater;
-	RemoveDuplicateWaterSystemObjects(waterSystem, uw.gWaterLOD ? *uw.gWaterLOD : nullptr);
+
+	// Game-thread fallback for deferred child-worldspace cull completion.
+	// Needed when entering child worldspaces with already-attached LOD blocks,
+	// where BGSTerrainBlock_Attach/UpdateWaterMeshSubVisibility may not run.
+	uw.TryCompleteDeferredChildWorldspaceCull(uw.cachedTes.load(std::memory_order_acquire));
 
 	if (!uw.flowmap)
 		return;

--- a/src/Features/UnifiedWater.h
+++ b/src/Features/UnifiedWater.h
@@ -3,7 +3,7 @@
 #include "UnifiedWater/Flowmap.h"
 #include "UnifiedWater/WaterCache.h"
 
-#include <vector>
+#include <atomic>
 
 struct UnifiedWater : OverlayFeature
 {
@@ -60,6 +60,18 @@ struct UnifiedWater : OverlayFeature
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
+	struct TES_SetWorldSpace
+	{
+		static void thunk(RE::TES* tes, RE::TESWorldSpace* worldSpace, bool isExterior);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	struct TES_DestroySkyCell
+	{
+		static void thunk(RE::TES* tes);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
 	struct BSWaterShader_SetupGeometry
 	{
 		static void thunk(RE::BSShader* waterShader, RE::BSRenderPass* pass);
@@ -101,7 +113,12 @@ private:
 	RE::NiPoint2* gDisplacementMeshPos = nullptr;
 	RE::NiPoint2* gDisplacementMeshFlowCellOffset = nullptr;
 
-	bool BuildWaterForBlock(RE::BGSTerrainBlock* block, RE::TESWaterSystem* waterSystem);
+	std::atomic<RE::TESWorldSpace*> currentPlayerWorldSpace{ nullptr };
+	std::atomic<bool> pendingChildWsCull{ false };
+	// Game-thread TES snapshot used by deferred child-worldspace cull fallbacks.
+	std::atomic<RE::TES*> cachedTes{ nullptr };
+
+	void TryCompleteDeferredChildWorldspaceCull(RE::TES* tes = nullptr);
 
 	void SetFlowmapTex() const;
 	static bool LoadOrderChanged();

--- a/src/Features/UnifiedWater.h
+++ b/src/Features/UnifiedWater.h
@@ -3,8 +3,6 @@
 #include "UnifiedWater/Flowmap.h"
 #include "UnifiedWater/WaterCache.h"
 
-#include <atomic>
-
 struct UnifiedWater : OverlayFeature
 {
 	virtual inline std::string GetName() override { return "Unified Water"; }
@@ -112,13 +110,6 @@ private:
 	float4* gDisplacementCellTexCoordOffset = nullptr;
 	RE::NiPoint2* gDisplacementMeshPos = nullptr;
 	RE::NiPoint2* gDisplacementMeshFlowCellOffset = nullptr;
-
-	std::atomic<RE::TESWorldSpace*> currentPlayerWorldSpace{ nullptr };
-	std::atomic<bool> pendingChildWsCull{ false };
-	// Game-thread TES snapshot used by deferred child-worldspace cull fallbacks.
-	std::atomic<RE::TES*> cachedTes{ nullptr };
-
-	void TryCompleteDeferredChildWorldspaceCull(RE::TES* tes = nullptr);
 
 	void SetFlowmapTex() const;
 	static bool LoadOrderChanged();

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -102,7 +102,6 @@ namespace globals
 		RE::BSGraphics::Renderer* renderer = nullptr;
 		RE::BSShaderManager::State* smState = nullptr;
 		RE::TES* tes = nullptr;
-		RE::TESWaterSystem* waterSystem = nullptr;
 		bool isVR = false;
 		RE::MemoryManager* memoryManager = nullptr;
 		RE::INISettingCollection* iniSettingCollection = nullptr;
@@ -178,7 +177,6 @@ namespace globals
 			iniPrefSettingCollection = RE::INIPrefSettingCollection::GetSingleton();
 			gameSettingCollection = RE::GameSettingCollection::GetSingleton();
 			RefreshTES();
-			waterSystem = RE::TESWaterSystem::GetSingleton();
 			cameraNear = (float*)(REL::RelocationID(517032, 403540).address() + 0x40);
 			cameraFar = (float*)(REL::RelocationID(517032, 403540).address() + 0x44);
 			deltaTime = (float*)REL::RelocationID(523660, 410199).address();
@@ -218,7 +216,6 @@ namespace globals
 		player = RE::PlayerCharacter::GetSingleton();
 		sky = RE::Sky::GetSingleton();
 		utilityShader = RE::BSUtilityShader::GetSingleton();
-		waterSystem = RE::TESWaterSystem::GetSingleton();
 
 		bEnableLandFade = iniSettingCollection->GetSetting("bEnableLandFade:Display");
 

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -216,7 +216,6 @@ namespace globals
 		extern RE::BSGraphics::Renderer* renderer;
 		extern RE::BSShaderManager::State* smState;
 		extern RE::TES* tes;
-		extern RE::TESWaterSystem* waterSystem;
 		extern bool isVR;
 		extern RE::MemoryManager* memoryManager;
 		extern RE::INISettingCollection* iniSettingCollection;


### PR DESCRIPTION
Fixes flicker after interior -> exterior transition by patching a 2nd path which iterates the root LOD multibound causing materials to be initialized twice.

This PR reverts #1998, #2019, #2353, #2367 and supersedes PR #2391. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal water rendering system for improved stability and efficiency.
  * Optimized water mesh management and attachment handling during world transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2419?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->