### PR TITLE
feat(volumetric-shadows): EVSM shadow mapping with global depth normalization

### DIFF
--- a/features/Volumetric Shadows/Shaders/VolumetricShadows/BlurShadowCS.hlsl
+++ b/features/Volumetric Shadows/Shaders/VolumetricShadows/BlurShadowCS.hlsl
@@ -1,33 +1,29 @@
-// 11x11 separable Gaussian blur for VSM shadow map
+// Separable Gaussian blur for shadow map moments
 // BLUR_HORIZONTAL - horizontal pass
 // BLUR_VERTICAL - vertical pass
 
-Texture2D<float2> InputTexture : register(t0);
-RWTexture2D<float2> OutputTexture : register(u0);
+Texture2D<float4> InputTexture : register(t0);
+RWTexture2D<float4> OutputTexture : register(u0);
 
-// Gaussian weights for 11-tap kernel (sigma ~= 2.5)
-static const float weights[6] = {
-	0.198596,  // center
-	0.175713,  // +/- 1
-	0.121703,  // +/- 2
-	0.065984,  // +/- 3
-	0.028002,  // +/- 4
-	0.009302   // +/- 5
+cbuffer BlurCB : register(b0)
+{
+	uint BlurRadius;
+	uint _pad[3];
 };
 
-#define KERNEL_RADIUS 5
+#define MAX_KERNEL_RADIUS 32
 #define GROUP_SIZE 128
 
 // Shared memory for efficient loading
-// We need GROUP_SIZE + 2 * KERNEL_RADIUS elements
-groupshared float2 g_cache[GROUP_SIZE + 2 * KERNEL_RADIUS];
+// We need GROUP_SIZE + 2 * MAX_KERNEL_RADIUS elements
+groupshared float4 g_cache[GROUP_SIZE + 2 * MAX_KERNEL_RADIUS];
 
 #if defined(BLUR_HORIZONTAL)
 [numthreads(GROUP_SIZE, 1, 1)] void main(uint3 groupID : SV_GroupID, uint3 groupThreadID : SV_GroupThreadID, uint3 dispatchThreadID : SV_DispatchThreadID) {
 	uint width, height;
 	InputTexture.GetDimensions(width, height);
 
-	int2 baseCoord = int2(groupID.x * GROUP_SIZE - KERNEL_RADIUS, groupID.y);
+	int2 baseCoord = int2(groupID.x * GROUP_SIZE - MAX_KERNEL_RADIUS, groupID.y);
 	int localIdx = groupThreadID.x;
 
 	// Load main data
@@ -36,7 +32,7 @@ groupshared float2 g_cache[GROUP_SIZE + 2 * KERNEL_RADIUS];
 	g_cache[localIdx] = InputTexture[coord];
 
 	// Load extra data for kernel overlap
-	if (localIdx < 2 * KERNEL_RADIUS) {
+	if (localIdx < 2 * MAX_KERNEL_RADIUS) {
 		coord = baseCoord + int2(GROUP_SIZE + localIdx, 0);
 		coord.x = clamp(coord.x, 0, (int)width - 1);
 		g_cache[GROUP_SIZE + localIdx] = InputTexture[coord];
@@ -48,16 +44,21 @@ groupshared float2 g_cache[GROUP_SIZE + 2 * KERNEL_RADIUS];
 	if (dispatchThreadID.x >= width || dispatchThreadID.y >= height)
 		return;
 
-	// Apply horizontal blur
-	float2 result = g_cache[localIdx + KERNEL_RADIUS] * weights[0];
+	// Apply horizontal blur with dynamic radius
+	uint radius = min(BlurRadius, (uint)MAX_KERNEL_RADIUS);
+	float sigma = max(float(radius) * 0.5, 0.5);
+	float rcpTwoSigma2 = rcp(2.0 * sigma * sigma);
 
-	[unroll] for (int i = 1; i <= KERNEL_RADIUS; i++)
-	{
-		result += g_cache[localIdx + KERNEL_RADIUS - i] * weights[i];
-		result += g_cache[localIdx + KERNEL_RADIUS + i] * weights[i];
+	float4 result = g_cache[localIdx + MAX_KERNEL_RADIUS];
+	float totalWeight = 1.0;
+
+	for (uint i = 1; i <= radius; i++) {
+		float w = exp(-float(i * i) * rcpTwoSigma2);
+		result += (g_cache[localIdx + MAX_KERNEL_RADIUS - i] + g_cache[localIdx + MAX_KERNEL_RADIUS + i]) * w;
+		totalWeight += 2.0 * w;
 	}
 
-	OutputTexture[dispatchThreadID.xy] = result;
+	OutputTexture[dispatchThreadID.xy] = result * rcp(totalWeight);
 }
 
 #elif defined(BLUR_VERTICAL)
@@ -65,7 +66,7 @@ groupshared float2 g_cache[GROUP_SIZE + 2 * KERNEL_RADIUS];
 	uint width, height;
 	InputTexture.GetDimensions(width, height);
 
-	int2 baseCoord = int2(groupID.x, groupID.y * GROUP_SIZE - KERNEL_RADIUS);
+	int2 baseCoord = int2(groupID.x, groupID.y * GROUP_SIZE - MAX_KERNEL_RADIUS);
 	int localIdx = groupThreadID.y;
 
 	// Load main data
@@ -74,7 +75,7 @@ groupshared float2 g_cache[GROUP_SIZE + 2 * KERNEL_RADIUS];
 	g_cache[localIdx] = InputTexture[coord];
 
 	// Load extra data for kernel overlap
-	if (localIdx < 2 * KERNEL_RADIUS) {
+	if (localIdx < 2 * MAX_KERNEL_RADIUS) {
 		coord = baseCoord + int2(0, GROUP_SIZE + localIdx);
 		coord.y = clamp(coord.y, 0, (int)height - 1);
 		g_cache[GROUP_SIZE + localIdx] = InputTexture[coord];
@@ -86,15 +87,20 @@ groupshared float2 g_cache[GROUP_SIZE + 2 * KERNEL_RADIUS];
 	if (dispatchThreadID.x >= width || dispatchThreadID.y >= height)
 		return;
 
-	// Apply vertical blur
-	float2 result = g_cache[localIdx + KERNEL_RADIUS] * weights[0];
+	// Apply vertical blur with dynamic radius
+	uint radius = min(BlurRadius, (uint)MAX_KERNEL_RADIUS);
+	float sigma = max(float(radius) * 0.5, 0.5);
+	float rcpTwoSigma2 = rcp(2.0 * sigma * sigma);
 
-	[unroll] for (int i = 1; i <= KERNEL_RADIUS; i++)
-	{
-		result += g_cache[localIdx + KERNEL_RADIUS - i] * weights[i];
-		result += g_cache[localIdx + KERNEL_RADIUS + i] * weights[i];
+	float4 result = g_cache[localIdx + MAX_KERNEL_RADIUS];
+	float totalWeight = 1.0;
+
+	for (uint i = 1; i <= radius; i++) {
+		float w = exp(-float(i * i) * rcpTwoSigma2);
+		result += (g_cache[localIdx + MAX_KERNEL_RADIUS - i] + g_cache[localIdx + MAX_KERNEL_RADIUS + i]) * w;
+		totalWeight += 2.0 * w;
 	}
 
-	OutputTexture[dispatchThreadID.xy] = result;
+	OutputTexture[dispatchThreadID.xy] = result * rcp(totalWeight);
 }
 #endif

--- a/features/Volumetric Shadows/Shaders/VolumetricShadows/BlurShadowCS.hlsl
+++ b/features/Volumetric Shadows/Shaders/VolumetricShadows/BlurShadowCS.hlsl
@@ -1,4 +1,4 @@
-// Separable Gaussian blur for shadow map moments
+// Separable Gaussian blur for EVSM shadow map moments
 // BLUR_HORIZONTAL - horizontal pass
 // BLUR_VERTICAL - vertical pass
 

--- a/features/Volumetric Shadows/Shaders/VolumetricShadows/DownsampleShadowCS.hlsl
+++ b/features/Volumetric Shadows/Shaders/VolumetricShadows/DownsampleShadowCS.hlsl
@@ -7,21 +7,26 @@ cbuffer EVSMLinearizeCB : register(b0)
 {
 	float CascadeNear;
 	float CascadeFar;
+	float GlobalNear;
+	float GlobalFar;
 	float ExponentPositive;
 	float ExponentNegative;
 };
 
-float LinearizeDepth(float depth)
+// Convert orthographic shadow map depth [0,1] to globally-normalized linear depth [0,1].
+// Shadow map depth is linear within each cascade: worldZ = near + depth * (far - near).
+// We then remap to a global range shared by both cascades so exponents behave consistently.
+float NormalizeDepth(float depth)
 {
-	float linZ = CascadeNear * CascadeFar / (CascadeFar - depth * (CascadeFar - CascadeNear));
-	return (linZ - CascadeNear) / (CascadeFar - CascadeNear);
+	float worldZ = CascadeNear + depth * (CascadeFar - CascadeNear);
+	return (worldZ - GlobalNear) / (GlobalFar - GlobalNear);
 }
 
-// Warp depth into EVSM moments: (e^(c*z), e^(2c*z), e^(-c*z), e^(-2c*z))
+// Warp depth into EVSM moments: (e^(c*d), e^(2c*d), e^(-c*d), e^(-2c*d))
 // Positive exponent detects front-face occlusion, negative detects back-face (light bleeding).
 float4 WarpDepth(float depth)
 {
-	float d = LinearizeDepth(depth);
+	float d = NormalizeDepth(depth);
 	float posWarp = exp(ExponentPositive * d);
 	float negWarp = exp(-ExponentNegative * d);
 	return float4(posWarp, posWarp * posWarp, negWarp, negWarp * negWarp);

--- a/features/Volumetric Shadows/Shaders/VolumetricShadows/DownsampleShadowCS.hlsl
+++ b/features/Volumetric Shadows/Shaders/VolumetricShadows/DownsampleShadowCS.hlsl
@@ -1,19 +1,43 @@
 Texture2DArray<float> InputTexture : register(t0);
 Texture2DArray<float> ESRAMShadow : register(t1);
-RWTexture2D<float2> OutputTexture : register(u0);
+RWTexture2D<float4> OutputTexture : register(u0);
 SamplerState LinearSampler : register(s0);
 
-float2 GetVSMMoments(in float depth)
+cbuffer VSMLinearizeCB : register(b0)
 {
-	return float2(depth, depth * depth);
+	float CascadeNear;
+	float CascadeFar;
+	float2 _pad;
+};
+
+float LinearizeDepth(float depth)
+{
+	float linZ = CascadeNear * CascadeFar / (CascadeFar - depth * (CascadeFar - CascadeNear));
+	return (linZ - CascadeNear) / (CascadeFar - CascadeNear);
 }
 
-float2 ReduceMoments(float2 a, float2 b, float2 c, float2 d)
+// Compute 4 power moments with RGBA16 quantization optimization
+// Reference: Peters, "Moment Shadow Mapping" (I3D 2015)
+float4 GetOptimizedMoments(in float depth)
+{
+	float d = LinearizeDepth(depth);
+	float d2 = d * d;
+	float4 moments = float4(d, d2, d * d2, d2 * d2);
+	float4 optimized = mul(moments, float4x4(
+		-2.07224649,     13.7948857237,   0.105877704,    9.7924062118,
+		 32.23703778,   -59.4683975703,  -1.9077466311,  -33.7652110555,
+		-68.571074599,   82.0359750338,   9.3496555107,   47.9456096605,
+		 39.3703274134, -35.364903257,   -6.6543490743,  -23.9728048165));
+	optimized[0] += 0.035955884801;
+	return optimized;
+}
+
+float4 ReduceMoments(float4 a, float4 b, float4 c, float4 d)
 {
 	return (a + b + c + d) * 0.25;
 }
 
-groupshared float2 g_scratchDepths[8][8];
+groupshared float4 g_scratchDepths[8][8];
 
 #if defined(DOWNSAMPLE_SHADOW_MIP0)
 static const uint CASCADE = 1;
@@ -47,12 +71,12 @@ static const uint CASCADE = 0;
 	float4 esramDepths = ESRAMShadow.GatherRed(LinearSampler, float3(uv, CASCADE));
 	depths = min(depths, esramDepths);
 
-	float2 vsmDepth = 0;
+	float4 msmMoments = 0;
 	for (uint i = 0; i < 4; i++)
-		vsmDepth += GetVSMMoments(depths[i]);
-	vsmDepth *= 0.25;
+		msmMoments += GetOptimizedMoments(depths[i]);
+	msmMoments *= 0.25;
 
-	g_scratchDepths[groupThreadID.x][groupThreadID.y] = vsmDepth;
+	g_scratchDepths[groupThreadID.x][groupThreadID.y] = msmMoments;
 
 	GroupMemoryBarrierWithGroupSync();
 

--- a/features/Volumetric Shadows/Shaders/VolumetricShadows/DownsampleShadowCS.hlsl
+++ b/features/Volumetric Shadows/Shaders/VolumetricShadows/DownsampleShadowCS.hlsl
@@ -3,11 +3,12 @@ Texture2DArray<float> ESRAMShadow : register(t1);
 RWTexture2D<float4> OutputTexture : register(u0);
 SamplerState LinearSampler : register(s0);
 
-cbuffer VSMLinearizeCB : register(b0)
+cbuffer EVSMLinearizeCB : register(b0)
 {
 	float CascadeNear;
 	float CascadeFar;
-	float2 _pad;
+	float ExponentPositive;
+	float ExponentNegative;
 };
 
 float LinearizeDepth(float depth)
@@ -16,20 +17,14 @@ float LinearizeDepth(float depth)
 	return (linZ - CascadeNear) / (CascadeFar - CascadeNear);
 }
 
-// Compute 4 power moments with RGBA16 quantization optimization
-// Reference: Peters, "Moment Shadow Mapping" (I3D 2015)
-float4 GetOptimizedMoments(in float depth)
+// Warp depth into EVSM moments: (e^(c*z), e^(2c*z), e^(-c*z), e^(-2c*z))
+// Positive exponent detects front-face occlusion, negative detects back-face (light bleeding).
+float4 WarpDepth(float depth)
 {
 	float d = LinearizeDepth(depth);
-	float d2 = d * d;
-	float4 moments = float4(d, d2, d * d2, d2 * d2);
-	float4 optimized = mul(moments, float4x4(
-		-2.07224649,     13.7948857237,   0.105877704,    9.7924062118,
-		 32.23703778,   -59.4683975703,  -1.9077466311,  -33.7652110555,
-		-68.571074599,   82.0359750338,   9.3496555107,   47.9456096605,
-		 39.3703274134, -35.364903257,   -6.6543490743,  -23.9728048165));
-	optimized[0] += 0.035955884801;
-	return optimized;
+	float posWarp = exp(ExponentPositive * d);
+	float negWarp = exp(-ExponentNegative * d);
+	return float4(posWarp, posWarp * posWarp, negWarp, negWarp * negWarp);
 }
 
 float4 ReduceMoments(float4 a, float4 b, float4 c, float4 d)
@@ -71,12 +66,12 @@ static const uint CASCADE = 0;
 	float4 esramDepths = ESRAMShadow.GatherRed(LinearSampler, float3(uv, CASCADE));
 	depths = min(depths, esramDepths);
 
-	float4 msmMoments = 0;
+	float4 evsmMoments = 0;
 	for (uint i = 0; i < 4; i++)
-		msmMoments += GetOptimizedMoments(depths[i]);
-	msmMoments *= 0.25;
+		evsmMoments += WarpDepth(depths[i]);
+	evsmMoments *= 0.25;
 
-	g_scratchDepths[groupThreadID.x][groupThreadID.y] = msmMoments;
+	g_scratchDepths[groupThreadID.x][groupThreadID.y] = evsmMoments;
 
 	GroupMemoryBarrierWithGroupSync();
 

--- a/features/Volumetric Shadows/Shaders/VolumetricShadows/VolumetricShadows.hlsli
+++ b/features/Volumetric Shadows/Shaders/VolumetricShadows/VolumetricShadows.hlsli
@@ -11,10 +11,13 @@ namespace VolumetricShadows
 	static const float EVSM_VARIANCE_BIAS = 0.001;
 	static const float EVSM_LIGHT_BLEED_REDUCTION = 0.3;
 
-	float LinearizeDepth(float depth, float cascadeNear, float cascadeFar)
+	// Convert orthographic shadow projection depth to globally-normalized [0,1].
+	// positionLS.z from mul(ShadowProj, worldPos) is orthographic [0,1] within the cascade.
+	// We remap through world space to the same global range used during moment generation.
+	float NormalizeDepth(float depth, float cascadeNear, float cascadeFar, float globalNear, float globalFar)
 	{
-		float linZ = cascadeNear * cascadeFar / (cascadeFar - depth * (cascadeFar - cascadeNear));
-		return (linZ - cascadeNear) / (cascadeFar - cascadeNear);
+		float worldZ = cascadeNear + depth * (cascadeFar - cascadeNear);
+		return (worldZ - globalNear) / (globalFar - globalNear);
 	}
 
 	// Chebyshev upper bound: P(x >= t) <= variance / (variance + (t - mean)^2)
@@ -35,9 +38,9 @@ namespace VolumetricShadows
 
 	// Compute EVSM shadow from stored moments
 	// moments = (E[e^cz], E[e^2cz], E[e^-cz], E[e^-2cz])
-	float ComputeEVSM(float4 moments, float depth, float cascadeNear, float cascadeFar)
+	float ComputeEVSM(float4 moments, float depth, float cascadeNear, float cascadeFar, float globalNear, float globalFar)
 	{
-		float d = LinearizeDepth(depth, cascadeNear, cascadeFar);
+		float d = NormalizeDepth(depth, cascadeNear, cascadeFar, globalNear, globalFar);
 		float posWarp = exp(EVSM_EXPONENT_POS * d);
 		float negWarp = exp(-EVSM_EXPONENT_NEG * d);
 
@@ -45,7 +48,6 @@ namespace VolumetricShadows
 		float posShadow = ChebyshevUpperBound(moments.x, moments.y, posWarp);
 
 		// Negative exponent test (back-face light bleed suppression)
-		// For negative warp, smaller values are "deeper", so the comparison inverts
 		float negShadow = ChebyshevUpperBound(moments.z, moments.w, negWarp);
 
 		return min(posShadow, negShadow);
@@ -61,6 +63,8 @@ namespace VolumetricShadows
 		float3 endPositionLS,
 		float cascadeNear,
 		float cascadeFar,
+		float globalNear,
+		float globalFar,
 		out float firstSample)
 	{
 		float shadow = 0.0;
@@ -72,7 +76,7 @@ namespace VolumetricShadows
 			float3 samplePosLS = lerp(endPositionLS, startPositionLS, t);
 
 			float4 moments = SharedShadowMap.SampleLevel(LinearSampler, samplePosLS.xy, 1u - cascadeIndex);
-			float lit = ComputeEVSM(moments, samplePosLS.z, cascadeNear, cascadeFar);
+			float lit = ComputeEVSM(moments, samplePosLS.z, cascadeNear, cascadeFar, globalNear, globalFar);
 
 			// Last to set firstSample is start position
 			firstSample = lit;
@@ -115,6 +119,9 @@ namespace VolumetricShadows
 		bool needsBlending = (cascadeSelect > 0.0) && (cascadeSelect < 1.0);
 
 		float4 depthParams = directionalShadowLightData.CascadeDepthParams;
+		float4 globalParams = directionalShadowLightData.GlobalDepthParams;
+		float globalNear = globalParams.x;
+		float globalFar = globalParams.y;
 
 		// Transform ray to light space for primary cascade
 		float4x4 shadowProj = directionalShadowLightData.ShadowProj[primaryCascade];
@@ -128,7 +135,7 @@ namespace VolumetricShadows
 
 		// Sample primary cascade
 		float primaryFirstSample;
-		float shadow = SampleEVSMCascade3D(primaryCascade, noise, sampleCount, rcpSampleCount, startLS, endLS, primaryNear, primaryFar, primaryFirstSample);
+		float shadow = SampleEVSMCascade3D(primaryCascade, noise, sampleCount, rcpSampleCount, startLS, endLS, primaryNear, primaryFar, globalNear, globalFar, primaryFirstSample);
 		surfaceShadow = primaryFirstSample;
 
 		// Blend with secondary cascade if needed
@@ -146,7 +153,7 @@ namespace VolumetricShadows
 			float secondaryFar = secondaryCascade == 0 ? depthParams.y : depthParams.w;
 
 			float secondaryFirstSample;
-			float shadowBlend = SampleEVSMCascade3D(secondaryCascade, noise, sampleCount, rcpSampleCount, startLS, endLS, secondaryNear, secondaryFar, secondaryFirstSample);
+			float shadowBlend = SampleEVSMCascade3D(secondaryCascade, noise, sampleCount, rcpSampleCount, startLS, endLS, secondaryNear, secondaryFar, globalNear, globalFar, secondaryFirstSample);
 			shadow = lerp(shadow, shadowBlend, cascadeSelect);
 			surfaceShadow = lerp(surfaceShadow, secondaryFirstSample, cascadeSelect);
 		}
@@ -158,10 +165,10 @@ namespace VolumetricShadows
 	}
 
 	// Sample a single cascade for EVSM shadow (2D point sample)
-	float SampleEVSMCascade2D(uint cascadeIndex, float3 positionLS, float cascadeNear, float cascadeFar)
+	float SampleEVSMCascade2D(uint cascadeIndex, float3 positionLS, float cascadeNear, float cascadeFar, float globalNear, float globalFar)
 	{
 		float4 moments = SharedShadowMap.SampleLevel(LinearSampler, positionLS.xy, 1u - cascadeIndex);
-		return ComputeEVSM(moments, positionLS.z, cascadeNear, cascadeFar);
+		return ComputeEVSM(moments, positionLS.z, cascadeNear, cascadeFar, globalNear, globalFar);
 	}
 
 	float GetVSMShadow2D(float3 position, out float detailedShadow)
@@ -190,6 +197,9 @@ namespace VolumetricShadows
 		bool needsBlending = (cascadeSelect > 0.0) && (cascadeSelect < 1.0);
 
 		float4 depthParams = directionalShadowLightData.CascadeDepthParams;
+		float4 globalParams = directionalShadowLightData.GlobalDepthParams;
+		float globalNear = globalParams.x;
+		float globalFar = globalParams.y;
 
 		// Transform position to light space for primary cascade
 		float3 positionLS = mul(directionalShadowLightData.ShadowProj[primaryCascade], float4(positionWS, 1)).xyz;
@@ -199,7 +209,7 @@ namespace VolumetricShadows
 		float primaryFar = primaryCascade == 0 ? depthParams.y : depthParams.w;
 
 		// Sample primary cascade
-		float shadow = SampleEVSMCascade2D(primaryCascade, positionLS, primaryNear, primaryFar);
+		float shadow = SampleEVSMCascade2D(primaryCascade, positionLS, primaryNear, primaryFar, globalNear, globalFar);
 
 		// Blend with secondary cascade if needed
 		[branch] if (needsBlending)
@@ -212,7 +222,7 @@ namespace VolumetricShadows
 			float secondaryNear = secondaryCascade == 0 ? depthParams.x : depthParams.z;
 			float secondaryFar = secondaryCascade == 0 ? depthParams.y : depthParams.w;
 
-			float shadowBlend = SampleEVSMCascade2D(secondaryCascade, positionLS, secondaryNear, secondaryFar);
+			float shadowBlend = SampleEVSMCascade2D(secondaryCascade, positionLS, secondaryNear, secondaryFar, globalNear, globalFar);
 			shadow = lerp(shadow, shadowBlend, cascadeSelect);
 		}
 

--- a/features/Volumetric Shadows/Shaders/VolumetricShadows/VolumetricShadows.hlsli
+++ b/features/Volumetric Shadows/Shaders/VolumetricShadows/VolumetricShadows.hlsli
@@ -5,7 +5,11 @@ namespace VolumetricShadows
 {
 	Texture2D<float4> SharedShadowMap : register(t18);
 
-	static const float MSM_MOMENT_BIAS = 0.003;
+	// EVSM exponents — must match values set in C++ (VolumetricShadows.h)
+	static const float EVSM_EXPONENT_POS = 40.0;
+	static const float EVSM_EXPONENT_NEG = 5.0;
+	static const float EVSM_VARIANCE_BIAS = 0.001;
+	static const float EVSM_LIGHT_BLEED_REDUCTION = 0.3;
 
 	float LinearizeDepth(float depth, float cascadeNear, float cascadeFar)
 	{
@@ -13,66 +17,42 @@ namespace VolumetricShadows
 		return (linZ - cascadeNear) / (cascadeFar - cascadeNear);
 	}
 
-	// Inverse RGBA16 quantization: recover power moments from optimized storage
-	// Reference: Peters, "Moment Shadow Mapping" (I3D 2015)
-	float4 ConvertOptimizedMoments(float4 optimizedMoments)
+	// Chebyshev upper bound: P(x >= t) <= variance / (variance + (t - mean)^2)
+	// Returns visibility [0,1] where 1 = fully lit
+	float ChebyshevUpperBound(float mean, float meanSq, float testValue)
 	{
-		optimizedMoments[0] -= 0.035955884801;
-		return mul(optimizedMoments, float4x4(
-			0.2227744146,  0.1549679261,  0.1451988946,  0.163127443,
-			0.0771972861,  0.1394629426,  0.2120202157,  0.2591432266,
-			0.7926986636,  0.7963415838,  0.7258694464,  0.6539092497,
-			0.0319417555, -0.1722823173, -0.2758014811, -0.3376131734));
+		float variance = max(meanSq - mean * mean, EVSM_VARIANCE_BIAS);
+
+		float d = testValue - mean;
+		float pMax = variance / (variance + d * d);
+
+		// Reduce light bleeding by remapping [bleedReduction..1] -> [0..1]
+		pMax = saturate((pMax - EVSM_LIGHT_BLEED_REDUCTION) / (1.0 - EVSM_LIGHT_BLEED_REDUCTION));
+
+		// If the test value is behind the mean, it's fully lit
+		return (testValue <= mean) ? 1.0 : pMax;
 	}
 
-	// Hamburger 4-moment shadow reconstruction
-	// Reference: Peters, "Moment Shadow Mapping" (I3D 2015)
-	float ComputeMSM(float4 optimizedMoments, float depth)
+	// Compute EVSM shadow from stored moments
+	// moments = (E[e^cz], E[e^2cz], E[e^-cz], E[e^-2cz])
+	float ComputeEVSM(float4 moments, float depth, float cascadeNear, float cascadeFar)
 	{
-		float4 b = ConvertOptimizedMoments(optimizedMoments);
+		float d = LinearizeDepth(depth, cascadeNear, cascadeFar);
+		float posWarp = exp(EVSM_EXPONENT_POS * d);
+		float negWarp = exp(-EVSM_EXPONENT_NEG * d);
 
-		// Bias moments to reduce light bleeding
-		b = lerp(b, 0.5, MSM_MOMENT_BIAS);
+		// Positive exponent test (standard front-face shadow)
+		float posShadow = ChebyshevUpperBound(moments.x, moments.y, posWarp);
 
-		float3 z;
-		z[0] = depth;
+		// Negative exponent test (back-face light bleed suppression)
+		// For negative warp, smaller values are "deeper", so the comparison inverts
+		float negShadow = ChebyshevUpperBound(moments.z, moments.w, negWarp);
 
-		// Cholesky factorization of the Hankel matrix
-		float L32D22 = mad(-b[0], b[1], b[2]);
-		float D22 = mad(-b[0], b[0], b[1]);
-		float squaredDepthVariance = mad(-b[1], b[1], b[3]);
-		float D33D22 = dot(float2(squaredDepthVariance, -L32D22), float2(D22, L32D22));
-		float InvD22 = 1.0 / D22;
-		float L32 = L32D22 * InvD22;
-
-		// Solve for the quadratic polynomial whose roots give the 2-point distribution
-		float3 c = float3(1.0, z[0], z[0] * z[0]);
-		c[1] -= b.x;
-		c[2] -= b.y + L32 * c[1];
-		c[1] *= InvD22;
-		c[2] *= D22 / D33D22;
-		c[1] -= L32 * c[2];
-		c[0] -= dot(c.yz, b.xy);
-
-		float p = c[1] / c[2];
-		float q = c[0] / c[2];
-		float D = (p * p * 0.25) - q;
-		float r = sqrt(max(D, 0.0));
-		z[1] = -p * 0.5 - r;
-		z[2] = -p * 0.5 + r;
-
-		// Compute shadow intensity from the 2-point distribution
-		float4 switchVal = (z[2] < z[0]) ? float4(z[1], z[0], 1.0, 1.0) :
-		                  ((z[1] < z[0]) ? float4(z[0], z[1], 0.0, 1.0) :
-		                  float4(0.0, 0.0, 0.0, 0.0));
-		float quotient = (switchVal[0] * z[2] - b[0] * (switchVal[0] + z[2]) + b[1])
-		                 / ((z[2] - switchVal[1]) * (z[0] - z[1]));
-		float shadowIntensity = switchVal[2] + switchVal[3] * quotient;
-		return 1.0 - saturate(shadowIntensity);
+		return min(posShadow, negShadow);
 	}
 
-	// Sample a single cascade for MSM shadow
-	float SampleVSMCascade3D(
+	// Sample a single cascade for EVSM shadow (3D ray march)
+	float SampleEVSMCascade3D(
 		uint cascadeIndex,
 		float noise,
 		uint sampleCount,
@@ -92,8 +72,7 @@ namespace VolumetricShadows
 			float3 samplePosLS = lerp(endPositionLS, startPositionLS, t);
 
 			float4 moments = SharedShadowMap.SampleLevel(LinearSampler, samplePosLS.xy, 1u - cascadeIndex);
-			float depth = LinearizeDepth(samplePosLS.z, cascadeNear, cascadeFar);
-			float lit = ComputeMSM(moments, depth);
+			float lit = ComputeEVSM(moments, samplePosLS.z, cascadeNear, cascadeFar);
 
 			// Last to set firstSample is start position
 			firstSample = lit;
@@ -149,7 +128,7 @@ namespace VolumetricShadows
 
 		// Sample primary cascade
 		float primaryFirstSample;
-		float shadow = SampleVSMCascade3D(primaryCascade, noise, sampleCount, rcpSampleCount, startLS, endLS, primaryNear, primaryFar, primaryFirstSample);
+		float shadow = SampleEVSMCascade3D(primaryCascade, noise, sampleCount, rcpSampleCount, startLS, endLS, primaryNear, primaryFar, primaryFirstSample);
 		surfaceShadow = primaryFirstSample;
 
 		// Blend with secondary cascade if needed
@@ -167,7 +146,7 @@ namespace VolumetricShadows
 			float secondaryFar = secondaryCascade == 0 ? depthParams.y : depthParams.w;
 
 			float secondaryFirstSample;
-			float shadowBlend = SampleVSMCascade3D(secondaryCascade, noise, sampleCount, rcpSampleCount, startLS, endLS, secondaryNear, secondaryFar, secondaryFirstSample);
+			float shadowBlend = SampleEVSMCascade3D(secondaryCascade, noise, sampleCount, rcpSampleCount, startLS, endLS, secondaryNear, secondaryFar, secondaryFirstSample);
 			shadow = lerp(shadow, shadowBlend, cascadeSelect);
 			surfaceShadow = lerp(surfaceShadow, secondaryFirstSample, cascadeSelect);
 		}
@@ -178,12 +157,11 @@ namespace VolumetricShadows
 		return lerp(1.0, shadow, fadeFactor);
 	}
 
-	// Sample a single cascade for MSM shadow (2D point sample)
-	float SampleVSMCascade2D(uint cascadeIndex, float3 positionLS, float cascadeNear, float cascadeFar)
+	// Sample a single cascade for EVSM shadow (2D point sample)
+	float SampleEVSMCascade2D(uint cascadeIndex, float3 positionLS, float cascadeNear, float cascadeFar)
 	{
 		float4 moments = SharedShadowMap.SampleLevel(LinearSampler, positionLS.xy, 1u - cascadeIndex);
-		float depth = LinearizeDepth(positionLS.z, cascadeNear, cascadeFar);
-		return ComputeMSM(moments, depth);
+		return ComputeEVSM(moments, positionLS.z, cascadeNear, cascadeFar);
 	}
 
 	float GetVSMShadow2D(float3 position, out float detailedShadow)
@@ -221,7 +199,7 @@ namespace VolumetricShadows
 		float primaryFar = primaryCascade == 0 ? depthParams.y : depthParams.w;
 
 		// Sample primary cascade
-		float shadow = SampleVSMCascade2D(primaryCascade, positionLS, primaryNear, primaryFar);
+		float shadow = SampleEVSMCascade2D(primaryCascade, positionLS, primaryNear, primaryFar);
 
 		// Blend with secondary cascade if needed
 		[branch] if (needsBlending)
@@ -234,7 +212,7 @@ namespace VolumetricShadows
 			float secondaryNear = secondaryCascade == 0 ? depthParams.x : depthParams.z;
 			float secondaryFar = secondaryCascade == 0 ? depthParams.y : depthParams.w;
 
-			float shadowBlend = SampleVSMCascade2D(secondaryCascade, positionLS, secondaryNear, secondaryFar);
+			float shadowBlend = SampleEVSMCascade2D(secondaryCascade, positionLS, secondaryNear, secondaryFar);
 			shadow = lerp(shadow, shadowBlend, cascadeSelect);
 		}
 

--- a/features/Volumetric Shadows/Shaders/VolumetricShadows/VolumetricShadows.hlsli
+++ b/features/Volumetric Shadows/Shaders/VolumetricShadows/VolumetricShadows.hlsli
@@ -1,33 +1,77 @@
 #ifndef __VOLUMETRIC_SHADOWS_HLSLI__
 #define __VOLUMETRIC_SHADOWS_HLSLI__
 
-// Variance Shadow Maps (VSM)
-// Chebyshev's inequality on filtered depth moments
-
 namespace VolumetricShadows
 {
-	Texture2D<float2> SharedShadowMap : register(t18);
+	Texture2D<float4> SharedShadowMap : register(t18);
 
-	static const float VSM_MIN_VARIANCE = 0.00001;
-	static const float VSM_BLEEDING_REDUCTION = 0.2;
+	static const float MSM_MOMENT_BIAS = 0.003;
 
-	// Chebyshev upper bound on P(X >= t)
-	// moments.x = mean(z), moments.y = mean(z^2)
-	float ComputeVSM(float2 moments, float depth)
+	float LinearizeDepth(float depth, float cascadeNear, float cascadeFar)
 	{
-		float variance = max(moments.y - moments.x * moments.x, VSM_MIN_VARIANCE);
-		float d = depth - moments.x;
-		float pMax = variance / (variance + d * d);
-		return (depth <= moments.x) ? 1.0 : pMax;
+		float linZ = cascadeNear * cascadeFar / (cascadeFar - depth * (cascadeFar - cascadeNear));
+		return (linZ - cascadeNear) / (cascadeFar - cascadeNear);
 	}
 
-	// Reduces light bleeding by remapping shadow values below a threshold to zero
-	float ReduceBleeding(float shadow, float amount)
+	// Inverse RGBA16 quantization: recover power moments from optimized storage
+	// Reference: Peters, "Moment Shadow Mapping" (I3D 2015)
+	float4 ConvertOptimizedMoments(float4 optimizedMoments)
 	{
-		return saturate((shadow - amount) / (1.0 - amount));
+		optimizedMoments[0] -= 0.035955884801;
+		return mul(optimizedMoments, float4x4(
+			0.2227744146,  0.1549679261,  0.1451988946,  0.163127443,
+			0.0771972861,  0.1394629426,  0.2120202157,  0.2591432266,
+			0.7926986636,  0.7963415838,  0.7258694464,  0.6539092497,
+			0.0319417555, -0.1722823173, -0.2758014811, -0.3376131734));
 	}
 
-	// Sample a single cascade for VSM shadow
+	// Hamburger 4-moment shadow reconstruction
+	// Reference: Peters, "Moment Shadow Mapping" (I3D 2015)
+	float ComputeMSM(float4 optimizedMoments, float depth)
+	{
+		float4 b = ConvertOptimizedMoments(optimizedMoments);
+
+		// Bias moments to reduce light bleeding
+		b = lerp(b, 0.5, MSM_MOMENT_BIAS);
+
+		float3 z;
+		z[0] = depth;
+
+		// Cholesky factorization of the Hankel matrix
+		float L32D22 = mad(-b[0], b[1], b[2]);
+		float D22 = mad(-b[0], b[0], b[1]);
+		float squaredDepthVariance = mad(-b[1], b[1], b[3]);
+		float D33D22 = dot(float2(squaredDepthVariance, -L32D22), float2(D22, L32D22));
+		float InvD22 = 1.0 / D22;
+		float L32 = L32D22 * InvD22;
+
+		// Solve for the quadratic polynomial whose roots give the 2-point distribution
+		float3 c = float3(1.0, z[0], z[0] * z[0]);
+		c[1] -= b.x;
+		c[2] -= b.y + L32 * c[1];
+		c[1] *= InvD22;
+		c[2] *= D22 / D33D22;
+		c[1] -= L32 * c[2];
+		c[0] -= dot(c.yz, b.xy);
+
+		float p = c[1] / c[2];
+		float q = c[0] / c[2];
+		float D = (p * p * 0.25) - q;
+		float r = sqrt(max(D, 0.0));
+		z[1] = -p * 0.5 - r;
+		z[2] = -p * 0.5 + r;
+
+		// Compute shadow intensity from the 2-point distribution
+		float4 switchVal = (z[2] < z[0]) ? float4(z[1], z[0], 1.0, 1.0) :
+		                  ((z[1] < z[0]) ? float4(z[0], z[1], 0.0, 1.0) :
+		                  float4(0.0, 0.0, 0.0, 0.0));
+		float quotient = (switchVal[0] * z[2] - b[0] * (switchVal[0] + z[2]) + b[1])
+		                 / ((z[2] - switchVal[1]) * (z[0] - z[1]));
+		float shadowIntensity = switchVal[2] + switchVal[3] * quotient;
+		return 1.0 - saturate(shadowIntensity);
+	}
+
+	// Sample a single cascade for MSM shadow
 	float SampleVSMCascade3D(
 		uint cascadeIndex,
 		float noise,
@@ -35,6 +79,8 @@ namespace VolumetricShadows
 		float rcpSampleCount,
 		float3 startPositionLS,
 		float3 endPositionLS,
+		float cascadeNear,
+		float cascadeFar,
 		out float firstSample)
 	{
 		float shadow = 0.0;
@@ -45,8 +91,9 @@ namespace VolumetricShadows
 			float t = (float(k) + noise) * rcpSampleCount;
 			float3 samplePosLS = lerp(endPositionLS, startPositionLS, t);
 
-			float2 moments = SharedShadowMap.SampleLevel(LinearSampler, samplePosLS.xy, 1u - cascadeIndex);
-			float lit = ComputeVSM(moments, samplePosLS.z);
+			float4 moments = SharedShadowMap.SampleLevel(LinearSampler, samplePosLS.xy, 1u - cascadeIndex);
+			float depth = LinearizeDepth(samplePosLS.z, cascadeNear, cascadeFar);
+			float lit = ComputeMSM(moments, depth);
 
 			// Last to set firstSample is start position
 			firstSample = lit;
@@ -88,6 +135,8 @@ namespace VolumetricShadows
 		uint primaryCascade = uint(cascadeSelect);
 		bool needsBlending = (cascadeSelect > 0.0) && (cascadeSelect < 1.0);
 
+		float4 depthParams = directionalShadowLightData.CascadeDepthParams;
+
 		// Transform ray to light space for primary cascade
 		float4x4 shadowProj = directionalShadowLightData.ShadowProj[primaryCascade];
 		float3 startLS = mul(shadowProj, float4(startPosition, 1)).xyz;
@@ -95,9 +144,12 @@ namespace VolumetricShadows
 		startLS.xy = saturate(startLS.xy);
 		endLS.xy = saturate(endLS.xy);
 
+		float primaryNear = primaryCascade == 0 ? depthParams.x : depthParams.z;
+		float primaryFar = primaryCascade == 0 ? depthParams.y : depthParams.w;
+
 		// Sample primary cascade
 		float primaryFirstSample;
-		float shadow = SampleVSMCascade3D(primaryCascade, noise, sampleCount, rcpSampleCount, startLS, endLS, primaryFirstSample);
+		float shadow = SampleVSMCascade3D(primaryCascade, noise, sampleCount, rcpSampleCount, startLS, endLS, primaryNear, primaryFar, primaryFirstSample);
 		surfaceShadow = primaryFirstSample;
 
 		// Blend with secondary cascade if needed
@@ -111,8 +163,11 @@ namespace VolumetricShadows
 			startLS.xy = saturate(startLS.xy);
 			endLS.xy = saturate(endLS.xy);
 
+			float secondaryNear = secondaryCascade == 0 ? depthParams.x : depthParams.z;
+			float secondaryFar = secondaryCascade == 0 ? depthParams.y : depthParams.w;
+
 			float secondaryFirstSample;
-			float shadowBlend = SampleVSMCascade3D(secondaryCascade, noise, sampleCount, rcpSampleCount, startLS, endLS, secondaryFirstSample);
+			float shadowBlend = SampleVSMCascade3D(secondaryCascade, noise, sampleCount, rcpSampleCount, startLS, endLS, secondaryNear, secondaryFar, secondaryFirstSample);
 			shadow = lerp(shadow, shadowBlend, cascadeSelect);
 			surfaceShadow = lerp(surfaceShadow, secondaryFirstSample, cascadeSelect);
 		}
@@ -123,11 +178,12 @@ namespace VolumetricShadows
 		return lerp(1.0, shadow, fadeFactor);
 	}
 
-	// Sample a single cascade for VSM shadow (2D point sample)
-	float SampleVSMCascade2D(uint cascadeIndex, float3 positionLS)
+	// Sample a single cascade for MSM shadow (2D point sample)
+	float SampleVSMCascade2D(uint cascadeIndex, float3 positionLS, float cascadeNear, float cascadeFar)
 	{
-		float2 moments = SharedShadowMap.SampleLevel(LinearSampler, positionLS.xy, 1u - cascadeIndex);
-		return ComputeVSM(moments, positionLS.z);
+		float4 moments = SharedShadowMap.SampleLevel(LinearSampler, positionLS.xy, 1u - cascadeIndex);
+		float depth = LinearizeDepth(positionLS.z, cascadeNear, cascadeFar);
+		return ComputeMSM(moments, depth);
 	}
 
 	float GetVSMShadow2D(float3 position, out float detailedShadow)
@@ -155,12 +211,17 @@ namespace VolumetricShadows
 		uint primaryCascade = uint(cascadeSelect);
 		bool needsBlending = (cascadeSelect > 0.0) && (cascadeSelect < 1.0);
 
+		float4 depthParams = directionalShadowLightData.CascadeDepthParams;
+
 		// Transform position to light space for primary cascade
 		float3 positionLS = mul(directionalShadowLightData.ShadowProj[primaryCascade], float4(positionWS, 1)).xyz;
 		positionLS.xy = saturate(positionLS.xy);
 
+		float primaryNear = primaryCascade == 0 ? depthParams.x : depthParams.z;
+		float primaryFar = primaryCascade == 0 ? depthParams.y : depthParams.w;
+
 		// Sample primary cascade
-		float shadow = SampleVSMCascade2D(primaryCascade, positionLS);
+		float shadow = SampleVSMCascade2D(primaryCascade, positionLS, primaryNear, primaryFar);
 
 		// Blend with secondary cascade if needed
 		[branch] if (needsBlending)
@@ -170,14 +231,17 @@ namespace VolumetricShadows
 			positionLS = mul(directionalShadowLightData.ShadowProj[secondaryCascade], float4(positionWS, 1)).xyz;
 			positionLS.xy = saturate(positionLS.xy);
 
-			float shadowBlend = SampleVSMCascade2D(secondaryCascade, positionLS);
+			float secondaryNear = secondaryCascade == 0 ? depthParams.x : depthParams.z;
+			float secondaryFar = secondaryCascade == 0 ? depthParams.y : depthParams.w;
+
+			float shadowBlend = SampleVSMCascade2D(secondaryCascade, positionLS, secondaryNear, secondaryFar);
 			shadow = lerp(shadow, shadowBlend, cascadeSelect);
 		}
 
 		// Apply distance fade
 		float fadeFactor = 1.0 - pow(fade * fade, 8);
-		detailedShadow = lerp(1.0, ReduceBleeding(shadow, VSM_BLEEDING_REDUCTION), fadeFactor);
-		return lerp(1.0, shadow, fadeFactor);
+		detailedShadow = lerp(1.0, shadow, fadeFactor);
+		return detailedShadow;
 	}
 }
 

--- a/package/Shaders/Common/ShadowSampling.hlsli
+++ b/package/Shaders/Common/ShadowSampling.hlsli
@@ -31,6 +31,7 @@ struct DirectionalShadowLightData
 	float2 EndSplitDistances;
 	float2 StartSplitDistances;
 	float4 CascadeDepthParams;
+	float4 GlobalDepthParams;
 };
 
 StructuredBuffer<DirectionalShadowLightData> DirectionalShadowLights : register(t98);

