### PR TITLE
fix(ibl): disable skyibl in interior

### DIFF
--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -78,6 +78,9 @@ namespace DynamicCubemaps
 				skySpecular *= skylightingSpecular;
 #			endif
 			}
+			if (SharedData::InInterior) {
+				skySpecular = 0;
+			}
 
 			finalIrradiance = envSpecular + skySpecular;
 		} else
@@ -178,6 +181,9 @@ namespace DynamicCubemaps
 #			if defined(SKYLIGHTING)
 				skySpecular *= skylightingSpecular;
 #			endif
+			}
+			if (SharedData::InInterior) {
+				skySpecular = 0;
 			}
 
 			finalIrradiance = envSpecular + skySpecular;

--- a/features/IBL/Shaders/Features/ImageBasedLighting.ini
+++ b/features/IBL/Shaders/Features/ImageBasedLighting.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-1-0
+Version = 1-1-1
 
 [Nexus]
 autoupload = false

--- a/features/IBL/Shaders/IBL/IBL.hlsli
+++ b/features/IBL/Shaders/IBL/IBL.hlsli
@@ -119,6 +119,17 @@ namespace ImageBasedLighting
 		return Color::IrradianceToGamma(linEnv + linSky);
 	}
 
+	float3 GetDiffuseIBLNoSky(float3 vanillaDALC, float3 rayDir)
+	{
+		float3 linEnv;
+		if (SharedData::iblSettings.DALCMode >= 2) {
+			linEnv = Color::IrradianceToLinear(vanillaDALC * SharedData::iblSettings.DALCAmount);
+		} else {
+			linEnv = GetEnvIBLColor(rayDir);
+		}
+		return Color::IrradianceToGamma(linEnv);
+	}
+
 	/// Compute diffuse IBL ambient (gamma-space) with visibility applied per DALCMode.
 	/// visibility: scalar skylighting factor (already computed in Lighting.hlsl).
 	float3 GetDiffuseIBLOccluded(float3 vanillaDALC, float3 rayDir, float visibility)

--- a/features/IBL/Shaders/IBL/IBL.hlsli
+++ b/features/IBL/Shaders/IBL/IBL.hlsli
@@ -93,11 +93,17 @@ namespace ImageBasedLighting
 
 	float3 GetSkyIBLColor(float3 rayDir)
 	{
+		if (SharedData::InInterior) {
+			return 0;
+		}
 		return Color::Saturation(GetSkyIBL(rayDir), SharedData::iblSettings.SkyIBLSaturation) * SharedData::iblSettings.SkyIBLScale;
 	}
 
 	float3 GetSkyIBLColorOccluded(float3 rayDir, float visibility)
 	{
+		if (SharedData::InInterior) {
+			return 0;
+		}
 		return Color::Saturation(GetSkyIBLOccluded(rayDir, visibility), SharedData::iblSettings.SkyIBLSaturation) * SharedData::iblSettings.SkyIBLScale;
 	}
 
@@ -117,17 +123,6 @@ namespace ImageBasedLighting
 			linSky = GetSkyIBLColor(rayDir);
 		}
 		return Color::IrradianceToGamma(linEnv + linSky);
-	}
-
-	float3 GetDiffuseIBLNoSky(float3 vanillaDALC, float3 rayDir)
-	{
-		float3 linEnv;
-		if (SharedData::iblSettings.DALCMode >= 2) {
-			linEnv = Color::IrradianceToLinear(vanillaDALC * SharedData::iblSettings.DALCAmount);
-		} else {
-			linEnv = GetEnvIBLColor(rayDir);
-		}
-		return Color::IrradianceToGamma(linEnv);
 	}
 
 	/// Compute diffuse IBL ambient (gamma-space) with visibility applied per DALCMode.

--- a/package/Shaders/DeferredCompositeCS.hlsl
+++ b/package/Shaders/DeferredCompositeCS.hlsl
@@ -242,8 +242,6 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, inout float ao, out float3 il,
 #		if defined(SKYLIGHTING)
 				envSpecular *= (SharedData::iblSettings.DALCMode == 3) ? skylightingSpecular : 1.0;
 				skySpecular *= skylightingSpecular;
