### PR TITLE
refactor(skin): move util functions to common

### DIFF
--- a/features/Skin/Shaders/Skin/Skin.hlsli
+++ b/features/Skin/Shaders/Skin/Skin.hlsli
@@ -80,14 +80,6 @@ namespace Skin
 		return D * G * F;
 	}
 
-	// a contact shadow approximation, totally not physically correct; a riff on "Chan 2018, "Material Advances in Call of Duty: WWII" and "The Technical Art of Uncharted 4" http://advances.realtimerendering.com/other/2016/naughty_dog/NaughtyDog_TechArt_Final.pdf (microshadowing)"
-	float ApproximateDirectOcculusion(float aoVisibility, float NdotL)
-	{
-		float aperture = rsqrt(1.0000001 - aoVisibility);
-		NdotL += 0.1;  // when using bent normals, avoids overshadowing - bent normals are just approximation anyhow
-		return saturate(NdotL * aperture);
-	}
-
 	void SkinDirectLightInput(
 		out DirectLightingOutput lightingOutput,
 		DirectContext context,
@@ -180,58 +172,6 @@ namespace Skin
 		lobeWeights.specular *= specularAO;
 
 		lobeWeights.specular *= saturate(1 - material.Curvature);
-	}
-
-	// https://blog.selfshadow.com/publications/blending-in-detail/
-	// geometric normal s, a base normal t and a secondary (or detail) normal u
-	float3 ReorientNormal(float3 u, float3 t, float3 s)
-	{
-		// Build the shortest-arc quaternion
-		float4 q = float4(cross(s, t), dot(s, t) + 1) / sqrt(2 * (dot(s, t) + 1));
-
-		// Rotate the normal
-		return u * (q.w * q.w - dot(q.xyz, q.xyz)) + 2 * q.xyz * dot(q.xyz, u) + 2 * q.w * cross(q.xyz, u);
-	}
-
-	// for when s = (0,0,1)
-	float3 ReorientNormal(float3 n1, float3 n2)
-	{
-		n1 += float3(0, 0, 1);
-		n2 *= float3(-1, -1, 1);
-
-		return n1 * dot(n1, n2) / n1.z - n2;
-	}
-
-	float3x3 ReconstructTBN(float3 worldPos, float3 worldNormal, float2 uv)
-	{
-		float3 dFdx = ddx(worldPos);
-		float3 dFdy = ddy(worldPos);
-		float2 dUVdx = ddx(uv);
-		float2 dUVdy = ddy(uv);
-		float3 tangent = normalize(dFdx * dUVdy.y - dFdy * dUVdx.y);
-		float3 bitangent = normalize(dFdy * dUVdx.x - dFdx * dUVdy.x);
-		tangent = normalize(tangent - worldNormal * dot(worldNormal, tangent));
-		bitangent = normalize(bitangent - worldNormal * dot(worldNormal, bitangent));
-
-		return float3x3(tangent, bitangent, normalize(worldNormal));
-	}
-
-	float3 CalculateNormalFromHeight(float height, float heightScale, float2 uv)
-	{
-		float dHdx = ddx(height);
-		float dHdy = ddy(height);
-		float2 dUVdx = ddx(uv);
-		float2 dUVdy = ddy(uv);
-
-		float det = dUVdx.x * dUVdy.y - dUVdx.y * dUVdy.x;
-		if (det == 0.0f) {
-			return float3(0, 0, 1);  // Avoid division by zero
-		}
-
-		float dHdx_Tex = (dHdx * dUVdy.y - dHdy * dUVdx.y) / det;
-		float dHdy_Tex = (dHdy * dUVdx.x - dHdx * dUVdy.x) / det;
-		float3 normal = float3(-dHdx_Tex, -dHdy_Tex, 0);
-		return normal * heightScale + float3(0, 0, 1);
 	}
 
 	float FBM(float2 uv, float base_scale, int octaves, float lacunarity, float persistence, float z_offset_multiplier)

--- a/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
+++ b/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
@@ -1,4 +1,5 @@
 #include "Common/BRDF.hlsli"
+#include "Common/Shading.hlsli"
 #include "WetnessEffects/optimized-ggx.hlsli"
 
 namespace WetnessEffects
@@ -21,26 +22,6 @@ namespace WetnessEffects
 
 		float val = lerp(1.0, 0.0, (normalised_t - rain_stay) / (1.0 - rain_stay));
 		return val * val;
