### PR TITLE
fix(unified water): add IsDisabledByDefault

### DIFF
--- a/src/Feature.h
+++ b/src/Feature.h
@@ -74,6 +74,13 @@ public:
 	virtual std::string_view GetCategory() const { return FeatureCategories::kOther; }
 
 	/**
+	 * Whether the feature is disabled at boot by default (before any user override).
+	 * Features that override this to return true will start disabled on first install;
+	 * users can still enable them via the "Disable at Boot" menu.
+	 */
+	virtual bool IsDisabledByDefault() const { return false; }
+
+	/**
 	 * Whether the feature will show up in the GUI menu
 	 */
 	virtual bool IsInMenu() const { return true; }

--- a/src/Features/UnifiedWater.h
+++ b/src/Features/UnifiedWater.h
@@ -105,6 +105,7 @@ struct UnifiedWater : OverlayFeature
 	virtual void RestoreDefaultSettings() override;
 
 	virtual bool IsCore() const override { return true; }
+	virtual bool IsDisabledByDefault() const override { return true; }
 	virtual bool SupportsVR() override { return true; }
 
 	virtual void PostPostLoad() override;

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -366,6 +366,10 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 		for (auto* feature : Feature::GetFeatureList()) {
 			try {
 				const std::string featureName = feature->GetShortName();
+				if (!disabledFeatures.contains(featureName) && feature->IsDisabledByDefault()) {
+					disabledFeatures[featureName] = true;
+					logger::info("Feature '{}' is disabled by default", featureName);
+				}
 				bool isDisabled = disabledFeatures.contains(featureName) && disabledFeatures[featureName];
 				if (!isDisabled) {
 					logger::info("Loading Feature: '{}'", featureName);


### PR DESCRIPTION
## Summary
- Adds `virtual bool IsDisabledByDefault() const` to the `Feature` base class (returns `false` by default)
- During `State::Load`, features not already in the user's saved config that declare `IsDisabledByDefault() == true` are automatically disabled at boot
- User's explicit enable/disable choice is always preserved once saved
- `UnifiedWater` overrides this to return `true`, so it starts disabled on fresh installs

## Test plan
- [ ] Fresh install: verify Unified Water is disabled at boot without any user config
- [ ] Existing install with Unified Water enabled: verify it stays enabled (user override preserved)
- [ ] Toggle Unified Water on via Disable at Boot menu, restart — verify it stays enabled
- [ ] Verify other features are unaffected (all default to enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Features can now be disabled by default at startup while remaining user-configurable.
  * UnifiedWater is now disabled by default at boot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->