--- a/package/Shaders/Common/ShadowSampling.hlsli
+++ b/package/Shaders/Common/ShadowSampling.hlsli
@@ -30,6 +30,7 @@ struct DirectionalShadowLightData
 	column_major float4x4 InvShadowProj[2];
 	float2 EndSplitDistances;
 	float2 StartSplitDistances;
+	float4 CascadeDepthParams;
 };
 
 StructuredBuffer<DirectionalShadowLightData> DirectionalShadowLights : register(t98);

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -8,6 +8,7 @@
 
 #include "Features/DynamicCubemaps.h"
 #include "Features/IBL.h"
+#include "Features/VolumetricShadows.h"
 #include "Features/ScreenSpaceGI.h"
 #include "Features/Skylighting.h"
 #include "Features/SubsurfaceScattering.h"
@@ -557,6 +558,8 @@ void Deferred::CopyShadowLightData()
 	dd.StartSplitDistances = { dirData.startSplitDistances[0], dirData.startSplitDistances[1] };
 
 	SetShadowCascadeParameters(sunShadowLight->GetRuntimeData(), dd);
+
+	dd.CascadeDepthParams = globals::features::volumetricShadows.GetCascadeDepthParams();
 
 	D3D11_MAPPED_SUBRESOURCE mapped{};
 	DX::ThrowIfFailed(context->Map(directionalShadowLights->resource.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -560,6 +560,7 @@ void Deferred::CopyShadowLightData()
 	SetShadowCascadeParameters(sunShadowLight->GetRuntimeData(), dd);
 
 	dd.CascadeDepthParams = globals::features::volumetricShadows.GetCascadeDepthParams();
+	dd.GlobalDepthParams = globals::features::volumetricShadows.GetGlobalDepthParams();
 
 	D3D11_MAPPED_SUBRESOURCE mapped{};
 	DX::ThrowIfFailed(context->Map(directionalShadowLights->resource.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));

--- a/src/Deferred.h
+++ b/src/Deferred.h
@@ -27,6 +27,7 @@ public:
 		float4x4 InvShadowProj[2];
 		float2 EndSplitDistances;
 		float2 StartSplitDistances;
+		float4 CascadeDepthParams;
 	};
 	STATIC_ASSERT_ALIGNAS_16(DirectionalShadowLightData);
 

--- a/src/Deferred.h
+++ b/src/Deferred.h
@@ -28,6 +28,7 @@ public:
 		float2 EndSplitDistances;
 		float2 StartSplitDistances;
 		float4 CascadeDepthParams;
+		float4 GlobalDepthParams;  // x=globalNear, y=globalFar, zw=unused
 	};
 	STATIC_ASSERT_ALIGNAS_16(DirectionalShadowLightData);
 

