### PR TITLE
fix(volumetric shadows): reduce flickering on cascades blending

### DIFF
--- a/features/Volumetric Shadows/Shaders/VolumetricShadows/VolumetricShadows.hlsli
+++ b/features/Volumetric Shadows/Shaders/VolumetricShadows/VolumetricShadows.hlsli
@@ -81,7 +81,7 @@ namespace VolumetricShadows
 		uint sampleCount = max(1, ceil(float(baseSampleCount) * (1.0 - fade)));
 		float rcpSampleCount = rcp(sampleCount);
 
-		// Compute cascade blend factor with smoothstep
+		// Compute cascade blend factor
 		float cascadeSelect = saturate((shadowMapDepth - directionalShadowLightData.StartSplitDistances.y) / (directionalShadowLightData.EndSplitDistances.x - directionalShadowLightData.StartSplitDistances.y));
 
 		// Determine which cascade(s) to sample
@@ -113,8 +113,9 @@ namespace VolumetricShadows
 
 			float secondaryFirstSample;
 			float shadowBlend = SampleVSMCascade3D(secondaryCascade, noise, sampleCount, rcpSampleCount, startLS, endLS, secondaryFirstSample);
-			shadow = lerp(shadow, shadowBlend, cascadeSelect);
-			surfaceShadow = lerp(surfaceShadow, secondaryFirstSample, cascadeSelect);
+			float blendFactor = smoothstep(0, 1, cascadeSelect);
+			shadow = lerp(shadow, shadowBlend, blendFactor);
+			surfaceShadow = lerp(surfaceShadow, secondaryFirstSample, blendFactor);
 		}
 
 		// Apply distance fade
@@ -148,7 +149,7 @@ namespace VolumetricShadows
 		// Cascade projections are world-space; position comes in camera-relative.
 		float3 positionWS = position + FrameBuffer::CameraPosAdjust.xyz;
 
-		// Compute cascade blend factor with smoothstep
+		// Compute cascade blend factor
 		float cascadeSelect = saturate((shadowMapDepth - directionalShadowLightData.StartSplitDistances.y) / (directionalShadowLightData.EndSplitDistances.x - directionalShadowLightData.StartSplitDistances.y));
 
 		// Determine which cascade(s) to sample
@@ -171,7 +172,7 @@ namespace VolumetricShadows
 			positionLS.xy = saturate(positionLS.xy);
 
 			float shadowBlend = SampleVSMCascade2D(secondaryCascade, positionLS);
-			shadow = lerp(shadow, shadowBlend, cascadeSelect);
+			shadow = lerp(shadow, shadowBlend, smoothstep(0, 1, cascadeSelect));
 		}
 
 		// Apply distance fade

--- a/src/Features/VolumetricShadows.cpp
+++ b/src/Features/VolumetricShadows.cpp
@@ -101,7 +101,7 @@ void VolumetricShadows::CopyShadowLightData()
 				copyDesc.Height = SHADOW_COPY_SIZE;
 				copyDesc.MipLevels = 2;
 				copyDesc.ArraySize = 1;
-				copyDesc.Format = DXGI_FORMAT_R16G16_UNORM;
+				copyDesc.Format = DXGI_FORMAT_R32G32_UNORM;
 				copyDesc.SampleDesc.Count = 1;
 				copyDesc.SampleDesc.Quality = 0;
 				copyDesc.Usage = D3D11_USAGE_DEFAULT;

--- a/src/Features/VolumetricShadows.cpp
+++ b/src/Features/VolumetricShadows.cpp
@@ -101,7 +101,7 @@ void VolumetricShadows::CopyShadowLightData()
 				copyDesc.Height = SHADOW_COPY_SIZE;
 				copyDesc.MipLevels = 2;
 				copyDesc.ArraySize = 1;
-				copyDesc.Format = DXGI_FORMAT_R32G32_UNORM;
+				copyDesc.Format = DXGI_FORMAT_R32G32_FLOAT;
 				copyDesc.SampleDesc.Count = 1;
 				copyDesc.SampleDesc.Quality = 0;
 				copyDesc.Usage = D3D11_USAGE_DEFAULT;

--- a/src/Features/VolumetricShadows.cpp
+++ b/src/Features/VolumetricShadows.cpp
@@ -101,7 +101,7 @@ void VolumetricShadows::CopyShadowLightData()
 				copyDesc.Height = SHADOW_COPY_SIZE;
 				copyDesc.MipLevels = 2;
 				copyDesc.ArraySize = 1;
-				copyDesc.Format = DXGI_FORMAT_R32G32_FLOAT;
+				copyDesc.Format = DXGI_FORMAT_R16G16_UNORM;
 				copyDesc.SampleDesc.Count = 1;
 				copyDesc.SampleDesc.Quality = 0;
 				copyDesc.Usage = D3D11_USAGE_DEFAULT;


### PR DESCRIPTION
reduces flickering on edges of cascade

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Smoother volumetric shadow cascade blending for more natural transitions between shadow regions.
  * Increased precision of shadow data storage for improved shadow detail and visual fidelity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->