### PR TITLE
fix(i18n): add 'ready_for_review' type to pull request triggers

### DIFF
--- a/.github/workflows/pr-i18n.yaml
+++ b/.github/workflows/pr-i18n.yaml
@@ -2,7 +2,7 @@ name: "PR: i18n Check"
 
 on:
     pull_request:
-        types: [opened, synchronize, reopened]
+        types: [opened, synchronize, reopened, ready_for_review]
         paths:
             - "src/**"
             - "package/SKSE/Plugins/CommunityShaders/Translations/**"
@@ -15,6 +15,7 @@ permissions:
 jobs:
     i18n-check:
         name: Verify en.json is in sync with source
+        if: ${{ !github.event.pull_request.draft }}
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request validation workflow for better development efficiency. Internationalization validation checks now trigger when pull requests transition to ready for review status and automatically skip for draft pull requests, ensuring quality checks happen at appropriate stages and reducing unnecessary processing overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->