### PR TITLE
fix(unified-water): validate water cells and clear stale LOD

### DIFF
--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -10,6 +10,16 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	UnifiedWater::Settings,
 	UseOptimisedMeshes)
 
+namespace
+{
+	bool IsInteriorCellActive()
+	{
+		const auto tes = RE::TES::GetSingleton();
+		return tes && tes->interiorCell;
+	}
+
+}
+
 void UnifiedWater::LoadSettings(json& o_json)
 {
 	settings = o_json;
@@ -318,18 +328,37 @@ int32_t UnifiedWater::BSWaterShaderMaterial_ComputeCRC32::thunk(RE::BSWaterShade
 	return func(material, srcHash);
 }
 
+bool UnifiedWater::IsExteriorWorldspaceActive() const
+{
+	// Interior cells may still inherit stale exterior worldspace state during transitions
+	return exteriorWorldspaceActive.load(std::memory_order_acquire) && !IsInteriorCellActive();
+}
+
+void UnifiedWater::UpdateWaterLODCull() const
+{
+	// Only hide UW's generated LOD root, preserving child tile cull flags
+	if (gWaterLOD && *gWaterLOD)
+		(*gWaterLOD)->SetAppCulled(!IsExteriorWorldspaceActive());
+}
+
 void UnifiedWater::TES_SetWorldSpace::thunk(RE::TES* tes, RE::TESWorldSpace* worldSpace, bool isExterior)
 {
 	func(tes, worldSpace, isExterior);
 
-	globals::features::unifiedWater.waterCache->SetCurrentWorldSpace(worldSpace);
+	auto& singleton = globals::features::unifiedWater;
+	singleton.exteriorWorldspaceActive.store(worldSpace && isExterior, std::memory_order_release);
+	singleton.waterCache->SetCurrentWorldSpace(worldSpace);
+	singleton.UpdateWaterLODCull();
 }
 
 void UnifiedWater::TES_DestroySkyCell::thunk(RE::TES* tes)
 {
 	func(tes);
 
-	globals::features::unifiedWater.waterCache->SetCurrentWorldSpace(nullptr);
+	auto& singleton = globals::features::unifiedWater;
+	singleton.exteriorWorldspaceActive.store(false, std::memory_order_release);
+	singleton.waterCache->SetCurrentWorldSpace(nullptr);
+	singleton.UpdateWaterLODCull();
 }
 
 void UnifiedWater::BGSTerrainNode_UpdateWaterMeshSubVisibility::thunk(const RE::BGSTerrainNode* node, RE::BSMultiBoundNode* waterParent)
@@ -454,6 +483,7 @@ void UnifiedWater::BGSTerrainBlock_Attach::thunk(RE::BGSTerrainBlock* block)
 	}
 
 	(*singleton.gWaterLOD)->AttachChild(block->water, true);
+	singleton.UpdateWaterLODCull();
 	waterSystem->Enable();
 }
 
@@ -474,13 +504,15 @@ void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 
 		(*globals::features::unifiedWater.gWaterLOD)->DetachChild(water);
 		block->waterAttached = false;
