### PR TITLE
fix(UI): invisible cursor on alt-tab in windowed mode

### DIFF
--- a/src/Menu/ThemeManager.cpp
+++ b/src/Menu/ThemeManager.cpp
@@ -207,6 +207,7 @@ void ThemeManager::SetupImGuiStyle(const Menu& menu)
 	styleCopy.TabBarBorderSize = scaleSize(themeSettings.Style.TabBarBorderSize);
 	styleCopy.SeparatorTextBorderSize = scaleSize(themeSettings.Style.SeparatorTextBorderSize);
 	styleCopy.DockingSeparatorSize = scaleSize(themeSettings.Style.DockingSeparatorSize);
+	styleCopy.MouseCursorScale = ImMax(1.0f, themeSettings.Style.MouseCursorScale * scaleFactor);
 
 	style = styleCopy;
 	style.HoverDelayNormal = themeSettings.TooltipHoverDelay;

--- a/src/Menu/ThemeManager.cpp
+++ b/src/Menu/ThemeManager.cpp
@@ -207,7 +207,7 @@ void ThemeManager::SetupImGuiStyle(const Menu& menu)
 	styleCopy.TabBarBorderSize = scaleSize(themeSettings.Style.TabBarBorderSize);
 	styleCopy.SeparatorTextBorderSize = scaleSize(themeSettings.Style.SeparatorTextBorderSize);
 	styleCopy.DockingSeparatorSize = scaleSize(themeSettings.Style.DockingSeparatorSize);
-	styleCopy.MouseCursorScale = ImMax(1.0f, themeSettings.Style.MouseCursorScale * scaleFactor);
+	styleCopy.MouseCursorScale = ImMax(1.0f, themeSettings.Style.MouseCursorScale);
 
 	style = styleCopy;
 	style.HoverDelayNormal = themeSettings.TooltipHoverDelay;


### PR DESCRIPTION
ScaleAllSizes truncates MouseCursorScale toward zero, 
hiding the cursor entirely when scaleFactor < 1. 
Recompute it clamped to 1.0 so the cursor never vanishes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures mouse cursor scaling honors a minimum size so the cursor no longer becomes too small when theme or font scaling settings are applied, improving visibility and consistency across the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->