--- a/src/Features/VolumetricShadows.cpp
+++ b/src/Features/VolumetricShadows.cpp
@@ -8,7 +8,9 @@
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	VolumetricShadows::Settings,
-	BlurRadius)
+	BlurRadius,
+	ExponentPositive,
+	ExponentNegative)
 
 void VolumetricShadows::SetupResources()
 {
@@ -31,7 +33,7 @@ void VolumetricShadows::SetupResources()
 	// Create linearization cbuffer
 	{
 		D3D11_BUFFER_DESC cbDesc{};
-		cbDesc.ByteWidth = sizeof(VSMLinearizeCB);
+		cbDesc.ByteWidth = sizeof(EVSMLinearizeCB);
 		cbDesc.Usage = D3D11_USAGE_DYNAMIC;
 		cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
 		cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
@@ -163,7 +165,7 @@ void VolumetricShadows::CopyShadowLightData()
 		if (shadowView) {
 			constexpr uint32_t SHADOW_COPY_SIZE = 512;
 
-			// Lazily create fixed-size output textures
+			// Lazily create fixed-size output textures (RGBA16F for EVSM exponential moments)
 			if (!shadowCopyTexture) {
 				shadowCopyWidth = SHADOW_COPY_SIZE;
 				shadowCopyHeight = SHADOW_COPY_SIZE;
@@ -173,7 +175,7 @@ void VolumetricShadows::CopyShadowLightData()
 				copyDesc.Height = SHADOW_COPY_SIZE;
 				copyDesc.MipLevels = 2;
 				copyDesc.ArraySize = 1;
-				copyDesc.Format = DXGI_FORMAT_R16G16B16A16_UNORM;
+				copyDesc.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
 				copyDesc.SampleDesc.Count = 1;
 				copyDesc.SampleDesc.Quality = 0;
 				copyDesc.Usage = D3D11_USAGE_DEFAULT;
@@ -273,13 +275,15 @@ void VolumetricShadows::CopyShadowLightData()
 					// Dispatch covers full input: each thread gathers 2x2, 8 threads per group
 					auto dispatchSize = srcDesc.Width / 16;
 
-					// Mip 0 (cascade 1) - update cbuffer with cascade 1 near/far
+					// Mip 0 (cascade 1) - update cbuffer with cascade 1 near/far + exponents
 					{
 						D3D11_MAPPED_SUBRESOURCE mapped{};
 						DX::ThrowIfFailed(context->Map(linearizeCB, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));
-						auto* cb = static_cast<VSMLinearizeCB*>(mapped.pData);
+						auto* cb = static_cast<EVSMLinearizeCB*>(mapped.pData);
 						cb->CascadeNear = cascadeNear[1];
 						cb->CascadeFar = cascadeFar[1];
+						cb->ExponentPositive = settings.ExponentPositive;
+						cb->ExponentNegative = settings.ExponentNegative;
 						context->Unmap(linearizeCB, 0);
 						context->CSSetConstantBuffers(0, 1, &linearizeCB);
 					}
@@ -291,13 +295,15 @@ void VolumetricShadows::CopyShadowLightData()
 					context->Dispatch(dispatchSize, dispatchSize, 1);
 					globals::profiler->EndPass();
 
-					// Mip 1 (cascade 0) - update cbuffer with cascade 0 near/far
+					// Mip 1 (cascade 0) - update cbuffer with cascade 0 near/far + exponents
 					{
 						D3D11_MAPPED_SUBRESOURCE mapped{};
 						DX::ThrowIfFailed(context->Map(linearizeCB, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));
-						auto* cb = static_cast<VSMLinearizeCB*>(mapped.pData);
+						auto* cb = static_cast<EVSMLinearizeCB*>(mapped.pData);
 						cb->CascadeNear = cascadeNear[0];
 						cb->CascadeFar = cascadeFar[0];
+						cb->ExponentPositive = settings.ExponentPositive;
+						cb->ExponentNegative = settings.ExponentNegative;
 						context->Unmap(linearizeCB, 0);
 					}
 
@@ -446,6 +452,14 @@ void VolumetricShadows::DrawSettings()
 	if (ImGui::IsItemHovered())
 		ImGui::SetTooltip("Blur radius in world units. Both cascades are scaled to match this world-space softness.");
 
+	ImGui::SliderFloat("Positive Exponent", &settings.ExponentPositive, 1.0f, 80.0f, "%.1f");
+	if (ImGui::IsItemHovered())
+		ImGui::SetTooltip("Controls shadow sharpness. Higher = sharper shadows but more numerical instability.");
+
+	ImGui::SliderFloat("Negative Exponent", &settings.ExponentNegative, 1.0f, 40.0f, "%.1f");
+	if (ImGui::IsItemHovered())
+		ImGui::SetTooltip("Controls light bleed suppression. Higher = less light bleed but may cause artifacts.");
+
 	ImGui::SeparatorText("Debug");
 
 	if (ImGui::TreeNode("Info")) {
@@ -477,8 +491,8 @@ void VolumetricShadows::DrawSettings()
 			}
 		};
 
-		DisplayRT("MSM Cascade 0", shadowCopyTexture, shadowCopyMip0SRV);
-		DisplayRT("MSM Cascade 1", shadowCopyTexture, shadowCopyMip1SRV);
+		DisplayRT("EVSM Cascade 0", shadowCopyTexture, shadowCopyMip0SRV);
+		DisplayRT("EVSM Cascade 1", shadowCopyTexture, shadowCopyMip1SRV);
 
 		ImGui::TreePop();
 	}

--- a/src/Features/VolumetricShadows.cpp
+++ b/src/Features/VolumetricShadows.cpp
@@ -127,17 +127,10 @@ void VolumetricShadows::ExtractCascadeNearFar()
 		cascadeScale[cascadeIdx] = std::sqrt(sx * sx + sy * sy + sz * sz);
 	};
 
-	if (globals::game::isVR) {
-		auto& lightData = sunShadowLight->GetVRRuntimeData();
-		const auto count = std::min(lightData.shadowmapDescriptors.size(), 2u);
-		for (uint32_t i = 0; i < count; i++)
-			extractCascade(lightData.shadowmapDescriptors[i].camera[0].get(), lightData.shadowmapDescriptors[i].lightTransform, i);
-	} else {
-		auto& lightData = sunShadowLight->GetRuntimeData();
-		const auto count = std::min(lightData.shadowmapDescriptors.size(), 2u);
-		for (uint32_t i = 0; i < count; i++)
-			extractCascade(lightData.shadowmapDescriptors[i].camera.get(), lightData.shadowmapDescriptors[i].lightTransform, i);
-	}
+	auto& lightData = sunShadowLight->GetRuntimeData();
+	const auto count = std::min(lightData.shadowmapDescriptors.size(), 2u);
+	for (uint32_t i = 0; i < count; i++)
+		extractCascade(lightData.shadowmapDescriptors[i].camera.get(), lightData.shadowmapDescriptors[i].lightTransform, i);
 }
 
 float4 VolumetricShadows::GetCascadeDepthParams()