+		globals::features::unifiedWater.UpdateWaterLODCull();
 	}
 }
 
 void UnifiedWater::BSWaterShader_SetupGeometry::thunk(RE::BSShader* waterShader, RE::BSRenderPass* pass)
 {
 	const auto& singleton = globals::features::unifiedWater;
-	if (singleton.flowmap) {
+
+	if (singleton.IsExteriorWorldspaceActive() && singleton.flowmap && pass && pass->geometry) {
 		// ObjectUV.xyz below, xy contains width and height, z contains mesh scale
 		// Previously flowmap size was in x, yz contained flowmap offset for water displacement mesh
 		*singleton.gFlowMapSize = singleton.flowmap->GetWidth();                                            // ObjectUV.x
@@ -510,7 +542,9 @@ void UnifiedWater::TESWaterSystem_UpdateDisplacementMeshPosition::thunk(RE::TESW
 	func(waterSystem);
 
 	const auto& singleton = globals::features::unifiedWater;
-	if (!singleton.flowmap)
+	singleton.UpdateWaterLODCull();
+
+	if (!singleton.flowmap || !singleton.IsExteriorWorldspaceActive())
 		return;
 
 	const float posX = singleton.gDisplacementMeshPos->x / 4096.0f;

--- a/src/Features/UnifiedWater.h
+++ b/src/Features/UnifiedWater.h
@@ -3,6 +3,8 @@
 #include "UnifiedWater/Flowmap.h"
 #include "UnifiedWater/WaterCache.h"
 
+#include <atomic>
+
 struct UnifiedWater : OverlayFeature
 {
 	virtual inline std::string GetName() override { return "Unified Water"; }
@@ -112,6 +114,10 @@ private:
 	RE::NiPoint2* gDisplacementMeshPos = nullptr;
 	RE::NiPoint2* gDisplacementMeshFlowCellOffset = nullptr;
 
+	std::atomic_bool exteriorWorldspaceActive{ false };
+
 	void SetFlowmapTex() const;
+	bool IsExteriorWorldspaceActive() const;
+	void UpdateWaterLODCull() const;
 	static bool LoadOrderChanged();
 };

--- a/src/Features/UnifiedWater/WaterCache.cpp
+++ b/src/Features/UnifiedWater/WaterCache.cpp
@@ -1,13 +1,32 @@
 ﻿#include "WaterCache.h"
 
 #include <BS_thread_pool.hpp>
+#include <cmath>
 
 #include "Utils/WinApi.h"
 
+namespace
+{
+	// Far beyond normal terrain heights, but below sentinel/garbage values
+	constexpr float kMaxValidCellHeight = 50000.0f;
+
+	bool IsValidCellHeight(const float height)
+	{
+		// Cell records may use sentinel or garbage heights for absent water data
+		return std::isfinite(height) &&
+		       height != FLT_MIN &&
+		       height != FLT_MAX &&
+		       std::fabs(height) < kMaxValidCellHeight;
+	}
+}
+
 bool WaterCache::SetCurrentWorldSpace(const RE::TESWorldSpace* worldSpace)
 {
-	if (!worldSpace)
+	if (!worldSpace) {
+		currentCache.reset();
+		currentWorldSpace.clear();
 		return false;
+	}
 
 	while (worldSpace->parentWorld && worldSpace->parentUseFlags.all(RE::TESWorldSpace::ParentUseFlag::kUseWaterData))
 		worldSpace = worldSpace->parentWorld;
@@ -349,25 +368,50 @@ bool WaterCache::BuildDiskCache(RE::TESWorldSpace* worldSpace, DiskCache& diskCa
 	auto cellData = std::vector<CellData>(hdr.width * hdr.height);
 
 	int32_t waterCellCount = 0;
+	int32_t precacheFallbackCount = 0;
+	int32_t skippedMissingCellDataCount = 0;
+	int32_t skippedInvalidHeightCount = 0;
 
 	for (auto y = minY; y <= maxY; ++y) {
 		for (auto x = minX; x <= maxX; ++x) {
 			const int32_t idx = (y - minY) * hdr.width + x - minX;
 
-			RE::FormID formID;
-			float landHeight, waterHeight;
+			RE::FormID formID = 0;
+			float landHeight = FLT_MAX;
+			float waterHeight = FLT_MAX;
 
-			if (!TryGetCellData(worldSpace, files, x, y, formID, waterHeight, landHeight, true) && hasPrecache) {
-				auto [land, water] = preCache.heights[idx];
+			if (!TryGetCellData(worldSpace, files, x, y, formID, waterHeight, landHeight, true)) {
+				if (!hasPrecache) {
+					skippedMissingCellDataCount++;
+					cellData[idx] = {};
+					continue;
+				}
+
+				const auto precacheIdx = static_cast<size_t>(idx);
+				if (precacheIdx >= preCache.heights.size()) {
+					// Corrupt precache files can have headers that outlive their payload
+					skippedMissingCellDataCount++;
+					cellData[idx] = {};
+					continue;
+				}
+
+				const auto [land, water] = preCache.heights[precacheIdx];
 				landHeight = land;
 				waterHeight = water;
+				precacheFallbackCount++;
 			}
 
-			if (waterHeight > landHeight && fabs(waterHeight) < 50000.0f) {
-				if (!formID)
+			const bool validHeights = IsValidCellHeight(waterHeight) && IsValidCellHeight(landHeight);
+
+			if (validHeights && waterHeight > landHeight) {
+				if (!formID && worldSpace->worldWater)
 					formID = worldSpace->worldWater->formID;  // Use default world water if no water form set
-			} else
+			} else {
+				if (!validHeights)
+					skippedInvalidHeightCount++;
+				// Discard invalid tiles before they can generate floating water planes
 				formID = 0;
+			}
 
 			RE::TESWaterForm* form = formID ? RE::TESWaterForm::LookupByID<RE::TESWaterForm>(formID) : nullptr;
 			if ((formID && !form) || (form && form->formType != RE::FormType::Water)) {
@@ -380,6 +424,11 @@ bool WaterCache::BuildDiskCache(RE::TESWorldSpace* worldSpace, DiskCache& diskCa
 
 			cellData[idx] = { landHeight, waterHeight, formID, form };
 		}
+	}
+
+	if (precacheFallbackCount || skippedMissingCellDataCount || skippedInvalidHeightCount) {
+		logger::debug("[Unified Water] [Cache] {}: {} cells used precache fallback, {} cells skipped due to missing data, {} cells skipped due to invalid heights",
+			editorID.c_str(), precacheFallbackCount, skippedMissingCellDataCount, skippedInvalidHeightCount);
 	}
 
 	logger::debug("[Unified Water] [Cache] {}: Generating instructions for {} water cells...", editorID.c_str(), waterCellCount);
@@ -557,6 +606,7 @@ bool WaterCache::TryBuildRuntimeCache(const DiskCache& diskCache, RuntimeCache& 
 	cache.header = hdr;
 
 	int32_t diskReadIndex = 0;
+	int32_t skippedInvalidInstructionCount = 0;
 
 	for (int32_t lodLevelIdx = 0; lodLevelIdx < 4; ++lodLevelIdx) {
 		auto& lodInstructions = cache.instructions[lodLevelIdx];
@@ -575,10 +625,23 @@ bool WaterCache::TryBuildRuntimeCache(const DiskCache& diskCache, RuntimeCache& 
 			if (instruction.lodLevel != static_cast<uint32_t>(lodLevel))
 				break;
 
+			if (!IsValidCellHeight(instruction.waterHeight)) {
+				// Keep old or malformed disk caches from restoring bad water tiles
+				skippedInvalidInstructionCount++;
+				diskReadIndex++;
+				continue;
+			}
+
 			int32_t lodX, lodY;
 			GetLODCoords(lodLevel, instruction.x, instruction.y, lodX, lodY);
 			lodX -= lodMinX;
 			lodY -= lodMinY;
+
+			if (lodX < 0 || lodY < 0 || lodX >= lodWidth || lodY >= lodHeight) {
+				logger::warn("[Unified Water] [Cache] Skipping out-of-bounds LOD{} instruction at {},{}", lodLevel, instruction.x, instruction.y);
+				diskReadIndex++;
+				continue;
+			}
 
 			instruction.form.ptr = RE::TESForm::LookupByID<RE::TESWaterForm>(instruction.form.id);
 			if (!instruction.form.ptr || instruction.form.ptr->formType != RE::FormType::Water) {
@@ -595,6 +658,10 @@ bool WaterCache::TryBuildRuntimeCache(const DiskCache& diskCache, RuntimeCache& 
 
 			diskReadIndex++;
 		}
+	}
+
+	if (skippedInvalidInstructionCount) {
+		logger::debug("[Unified Water] [Cache] Skipped {} cached instructions with invalid water heights", skippedInvalidInstructionCount);
 	}
 
 	return true;


### PR DESCRIPTION
Fixes bad Unified Water tiles being generated from cells where height data could not be read cleanly and cull UW LODs when entering interiors

Changes:
- Skip cells with missing height data instead of treating them as valid water
- Reject non-finite and sentinel water/land heights before generating UW instructions
- Ignore invalid cached water instructions at runtime, so stale bad caches do not keep rendering broken tiles
- Clear the active runtime cache when leaving an exterior worldspace
- Cull Unified Water's generated LOD tree while an interior cell is active