-	}
-
-	// https://blog.selfshadow.com/publications/blending-in-detail/
-	// geometric normal s, a base normal t and a secondary (or detail) normal u
-	float3 ReorientNormal(float3 u, float3 t, float3 s)
-	{
-		// Build the shortest-arc quaternion
-		float4 q = float4(cross(s, t), dot(s, t) + 1) / sqrt(2 * (dot(s, t) + 1));
-
-		// Rotate the normal
-		return u * (q.w * q.w - dot(q.xyz, q.xyz)) + 2 * q.xyz * dot(q.xyz, u) + 2 * q.w * cross(q.xyz, u);
-	}
-
-	// for when s = (0,0,1)
-	float3 ReorientNormal(float3 n1, float3 n2)
-	{
-		n1 += float3(0, 0, 1);
-		n2 *= float3(-1, -1, 1);
-
-		return n1 * dot(n1, n2) / n1.z - n2;
 	}
 
 	// xyz - ripple normal, w - splotches

--- a/package/Shaders/Common/LightingCommon.hlsli
+++ b/package/Shaders/Common/LightingCommon.hlsli
@@ -108,18 +108,4 @@ float ShininessToRoughness(float shininess)
 {
 	return pow(abs(2.0 / (shininess + 2.0)), 0.25);
 }
-
-float3x3 ReconstructTBN(float3 worldPos, float3 worldNormal, float2 uv)
-{
-	float3 dFdx = ddx(worldPos);
-	float3 dFdy = ddy(worldPos);
-	float2 dUVdx = ddx(uv);
-	float2 dUVdy = ddy(uv);
-	float3 tangent = normalize(dFdx * dUVdy.y - dFdy * dUVdx.y);
-	float3 bitangent = normalize(dFdy * dUVdx.x - dFdx * dUVdy.x);
-	tangent = normalize(tangent - worldNormal * dot(worldNormal, tangent));
-	bitangent = normalize(bitangent - worldNormal * dot(worldNormal, bitangent));
-
-	return float3x3(tangent, bitangent, normalize(worldNormal));
-}
 #endif

--- a/package/Shaders/Common/Shading.hlsli
+++ b/package/Shaders/Common/Shading.hlsli
@@ -21,4 +21,64 @@ float SpecularOcclusion(float NdotV, float alpha, float occlusion)
 	return saturate(pow(abs(NdotV + occlusion), alpha) - 1.0 + occlusion);
 }
 
+// a contact shadow approximation, totally not physically correct; a riff on "Chan 2018, "Material Advances in Call of Duty: WWII" and "The Technical Art of Uncharted 4" http://advances.realtimerendering.com/other/2016/naughty_dog/NaughtyDog_TechArt_Final.pdf (microshadowing)"
+float ApproximateDirectOcculusion(float aoVisibility, float NdotL)
+{
+	float aperture = rsqrt(1.0000001 - aoVisibility);
+	NdotL += 0.1;  // when using bent normals, avoids overshadowing - bent normals are just approximation anyhow
+	return saturate(NdotL * aperture);
+}
+
+// https://blog.selfshadow.com/publications/blending-in-detail/
+// geometric normal s, a base normal t and a secondary (or detail) normal u
+float3 ReorientNormal(float3 u, float3 t, float3 s)
+{
+	// Build the shortest-arc quaternion
+	float4 q = float4(cross(s, t), dot(s, t) + 1) / sqrt(2 * (dot(s, t) + 1));
+
+	// Rotate the normal
+	return u * (q.w * q.w - dot(q.xyz, q.xyz)) + 2 * q.xyz * dot(q.xyz, u) + 2 * q.w * cross(q.xyz, u);
+}
+
+// for when s = (0,0,1)
+float3 ReorientNormal(float3 n1, float3 n2)
+{
+	n1 += float3(0, 0, 1);
+	n2 *= float3(-1, -1, 1);
+
+	return n1 * dot(n1, n2) / n1.z - n2;
+}
+
+float3x3 ReconstructTBN(float3 worldPos, float3 worldNormal, float2 uv)
+{
+	float3 dFdx = ddx(worldPos);
+	float3 dFdy = ddy(worldPos);
+	float2 dUVdx = ddx(uv);
+	float2 dUVdy = ddy(uv);
+	float3 tangent = normalize(dFdx * dUVdy.y - dFdy * dUVdx.y);
+	float3 bitangent = normalize(dFdy * dUVdx.x - dFdx * dUVdy.x);
+	tangent = normalize(tangent - worldNormal * dot(worldNormal, tangent));
+	bitangent = normalize(bitangent - worldNormal * dot(worldNormal, bitangent));
+
+	return float3x3(tangent, bitangent, normalize(worldNormal));
+}
+
+float3 CalculateNormalFromHeight(float height, float heightScale, float2 uv)
+{
+	float dHdx = ddx(height);
+	float dHdy = ddy(height);
+	float2 dUVdx = ddx(uv);
+	float2 dUVdy = ddy(uv);
+
+	float det = dUVdx.x * dUVdy.y - dUVdx.y * dUVdy.x;
+	if (det == 0.0f) {
+		return float3(0, 0, 1);  // Avoid division by zero
+	}
+
+	float dHdx_Tex = (dHdx * dUVdy.y - dHdy * dUVdx.y) / det;
+	float dHdy_Tex = (dHdy * dUVdx.x - dHdx * dUVdy.x) / det;
+	float3 normal = float3(-dHdx_Tex, -dHdy_Tex, 0);
+	return normal * heightScale + float3(0, 0, 1);
+}
+
 #endif  // __SHADING_HLSLI__

