### PR TITLE
fix(ci): resolve broken job name in shader validation workflow

### DIFF
--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -124,16 +124,10 @@ jobs:
 
     shader-validation:
         if: inputs.run-shader-validation
-        name: Validate shader compilation (${{ matrix.config.name }})
+        name: Validate shader compilation (Flatrim)
         runs-on: windows-2025
         permissions:
             contents: read
-        strategy:
-            matrix:
-                config:
-                    - name: "Flatrim"
-                      file: ".github/configs/shader-validation.yaml"
-            fail-fast: false
         steps:
             - name: Checkout code
               uses: actions/checkout@v6
@@ -152,7 +146,7 @@ jobs:
               if: steps.check-hlsl.outputs.skip != 'true'
               uses: ./.github/actions/setup-build-environment
               with:
-                  cache-key-suffix: "validation-${{ matrix.config.name }}${{ inputs.cache-key-suffix }}"
+                  cache-key-suffix: "validation-Flatrim${{ inputs.cache-key-suffix }}"
             - name: Prepare shaders
               if: steps.check-hlsl.outputs.skip != 'true'
               uses: ./.github/actions/prepare-shaders
@@ -185,7 +179,7 @@ jobs:
                     }
                   }
 
-            - name: Validate shader compilation (${{ matrix.config.name }})
+            - name: Validate shader compilation (Flatrim)
               if: steps.check-hlsl.outputs.skip != 'true'
               shell: bash
               run: |
@@ -193,13 +187,13 @@ jobs:
                     echo "fxc.exe not found - shader validation requires fxc.exe. Set --fxc to a valid path or ensure fxc.exe is in PATH." >&2
                     exit 1
                   fi
-                  hlslkit-compile --fxc "${{ steps.find_fxc.outputs.fxc_path }}" --shader-dir build/ALL/aio/Shaders --output-dir build/ShaderCache --config ${{ matrix.config.file }} --max-warnings 0 --suppress-warnings X1519
+                  hlslkit-compile --fxc "${{ steps.find_fxc.outputs.fxc_path }}" --shader-dir build/ALL/aio/Shaders --output-dir build/ShaderCache --config .github/configs/shader-validation.yaml --max-warnings 0 --suppress-warnings X1519
 
             - name: Upload shader validation logs
               if: failure() && steps.check-hlsl.outputs.skip != 'true'
               uses: actions/upload-artifact@v7
               with:
-                  name: shader-validation-logs-${{ matrix.config.name }}
+                  name: shader-validation-logs-Flatrim
                   path: |
                       build/ShaderCache/new_issues.log
                       build/ShaderCache/*.log

--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -146,7 +146,7 @@ jobs:
               if: steps.check-hlsl.outputs.skip != 'true'
               uses: ./.github/actions/setup-build-environment
               with:
-                  cache-key-suffix: "validation-Flatrim${{ inputs.cache-key-suffix }}"
+                  cache-key-suffix: "validation${{ inputs.cache-key-suffix }}"
             - name: Prepare shaders
               if: steps.check-hlsl.outputs.skip != 'true'
               uses: ./.github/actions/prepare-shaders
@@ -193,7 +193,7 @@ jobs:
               if: failure() && steps.check-hlsl.outputs.skip != 'true'
               uses: actions/upload-artifact@v7
               with:
-                  name: shader-validation-logs-Flatrim
+                  name: shader-validation-logs
                   path: |
                       build/ShaderCache/new_issues.log
                       build/ShaderCache/*.log

--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -124,7 +124,7 @@ jobs:
 
     shader-validation:
         if: inputs.run-shader-validation
-        name: Validate shader compilation (Flatrim)
+        name: Validate shader compilation
         runs-on: windows-2025
         permissions:
             contents: read
@@ -179,7 +179,7 @@ jobs:
                     }
                   }
 
-            - name: Validate shader compilation (Flatrim)
+            - name: Validate shader compilation
               if: steps.check-hlsl.outputs.skip != 'true'
               shell: bash
               run: |


### PR DESCRIPTION
## Summary
- Removed the single-entry matrix strategy from the `shader-validation` job in `_shared-build.yaml`
- Inlined the "Flatrim" name and config file path directly into the job

## Why
When the `shader-validation` job is skipped (because `inputs.run-shader-validation` is false), GitHub Actions doesn't expand matrix expressions — causing the job name to display as the raw literal `${{ matrix.config.name }}` in the UI. Since the matrix only ever had one entry, removing it and inlining the values fixes the display without changing behavior.

## Test plan
- [ ] Verify the job name shows "Validate shader compilation (Flatrim)" in the PR checks UI
- [ ] Confirm shader validation still runs correctly when triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified shader validation workflow to streamline the build pipeline with more consistent processing and cleaner artifact management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->