### PR TITLE
perf: remove per-update heap allocation from feature cbuffer path

### DIFF
--- a/src/FeatureBuffer.cpp
+++ b/src/FeatureBuffer.cpp
@@ -1,5 +1,7 @@
 #include "FeatureBuffer.h"
 
+#include <array>
+
 #include "Features/CloudShadows.h"
 #include "Features/DynamicCubemaps.h"
 #include "Features/ExponentialHeightFog.h"
@@ -22,17 +24,20 @@
 template <class... Ts>
 std::pair<unsigned char*, size_t> _GetFeatureBufferData(Ts... feat_datas)
 {
-	size_t totalSize = (... + sizeof(Ts));
-	auto data = new unsigned char[totalSize];
+	// The packed size is a compile-time constant, so reuse one aligned, thread-local buffer
+	// instead of allocating/freeing every UpdateSharedData call. The returned pointer is
+	// non-owning and must NOT be deleted by the caller.
+	constexpr size_t totalSize = (... + sizeof(Ts));
+	alignas(16) static thread_local std::array<unsigned char, totalSize> storage;
 	size_t offset = 0;
 
 	([&] {
-		*((decltype(feat_datas)*)(data + offset)) = feat_datas;
+		*reinterpret_cast<decltype(feat_datas)*>(storage.data() + offset) = feat_datas;
 		offset += sizeof(decltype(feat_datas));
 	}(),
 		...);
 
-	return std::make_pair(data, totalSize);
+	return std::make_pair(storage.data(), storage.size());
 }
 
 std::pair<unsigned char*, size_t> GetFeatureBufferData(bool a_inWorld)

--- a/src/FeatureBuffer.h
+++ b/src/FeatureBuffer.h
@@ -1,3 +1,5 @@
 #pragma once
 
+// Returns a pointer into reused, thread-local storage and the packed size.
+// The pointer is non-owning: do NOT delete[] it.
 std::pair<unsigned char*, size_t> GetFeatureBufferData(bool a_early);

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -748,7 +748,6 @@ void State::SetupResources()
 
 	auto [data, size] = GetFeatureBufferData(false);
 	featureDataCB = new ConstantBuffer(ConstantBufferDesc((uint32_t)size));
-	delete[] data;
 
 	// Grab main texture to get resolution
 	// VR cannot use viewport->screenWidth/Height as it's the desktop preview window's resolution and not HMD
@@ -1032,8 +1031,6 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 		auto [data, size] = GetFeatureBufferData(a_inWorld);
 
 		featureDataCB->Update(data, size);
-
-		delete[] data;
 	}
 
 	auto* srv = Util::GetCurrentSceneDepthSRV(true);

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -747,6 +747,7 @@ void State::SetupResources()
 	sharedDataCB = new ConstantBuffer(ConstantBufferDesc<SharedDataCB>());
 
 	auto [data, size] = GetFeatureBufferData(false);
+	(void)data;
 	featureDataCB = new ConstantBuffer(ConstantBufferDesc((uint32_t)size));
 
 	// Grab main texture to get resolution


### PR DESCRIPTION
something claude found when trying to optimise tv

What's happening now. Every time UpdateSharedData runs — once per frame, twice under VR — the code calls new unsigned char[totalSize], fills the buffer, uploads it to the GPU cbuffer, then immediately delete[]s it. The buffer is created, used for microseconds, and thrown away. This happens every single frame for the lifetime of the game session.
Why heap allocation hurts on the hot path. new/delete aren't free even for small buffers. The allocator has to acquire a lock (or at minimum do a lock-free CAS), walk a free-list or bin structure, potentially zero memory, and on delete do the same in reverse. On a frame where many systems are allocating simultaneously — which is every frame — this adds contention and unpredictable latency spikes. It also fragments the heap over a long session.
What thread_local static gives you. The buffer is allocated exactly once, on first use, and lives for the thread's lifetime. Every subsequent frame just writes into the same memory that's already warm in cache from last frame. No lock, no free-list walk, no delete. The size is a compile-time constant (it's the sum of the fixed settings structs), so the storage can be a properly-aligned std::array sized at compile time — the compiler knows exactly what it is.
The VR angle. VR calls UpdateSharedData twice per frame (once per eye). That doubles the allocation/free pairs, so the saving is proportionally larger there. thread_local handles the two-eye case cleanly since both calls happen on the same render thread anyway.
What doesn't change. The buffer contents, the upload call, the cbuffer layout — none of that moves. This is purely replacing the storage backing the temporary, so there's zero risk to correctness and nothing downstream even notices.
The practical effect is a small but guaranteed per-frame saving that never gets worse over a long session, and removes one source of heap fragmentation that could otherwise cause the allocator to slow down over time as memory gets carved up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced runtime memory usage and improved performance by reusing internal buffer storage.
  * Eliminated redundant buffer deallocation to simplify resource handling.

* **Documentation**
  * Clarified behavior of buffer data retrieval in API comments so callers know the returned data is non-owning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->