### PR TITLE
fix(UI): hide profiling when data not available 

### DIFF
--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -812,7 +812,7 @@ void FeatureListRenderer::DrawMenuVisitor::RenderFeatureSettings(Feature* feat, 
 			ImVec2 cursorPosBefore = ImGui::GetCursorPos();
 			feat->DrawSettings();
 
-			if (feat != &globals::features::csEditor) {
+			if (feat != &globals::features::csEditor && ProfilingRenderer::HasFeatureTimers(feat->GetShortName())) {
 				ImGui::SeparatorText(T("menu.features.profiling", "Profiling"));
 				ProfilingRenderer::RenderFeatureTimers(feat->GetShortName());
 			}

--- a/src/Menu/ProfilingRenderer.cpp
+++ b/src/Menu/ProfilingRenderer.cpp
@@ -370,9 +370,9 @@ void ProfilingRenderer::RenderFeatureTimers(const std::string& featurePrefix)
 	float maxP95 = 0.0f;
 	float maxP99 = 0.0f;
 
-	std::string prefix = featurePrefix + "::";
+	const auto prefix = GetFeatureTimerPrefix(featurePrefix);
 	for (const auto& r : results) {
-		if (!r.valid || !r.name.starts_with(prefix))
+		if (!IsFeatureTimerResult(r, prefix))
 			continue;
 		std::string label = r.name.substr(prefix.size());
 		float timeMs = cpuMode ? r.cpuTimeMs : r.gpuTimeMs;
@@ -450,4 +450,24 @@ void ProfilingRenderer::RenderFeatureTimers(const std::string& featurePrefix)
 
 		ImGui::EndTable();
 	}
+}
+
+bool ProfilingRenderer::HasFeatureTimers(const std::string& featurePrefix)
+{
+	const auto prefix = GetFeatureTimerPrefix(featurePrefix);
+	const auto& results = globals::profiler->GetResults();
+
+	return std::ranges::any_of(results, [&prefix](const auto& result) {
+		return IsFeatureTimerResult(result, prefix);
+	});
+}
+
+std::string ProfilingRenderer::GetFeatureTimerPrefix(const std::string& featurePrefix)
+{
+	return featurePrefix + "::";
+}
+
+bool ProfilingRenderer::IsFeatureTimerResult(const Profiler::TimerResult& result, std::string_view prefix)
+{
+	return result.valid && result.name.starts_with(prefix);
 }

--- a/src/Menu/ProfilingRenderer.h
+++ b/src/Menu/ProfilingRenderer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -20,6 +21,7 @@ public:
 
 	static void RenderStatistics(bool showTable = true, bool showModeToggle = true);
 	static void RenderFeatureTimers(const std::string& featurePrefix);
+	static bool HasFeatureTimers(const std::string& featurePrefix);
 
 private:
 	static inline TimingMode timingMode = TimingMode::GPU;
@@ -67,4 +69,6 @@ private:
 	static void RenderTimingModeToggle();
 	static void SetupTimingTableColumns(bool includePercentColumn);
 	static void RenderGraph();
+	static std::string GetFeatureTimerPrefix(const std::string& featurePrefix);
+	static bool IsFeatureTimerResult(const Profiler::TimerResult& result, std::string_view prefix);
 };


### PR DESCRIPTION
Hides profiling at bottom of features when data is not available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profiling section in menus to only display when profiling timers are available, eliminating empty profiling sections from appearing in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->