### PR TITLE
fix(lighting): guard EMAT parallax shadow against undefined TBN

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2905,7 +2905,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 		float parallaxShadow = 1;
 
-#			if defined(EMAT)
+#			if defined(EMAT) && (defined(SKINNED) || !defined(MODELSPACENORMALS))
 		[branch] if (
 			SharedData::extendedMaterialSettings.EnableShadows &&
 			!(light.lightFlags & LightLimitFix::LightFlags::Simple) &&
@@ -2935,7 +2935,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 				parallaxShadow = ExtendedMaterials::GetParallaxSoftShadowMultiplier(uv, mipLevel, lightDirectionTS, sh0, TexParallaxSampler, SampParallaxSampler, 0, parallaxShadowQuality, screenNoise, displacementParams);
 #				endif
 		}
-#			endif
+#			endif  // defined(EMAT) && (defined(SKINNED) || !defined(MODELSPACENORMALS))
 
 		DirectContext pointLightContext;
 		DirectLightingOutput pointLightOutput;


### PR DESCRIPTION
## Summary

The EMAT parallax-shadow block in `Lighting.hlsl` reads the tangent-space basis `tbn` via `mul(refractedLightDirection, tbn)`, but `tbn` is only defined under `defined(SKINNED) || !defined(MODELSPACENORMALS)`. For `MODELSPACENORMALS && !SKINNED` permutations, the block read an **undefined `tbn`**, producing garbage parallax soft-shadow results.

This gates the block on the same condition that defines `tbn`, matching the idiom already used elsewhere in the file (e.g. the EMAT normal-mapping block and the `tbn` definition itself).

## Change

`package/Shaders/Lighting.hlsl` — two lines: tighten `#if defined(EMAT)` → `#if defined(EMAT) && (defined(SKINNED) || !defined(MODELSPACENORMALS))` around the parallax-shadow block (and annotate the matching `#endif`).

The guard only *removes* the block from permutations where `tbn` was undefined, so it cannot introduce a compile error — only fix the latent undefined read. CI shader validation covers the affected permutations.

## Attribution

Ported from [ParticleTroned/skyrim-community-shaders](https://github.com/ParticleTroned/skyrim-community-shaders) (`fix(lighting): guard EMAT parallax shadow TBN use`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Cherrypicked from open shaders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted parallax shadow rendering to activate only under specific rendering configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->