--- a/package/Shaders/Common/Shading.hlsli
+++ b/package/Shaders/Common/Shading.hlsli
@@ -1,6 +1,8 @@
 #ifndef __SHADING_HLSLI__
 #define __SHADING_HLSLI__
 
+#include "Common/Math.hlsli"
+
 // [Jimenez et al. 2016, "Practical Realtime Strategies for Accurate Indirect Occlusion"]
 float3 MultiBounceAO(float3 baseColor, float ao)
 {
@@ -71,7 +73,7 @@ float3 CalculateNormalFromHeight(float height, float heightScale, float2 uv)
 	float2 dUVdy = ddy(uv);
 
 	float det = dUVdx.x * dUVdy.y - dUVdx.y * dUVdy.x;
-	if (det == 0.0f) {
+	if (det < EPSILON_DIVISION) {
 		return float3(0, 0, 1);  // Avoid division by zero
 	}
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1816,7 +1816,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		skinWetnessSample = TexSkinWetnessSampler.Sample(SampColorSampler, uv);
 		if ((skinWetnessSample.y == 0 && skinWetnessSample.z == 0) || (skinWetnessSample.x == skinWetnessSample.y && skinWetnessSample.y == skinWetnessSample.z && skinWetnessSample.w >= 0.99f)) {
 			skinWetMask = skinWetnessSample.x;
-			skinWetnessNormal.xyz = Skin::CalculateNormalFromHeight(skinWetMask, SharedData::skinData.wetParams.w * 0.0001, uv) * 0.5 + 0.5;
+			skinWetnessNormal.xyz = CalculateNormalFromHeight(skinWetMask, SharedData::skinData.wetParams.w * 0.0001, uv) * 0.5 + 0.5;
 		} else {
 			skinWetnessNormal.xyz = skinWetnessSample.xyz;
 			skinWetMask = skinWetnessSample.w;
@@ -2010,7 +2010,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float2 detailUV = input.TexCoord0.xy * SharedData::skinData.skinDetailParams.x * SharedData::skinData.skinDetailParams.y;
 #		endif  // FACEGEN
 #		if defined(MODELSPACENORMALS)
-		const float3x3 tbnTr = Skin::ReconstructTBN(input.WorldPosition.xyz, worldNormal, screenUV);
+		const float3x3 tbnTr = ReconstructTBN(input.WorldPosition.xyz, worldNormal, screenUV);
 		const float3x3 tbn = transpose(tbnTr);
 		const float3 tangentNormal = mul(tbnTr, worldNormal.xyz);
 #		else
@@ -2019,17 +2019,16 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float3 detailNormal = float3(Skin::TexSkinDetailNormal.SampleBias(SampNormalSampler, detailUV, SharedData::MipBias - 1.0f).xy, 0.5f);
 		skinAO *= Skin::TexSkinDetailNormal.Sample(SampNormalSampler, detailUV).w;
 		detailNormal = (detailNormal * 2.0 - 1.0) * SharedData::skinData.skinDetailParams.z;
-		float3 combinedTangentNormal = normalize(float3(Skin::ReorientNormal(detailNormal, tangentNormal).xy, tangentNormal.z));
+		float3 combinedTangentNormal = normalize(float3(ReorientNormal(detailNormal, tangentNormal).xy, tangentNormal.z));
 		float3 combinedNormal = normalize(mul(tbn, combinedTangentNormal));
 		if (SharedData::skinData.skinDetailParams.w > 0.0f)
 			worldNormal.xyz = combinedNormal;
 #		if defined(WETNESS_EFFECTS)
 		if (skinWetness > 0.0f) {
-			float3 wetNormal = Skin::CalculateNormalFromHeight(skinWetness, SharedData::skinData.wetParams.w * 0.0005, uv);
+			float3 wetNormal = CalculateNormalFromHeight(skinWetness, SharedData::skinData.wetParams.w * 0.0005, uv);
 			if (hasSkinWetness) {
-				// float3 wetMaskNormal = Skin::CalculateNormalFromHeight(skinWetMask, SharedData::skinData.wetParams.w * 0.00005, uv);
 				float3 wetMaskNormal = (skinWetnessNormal.xyz * 2.0 - 1.0);
-				wetNormal = Skin::ReorientNormal(wetMaskNormal, wetNormal);
+				wetNormal = ReorientNormal(wetMaskNormal, wetNormal);
 			}
 			if (SharedData::skinData.skinParams2.y > 1.0f) {
 				wetNormal = lerp(wetNormal, tangentNormal, saturate(SharedData::skinData.skinParams2.y - 1.0f));
@@ -2120,7 +2119,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			endif  // SPECULAR
 #		endif      // SPARKLE
 
-#	endif      // SNOW
+#	endif  // SNOW
 
 #	if defined(WORLD_MAP)
 	baseColor.xyz = GetWorldMapBaseColor(rawBaseColor.xyz, baseColor.xyz, projWeight);
@@ -2513,7 +2512,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	// Apply ripple normal effects
 	float3 rippleNormal = normalize(lerp(float3(0, 0, 1), raindropInfo.xyz, lerp(flatnessAmount, 1.0, 0.5)));
-	wetnessNormal = WetnessEffects::ReorientNormal(rippleNormal, wetnessNormal);
+	wetnessNormal = ReorientNormal(rippleNormal, wetnessNormal);
 
 #		if defined(SKIN) && defined(CS_SKIN)
 	if (skinEnabled && (skinWetness > 0.0f)) {

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -8,6 +8,7 @@
 #include "Common/MotionBlur.hlsli"
 #include "Common/Permutation.hlsli"
 #include "Common/Random.hlsli"
+#include "Common/Shading.hlsli"
 #include "Common/SharedData.hlsli"
 #include "Common/Skinned.hlsli"
 #include "Common/Triplanar.hlsli"

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -47,6 +47,7 @@ PS_OUTPUT main(PS_INPUT input)
 #	include "Common/MotionBlur.hlsli"
 #	include "Common/Permutation.hlsli"
 #	include "Common/Random.hlsli"
+#	include "Common/Shading.hlsli"
 #	include "Common/Color.hlsli"
 
 #	define WATER
@@ -321,8 +322,8 @@ Texture2D<float4> RawSSRReflectionTex : register(t11);
 
 cbuffer PerTechnique : register(b0)
 {
-	float4 VPOSOffset : packoffset(c0);    // inverse main render target width and height in xy, 0 in zw
-	float4 PosAdjust : packoffset(c1);  // inverse framebuffer range in w
+	float4 VPOSOffset : packoffset(c0);  // inverse main render target width and height in xy, 0 in zw
+	float4 PosAdjust : packoffset(c1);   // inverse framebuffer range in w
 	float4 CameraDataWater : packoffset(c2);
 	float4 SunDir : packoffset(c3);
 	float4 SunColor : packoffset(c4);
@@ -767,7 +768,7 @@ WaterNormalData GetWaterNormal(PS_INPUT input, float distanceFactor, float norma
 		result.rippleInfo.w = splashIntensity;
 	}
 	float3 rippleNormal = normalize(raindropInfo.xyz);
-	finalNormal = WetnessEffects::ReorientNormal(rippleNormal, finalNormal);
+	finalNormal = ReorientNormal(rippleNormal, finalNormal);
 #			endif
 
 	result.normal = finalNormal;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated shader utility helpers into a shared shading module for normals, height-derived normals, reorientation, and approximate occlusion.
  * Rendering systems (skin, wetness, water, lighting) now use the common helpers for more consistent normal and occlusion handling across effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->