-#		elif defined(INTERIOR)
-				skySpecular = 0;
 #		endif
 			} else {
 				// Mode 0/1: IBL ratio-based
@@ -252,9 +250,10 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, inout float ao, out float3 il,
 				skySpecular = Color::IrradianceToLinear(max(0, fullSample - envSample)) * SharedData::iblSettings.SkyIBLScale;
 #		if defined(SKYLIGHTING)
 				skySpecular *= skylightingSpecular;
-#		elif defined(INTERIOR)
-				skySpecular = 0;
 #		endif
+			}
+			if (SharedData::InInterior) {
+				skySpecular = 0;
 			}
 
 			finalIrradiance = envSpecular + skySpecular;

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -534,15 +534,11 @@ float3 GetEffectAmbientLighting(float skylightingDiffuse)
 
 #	if defined(IBL)
 	if (SharedData::iblSettings.EnableIBL) {
-		if (SharedData::InInterior) {
-			ambientColor = ImageBasedLighting::GetDiffuseIBLNoSky(ambientColor, ShadowSampling::ImageBasedLightingNormal);
-		} else {
 #		if defined(SKYLIGHTING)
-			ambientColor = ImageBasedLighting::GetDiffuseIBLOccluded(ambientColor, ShadowSampling::ImageBasedLightingNormal, skylightingDiffuse);
+		ambientColor = ImageBasedLighting::GetDiffuseIBLOccluded(ambientColor, ShadowSampling::ImageBasedLightingNormal, skylightingDiffuse);
 #		else
-			ambientColor = ImageBasedLighting::GetDiffuseIBL(ambientColor, ShadowSampling::ImageBasedLightingNormal);
+		ambientColor = ImageBasedLighting::GetDiffuseIBL(ambientColor, ShadowSampling::ImageBasedLightingNormal);
 #		endif
-		}
 	}
 #	endif
 

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -528,32 +528,76 @@ cbuffer PerGeometry : register(b2)
 
 #	include "Common/ShadowSampling.hlsli"
 