--- a/src/Features/VolumetricShadows.cpp
+++ b/src/Features/VolumetricShadows.cpp
@@ -4,6 +4,12 @@
 #include "State.h"
 #include "Utils/D3D.h"
 
+#include "RE/B/BSShadowDirectionalLight.h"
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+	VolumetricShadows::Settings,
+	BlurRadius)
+
 void VolumetricShadows::SetupResources()
 {
 	auto device = globals::d3d::device;
@@ -20,6 +26,28 @@ void VolumetricShadows::SetupResources()
 		samplerDesc.MaxLOD = D3D11_FLOAT32_MAX;
 		DX::ThrowIfFailed(device->CreateSamplerState(&samplerDesc, &linearSampler));
 		Util::SetResourceName(linearSampler, "VolumetricShadows::LinearSampler");
+	}
+
+	// Create linearization cbuffer
+	{
+		D3D11_BUFFER_DESC cbDesc{};
+		cbDesc.ByteWidth = sizeof(VSMLinearizeCB);
+		cbDesc.Usage = D3D11_USAGE_DYNAMIC;
+		cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+		cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+		DX::ThrowIfFailed(device->CreateBuffer(&cbDesc, nullptr, &linearizeCB));
+		Util::SetResourceName(linearizeCB, "VolumetricShadows::LinearizeCB");
+	}
+
+	// Create blur cbuffer
+	{
+		D3D11_BUFFER_DESC cbDesc{};
+		cbDesc.ByteWidth = sizeof(BlurCB);
+		cbDesc.Usage = D3D11_USAGE_DYNAMIC;
+		cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+		cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+		DX::ThrowIfFailed(device->CreateBuffer(&cbDesc, nullptr, &blurCB));
+		Util::SetResourceName(blurCB, "VolumetricShadows::BlurCB");
 	}
 
 	// Compile compute shaders
