### PR TITLE
ci: fix perm for hotfix workflow

### DIFF
--- a/.github/workflows/release-hotfix.yaml
+++ b/.github/workflows/release-hotfix.yaml
@@ -286,10 +286,7 @@ jobs:
             - name: Open PR against hotfix branch
               if: ${{ !inputs.dry_run && steps.cherry.outputs.picked_count != '0' }}
               env:
-                  # GITHUB_TOKEN suffices here: the workflow declares
-                  # `permissions: pull-requests: write`, and creating the
-                  # candidate PR requires no branch-protection bypass.
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   # Pass via env (not ${{ }} interpolation) so the literal
                   # backticks inside SOURCE_DESC don't get re-evaluated by
                   # bash as command substitution.


### PR DESCRIPTION
the current token doesn't allow opening PRs, with more elevated priviliges this does work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow authentication mechanism to enhance security in automated PR creation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->