+float3 GetEffectAmbientLighting(float skylightingDiffuse)
+{
+	float3 ambientColor = ShadowSampling::GetRawAmbientLighting(ShadowSampling::LightingSampleNormal);
+
+#	if defined(IBL)
+	if (SharedData::iblSettings.EnableIBL) {
+		if (SharedData::InInterior) {
+			ambientColor = ImageBasedLighting::GetDiffuseIBLNoSky(ambientColor, ShadowSampling::ImageBasedLightingNormal);
+		} else {
+#		if defined(SKYLIGHTING)
+			ambientColor = ImageBasedLighting::GetDiffuseIBLOccluded(ambientColor, ShadowSampling::ImageBasedLightingNormal, skylightingDiffuse);
+#		else
+			ambientColor = ImageBasedLighting::GetDiffuseIBL(ambientColor, ShadowSampling::ImageBasedLightingNormal);
+#		endif
+		}
+	}
+#	endif
+
+	return ambientColor;
+}
+
+void ExtractEffectLighting(float3 inputColor, out float3 dirColor, out float3 ambientColor, float skylightingDiffuse)
+{
+	float3 ambientColorAmb = GetEffectAmbientLighting(skylightingDiffuse);
+	float3 dirLightColorDir = ShadowSampling::GetDirectionalLighting();
+
+	float inputLuma = Color::RGBToLuminance(inputColor);
+	float ambientLuma = Color::RGBToLuminance(ambientColorAmb);
+	float dirLightLuma = Color::RGBToLuminance(dirLightColorDir);
+
+	float totalLuma = ambientLuma + dirLightLuma;
+
+	if (totalLuma > 0.0 && ambientLuma > 0.0)
+		ambientColorAmb *= inputLuma / totalLuma;
+
+	float3 dirLightColorAmb = max(0.0, inputColor - ambientColorAmb);
+
+	dirColor = dirLightColorAmb;
+	ambientColor = ambientColorAmb;
+}
+
 #	if defined(LIGHTING)
 float3 GetLightingColor(float3 msPosition, float3 worldPosition, float2 screenPosition, uint eyeIndex, inout float shadowVariance)
 {
 	float3 color = DLightColor.xyz * Color::EffectLightingMult();
 	bool suppressExternalEmittance = SharedData::InInterior && (Permutation::ExtraShaderDescriptor & Permutation::ExtraFlags::SuppressExternalEmittance);
 	if (suppressExternalEmittance) {
-		color = ShadowSampling::GetSceneLightingColor();
+		color = GetEffectAmbientLighting(1.0) + ShadowSampling::GetDirectionalLighting();
 	}
 
 #		if defined(SKYLIGHTING)
+	float skylightingDiffuse = 1.0;
+	if (!SharedData::InInterior) {
 #			if defined(VR)
-	float3 positionMSSkylight = worldPosition + FrameBuffer::CameraPosAdjust[eyeIndex].xyz - FrameBuffer::CameraPosAdjust[0].xyz;
+		float3 positionMSSkylight = worldPosition + FrameBuffer::CameraPosAdjust[eyeIndex].xyz - FrameBuffer::CameraPosAdjust[0].xyz;
 #			else
-	float3 positionMSSkylight = worldPosition;
+		float3 positionMSSkylight = worldPosition;
 #			endif
 
-	sh2 skylightingSH = Skylighting::SampleNoBias(positionMSSkylight);
-	float skylightingDiffuse = Skylighting::EvaluateDiffuse(skylightingSH, float3(0, 0, 1), Skylighting::GetFadeOutFactor(positionMSSkylight));
+		sh2 skylightingSH = Skylighting::SampleNoBias(positionMSSkylight);
+		skylightingDiffuse = Skylighting::EvaluateDiffuse(skylightingSH, float3(0, 0, 1), Skylighting::GetFadeOutFactor(positionMSSkylight));
+	}
 #		endif
 
 	float3 dirColor;
 	float3 ambientColor;
 #		if defined(SKYLIGHTING)
-	ShadowSampling::ExtractLighting(color, dirColor, ambientColor, skylightingDiffuse);
+	ExtractEffectLighting(color, dirColor, ambientColor, skylightingDiffuse);
 #		else
-	ShadowSampling::ExtractLighting(color, dirColor, ambientColor);
+	ExtractEffectLighting(color, dirColor, ambientColor, 1.0);
 #		endif
 
 	float3 viewDirection = normalize(worldPosition.xyz);
@@ -577,9 +621,14 @@ float3 GetLightingColor(float3 msPosition, float3 worldPosition, float2 screenPo
 #		endif
 
 #		if defined(SKYLIGHTING)
-	ambientColor = Color::IrradianceToLinear(ambientColor);
-	ambientColor *= skylightingDiffuse;
-	ambientColor = Color::IrradianceToGamma(ambientColor);
+#			if defined(IBL)
+	if (!SharedData::iblSettings.EnableIBL)
+#			endif
+	{
+		ambientColor = Color::IrradianceToLinear(ambientColor);
+		ambientColor *= skylightingDiffuse;
+		ambientColor = Color::IrradianceToGamma(ambientColor);
+	}
 #		endif
 
 	color = dirColor + ambientColor;
@@ -604,9 +653,9 @@ float3 GetLightingShadow(float3 color, float3 worldPosition, float2 screenPositi
 	float3 ambientColor;
 	float skylightingDiffuse = 1.0;
 #		if defined(SKYLIGHTING)
-	ShadowSampling::ExtractLighting(color, dirColor, ambientColor, skylightingDiffuse);
+	ExtractEffectLighting(color, dirColor, ambientColor, skylightingDiffuse);
 #		else
-	ShadowSampling::ExtractLighting(color, dirColor, ambientColor);
+	ExtractEffectLighting(color, dirColor, ambientColor, 1.0);
 #		endif
 
 	static const uint sampleCount = 8;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented sky/IBL contributions (including sky specular) from affecting interior/enclosed areas.

* **Refactor**
  * Improved lighting composition by splitting directional and ambient contributions and adding helper routines for more accurate effect lighting.

* **Chores**
  * Bumped Image-Based Lighting feature version to 1-1-1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->