@@ -72,6 +100,50 @@ void VolumetricShadows::ClearShaderCache()
 	blurShadowVerticalCS = static_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\VolumetricShadows\\BlurShadowCS.hlsl", defines, "cs_5_0"));
 }
 
+void VolumetricShadows::ExtractCascadeNearFar()
+{
+	auto* shadowSceneNode = globals::game::smState->shadowSceneNode[0];
+	if (!shadowSceneNode)
+		return;
+
+	auto* sunShadowLight = shadowSceneNode->GetRuntimeData().sunShadowDirLight;
+	if (!sunShadowLight)
+		return;
+
+	auto extractCascade = [&](RE::NiCamera* camera, const REX::W32::XMFLOAT4X4& transform, uint32_t cascadeIdx) {
+		if (camera) {
+			auto& frustum = camera->GetRuntimeData2().viewFrustum;
+			cascadeNear[cascadeIdx] = frustum.fNear;
+			cascadeFar[cascadeIdx] = frustum.fFar;
+		}
+		// Extract world-to-UV scale from shadow projection matrix
+		// Column 0 of the effective HLSL matrix = row 0 cross rows of C++ row-major storage
+		// The UV-per-world-unit scale is the length of the first output component's gradient
+		float sx = transform.m[0][0];
+		float sy = transform.m[1][0];
+		float sz = transform.m[2][0];
+		cascadeScale[cascadeIdx] = std::sqrt(sx * sx + sy * sy + sz * sz);
+	};
+
+	if (globals::game::isVR) {
+		auto& lightData = sunShadowLight->GetVRRuntimeData();
+		const auto count = std::min(lightData.shadowmapDescriptors.size(), 2u);
+		for (uint32_t i = 0; i < count; i++)
+			extractCascade(lightData.shadowmapDescriptors[i].camera[0].get(), lightData.shadowmapDescriptors[i].lightTransform, i);
+	} else {
+		auto& lightData = sunShadowLight->GetRuntimeData();
+		const auto count = std::min(lightData.shadowmapDescriptors.size(), 2u);
+		for (uint32_t i = 0; i < count; i++)
+			extractCascade(lightData.shadowmapDescriptors[i].camera.get(), lightData.shadowmapDescriptors[i].lightTransform, i);
+	}
+}
+
+float4 VolumetricShadows::GetCascadeDepthParams()
+{
+	ExtractCascadeNearFar();
+	return { cascadeNear[0], cascadeFar[0], cascadeNear[1], cascadeFar[1] };
+}
+
 void VolumetricShadows::CopyShadowLightData()
 {
 	ZoneScoped;
@@ -87,7 +159,7 @@ void VolumetricShadows::CopyShadowLightData()
 
 		context->PSGetShaderResources(4, 1, &shadowView);
 
-		// Downsample shadow texture array to fixed 512x512 (mip1: 256x256)
+		// Downsample shadow texture array to fixed size
 		if (shadowView) {
 			constexpr uint32_t SHADOW_COPY_SIZE = 512;
 
@@ -101,7 +173,7 @@ void VolumetricShadows::CopyShadowLightData()
 				copyDesc.Height = SHADOW_COPY_SIZE;
 				copyDesc.MipLevels = 2;
 				copyDesc.ArraySize = 1;
-				copyDesc.Format = DXGI_FORMAT_R16G16_UNORM;
+				copyDesc.Format = DXGI_FORMAT_R16G16B16A16_UNORM;
 				copyDesc.SampleDesc.Count = 1;
 				copyDesc.SampleDesc.Quality = 0;
 				copyDesc.Usage = D3D11_USAGE_DEFAULT;
@@ -166,6 +238,17 @@ void VolumetricShadows::CopyShadowLightData()
 				Util::SetResourceName(shadowBlurTempMip1UAV, "VolumetricShadows::ShadowBlurTemp UAV mip1");
 			}
 
+			// Extract cascade near/far and projection scale
+			ExtractCascadeNearFar();
+
+			// Compute per-cascade blur radii for consistent world-space softness
+			// Mip 0 (512x512) = cascade 1, Mip 1 (256x256) = cascade 0
+			// pixelRadius = worldRadius * cascadeScale * textureSize
+			uint32_t blurRadiusMip0 = std::max(1u, std::min(32u,
+				static_cast<uint32_t>(std::round(settings.BlurRadius * cascadeScale[1] * float(SHADOW_COPY_SIZE)))));
+			uint32_t blurRadiusMip1 = std::max(1u, std::min(32u,
+				static_cast<uint32_t>(std::round(settings.BlurRadius * cascadeScale[0] * float(SHADOW_COPY_SIZE / 2)))));
+
 			// Get input dimensions for dispatch sizing
 			ID3D11Resource* shadowResource = nullptr;
 			shadowView->GetResource(&shadowResource);
@@ -190,7 +273,17 @@ void VolumetricShadows::CopyShadowLightData()
 					// Dispatch covers full input: each thread gathers 2x2, 8 threads per group
 					auto dispatchSize = srcDesc.Width / 16;
 
-					// Mip 0 (cascade 1)
+					// Mip 0 (cascade 1) - update cbuffer with cascade 1 near/far
+					{
+						D3D11_MAPPED_SUBRESOURCE mapped{};
+						DX::ThrowIfFailed(context->Map(linearizeCB, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));
+						auto* cb = static_cast<VSMLinearizeCB*>(mapped.pData);
+						cb->CascadeNear = cascadeNear[1];
+						cb->CascadeFar = cascadeFar[1];
+						context->Unmap(linearizeCB, 0);
+						context->CSSetConstantBuffers(0, 1, &linearizeCB);
+					}
+
 					ID3D11UnorderedAccessView* csUavs[1]{ shadowCopyMip0UAV };
 					context->CSSetUnorderedAccessViews(0, 1, csUavs, nullptr);
 					context->CSSetShader(downsampleShadowMip0CS, nullptr, 0);
@@ -198,7 +291,16 @@ void VolumetricShadows::CopyShadowLightData()
 					context->Dispatch(dispatchSize, dispatchSize, 1);
 					globals::profiler->EndPass();
 
-					// Mip 1 (cascade 0)
+					// Mip 1 (cascade 0) - update cbuffer with cascade 0 near/far
+					{
+						D3D11_MAPPED_SUBRESOURCE mapped{};
+						DX::ThrowIfFailed(context->Map(linearizeCB, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));
+						auto* cb = static_cast<VSMLinearizeCB*>(mapped.pData);
+						cb->CascadeNear = cascadeNear[0];
+						cb->CascadeFar = cascadeFar[0];
+						context->Unmap(linearizeCB, 0);
+					}
+
 					csUavs[0] = shadowCopyMip1UAV;
 					context->CSSetUnorderedAccessViews(0, 1, csUavs, nullptr);
 					context->CSSetShader(downsampleShadowMip1CS, nullptr, 0);
@@ -212,13 +314,25 @@ void VolumetricShadows::CopyShadowLightData()
 					context->CSSetShaderResources(0, 2, csSrvs);
 					csUavs[0] = nullptr;
 					context->CSSetUnorderedAccessViews(0, 1, csUavs, nullptr);
+					ID3D11Buffer* nullCB = nullptr;
+					context->CSSetConstantBuffers(0, 1, &nullCB);
 
 					constexpr uint32_t mip0Size = SHADOW_COPY_SIZE;
 					constexpr uint32_t mip1Size = SHADOW_COPY_SIZE / 2;
 
-					// 11x11 separable blur for Mip 0
+					// Separable blur for Mip 0
 					{
 						const uint32_t GROUP_SIZE = 128;
+
+						// Update blur cbuffer for mip 0
+						{
+							D3D11_MAPPED_SUBRESOURCE mapped{};
+							DX::ThrowIfFailed(context->Map(blurCB, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));
+							auto* cb = static_cast<BlurCB*>(mapped.pData);
+							cb->BlurRadius = blurRadiusMip0;
+							context->Unmap(blurCB, 0);
+							context->CSSetConstantBuffers(0, 1, &blurCB);
+						}
 
 						// Horizontal pass: shadowCopy mip0 -> shadowBlurTemp mip0
 						ID3D11ShaderResourceView* blurSrvs[1]{ shadowCopyMip0SRV };
@@ -253,9 +367,18 @@ void VolumetricShadows::CopyShadowLightData()
 						context->CSSetUnorderedAccessViews(0, 1, csUavs, nullptr);
 					}
 
-					// 11x11 separable blur for Mip 1
+					// Separable blur for Mip 1
 					{
 						const uint32_t GROUP_SIZE = 128;
+
+						// Update blur cbuffer for mip 1
+						{
+							D3D11_MAPPED_SUBRESOURCE mapped{};
+							DX::ThrowIfFailed(context->Map(blurCB, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));
+							auto* cb = static_cast<BlurCB*>(mapped.pData);
+							cb->BlurRadius = blurRadiusMip1;
+							context->Unmap(blurCB, 0);
+						}
 
 						// Horizontal pass: shadowCopy mip1 -> shadowBlurTemp mip1
 						ID3D11ShaderResourceView* blurSrvs[1]{ shadowCopyMip1SRV };
@@ -293,6 +416,8 @@ void VolumetricShadows::CopyShadowLightData()
 					// Cleanup CS state
 					ID3D11SamplerState* nullSampler = nullptr;
 					context->CSSetSamplers(0, 1, &nullSampler);
+					ID3D11Buffer* nullCB2 = nullptr;
+					context->CSSetConstantBuffers(0, 1, &nullCB2);
 					context->CSSetShader(nullptr, nullptr, 0);
 
 					shadowTexture->Release();
@@ -317,7 +442,23 @@ void VolumetricShadows::SetSharedShadowMapSRV(ID3D11DeviceContext* a_context, ID
 
 void VolumetricShadows::DrawSettings()
 {
+	ImGui::SliderFloat("Blur Radius", &settings.BlurRadius, 0.0f, 500.0f, "%.0f");
+	if (ImGui::IsItemHovered())
+		ImGui::SetTooltip("Blur radius in world units. Both cascades are scaled to match this world-space softness.");
+
 	ImGui::SeparatorText("Debug");
+
+	if (ImGui::TreeNode("Info")) {
+		ImGui::Text("Cascade 0: scale=%.6f near=%.1f far=%.1f", cascadeScale[0], cascadeNear[0], cascadeFar[0]);
+		ImGui::Text("Cascade 1: scale=%.6f near=%.1f far=%.1f", cascadeScale[1], cascadeNear[1], cascadeFar[1]);
+
+		uint32_t blurMip0 = std::max(1u, std::min(32u,
+			static_cast<uint32_t>(std::round(settings.BlurRadius * cascadeScale[1] * float(shadowCopyWidth)))));
+		uint32_t blurMip1 = std::max(1u, std::min(32u,
+			static_cast<uint32_t>(std::round(settings.BlurRadius * cascadeScale[0] * float(shadowCopyWidth / 2)))));
+		ImGui::Text("Blur pixels: mip0=%u mip1=%u", blurMip0, blurMip1);
+		ImGui::TreePop();
+	}
 
 	if (ImGui::TreeNode("Buffer Viewer")) {
 		static float debugRescale = .3f;
@@ -336,26 +477,26 @@ void VolumetricShadows::DrawSettings()
 			}
 		};
 
-		DisplayRT("VSM Cascade 0", shadowCopyTexture, shadowCopyMip0SRV);
-		DisplayRT("VSM Cascade 1", shadowCopyTexture, shadowCopyMip1SRV);
+		DisplayRT("MSM Cascade 0", shadowCopyTexture, shadowCopyMip0SRV);
+		DisplayRT("MSM Cascade 1", shadowCopyTexture, shadowCopyMip1SRV);
 
 		ImGui::TreePop();
 	}
 }
 
-void VolumetricShadows::LoadSettings(json&)
+void VolumetricShadows::LoadSettings(json& o_json)
 {
-	// No settings currently
+	settings = o_json;
 }
 
-void VolumetricShadows::SaveSettings(json&)
+void VolumetricShadows::SaveSettings(json& o_json)
 {
-	// No settings currently
+	o_json = settings;
 }
 
 void VolumetricShadows::RestoreDefaultSettings()
 {
-	// No settings currently
+	settings = {};
 }
 
 struct CreateDepthStencil_VolumetricLighting
@@ -363,8 +504,8 @@ struct CreateDepthStencil_VolumetricLighting
 	static void thunk(RE::BSGraphics::Renderer* This, uint32_t a_target, RE::BSGraphics::DepthStencilTargetProperties* a_properties)
 	{
 		RE::BSGraphics::DepthStencilTargetProperties properties = *a_properties;
-		a_properties->height = 1024;
-		a_properties->width = 1024;
+		properties.height = 1024;
+		properties.width = 1024;
 		func(This, a_target, &properties);
 	}
 	static inline REL::Relocation<decltype(thunk)> func;

--- a/src/Features/VolumetricShadows.cpp
+++ b/src/Features/VolumetricShadows.cpp
@@ -139,6 +139,14 @@ float4 VolumetricShadows::GetCascadeDepthParams()
 	return { cascadeNear[0], cascadeFar[0], cascadeNear[1], cascadeFar[1] };
 }
 
