### PR TITLE
fix(UI): CTD when alt-tabbing with no cursor png

### DIFF
--- a/src/Menu/OverlayRenderer.cpp
+++ b/src/Menu/OverlayRenderer.cpp
@@ -366,7 +366,8 @@ void OverlayRenderer::HandleABTesting()
 
 void OverlayRenderer::FinalizeImGuiFrame()
 {
-	if (auto* menu = Menu::GetSingleton()) {
+	if (auto* menu = Menu::GetSingleton();
+		menu && menu->GetSettings().Theme.UseCustomCursor && Util::CursorLoader::GetLoadedCount() > 0) {
 		Util::CursorLoader::DrawCustomCursor(*menu);
 	}
 


### PR DESCRIPTION
dont merge, still testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom cursor rendering to only display when the feature is enabled and cursors are properly loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->