### PR TITLE
fix(terrain-shadows): add null protections

### DIFF
--- a/src/Features/TerrainShadows.cpp
+++ b/src/Features/TerrainShadows.cpp
@@ -329,10 +329,18 @@ void TerrainShadows::UpdateShadow()
 	}
 
 	auto accumulator = *globals::game::currentAccumulator.get();
+	if (!accumulator)
+		return;
+
 	auto shadowSceneNode = accumulator->GetRuntimeData().activeShadowSceneNode;
 	if (!shadowSceneNode)
 		return;
-	auto sunLight = skyrim_cast<RE::NiDirectionalLight*>(shadowSceneNode->GetRuntimeData().sunLight->light.get());
+
+	auto shadowSunLight = shadowSceneNode->GetRuntimeData().sunLight;
+	if (!shadowSunLight || !shadowSunLight->light)
+		return;
+
+	auto sunLight = skyrim_cast<RE::NiDirectionalLight*>(shadowSunLight->light.get());
 	if (!sunLight)
 		return;
 	TracyD3D11Zone(globals::state->tracyCtx, "Terrain Occlusion - Update Shadows");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability in terrain shadow rendering by adding defensive null checks to prevent crashes in edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->