+float4 VolumetricShadows::GetGlobalDepthParams()
+{
+	ExtractCascadeNearFar();
+	float globalNear = std::min(cascadeNear[0], cascadeNear[1]);
+	float globalFar = std::max(cascadeFar[0], cascadeFar[1]);
+	return { globalNear, globalFar, 0.f, 0.f };
+}
+
 void VolumetricShadows::CopyShadowLightData()
 {
 	ZoneScoped;
@@ -268,6 +276,10 @@ void VolumetricShadows::CopyShadowLightData()
 					// Dispatch covers full input: each thread gathers 2x2, 8 threads per group
 					auto dispatchSize = srcDesc.Width / 16;
 
+					// Global near/far: consistent [0,1] mapping across both cascades
+					float globalNear = std::min(cascadeNear[0], cascadeNear[1]);
+					float globalFar = std::max(cascadeFar[0], cascadeFar[1]);
+
 					// Mip 0 (cascade 1) - update cbuffer with cascade 1 near/far + exponents
 					{
 						D3D11_MAPPED_SUBRESOURCE mapped{};
@@ -275,6 +287,8 @@ void VolumetricShadows::CopyShadowLightData()
 						auto* cb = static_cast<EVSMLinearizeCB*>(mapped.pData);
 						cb->CascadeNear = cascadeNear[1];
 						cb->CascadeFar = cascadeFar[1];
+						cb->GlobalNear = globalNear;
+						cb->GlobalFar = globalFar;
 						cb->ExponentPositive = settings.ExponentPositive;
 						cb->ExponentNegative = settings.ExponentNegative;
 						context->Unmap(linearizeCB, 0);
@@ -295,6 +309,8 @@ void VolumetricShadows::CopyShadowLightData()
 						auto* cb = static_cast<EVSMLinearizeCB*>(mapped.pData);
 						cb->CascadeNear = cascadeNear[0];
 						cb->CascadeFar = cascadeFar[0];
+						cb->GlobalNear = globalNear;
+						cb->GlobalFar = globalFar;
 						cb->ExponentPositive = settings.ExponentPositive;
 						cb->ExponentNegative = settings.ExponentNegative;
 						context->Unmap(linearizeCB, 0);

--- a/src/Features/VolumetricShadows.h
+++ b/src/Features/VolumetricShadows.h
@@ -17,14 +17,35 @@ public:
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{
-		return { T("feature.volumetric_shadows.description", "Volumetric Shadows provides downsampled VSM shadow maps for use by effects like particles and decals.\nThis improves shadow quality on transparent objects with minimal performance impact."),
-			{ T("feature.volumetric_shadows.key_feature_1", "Downsampled VSM shadows"),
+		return { T("feature.volumetric_shadows.description", "Volumetric Shadows provides downsampled MSM shadow maps for use by effects like particles and decals.\nThis improves shadow quality on transparent objects with minimal performance impact."),
+			{ T("feature.volumetric_shadows.key_feature_1", "Downsampled MSM shadows"),
 				T("feature.volumetric_shadows.key_feature_2", "Gaussian blur filtering"),
 				T("feature.volumetric_shadows.key_feature_3", "Multi-cascade support"),
 				T("feature.volumetric_shadows.key_feature_4", "Optimized for effects rendering") } };
-	};
+	}
 
 	bool HasShaderDefine(RE::BSShader::Type shaderType) override;
+
+	struct Settings
+	{
+		float BlurRadius = 100.0f;
+	};
+	Settings settings;
+
+	struct alignas(16) VSMLinearizeCB
+	{
+		float CascadeNear;
+		float CascadeFar;
+		uint32_t _pad[2];
+	};
+
+	struct alignas(16) BlurCB
+	{
+		uint32_t BlurRadius;
+		uint32_t _pad[3];
+	};
+
+	float4 GetCascadeDepthParams();
 
 	// Compute shaders
 	ID3D11ComputeShader* downsampleShadowMip0CS = nullptr;
@@ -51,6 +72,15 @@ public:
 	ID3D11UnorderedAccessView* shadowBlurTempMip0UAV = nullptr;
 	ID3D11UnorderedAccessView* shadowBlurTempMip1UAV = nullptr;
 
+	// Cbuffers
+	ID3D11Buffer* linearizeCB = nullptr;
+	ID3D11Buffer* blurCB = nullptr;
+
+	// Cached cascade near/far values and projection scale
+	float cascadeNear[2] = { 0.f, 0.f };
+	float cascadeFar[2] = { 1.f, 1.f };
+	float cascadeScale[2] = { 1.f, 1.f };
+
 	// Samplers
 	ID3D11SamplerState* linearSampler = nullptr;
 
@@ -69,4 +99,5 @@ public:
 
 private:
 	static void SetSharedShadowMapSRV(ID3D11DeviceContext* a_context, ID3D11ShaderResourceView* a_srv);
+	void ExtractCascadeNearFar();
 };

--- a/src/Features/VolumetricShadows.h
+++ b/src/Features/VolumetricShadows.h
@@ -17,8 +17,8 @@ public:
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{
-		return { T("feature.volumetric_shadows.description", "Volumetric Shadows provides downsampled MSM shadow maps for use by effects like particles and decals.\nThis improves shadow quality on transparent objects with minimal performance impact."),
-			{ T("feature.volumetric_shadows.key_feature_1", "Downsampled MSM shadows"),
+		return { T("feature.volumetric_shadows.description", "Volumetric Shadows provides downsampled EVSM shadow maps for use by effects like particles and decals.\nThis improves shadow quality on transparent objects with minimal performance impact."),
+			{ T("feature.volumetric_shadows.key_feature_1", "Downsampled EVSM shadows"),
 				T("feature.volumetric_shadows.key_feature_2", "Gaussian blur filtering"),
 				T("feature.volumetric_shadows.key_feature_3", "Multi-cascade support"),
 				T("feature.volumetric_shadows.key_feature_4", "Optimized for effects rendering") } };
@@ -29,14 +29,17 @@ public:
 	struct Settings
 	{
 		float BlurRadius = 100.0f;
+		float ExponentPositive = 40.0f;
+		float ExponentNegative = 5.0f;
 	};
 	Settings settings;
 
-	struct alignas(16) VSMLinearizeCB
+	struct alignas(16) EVSMLinearizeCB
 	{
 		float CascadeNear;
 		float CascadeFar;
-		uint32_t _pad[2];
+		float ExponentPositive;
+		float ExponentNegative;
 	};
 
 	struct alignas(16) BlurCB

--- a/src/Features/VolumetricShadows.h
+++ b/src/Features/VolumetricShadows.h
@@ -38,8 +38,11 @@ public:
 	{
 		float CascadeNear;
 		float CascadeFar;
+		float GlobalNear;
+		float GlobalFar;
 		float ExponentPositive;
 		float ExponentNegative;
+		float _pad[2];
 	};
 
 	struct alignas(16) BlurCB
@@ -49,6 +52,7 @@ public:
 	};
 
 	float4 GetCascadeDepthParams();
+	float4 GetGlobalDepthParams();
 
 	// Compute shaders
 	ID3D11ComputeShader* downsampleShadowMip0CS = nullptr;


### PR DESCRIPTION
## Summary

- **Replaces Moment Shadow Maps (MSM) with Exponential Variance Shadow Maps (EVSM)** for volumetric shadow filtering. EVSM uses dual Chebyshev upper bounds (`exp(c*z)` positive + `exp(-c*z)` negative) instead of MSM's 4-moment Hamburger/Cholesky reconstruction, yielding simpler evaluation and better light bleed control.
- **Adds globally-consistent orthographic depth normalization** across both shadow cascades. Shadow map depth (already linear under orthographic projection) is remapped through world units to a shared `[0,1]` range (`globalNear`/`globalFar`), ensuring exponent application is consistent regardless of cascade frustum size or camera angle.
- **Implements configurable Gaussian blur** with dynamic radius for soft shadow filtering on the downsampled EVSM moments.
- **Stores EVSM moments in `RGBA16F`** (was `RG16_UNORM` for MSM) to accommodate exponential warping values.
- **Passes cascade and global depth parameters** through `DirectionalShadowLightData` structured buffer so the sampling shader matches the downsample shader's depth space exactly.

## Key changes

| File | What changed |
|------|-------------|
| `VolumetricShadows.h/cpp` | EVSM settings (exponents, blur radius), `EVSMLinearizeCB` with global range, cascade extraction, `GetCascadeDepthParams()`/`GetGlobalDepthParams()` |
| `DownsampleShadowCS.hlsl` | Orthographic `NormalizeDepth` + `WarpDepth` into EVSM moments using global range |
| `VolumetricShadows.hlsli` | `NormalizeDepth` + `ComputeEVSM` with dual Chebyshev, light bleed reduction, 3D ray march and 2D point sample paths |
| `BlurShadowCS.hlsl` | Separable Gaussian blur operating on float4 EVSM moments |
| `ShadowSampling.hlsli` | Added `CascadeDepthParams` and `GlobalDepthParams` to `DirectionalShadowLightData` struct |
| `Deferred.h/cpp` | Populates depth params from VolumetricShadows feature, fixes render target resource leak in `SetupRenderTarget` |
| `Hooks.cpp` | Removed old shadow copy hook (replaced by compute-based downsample) |

## EVSM algorithm overview

1. **Downsample**: Gather shadow depth → orthographic normalize to global `[0,1]` → warp to `(e^(c*d), e^(2c*d), e^(-c*d), e^(-2c*d))` → average
2. **Blur**: Separable Gaussian on float4 moments (preserves statistical properties)
3. **Sample**: Normalize receiver depth to same global space → warp → dual Chebyshev upper bound → min(positive, negative) → light bleed reduction remap

## Test plan

- [ ] Build with `ALL` preset — verified locally ✅
- [ ] In-game: verify shadow quality on particles, decals, and volumetric effects
- [ ] Test cascade transitions (walk from near to far) for consistent shadow sharpness
- [ ] Verify no fp16 overflow artifacts at default exponents (positive=40, negative=5)
- [ ] Test with different shadow quality settings and cascade distances
- [ ] Compare performance vs previous MSM implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded shadow map filtering algorithm from VSM to EVSM
  * Added runtime-configurable blur radius for shadow maps
  * Introduced global and per-cascade depth normalization parameters
  * Enhanced debug UI with cascade metrics and blur statistics
  * Enabled settings persistence for volumetric shadow configuration

* **Bug Fixes**
  * Corrected depth-stencil buffer sizing in volumetric lighting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->